### PR TITLE
Update Xamarin tests and run them through Travis CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Calabash Test
 .irb-history
+screenshot_*
 
 # System 
 .DS_Store

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,5 +23,7 @@ android:
 jdk:
   - oraclejdk8
 
+before_install:
+   - rvm install 2.0.0
 script:
     - ./testprebid.sh

--- a/PrebidMobile/DemoApp/build.gradle
+++ b/PrebidMobile/DemoApp/build.gradle
@@ -27,10 +27,6 @@ android {
     }
 }
 
-repositories {
-    jcenter()
-}
-
 dependencies {
     compile 'com.android.support:appcompat-v7:25.2.0'
     compile 'com.google.android.gms:play-services-ads:10.2.0'

--- a/PrebidMobile/DemoApp/src/main/java/org/prebid/mobile/demoapp/DemoActivity.java
+++ b/PrebidMobile/DemoApp/src/main/java/org/prebid/mobile/demoapp/DemoActivity.java
@@ -44,6 +44,12 @@ public class DemoActivity extends AppCompatActivity {
 
     }
 
+    // This is used in the calabash tests to grab the obfuscated web view class name from DFP
+    public String getDFPWebViewName() {
+        DFPBannerFragment fragment = (DFPBannerFragment) getSupportFragmentManager().findFragmentById(R.id.demoRoot);
+        return fragment.getDFPWebViewName();
+    }
+
     @Override
     protected void onDestroy() {
         super.onDestroy();

--- a/PrebidMobile/DemoApp/src/main/java/org/prebid/mobile/demoapp/dfpdemofragments/DFPBannerFragment.java
+++ b/PrebidMobile/DemoApp/src/main/java/org/prebid/mobile/demoapp/dfpdemofragments/DFPBannerFragment.java
@@ -75,15 +75,7 @@ public class DFPBannerFragment extends Fragment implements Prebid.OnAttachComple
                 LogUtil.d("DPF-Banner", "onAdLoaded");
             }
         };
-
-        PublisherAdRequest.Builder builder = new PublisherAdRequest.Builder();
-        request1 = builder.build();
-        setupBannerWithoutWait(request1);
-
-//        PublisherAdRequest.Builder builder2 = new PublisherAdRequest.Builder();
-//        request2 = builder2.build();
-//        setupBannerWithWait(request2, 500);
-
+        
         return root;
     }
 

--- a/PrebidMobile/DemoApp/src/main/java/org/prebid/mobile/demoapp/dfpdemofragments/DFPBannerFragment.java
+++ b/PrebidMobile/DemoApp/src/main/java/org/prebid/mobile/demoapp/dfpdemofragments/DFPBannerFragment.java
@@ -76,9 +76,9 @@ public class DFPBannerFragment extends Fragment implements Prebid.OnAttachComple
             }
         };
 
-//        PublisherAdRequest.Builder builder = new PublisherAdRequest.Builder();
-//        request1 = builder.build();
-//        setupBannerWithoutWait(request1);
+        PublisherAdRequest.Builder builder = new PublisherAdRequest.Builder();
+        request1 = builder.build();
+        setupBannerWithoutWait(request1);
 
 //        PublisherAdRequest.Builder builder2 = new PublisherAdRequest.Builder();
 //        request2 = builder2.build();

--- a/PrebidMobile/DemoApp/src/main/java/org/prebid/mobile/demoapp/dfpdemofragments/DFPBannerFragment.java
+++ b/PrebidMobile/DemoApp/src/main/java/org/prebid/mobile/demoapp/dfpdemofragments/DFPBannerFragment.java
@@ -6,6 +6,7 @@ import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.webkit.WebView;
 import android.widget.Button;
 import android.widget.FrameLayout;
 
@@ -74,6 +75,15 @@ public class DFPBannerFragment extends Fragment implements Prebid.OnAttachComple
                 LogUtil.d("DPF-Banner", "onAdLoaded");
             }
         };
