### PR TITLE
Fixed the DFP Interstitial ad

### DIFF
--- a/PrebidMobile/DemoApp/src/main/java/org/prebid/mobile/demoapp/Constants.java
+++ b/PrebidMobile/DemoApp/src/main/java/org/prebid/mobile/demoapp/Constants.java
@@ -9,9 +9,15 @@ public class Constants {
     public static final String MOPUB_AD_UNIT_ID_2 = "a9cb8ff85fef4b50b457e3b11119aabf";
     public static final String MOPUB_BANNER_ADUNIT_ID = "Mopub_Ad_Unit_ID";
     public static final String INTERSTITIAL_ADUNIT_ID = "Interstitial_Ad_Unit_ID";
+    // MoPub Interstitial
+    public static final String MOPUB_INTERSTITIAL_AD_UNIT_ID = "fc82df5c964945c79cceef4c5666e1e2";
+
     // DFP Banner
     public static final String DFP_BANNER_ADUNIT_320x50 = "/19968336/PriceCheck_320x50";
     public static final String DFP_BANNER_ADUNIT_300x250 = "/19968336/PriceCheck_300x250";
+    // DFP Interstitial
+    public static final String DFP_INTERSTITIAL_ADUNIT_320x480 = "/19968336/PriceCheck_Interstitial";
+
     // PBS Config
     public static final String PBS_CONFIG_APPNEXUS_DEMAND = "eebc307d-7f76-45d6-a7a7-68985169b138";
     public static final String PBS_CONFIG_300x250_APPNEXUS_DEMAND = "0c286d00-b3ee-4550-b15d-f71f8e746865";

--- a/PrebidMobile/DemoApp/src/main/java/org/prebid/mobile/demoapp/dfpdemofragments/DFPInterstitialFragment.java
+++ b/PrebidMobile/DemoApp/src/main/java/org/prebid/mobile/demoapp/dfpdemofragments/DFPInterstitialFragment.java
@@ -31,7 +31,7 @@ public class DFPInterstitialFragment extends Fragment {
         root = inflater.inflate(R.layout.fragment_interstitial, null);
         // interstitial set up
         mPublisherInterstitialAd = new PublisherInterstitialAd(getContext());
-        mPublisherInterstitialAd.setAdUnitId("/19968336/PriceCheck_Interstitial");
+        mPublisherInterstitialAd.setAdUnitId(Constants.DFP_INTERSTITIAL_ADUNIT_320x480);
         mPublisherInterstitialAd.setAdListener(new AdListener() {
             @Override
             public void onAdFailedToLoad(int i) {
@@ -67,6 +67,5 @@ public class DFPInterstitialFragment extends Fragment {
     public void loadInterstitial(View view) {
         Prebid.attachBids(request, Constants.INTERSTITIAL_ADUNIT_ID, getContext());
         mPublisherInterstitialAd.loadAd(request);
-        Prebid.detachUsedBid(request);
     }
 }

--- a/PrebidMobile/DemoApp/src/main/java/org/prebid/mobile/demoapp/mopubdemofragments/MoPubInterstitialFragment.java
+++ b/PrebidMobile/DemoApp/src/main/java/org/prebid/mobile/demoapp/mopubdemofragments/MoPubInterstitialFragment.java
@@ -1,6 +1,5 @@
 package org.prebid.mobile.demoapp.mopubdemofragments;
 
-
 import android.os.Bundle;
 import android.support.annotation.Nullable;
 import android.support.v4.app.Fragment;
@@ -16,7 +15,6 @@ import org.prebid.mobile.core.Prebid;
 import org.prebid.mobile.demoapp.Constants;
 import org.prebid.mobile.demoapp.R;
 
-
 public class MoPubInterstitialFragment extends Fragment implements Prebid.OnAttachCompleteListener, MoPubInterstitial.InterstitialAdListener {
     MoPubInterstitial interstitialAdView;
     private View root;
@@ -27,7 +25,7 @@ public class MoPubInterstitialFragment extends Fragment implements Prebid.OnAtta
         super.onCreateView(inflater, container, savedInstanceState);
         root = inflater.inflate(R.layout.fragment_interstitial, null);
 
-        interstitialAdView = new MoPubInterstitial(this.getActivity(), "fc82df5c964945c79cceef4c5666e1e2");
+        interstitialAdView = new MoPubInterstitial(this.getActivity(), Constants.MOPUB_INTERSTITIAL_AD_UNIT_ID);
 
         Button btnLoad = (Button) root.findViewById(R.id.loadInterstitial);
         btnLoad.setOnClickListener(new View.OnClickListener() {


### PR DESCRIPTION
- Fixed the DFP Interstitial Ad
  Primary ad server was not receiving the keywords due to Prebid.detachUsedBid removing them from the request object.
- Added Constants for Interstitial Fragments
  Use constants instead of hardcoded ad units for consistency.
