### PR TITLE
Grant ability to override request time out for http connection

### DIFF
--- a/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/ServerConnector.java
+++ b/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/ServerConnector.java
@@ -58,7 +58,7 @@ class ServerConnector extends AsyncTask<Object, Object, JSONObject> {
                 conn.setRequestProperty(Settings.COOKIE_HEADER, existingCookie);
             } // todo still pass cookie if limit ad tracking?
             conn.setRequestMethod("POST");
-            conn.setConnectTimeout(Settings.REQUEST_TIME_OUR_MILLIS);
+            conn.setConnectTimeout(Settings.REQUEST_TIME_OUT_MILLIS);
 
             // Add post data
             OutputStreamWriter wr = new OutputStreamWriter(conn.getOutputStream(), "UTF-8");

--- a/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/ServerConnector.java
+++ b/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/ServerConnector.java
@@ -95,6 +95,8 @@ class ServerConnector extends AsyncTask<Object, Object, JSONObject> {
             e.printStackTrace();
         } catch (JSONException e) {
             e.printStackTrace();
+        } catch (Exception e) {
+            e.printStackTrace(); // catches SocketTimeOutException, etc
         }
         return null;
     }

--- a/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/ServerConnector.java
+++ b/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/ServerConnector.java
@@ -58,7 +58,7 @@ class ServerConnector extends AsyncTask<Object, Object, JSONObject> {
                 conn.setRequestProperty(Settings.COOKIE_HEADER, existingCookie);
             } // todo still pass cookie if limit ad tracking?
             conn.setRequestMethod("POST");
-            conn.setConnectTimeout(Settings.REQUEST_TIME_OUT_MILLIS);
+            conn.setConnectTimeout(Settings.getConnectionTimeOutMillis());
 
             // Add post data
             OutputStreamWriter wr = new OutputStreamWriter(conn.getOutputStream(), "UTF-8");

--- a/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/internal/Settings.java
+++ b/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/internal/Settings.java
@@ -15,7 +15,7 @@ public class Settings {
     // connection settings
     public static final String REQUEST_URL_NON_SECURE = "http://prebid.adnxs.com/pbs/v1/auction";
     public static final String REQUEST_URL_SECURE = "https://prebid.adnxs.com/pbs/v1/auction";
-    public static int REQUEST_TIME_OUT_MILLIS = 500;
+    public static int connectionTimeOutMillis = 500;
     // request keys
     public static final String REQUEST_CACHE_MARKUP = "cache_markup";
     public static final String REQUEST_SORT_BIDS = "sort_bids";
@@ -90,12 +90,12 @@ public class Settings {
         // todo set user agent
     }
 
-    public static synchronized int getRequestTimeOutMillis() {
-        return REQUEST_TIME_OUT_MILLIS;
+    public static synchronized int getConnectionTimeOutMillis() {
+        return connectionTimeOutMillis;
     }
 
-    public static synchronized void setRequestTimeOutMillis(int timeOutMillis) {
-        REQUEST_TIME_OUT_MILLIS = timeOutMillis;
+    public static synchronized void setConnectionTimeOutMillis(int timeOutMillis) {
+        Settings.connectionTimeOutMillis = timeOutMillis;
     }
 
     public static synchronized int getMCC() {

--- a/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/internal/Settings.java
+++ b/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/internal/Settings.java
@@ -15,7 +15,7 @@ public class Settings {
     // connection settings
     public static final String REQUEST_URL_NON_SECURE = "http://prebid.adnxs.com/pbs/v1/auction";
     public static final String REQUEST_URL_SECURE = "https://prebid.adnxs.com/pbs/v1/auction";
-    public static int REQUEST_TIME_OUR_MILLIS = 500;
+    public static int REQUEST_TIME_OUT_MILLIS = 500;
     // request keys
     public static final String REQUEST_CACHE_MARKUP = "cache_markup";
     public static final String REQUEST_SORT_BIDS = "sort_bids";
@@ -88,6 +88,14 @@ public class Settings {
 
     static {
         // todo set user agent
+    }
+
+    public static synchronized int getRequestTimeOutMillis() {
+        return REQUEST_TIME_OUT_MILLIS;
+    }
+
+    public static synchronized void setRequestTimeOutMillis(int timeOutMillis) {
+        REQUEST_TIME_OUT_MILLIS = timeOutMillis;
     }
 
     public static synchronized int getMCC() {

--- a/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/internal/Settings.java
+++ b/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/internal/Settings.java
@@ -15,7 +15,7 @@ public class Settings {
     // connection settings
     public static final String REQUEST_URL_NON_SECURE = "http://prebid.adnxs.com/pbs/v1/auction";
     public static final String REQUEST_URL_SECURE = "https://prebid.adnxs.com/pbs/v1/auction";
-    public static final int REQUEST_TIME_OUR_MILLIS = 500;
+    public static int REQUEST_TIME_OUR_MILLIS = 500;
     // request keys
     public static final String REQUEST_CACHE_MARKUP = "cache_markup";
     public static final String REQUEST_SORT_BIDS = "sort_bids";

--- a/PrebidMobile/PrebidServerAdapter/src/test/java/org/prebid/mobile/prebidserver/PrebidServerAdapterTest.java
+++ b/PrebidMobile/PrebidServerAdapter/src/test/java/org/prebid/mobile/prebidserver/PrebidServerAdapterTest.java
@@ -43,9 +43,9 @@ public class PrebidServerAdapterTest extends BaseSetup {
     @Test
     public void testRequestTimeOutMillis() {
         // assert default value
-        assertEquals(500, Settings.REQUEST_TIME_OUT_MILLIS);
+        assertEquals(500, Settings.connectionTimeOutMillis);
         // test setter
-        Settings.setRequestTimeOutMillis(1000);
-        assertEquals(1000, Settings.getRequestTimeOutMillis());
+        Settings.setConnectionTimeOutMillis(1000);
+        assertEquals(1000, Settings.getConnectionTimeOutMillis());
     }
 }

--- a/PrebidMobile/PrebidServerAdapter/src/test/java/org/prebid/mobile/prebidserver/PrebidServerAdapterTest.java
+++ b/PrebidMobile/PrebidServerAdapter/src/test/java/org/prebid/mobile/prebidserver/PrebidServerAdapterTest.java
@@ -14,6 +14,7 @@ import org.robolectric.annotation.Config;
 
 import java.util.ArrayList;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @RunWith(RobolectricTestRunner.class)
@@ -37,5 +38,14 @@ public class PrebidServerAdapterTest extends BaseSetup {
         assertTrue(postData.has(Settings.REQUEST_DEVICE));
         assertTrue(postData.has(Settings.REQUEST_APP));
         assertTrue(postData.has(Settings.REQUEST_USER));
+    }
+
+    @Test
+    public void testRequestTimeOutMillis() {
+        // assert default value
+        assertEquals(500, Settings.REQUEST_TIME_OUT_MILLIS);
+        // test setter
+        Settings.setRequestTimeOutMillis(1000);
+        assertEquals(1000, Settings.getRequestTimeOutMillis());
     }
 }


### PR DESCRIPTION
Issue is from https://github.com/prebid/prebid-mobile-android/issues/9

This fix gives developer the ability to override the time out by changing Settings.REQUEST_TIME_OUR_MILLIS