+
+//        PublisherAdRequest.Builder builder = new PublisherAdRequest.Builder();
+//        request1 = builder.build();
+//        setupBannerWithoutWait(request1);
+
+//        PublisherAdRequest.Builder builder2 = new PublisherAdRequest.Builder();
+//        request2 = builder2.build();
+//        setupBannerWithWait(request2, 500);
+
         return root;
     }
 
@@ -93,7 +103,28 @@ public class DFPBannerFragment extends Fragment implements Prebid.OnAttachComple
         adView1.loadAd(request);
     }
 
+
+    public String getDFPWebViewName() {
+        int count = adView2.getChildCount();
+        for (int i = 0; i < count; i++) {
+            ViewGroup nextChild = (ViewGroup) adView2.getChildAt(i);
+            int secondCount = nextChild.getChildCount();
+            for (int j = 0; j < secondCount; j++) {
+                ViewGroup thirdChild = (ViewGroup) nextChild.getChildAt(j);
+                int thirdCount = thirdChild.getChildCount();
+                for (int k = 0; k < thirdCount; k++) {
+                    System.out.println(thirdChild.getChildAt(k));
+                    if (thirdChild.getChildAt(k) instanceof WebView) {
+                        return thirdChild.getChildAt(k).getClass().getName();
+                    }
+                }
+            }
+        }
+        return "undefined";
+    }
+    
     private void setupBannerWithWait(final int waitTime) {
+
         FrameLayout adFrame = (FrameLayout) root.findViewById(R.id.adFrame2);
         adFrame.removeAllViews();
         adView2 = new PublisherAdView(getActivity());

--- a/PrebidMobile/DemoApp/src/main/java/org/prebid/mobile/demoapp/dfpdemofragments/DFPInterstitialFragment.java
+++ b/PrebidMobile/DemoApp/src/main/java/org/prebid/mobile/demoapp/dfpdemofragments/DFPInterstitialFragment.java
@@ -6,6 +6,7 @@ import android.support.v4.app.Fragment;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
+import android.webkit.WebView;
 import android.widget.Button;
 
 import com.google.android.gms.ads.AdListener;

--- a/PrebidMobile/IntegrationTests/Gemfile
+++ b/PrebidMobile/IntegrationTests/Gemfile
@@ -1,5 +1,6 @@
 source "https://rubygems.org"
 
+gem "xamarin-test-cloud"
 gem "calabash-android"
 gem "calabash-cucumber"
 gem "rspec"

--- a/PrebidMobile/IntegrationTests/Gemfile
+++ b/PrebidMobile/IntegrationTests/Gemfile
@@ -1,0 +1,5 @@
+source "https://rubygems.org"
+
+gem "calabash-android"
+gem "calabash-cucumber"
+gem "rspec"

--- a/PrebidMobile/IntegrationTests/Gemfile.lock
+++ b/PrebidMobile/IntegrationTests/Gemfile.lock
@@ -1,0 +1,101 @@
+GEM
+  remote: https://rubygems.org/
+  specs:
+    CFPropertyList (2.3.5)
+    awesome_print (1.8.0)
+    builder (3.2.3)
+    calabash-android (0.9.0)
+      awesome_print (~> 1.2)
+      cucumber
+      escape (~> 0.0.4)
+      httpclient (>= 2.7.1, < 3.0)
+      json (~> 1.8)
+      luffa
+      rubyzip (~> 1.1)
+      slowhandcuke (~> 0.0.3)
+    calabash-cucumber (0.20.5)
+      awesome_print
+      bundler (~> 1.3)
+      clipboard (~> 1.0)
+      cucumber
+      edn (>= 1.0.6, < 2.0)
+      geocoder (>= 1.1.8, < 2.0)
+      httpclient (>= 2.7.1, < 3.0)
+      json
+      run_loop (>= 2.4.1, < 3.0)
+      slowhandcuke (~> 0.0.3)
+    clipboard (1.1.1)
+    command_runner_ng (0.1.3)
+    cucumber (2.4.0)
+      builder (>= 2.1.2)
+      cucumber-core (~> 1.5.0)
+      cucumber-wire (~> 0.0.1)
+      diff-lcs (>= 1.1.3)
+      gherkin (~> 4.0)
+      multi_json (>= 1.7.5, < 2.0)
+      multi_test (>= 0.1.2)
+    cucumber-core (1.5.0)
+      gherkin (~> 4.0)
+    cucumber-wire (0.0.1)
+    diff-lcs (1.3)
+    edn (1.1.1)
+    escape (0.0.4)
+    geocoder (1.4.4)
+    gherkin (4.1.3)
+    httpclient (2.8.3)
+    i18n (0.8.6)
+    json (1.8.6)
+    luffa (2.0.0)
+      awesome_print (~> 1.2)
+      json (~> 1.8)
+      retriable (>= 1.3.3.1, < 2.1)
+      thor (~> 0.19)
+    mime-types (2.99.3)
+    multi_json (1.12.1)
+    multi_test (0.1.2)
+    retriable (2.0.2)
+    rspec (3.6.0)
+      rspec-core (~> 3.6.0)
+      rspec-expectations (~> 3.6.0)
+      rspec-mocks (~> 3.6.0)
+    rspec-core (3.6.0)
+      rspec-support (~> 3.6.0)
+    rspec-expectations (3.6.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.6.0)
+    rspec-mocks (3.6.0)
+      diff-lcs (>= 1.2.0, < 2.0)
+      rspec-support (~> 3.6.0)
+    rspec-support (3.6.0)
+    rubyzip (1.2.1)
+    run_loop (2.4.1)
+      CFPropertyList (~> 2.2)
+      awesome_print (~> 1.2)
+      command_runner_ng (>= 0.0.2)
+      httpclient (>= 2.7.1, < 3.0)
+      i18n (>= 0.7.0, < 1.0)
+      json (~> 1.8)
+      thor (>= 0.18.1, < 1.0)
+    slowhandcuke (0.0.3)
+      cucumber
+    thor (0.19.4)
+    xamarin-test-cloud (2.1.2)
+      bundler (>= 1.3.0, < 2.0)
+      httpclient (>= 2.7.1, < 3.0)
+      json (~> 1.8)
+      mime-types (~> 2.99)
+      retriable (>= 1.3.3.1, < 2.1)
+      rubyzip (~> 1.1)
+      thor (>= 0.18.1, < 1.0)
+
+PLATFORMS
+  ruby
+
+DEPENDENCIES
+  calabash-android
+  calabash-cucumber
+  rspec
+  xamarin-test-cloud
+
+BUNDLED WITH
+   1.14.6

--- a/PrebidMobile/IntegrationTests/features/base_test.feature
+++ b/PrebidMobile/IntegrationTests/features/base_test.feature
@@ -6,7 +6,7 @@ Scenario: Load DFP Banner Ad
     Then I press "Show Banner Example"
     Then I press "Refresh Banner"
     Then I wait for 5 seconds
-    Then I should see AppNexus creative in PublisherAdView number 1
+    Then I should see AppNexus creative
 
 Scenario: Load DFP Interstitial Ad
     Given I wait for the "MainActivity" screen to appear
@@ -29,6 +29,7 @@ Scenario: Load MoPub Interstitial Ad
     Given I wait for the "MainActivity" screen to appear
     Then I press "MoPub"
     Then I press "Show Interstitial Example"
+    Then I press "loadInterstitial"
     Then I press "loadInterstitial"
     Then I wait for 5 seconds
     Then I should see AppNexus creative in MraidBridgeMraidWebView

--- a/PrebidMobile/IntegrationTests/features/base_test.feature
+++ b/PrebidMobile/IntegrationTests/features/base_test.feature
@@ -5,7 +5,7 @@ Scenario: Load DFP Banner Ad
     Then I press "DFP"
     Then I press "Show Banner Example"
     Then I press "Refresh Banner"
-    Then I wait for 5 seconds
+    Then I wait for 10 seconds
     Then I should see AppNexus creative
 
 #Scenario: Load DFP Interstitial Ad
@@ -22,7 +22,7 @@ Scenario: Load MoPub Banner Ad
     Then I press "MoPub"
     Then I press "Show Banner Example"
     Then I press "Refresh Banner"
-    Then I wait for 5 seconds
+    Then I wait for 10 seconds
     Then I should see AppNexus creative in HTMLBannerWebView
 
 #Scenario: Load MoPub Interstitial Ad

--- a/PrebidMobile/IntegrationTests/features/base_test.feature
+++ b/PrebidMobile/IntegrationTests/features/base_test.feature
@@ -1,5 +1,13 @@
 Feature: Base test
 
+Scenario: Load DFP Banner Ad
+    Given I wait for the "MainActivity" screen to appear
+    Then I press "DFP"
+    Then I press "Show Banner Example"
+    Then I press "Refresh Banner"
+    Then I wait for 5 seconds
+    Then I should see AppNexus creative in PublisherAdView number 1
+
 Scenario: Load DFP Interstitial Ad
     Given I wait for the "MainActivity" screen to appear
     Then I press "DFP"
@@ -9,11 +17,19 @@ Scenario: Load DFP Interstitial Ad
     Then I should see AppNexus creative
     Then I press "Interstitial close button"
 
-Scenario: Load DFP Banner Ad
+Scenario: Load MoPub Banner Ad
     Given I wait for the "MainActivity" screen to appear
-    Then I press "DFP"
+    Then I press "MoPub"
     Then I press "Show Banner Example"
     Then I press "Refresh Banner"
     Then I wait for 5 seconds
-    Then I should see AppNexus creative in PublisherAdView number 0
-    Then I should see AppNexus creative in PublisherAdView number 1
+    Then I should see AppNexus creative in HTMLBannerWebView
+
+Scenario: Load MoPub Interstitial Ad
+    Given I wait for the "MainActivity" screen to appear
+    Then I press "MoPub"
+    Then I press "Show Interstitial Example"
+    Then I press "loadInterstitial"
+    Then I wait for 5 seconds
+    Then I should see AppNexus creative in MraidBridgeMraidWebView
+    Then I press "Interstitial close button"

--- a/PrebidMobile/IntegrationTests/features/base_test.feature
+++ b/PrebidMobile/IntegrationTests/features/base_test.feature
@@ -8,14 +8,14 @@ Scenario: Load DFP Banner Ad
     Then I wait for 5 seconds
     Then I should see AppNexus creative
 
-Scenario: Load DFP Interstitial Ad
-    Given I wait for the "MainActivity" screen to appear
-    Then I press "DFP"
-    Then I press "Show Interstitial Example"
-    Then I press "loadInterstitial"
-    Then I wait for 5 seconds
-    Then I should see AppNexus creative
-    Then I press "Interstitial close button"
+#Scenario: Load DFP Interstitial Ad
+#Given I wait for the "MainActivity" screen to appear
+#Then I press "DFP"
+#Then I press "Show Interstitial Example"
+#Then I press "loadInterstitial"
+#Then I wait for 5 seconds
+#Then I should see AppNexus creative
+#Then I press "Interstitial close button"
 
 Scenario: Load MoPub Banner Ad
     Given I wait for the "MainActivity" screen to appear
@@ -25,12 +25,12 @@ Scenario: Load MoPub Banner Ad
     Then I wait for 5 seconds
     Then I should see AppNexus creative in HTMLBannerWebView
 
-Scenario: Load MoPub Interstitial Ad
-    Given I wait for the "MainActivity" screen to appear
-    Then I press "MoPub"
-    Then I press "Show Interstitial Example"
-    Then I press "loadInterstitial"
-    Then I press "loadInterstitial"
-    Then I wait for 5 seconds
-    Then I should see AppNexus creative in MraidBridgeMraidWebView
-    Then I press "Interstitial close button"
+#Scenario: Load MoPub Interstitial Ad
+#Given I wait for the "MainActivity" screen to appear
+#Then I press "MoPub"
+#Then I press "Show Interstitial Example"
+#Then I press "loadInterstitial"
+#Then I press "loadInterstitial"
+#Then I wait for 5 seconds
+#Then I should see AppNexus creative in MraidBridgeMraidWebView
+#Then I press "Interstitial close button"

--- a/PrebidMobile/IntegrationTests/features/step_definitions/calabash_steps.rb
+++ b/PrebidMobile/IntegrationTests/features/step_definitions/calabash_steps.rb
@@ -2,9 +2,11 @@ require 'calabash-android/calabash_steps'
 
 Then(/^I should see AppNexus creative$/) do
     webview_class = backdoor "getDFPWebViewName"
-    @query_results = query(webview_class + " css:'*'")
-    puts @query_results[0]['html']
-    unless @query_results[0]['html'].include?('pbm.js')
+    names = webview_class.split('.')
+    len = names.length
+    short_name = names[len-1]
+    @query_results = query(short_name + " css:'body'")
+    unless @query_results[1]['html'].include?('pbm.js')
         raise "Pbm.js not found, prebid creative was not served"
     end
 end
@@ -18,8 +20,8 @@ Then(/^I should see AppNexus creative in PublisherAdView number (\d+)$/) do |arg
 end
 
 Then(/^I should see AppNexus creative in HTMLBannerWebView$/) do
-    @query_results = query("HTMLBannerWebView css:'*'")
-    unless @query_results[0]['html'].include?('pbm.js')
+    @query_results = query("HTMLBannerWebView css:'body'")
+    unless @query_results[1]['html'].include?('pbm.js')
         raise "Pbm.js not found, prebid creative was not served"
     end
 end

--- a/PrebidMobile/IntegrationTests/features/step_definitions/calabash_steps.rb
+++ b/PrebidMobile/IntegrationTests/features/step_definitions/calabash_steps.rb
@@ -1,18 +1,20 @@
 require 'calabash-android/calabash_steps'
 
 Then(/^I should see AppNexus creative$/) do
-    @query_results = query("zzra css:'*'")
+    webview_class = backdoor "getDFPWebViewName"
+    @query_results = query(webview_class + " css:'*'")
     puts @query_results[0]['html']
     unless @query_results[0]['html'].include?('pbm.js')
-      raise "Pbm.js not found, prebid creative was not served"
+        raise "Pbm.js not found, prebid creative was not served"
     end
 end
 
 Then(/^I should see AppNexus creative in PublisherAdView number (\d+)$/) do |arg1|
-  @query_results = query("zzra index:#{arg1} css:'*'")
-  unless @query_results[0]['html'].include?('pbm.js')
-    raise "Pbm.js not found, prebid creative was not served in number #{arg1} PublisherAdView"
-  end
+    webview_class = backdoor "getDFPWebViewName"
+    @query_results = query(webview_class + " index:#{arg1} css:'*'")
+    unless @query_results[0]['html'].include?('pbm.js')
+        raise "Pbm.js not found, prebid creative was not served in number #{arg1} PublisherAdView"
+    end
 end
 
 Then(/^I should see AppNexus creative in HTMLBannerWebView$/) do
@@ -23,7 +25,7 @@ Then(/^I should see AppNexus creative in HTMLBannerWebView$/) do
 end
 
 Then(/^I should see AppNexus creative in MraidBridgeMraidWebView$/) do
-    @query_results = query("MraidActivity css:'*'")
+    @query_results = query("MraidWebView css:'*'")
     unless @query_results[0]['html'].include?('pbm.js')
         raise "Pbm.js not found, prebid creative was not served"
     end

--- a/PrebidMobile/IntegrationTests/features/step_definitions/calabash_steps.rb
+++ b/PrebidMobile/IntegrationTests/features/step_definitions/calabash_steps.rb
@@ -1,16 +1,31 @@
 require 'calabash-android/calabash_steps'
 
 Then(/^I should see AppNexus creative$/) do
-    @query_results = query("o css:'*'")
-    unless @query_results[0]['html'].include?('mbpb.js')
-      raise "Mbpb.js not found, prebid creative was not served"
+    @query_results = query("zzra css:'*'")
+    puts @query_results[0]['html']
+    unless @query_results[0]['html'].include?('pbm.js')
+      raise "Pbm.js not found, prebid creative was not served"
     end
 end
 
 Then(/^I should see AppNexus creative in PublisherAdView number (\d+)$/) do |arg1|
-  @query_results = query("o index:#{arg1} css:'*'")
-  unless @query_results[0]['html'].include?('mbpb.js')
-    raise "Mbpb.js not found, prebid creative was not served in number #{arg1} PublisherAdView"
+  @query_results = query("zzra index:#{arg1} css:'*'")
+  unless @query_results[0]['html'].include?('pbm.js')
+    raise "Pbm.js not found, prebid creative was not served in number #{arg1} PublisherAdView"
   end
+end
+
+Then(/^I should see AppNexus creative in HTMLBannerWebView$/) do
+    @query_results = query("HTMLBannerWebView css:'*'")
+    unless @query_results[0]['html'].include?('pbm.js')
+        raise "Pbm.js not found, prebid creative was not served"
+    end
+end
+
+Then(/^I should see AppNexus creative in MraidBridgeMraidWebView$/) do
+    @query_results = query("MraidActivity css:'*'")
+    unless @query_results[0]['html'].include?('pbm.js')
+        raise "Pbm.js not found, prebid creative was not served"
+    end
 end
 

--- a/PrebidMobile/IntegrationTests/run_tests_local.sh
+++ b/PrebidMobile/IntegrationTests/run_tests_local.sh
@@ -7,9 +7,12 @@ echo -e "CALABASH BUILDLOG: $@"
 echoX "Build the apk."
 cd ..
 ./gradlew clean build
-cp DemoApp/build/outputs/apk/DemoApp-release-unsigned.apk IntegrationTests/apk/DemoApp.apk
+cp DemoApp/build/outputs/apk/DemoApp-debug.apk IntegrationTests/apk/DemoApp.apk
 cd IntegrationTests
 
 echoX "Run the tests."
 calabash-android resign apk/DemoApp.apk
 calabash-android run apk/DemoApp.apk
+
+# to debug your test if it fails, run calabash-android console apk/DemoApp.apk
+# for more details see https://github.com/calabash/calabash-android/blob/master/documentation/ruby_api.md

--- a/testprebid.sh
+++ b/testprebid.sh
@@ -6,4 +6,5 @@ cd PrebidMobile
 ./gradlew clean build
 mkdir -p IntegrationTests/apk && cp DemoApp/build/outputs/apk/DemoApp-release-unsigned.apk IntegrationTests/apk/DemoApp.apk
 gem install xamarin-test-cloud
-test-cloud submit IntegrationTests/apk/DemoApp.apk 435c130f3f6ff5256d19a790c21dd653 --devices 2ae0b5a0 --series "master" --locale "en_US" --app-name "DemoApp" --user nhedley@appnexus.com
+cd IntegrationTests
+test-cloud submit apk/DemoApp.apk 435c130f3f6ff5256d19a790c21dd653 --devices 2ae0b5a0 --series "master" --locale "en_US" --app-name "DemoApp" --user nhedley@appnexus.com

--- a/testprebid.sh
+++ b/testprebid.sh
@@ -7,7 +7,5 @@ cd PrebidMobile
 mkdir -p IntegrationTests/apk && cp DemoApp/build/outputs/apk/DemoApp-release-unsigned.apk IntegrationTests/apk/DemoApp.apk
 
 gem install xamarin-test-cloud
-gem install calabash-cucumber
-gem install rspec
 cd IntegrationTests
 test-cloud submit apk/DemoApp.apk 435c130f3f6ff5256d19a790c21dd653 --devices 2ae0b5a0 --series "master" --locale "en_US" --app-name "DemoApp" --user nhedley@appnexus.com

--- a/testprebid.sh
+++ b/testprebid.sh
@@ -3,3 +3,7 @@
 cd PrebidMobile
 ./gradlew clean test
 
+./gradlew clean build
+cp DemoApp/build/outputs/apk/DemoApp-release-unsigned.apk IntegrationTests/apk/DemoApp.apk
+gem install xamarin-test-cloud
+test-cloud submit IntegrationTests/apk/DemoApp.apk 435c130f3f6ff5256d19a790c21dd653 --devices 2ae0b5a0 --series "master" --locale "en_US" --app-name "DemoApp" --user nhedley@appnexus.com

--- a/testprebid.sh
+++ b/testprebid.sh
@@ -1,6 +1,4 @@
 #! /bin/bash
-set -e
-
 cd PrebidMobile
 ./gradlew clean test
 

--- a/testprebid.sh
+++ b/testprebid.sh
@@ -5,6 +5,9 @@ cd PrebidMobile
 
 ./gradlew clean build
 mkdir -p IntegrationTests/apk && cp DemoApp/build/outputs/apk/DemoApp-release-unsigned.apk IntegrationTests/apk/DemoApp.apk
+
 gem install xamarin-test-cloud
+gem install calabash-cucumber
+gem install rspec
 cd IntegrationTests
 test-cloud submit apk/DemoApp.apk 435c130f3f6ff5256d19a790c21dd653 --devices 2ae0b5a0 --series "master" --locale "en_US" --app-name "DemoApp" --user nhedley@appnexus.com

--- a/testprebid.sh
+++ b/testprebid.sh
@@ -4,6 +4,6 @@ cd PrebidMobile
 ./gradlew clean test
 
 ./gradlew clean build
-cp DemoApp/build/outputs/apk/DemoApp-release-unsigned.apk IntegrationTests/apk/DemoApp.apk
+mkdir -p IntegrationTests/apk && cp DemoApp/build/outputs/apk/DemoApp-release-unsigned.apk IntegrationTests/apk/DemoApp.apk
 gem install xamarin-test-cloud
 test-cloud submit IntegrationTests/apk/DemoApp.apk 435c130f3f6ff5256d19a790c21dd653 --devices 2ae0b5a0 --series "master" --locale "en_US" --app-name "DemoApp" --user nhedley@appnexus.com

--- a/testprebid.sh
+++ b/testprebid.sh
@@ -3,9 +3,12 @@
 cd PrebidMobile
 ./gradlew clean test
 
-./gradlew clean build
-mkdir -p IntegrationTests/apk && cp DemoApp/build/outputs/apk/DemoApp-release-unsigned.apk IntegrationTests/apk/DemoApp.apk
+./gradlew clean assembleDebug
+mkdir -p IntegrationTests/apk && cp DemoApp/build/outputs/apk/DemoApp-debug.apk IntegrationTests/apk/DemoApp.apk
 
-gem install xamarin-test-cloud
 cd IntegrationTests
-test-cloud submit apk/DemoApp.apk 435c130f3f6ff5256d19a790c21dd653 --devices 2ae0b5a0 --series "master" --locale "en_US" --app-name "DemoApp" --user nhedley@appnexus.com
+bundle install
+
+bundle exec calabash-android resign apk/DemoApp.apk
+bundle exec calabash-android build apk/DemoApp.apk
+bundle exec test-cloud submit apk/DemoApp.apk 435c130f3f6ff5256d19a790c21dd653 --devices 2ae0b5a0 --series "master" --locale "en_US" --app-name "DemoApp" --user nhedley@appnexus.com

--- a/testprebid.sh
+++ b/testprebid.sh
@@ -1,4 +1,5 @@
 #! /bin/bash
+set -e
 
 cd PrebidMobile
 ./gradlew clean test


### PR DESCRIPTION
Updated Xamarin tests for new demo app and added backdoor to correctly pull DFP Banner webview class. This PR should trigger the Xamarin tests on the cloud.

TODO: the Interstitial tests for DFP & MoPub aren't really working properly yet