### PR TITLE
Openrtb compliant Prebid Server Adapter

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ android:
     - platform-tools
 
     # The BuildTools version used by your project
-    - build-tools-25.0.0 
+    - build-tools-26.0.2 
 
     # The SDK version used to compile your project
     - android-25 

--- a/PrebidMobile/DemoApp/src/main/java/org/prebid/mobile/demoapp/MainActivity.java
+++ b/PrebidMobile/DemoApp/src/main/java/org/prebid/mobile/demoapp/MainActivity.java
@@ -47,6 +47,16 @@ public class MainActivity extends AppCompatActivity {
             Field field = Prebid.class.getDeclaredField("adServer");
             field.setAccessible(true);
             field.set(null, adServer);
+            Field useLocalCache = Prebid.class.getDeclaredField("useLocalCache");
+            useLocalCache.setAccessible(true);
+            switch (adServer) {
+                case DFP:
+                    useLocalCache.set(null, true);
+                    break;
+                case MOPUB:
+                    useLocalCache.set(null, false);
+                    break;
+            }
             // refreshBids
             Method refreshBids = BidManager.class.getDeclaredMethod("refreshBids", Context.class);
             refreshBids.setAccessible(true);

--- a/PrebidMobile/DemoApp/src/main/java/org/prebid/mobile/demoapp/PrebidApplication.java
+++ b/PrebidMobile/DemoApp/src/main/java/org/prebid/mobile/demoapp/PrebidApplication.java
@@ -59,6 +59,7 @@ public class PrebidApplication extends Application {
         //Configure Ad-Slot2 with the same demand source
         BannerAdUnit adUnit2 = new BannerAdUnit(BANNER_300x250, PBS_CONFIG_300x250_APPNEXUS_DEMAND);
         adUnit2.addSize(300, 250);
+        adUnit2.addSize(300, 600);
 
         //Configure Interstitial Ad Unit
         InterstitialAdUnit adUnit3 = new InterstitialAdUnit(INTERSTITIAL_FULLSCREEN, PBS_CONFIG_APPNEXUS_DEMAND);

--- a/PrebidMobile/DemoApp/src/main/java/org/prebid/mobile/demoapp/PrebidApplication.java
+++ b/PrebidMobile/DemoApp/src/main/java/org/prebid/mobile/demoapp/PrebidApplication.java
@@ -70,14 +70,11 @@ public class PrebidApplication extends Application {
 
         // Set targeting
         TargetingParams.setGender(TargetingParams.GENDER.FEMALE);
-        TargetingParams.setAge(25);
+        TargetingParams.setYearOfBirth(1992);
         TargetingParams.setLocationDecimalDigits(2);
         TargetingParams.setLocationEnabled(true);
-        TargetingParams.setCustomTargeting("Test", "Prebid-Custom-1");
-        TargetingParams.setCustomTargeting("Test", "Prebid-Custom-2");
-        ArrayList<String> values = new ArrayList<String>();
-        values.add("Prebid-Custom-2");
-        TargetingParams.setCustomTargeting("Test2", values);
+        TargetingParams.addAppKeywords("PrebidKeyword1");
+        TargetingParams.addUserKeyword("PrebidKeyword2");
 
         // Register ad units for prebid.
         try {

--- a/PrebidMobile/PrebidMobileCore/src/main/java/org/prebid/mobile/core/BidManager.java
+++ b/PrebidMobile/PrebidMobileCore/src/main/java/org/prebid/mobile/core/BidManager.java
@@ -149,6 +149,12 @@ public class BidManager {
             bidMap.remove(adUnit.getCode());
             // save the bids sorted
             Collections.sort(bidResponses, new BidComparator());
+            if (Prebid.getAdServer() == Prebid.AdServer.DFP) {
+                BidResponse topBid = bidResponses.get(0);
+                if (topBid != null) {
+                    topBid.addCustomKeyword("hb_cache_id", topBid.getCreative());
+                }
+            }
             bidMap.put(adUnit.getCode(), bidResponses);
         }
 

--- a/PrebidMobile/PrebidMobileCore/src/main/java/org/prebid/mobile/core/BidManager.java
+++ b/PrebidMobile/PrebidMobileCore/src/main/java/org/prebid/mobile/core/BidManager.java
@@ -132,7 +132,7 @@ public class BidManager {
         void onBidFailure(AdUnit bidRequest, ErrorCode reason);
     }
 
-    private static BidResponseListener bidResponseListener = new BidResponseListener() {
+    static BidResponseListener bidResponseListener = new BidResponseListener() {
         @Override
         public void onBidSuccess(AdUnit adUnit, ArrayList<BidResponse> bidResponses) {
             //First iterate through the List of AdUnits.

--- a/PrebidMobile/PrebidMobileCore/src/main/java/org/prebid/mobile/core/CacheManager.java
+++ b/PrebidMobile/PrebidMobileCore/src/main/java/org/prebid/mobile/core/CacheManager.java
@@ -24,7 +24,7 @@ public class CacheManager {
         setupSDKCache();
     }
 
-    static void init(Context context) {
+    public static void init(Context context) {
         if (cache == null) {
             cache = new CacheManager(context);
         }

--- a/PrebidMobile/PrebidMobileCore/src/main/java/org/prebid/mobile/core/InterstitialAdUnit.java
+++ b/PrebidMobile/PrebidMobileCore/src/main/java/org/prebid/mobile/core/InterstitialAdUnit.java
@@ -21,6 +21,21 @@ import android.content.Context;
 import java.util.ArrayList;
 
 public class InterstitialAdUnit extends AdUnit {
+    private static ArrayList<AdSize> standardSizes = new ArrayList<>();
+
+    static {
+        standardSizes.add(new AdSize(300, 250));
+        standardSizes.add(new AdSize(300, 600));
+        standardSizes.add(new AdSize(320, 250));
+        standardSizes.add(new AdSize(254, 133));
+        standardSizes.add(new AdSize(580, 400));
+        standardSizes.add(new AdSize(320, 320));
+        standardSizes.add(new AdSize(320, 160));
+        standardSizes.add(new AdSize(320, 480));
+        standardSizes.add(new AdSize(336, 280));
+        standardSizes.add(new AdSize(320, 400));
+        standardSizes.add(new AdSize(1, 1));
+    }
 
     public InterstitialAdUnit(String code, String configId) {
         super(code, configId);
@@ -35,19 +50,6 @@ public class InterstitialAdUnit extends AdUnit {
         if (context != null) {
             int width = context.getResources().getDisplayMetrics().widthPixels;
             int height = context.getResources().getDisplayMetrics().heightPixels;
-            ArrayList<AdSize> standardSizes = new ArrayList<>();
-            standardSizes.add(new AdSize(300, 250));
-            standardSizes.add(new AdSize(300, 600));
-            standardSizes.add(new AdSize(320, 250));
-            standardSizes.add(new AdSize(254, 133));
-            standardSizes.add(new AdSize(580, 400));
-            standardSizes.add(new AdSize(320, 320));
-            standardSizes.add(new AdSize(320, 160));
-            standardSizes.add(new AdSize(320, 480));
-            standardSizes.add(new AdSize(336, 280));
-            standardSizes.add(new AdSize(320, 400));
-            standardSizes.add(new AdSize(1, 1));
-
             for (AdSize size : standardSizes) {
                 if (size.getWidth() <= width && size.getHeight() <= height) {
                     sizes.add(size);

--- a/PrebidMobile/PrebidMobileCore/src/main/java/org/prebid/mobile/core/Prebid.java
+++ b/PrebidMobile/PrebidMobileCore/src/main/java/org/prebid/mobile/core/Prebid.java
@@ -42,6 +42,7 @@ public class Prebid {
     private static boolean secureConnection = true; //by default, always use secured connection
     private static String accountId;
     private static final int kMoPubQueryStringLimit = 4000;
+    private static boolean useLocalCache = true;
 
     public enum AdServer {
         DFP,
@@ -83,6 +84,10 @@ public class Prebid {
 
     public static Host getHost() {
         return host;
+    }
+
+    public static boolean useLocalCache() {
+        return useLocalCache;
     }
 
     /**
@@ -151,7 +156,6 @@ public class Prebid {
      * @param accountId Prebid Server account
      * @param adServer  Primary AdServer you're using for you app
      * @throws PrebidException
-     *
      * @deprecated this method will be removed in the future, please use {@link #init(Context, ArrayList, String, AdServer, Host)} instead for better performance
      */
     public static void init(Context context, ArrayList<AdUnit> adUnits, String accountId, AdServer adServer) throws PrebidException {
@@ -166,6 +170,9 @@ public class Prebid {
         }
         Prebid.accountId = accountId;
         Prebid.adServer = adServer;
+        if (AdServer.MOPUB.equals(Prebid.adServer)) {
+            useLocalCache = false;
+        }
         // validate ad units and register them
         if (adUnits == null || adUnits.isEmpty()) {
             throw new PrebidException(PrebidException.PrebidError.EMPTY_ADUNITS);
@@ -226,6 +233,9 @@ public class Prebid {
         }
         Prebid.accountId = accountId;
         Prebid.adServer = adServer;
+        if (AdServer.MOPUB.equals(Prebid.adServer)) {
+            Prebid.useLocalCache = false;
+        }
         if (host == null)
             throw new PrebidException(PrebidException.PrebidError.NULL_HOST);
         Prebid.host = host;

--- a/PrebidMobile/PrebidMobileCore/src/main/java/org/prebid/mobile/core/Prebid.java
+++ b/PrebidMobile/PrebidMobileCore/src/main/java/org/prebid/mobile/core/Prebid.java
@@ -18,7 +18,6 @@ package org.prebid.mobile.core;
 
 import android.content.Context;
 import android.os.Bundle;
-import android.support.annotation.VisibleForTesting;
 import android.text.TextUtils;
 import android.util.Pair;
 
@@ -43,6 +42,8 @@ public class Prebid {
     private static String accountId;
     private static final int kMoPubQueryStringLimit = 4000;
     private static boolean useLocalCache = true;
+    private static Host host = Host.APPNEXUS;
+    private static AdServer adServer = AdServer.UNKNOWN;
 
     public enum AdServer {
         DFP,
@@ -68,19 +69,10 @@ public class Prebid {
         void onAttachComplete(Object adObj);
     }
 
-
-    private static AdServer adServer = AdServer.UNKNOWN;
-
     public static AdServer getAdServer() {
         return adServer;
     }
 
-    // for testing purpose
-    public static void setAdServer(AdServer adServer) {
-        Prebid.adServer = adServer;
-    }
-
-    private static Host host = Host.APPNEXUS;
 
     public static Host getHost() {
         return host;
@@ -158,6 +150,7 @@ public class Prebid {
      * @throws PrebidException
      * @deprecated this method will be removed in the future, please use {@link #init(Context, ArrayList, String, AdServer, Host)} instead for better performance
      */
+    @Deprecated
     public static void init(Context context, ArrayList<AdUnit> adUnits, String accountId, AdServer adServer) throws PrebidException {
         LogUtil.i("Initializing with a list of AdUnits");
         // validate context
@@ -442,10 +435,5 @@ public class Prebid {
         if (Prebid.adServer.equals(AdServer.MOPUB)) {
             Prebid.secureConnection = secureConnection;
         }
-    }
-
-    @VisibleForTesting
-    public static void setTestServer(String serverAdapter) {
-        PREBID_SERVER = serverAdapter;
     }
 }

--- a/PrebidMobile/PrebidMobileCore/src/main/java/org/prebid/mobile/core/Prebid.java
+++ b/PrebidMobile/PrebidMobileCore/src/main/java/org/prebid/mobile/core/Prebid.java
@@ -69,6 +69,11 @@ public class Prebid {
         return adServer;
     }
 
+    // for testing purpose
+    public static void setAdServer(AdServer adServer) {
+        Prebid.adServer = adServer;
+    }
+
 
     /**
      * This method is used to
@@ -349,7 +354,7 @@ public class Prebid {
      */
     public static void shouldLoadOverSecureConnection(boolean secureConnection) {
         // Only enables overrides for MoPub, DFP should always load over secured connection
-        if (getClassFromString(MOPUB_ADVIEW_CLASS) != null) {
+        if (Prebid.adServer.equals(AdServer.MOPUB)) {
             Prebid.secureConnection = secureConnection;
         }
     }

--- a/PrebidMobile/PrebidMobileCore/src/main/java/org/prebid/mobile/core/TargetingParams.java
+++ b/PrebidMobile/PrebidMobileCore/src/main/java/org/prebid/mobile/core/TargetingParams.java
@@ -20,15 +20,13 @@ import android.content.Context;
 import android.content.pm.PackageManager;
 import android.location.Location;
 import android.location.LocationManager;
-import android.text.TextUtils;
 
 import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.Set;
+import java.util.Calendar;
 
 
 /**
- * TargetingParams class sets the Targeting parameters like age, gender, location
+ * TargetingParams class sets the Targeting parameters like yob, gender, location
  * and other custom parameters for the adUnits to be made available in the auction.
  */
 public class TargetingParams {
@@ -40,12 +38,17 @@ public class TargetingParams {
         TAG = LogUtil.getTagWithBase("TP");
     }
 
-    private static int age;
+    private static int yob = 0;
     private static GENDER gender = GENDER.UNKNOWN;
     private static boolean locationEnabled = false; // default location access is disabled
     private static int locationDecimalDigits = -1;
-    private static HashMap<String, ArrayList<String>> customKeywords = new HashMap<String, ArrayList<String>>();
+    private static ArrayList<String> appKeywords = new ArrayList<String>();
+    private static ArrayList<String> userKeywords = new ArrayList<String>();
     private static Location location;
+    private static String domain = "";
+    private static String storeUrl = "";
+    private static int privacyPolicy = 0;
+    private static String bundleName = null;
     //endregion
 
     //region Private Constructor
@@ -109,21 +112,23 @@ public class TargetingParams {
     //region Public APIs
 
     /**
-     * Get the age for targeting
+     * Get the year of birth for targeting
      *
-     * @return age
+     * @return yob
      */
-    public static int getAge() {
-        return age;
+    public static int getYearOfBirth() {
+        return yob;
     }
 
     /**
-     * Set the age for targeting
+     * Set the year of birth for targeting
      *
-     * @param age age of the user
+     * @param yob yob of the user
      */
-    public static void setAge(int age) {
-        TargetingParams.age = age;
+    public static void setYearOfBirth(int yob) {
+        if (yob > 0 && yob <= Calendar.getInstance().get(Calendar.YEAR)) {
+            TargetingParams.yob = yob;
+        }
     }
 
     public enum GENDER {
@@ -219,76 +224,166 @@ public class TargetingParams {
     }
 
     /**
-     * Retrieve the array of custom keywords that will passed to demand sources.
+     * Set the keywords that're related to the app
      *
-     * @return The current list of key-value pairs of custom keywords.
+     * @param appKeywords list of keywords
      */
-    public synchronized static HashMap<String, ArrayList<String>> getCustomKeywords() {
-        HashMap<String, ArrayList<String>> result = new HashMap<String, ArrayList<String>>();
-        Set<String> keys = customKeywords.keySet();
-        for (String key : keys) {
-            ArrayList<String> values = new ArrayList<>();
-            ArrayList<String> originalValues = customKeywords.get(key);
-            if (originalValues != null) {
-                for (String value : originalValues) {
-                    values.add(value);
-                }
-            }
-            result.put(key, values);
+    public static void setAppKeywords(ArrayList<String> appKeywords) {
+        if (appKeywords != null) {
+            TargetingParams.appKeywords = appKeywords;
         }
-        return result;
+    }
+
+    public static ArrayList<String> getAppKeywords() {
+        return appKeywords;
+    }
+
+
+    /**
+     * Clear all the keywords that're related to the app
+     */
+    public static void clearAppKeywords() {
+        TargetingParams.appKeywords.clear();
     }
 
     /**
-     * Remove a custom keyword from the targeting params. Use this to remove a keyword
-     * previously set using addCustomKeywords.
+     * Add one keyword to app related keywords
      *
-     * @param key The key to remove; this should not be null or empty.
+     * @param keyword keyword to be added
      */
-    public synchronized static void removeCustomKeyword(String key) {
-        if (TextUtils.isEmpty(key))
-            return;
-        customKeywords.remove(key);
-    }
-
-    /**
-     * Set a custom key/value pair for customized targeting.
-     * Note this will override existing values for the same key.
-     *
-     * @param key   The key to add; this should not be null or empty.
-     * @param value The value to add; this should not be null or empty.
-     */
-    public synchronized static void setCustomTargeting(String key, String value) {
-        if (TextUtils.isEmpty(key) || TextUtils.isEmpty(value)) {
-            LogUtil.w("Null/empty values passed in for custom targeting.");
-        } else {
-            ArrayList<String> values = new ArrayList<String>();
-            values.add(value);
-            customKeywords.put(key, values);
+    public static void addAppKeywords(String keyword) {
+        if (!appKeywords.contains(keyword)) {
+            appKeywords.add(keyword);
         }
     }
 
     /**
-     * Set a custom key/values pair for customized targeting.
-     * Note this will override existing values for the same key.
+     * Remove one keyword to app related keywords
      *
-     * @param key    The key to add; this should not be null or empty.
-     * @param values The values to add; this should not be null or empty.
+     * @param keyword keyword to be added
      */
-    public synchronized static void setCustomTargeting(String key, ArrayList<String> values) {
-        if (TextUtils.isEmpty(key) || values == null || values.isEmpty()) {
-            LogUtil.w("Null/empty values passed in for custom targeting.");
-        } else {
-            customKeywords.put(key, values);
+    public static void removeAppKeyword(String keyword) {
+        appKeywords.remove(keyword);
+    }
+
+    /**
+     * Set the keywords that're related to the
+     *
+     * @param userKeywords
+     */
+    public static void setUserKeywords(ArrayList<String> userKeywords) {
+        if (userKeywords != null) {
+            TargetingParams.userKeywords = userKeywords;
         }
     }
 
     /**
-     * Clear all custom keywords.
+     * Get the keywords for user
+     *
+     * @return a list of keywords
      */
-    public synchronized static void clearCustomKeywords() {
-        customKeywords.clear();
+    public static ArrayList<String> getUserKeywords() {
+        return userKeywords;
     }
 
-    //endregion
+    /**
+     * Clear the keywords for user
+     */
+    public static void clearUserKeywords() {
+        userKeywords.clear();
+    }
+
+    /**
+     * Add one keyword to user related keywords
+     *
+     * @param keyword keyword to be added
+     */
+    public static void addUserKeyword(String keyword) {
+        if (!userKeywords.contains(keyword)) {
+            userKeywords.add(keyword);
+        }
+    }
+
+    /**
+     * Remove one keyword to user related keywords
+     *
+     * @param keyword keyword to be removed
+     */
+    public static void removeUserKeyword(String keyword) {
+        userKeywords.remove(keyword);
+    }
+
+    /**
+     * Get the platform-specific identifier, should be bundle/package name
+     */
+    public static synchronized String getBundleName() {
+        return bundleName;
+    }
+
+    /**
+     * Set the platform-specific identifier for targeting purpose
+     * Should be bundle/package name
+     */
+    public static synchronized void setBundleName(String bundleName) {
+        TargetingParams.bundleName = bundleName;
+    }
+
+    /**
+     * Set the domain of your app for targeting purpose
+     *
+     * @param domain domain of your app
+     */
+    public static synchronized void setDomain(String domain) {
+        TargetingParams.domain = domain;
+    }
+
+    /**
+     * Get the domain of your app
+     *
+     * @return domain of your app
+     */
+    public static synchronized String getDomain() {
+        return domain;
+    }
+
+    /**
+     * Set the store url of your app
+     *
+     * @param storeUrl store url
+     */
+    public static synchronized void setStoreUrl(String storeUrl) {
+        TargetingParams.storeUrl = storeUrl;
+    }
+
+    /**
+     * Get the store url of your app
+     *
+     * @return store url
+     */
+    public static synchronized String getStoreUrl() {
+        return storeUrl;
+    }
+
+    /**
+     * Set whether the app has a privacy policy, where 0 = no, 1 = yes
+     *
+     * @param privacyPolicy default value is 0
+     */
+    public static synchronized void setPrivacyPolicy(int privacyPolicy) {
+        if (privacyPolicy == 0 || privacyPolicy == 1) {
+            TargetingParams.privacyPolicy = privacyPolicy;
+        }
+    }
+
+    /**
+     * Get whether the app has a privacy policy
+     *
+     * @return 1 if it has one
+     */
+    public static synchronized int getPrivacyPolicy() {
+        return privacyPolicy;
+    }
+
+
+//endregion
 }

--- a/PrebidMobile/PrebidMobileCore/src/test/java/org/prebid/mobile/core/BidManagerTest.java
+++ b/PrebidMobile/PrebidMobileCore/src/test/java/org/prebid/mobile/core/BidManagerTest.java
@@ -46,11 +46,9 @@ public class BidManagerTest extends BaseSetup {
         adUnit3 = new InterstitialAdUnit(TestConstants.interstitialAdUnit, TestConstants.configID3);
 
         TargetingParams.setGender(TargetingParams.GENDER.FEMALE);
-        TargetingParams.setAge(25);
+        TargetingParams.setYearOfBirth(1992);
         TargetingParams.setLocationDecimalDigits(2);
         TargetingParams.setLocationEnabled(true);
-        TargetingParams.setCustomTargeting("Test", "Prebid-Custom-1");
-        TargetingParams.setCustomTargeting("Test2", "Prebid-Custom-2");
     }
 
     @Test
@@ -210,7 +208,8 @@ public class BidManagerTest extends BaseSetup {
         super.tearDown();
 
         // Clear targeting since these are static settings
-        TargetingParams.clearCustomKeywords();
+        TargetingParams.clearAppKeywords();
+        TargetingParams.clearUserKeywords();
         TargetingParams.setLocation(null);
         TargetingParams.setLocationDecimalDigits(-1);
         TargetingParams.setGender(TargetingParams.GENDER.UNKNOWN);

--- a/PrebidMobile/PrebidMobileCore/src/test/java/org/prebid/mobile/core/BidManagerTest.java
+++ b/PrebidMobile/PrebidMobileCore/src/test/java/org/prebid/mobile/core/BidManagerTest.java
@@ -12,6 +12,7 @@ import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 
 import static junit.framework.Assert.assertEquals;
@@ -32,8 +33,18 @@ public class BidManagerTest extends BaseSetup {
         initializePrebid();
     }
 
+    private void setTestServer(String serverName) {
+        try {
+            Field prebidServerField = Prebid.class.getDeclaredField("PREBID_SERVER");
+            prebidServerField.setAccessible(true);
+            prebidServerField.set(null, serverName);
+        } catch (NoSuchFieldException e) {
+        } catch (IllegalAccessException e) {
+        }
+    }
+
     private void initializePrebid() {
-        Prebid.setTestServer(MockServer.class.getName());
+        setTestServer(MockServer.class.getName());
         //Configure Banner Ad-Units
         adUnit1 = new BannerAdUnit(TestConstants.bannerAdUnit1, TestConstants.configID1);
         adUnit1.addSize(320, 50);
@@ -51,9 +62,19 @@ public class BidManagerTest extends BaseSetup {
         TargetingParams.setLocationEnabled(true);
     }
 
+    private void setAdServer(Prebid.AdServer adServer) {
+        try {
+            Field adServerField = Prebid.class.getDeclaredField("adServer");
+            adServerField.setAccessible(true);
+            adServerField.set(null, adServer);
+        } catch (IllegalAccessException e) {
+        } catch (NoSuchFieldException e) {
+        }
+    }
+
     @Test
     public void testBidManagerAddingCacheIdToTopBid() throws Exception {
-        Prebid.setAdServer(Prebid.AdServer.DFP);
+        setAdServer(Prebid.AdServer.DFP);
         BannerAdUnit adUnit = new BannerAdUnit("Banner", "12345");
         adUnit.addSize(300, 250);
         ArrayList<BidResponse> responses = new ArrayList<BidResponse>();
@@ -71,7 +92,7 @@ public class BidManagerTest extends BaseSetup {
         assertTrue(sortedResponses.get(1).getCustomKeywords().size() == 0);
         assertTrue(sortedResponses.get(2).getCustomKeywords().size() == 0);
         // test that for MoPub, nothing will be added for the bids
-        Prebid.setAdServer(Prebid.AdServer.MOPUB);
+        setAdServer(Prebid.AdServer.MOPUB);
         topBid.getCustomKeywords().clear();
         BidManager.bidResponseListener.onBidSuccess(adUnit, responses);
         sortedResponses = BidManager.getBidMap().get(adUnit.getCode());

--- a/PrebidMobile/PrebidMobileCore/src/test/java/org/prebid/mobile/core/PrebidInitTest.java
+++ b/PrebidMobile/PrebidMobileCore/src/test/java/org/prebid/mobile/core/PrebidInitTest.java
@@ -11,6 +11,7 @@ import org.prebid.mobile.unittestutils.TestConstants;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 
 import static org.junit.Assert.assertEquals;
@@ -22,7 +23,17 @@ public class PrebidInitTest extends BaseSetup {
     @Before
     public void setUp() {
         super.setup();
-        Prebid.setTestServer(MockServer.class.getName());
+        setTestServer(MockServer.class.getName());
+    }
+
+    private void setTestServer(String serverName) {
+        try {
+            Field prebidServerField = Prebid.class.getDeclaredField("PREBID_SERVER");
+            prebidServerField.setAccessible(true);
+            prebidServerField.set(null, serverName);
+        } catch (NoSuchFieldException e) {
+        } catch (IllegalAccessException e) {
+        }
     }
 
     // Check if the ad units passed in are stored correctly in the BidManager after init.
@@ -83,7 +94,7 @@ public class PrebidInitTest extends BaseSetup {
 
     @Test
     public void testUnableToInitDemandAdapterException() {
-        Prebid.setTestServer("random value");
+        setTestServer("random value");
         ArrayList<AdUnit> adUnits = new ArrayList<AdUnit>();
         BannerAdUnit adUnit = new BannerAdUnit(TestConstants.bannerAdUnit1, TestConstants.configID1);
         adUnit.addSize(320, 50);
@@ -97,7 +108,7 @@ public class PrebidInitTest extends BaseSetup {
 
     @Test
     public void testUnableToInitNullHostException() {
-        Prebid.setTestServer("random value");
+        setTestServer("random value");
         ArrayList<AdUnit> adUnits = new ArrayList<AdUnit>();
         BannerAdUnit adUnit = new BannerAdUnit(TestConstants.bannerAdUnit1, TestConstants.configID1);
         adUnit.addSize(320, 50);

--- a/PrebidMobile/PrebidMobileCore/src/test/java/org/prebid/mobile/core/TargetingParamsTest.java
+++ b/PrebidMobile/PrebidMobileCore/src/test/java/org/prebid/mobile/core/TargetingParamsTest.java
@@ -7,13 +7,26 @@ import org.junit.runner.RunWith;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-import java.util.ArrayList;
+import java.util.Calendar;
 
 import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 21)
 public class TargetingParamsTest {
+
+    @Test
+    public void testSetYearOfBirth() throws Exception {
+        TargetingParams.setYearOfBirth(-1);
+        assertTrue(TargetingParams.getYearOfBirth() != -1);
+        int year = Calendar.getInstance().get(Calendar.YEAR) + 1;
+        TargetingParams.setYearOfBirth(year);
+        assertTrue(TargetingParams.getYearOfBirth() != year);
+        year = Calendar.getInstance().get(Calendar.YEAR) - 5;
+        TargetingParams.setYearOfBirth(year);
+        assertTrue(TargetingParams.getYearOfBirth() == year);
+    }
 
     @Test
     public void testSetGender() {
@@ -47,40 +60,68 @@ public class TargetingParamsTest {
     }
 
     @Test
-    public void testCustomKeywords() {
-        // Clearing the custom keywords
-        TargetingParams.clearCustomKeywords();
-        assertEquals(0, TargetingParams.getCustomKeywords().size());
-        // Set one value for one key
-        TargetingParams.setCustomTargeting("TestKey1", "TestValue1");
-        assertEquals(1, TargetingParams.getCustomKeywords().size());
-        assertEquals(1, TargetingParams.getCustomKeywords().get("TestKey1").size());
-        assertEquals("TestValue1", TargetingParams.getCustomKeywords().get("TestKey1").get(0));
-        // Set another value for the same key
-        TargetingParams.setCustomTargeting("TestKey1", "TestValue2");
-        assertEquals(1, TargetingParams.getCustomKeywords().size());
-        assertEquals(1, TargetingParams.getCustomKeywords().get("TestKey1").size());
-        assertEquals("TestValue2", TargetingParams.getCustomKeywords().get("TestKey1").get(0));
-        // Set value for a different key
-        TargetingParams.setCustomTargeting("TestKey2", "TestValue2");
-        assertEquals(2, TargetingParams.getCustomKeywords().size());
-        assertEquals(1, TargetingParams.getCustomKeywords().get("TestKey2").size());
-        assertEquals("TestValue2", TargetingParams.getCustomKeywords().get("TestKey2").get(0));
-        // Override values array for existing key
-        ArrayList<String> values = new ArrayList<String>();
-        values.add("TestValue3");
-        values.add("TestValue4");
-        TargetingParams.setCustomTargeting("TestKey1", values);
-        assertEquals(2, TargetingParams.getCustomKeywords().size());
-        assertEquals(2, TargetingParams.getCustomKeywords().get("TestKey1").size());
-        assertEquals("TestValue3", TargetingParams.getCustomKeywords().get("TestKey1").get(0));
-        assertEquals("TestValue4", TargetingParams.getCustomKeywords().get("TestKey1").get(1));
-        assertEquals(1, TargetingParams.getCustomKeywords().get("TestKey2").size());
-        assertEquals("TestValue2", TargetingParams.getCustomKeywords().get("TestKey2").get(0));
-        // Remove values for the first key
-        TargetingParams.removeCustomKeyword("TestKey1");
-        assertEquals(1, TargetingParams.getCustomKeywords().size());
-        assertEquals(1, TargetingParams.getCustomKeywords().get("TestKey2").size());
-        assertEquals(false, TargetingParams.getCustomKeywords().containsKey("TestKey1"));
+    public void testSetAppKeywords() throws Exception {
+        TargetingParams.clearAppKeywords();
+        TargetingParams.addAppKeywords("keyword1");
+        TargetingParams.addAppKeywords("keyword2");
+        assertEquals(2, TargetingParams.getAppKeywords().size());
+        assertEquals("keyword1", TargetingParams.getAppKeywords().get(0));
+        assertEquals("keyword2", TargetingParams.getAppKeywords().get(1));
+        TargetingParams.removeAppKeyword("keyword");
+        assertEquals(2, TargetingParams.getAppKeywords().size());
+        assertEquals("keyword1", TargetingParams.getAppKeywords().get(0));
+        assertEquals("keyword2", TargetingParams.getAppKeywords().get(1));
+        TargetingParams.removeAppKeyword("keyword1");
+        assertEquals(1, TargetingParams.getAppKeywords().size());
+        assertEquals("keyword2", TargetingParams.getAppKeywords().get(0));
+        TargetingParams.clearAppKeywords();
+        assertEquals(0, TargetingParams.getAppKeywords().size());
+    }
+
+    @Test
+    public void testSetUserKeywords() throws Exception {
+        TargetingParams.clearUserKeywords();
+        TargetingParams.addUserKeyword("keyword1");
+        TargetingParams.addUserKeyword("keyword2");
+        assertEquals(2, TargetingParams.getUserKeywords().size());
+        assertEquals("keyword1", TargetingParams.getUserKeywords().get(0));
+        assertEquals("keyword2", TargetingParams.getUserKeywords().get(1));
+        TargetingParams.removeUserKeyword("keyword");
+        assertEquals(2, TargetingParams.getUserKeywords().size());
+        assertEquals("keyword1", TargetingParams.getUserKeywords().get(0));
+        assertEquals("keyword2", TargetingParams.getUserKeywords().get(1));
+        TargetingParams.removeUserKeyword("keyword1");
+        assertEquals(1, TargetingParams.getUserKeywords().size());
+        assertEquals("keyword2", TargetingParams.getUserKeywords().get(0));
+        TargetingParams.clearUserKeywords();
+        assertEquals(0, TargetingParams.getUserKeywords().size());
+    }
+
+    @Test
+    public void testSetBundleName() throws Exception {
+        TargetingParams.setBundleName("Prebid Mobile DemoApp");
+        assertEquals("Prebid Mobile DemoApp", TargetingParams.getBundleName());
+    }
+
+    @Test
+    public void testSetDomain() throws Exception {
+        TargetingParams.setDomain("http://www.prebid.org");
+        assertEquals("http://www.prebid.org", TargetingParams.getDomain());
+    }
+
+    @Test
+    public void testSetStoreUrl() throws Exception {
+        TargetingParams.setStoreUrl("https://play.google.com/store/apps/details?id=com.appnexus.opensdkapp&hl=en");
+        assertEquals("https://play.google.com/store/apps/details?id=com.appnexus.opensdkapp&hl=en", TargetingParams.getStoreUrl());
+    }
+
+    @Test
+    public void testSetPrivacyPolicy() throws Exception {
+        TargetingParams.setPrivacyPolicy(1);
+        assertEquals(1, TargetingParams.getPrivacyPolicy());
+        TargetingParams.setPrivacyPolicy(2);
+        assertEquals(1, TargetingParams.getPrivacyPolicy());
+        TargetingParams.setPrivacyPolicy(0);
+        assertEquals(0, TargetingParams.getPrivacyPolicy());
     }
 }

--- a/PrebidMobile/PrebidServerAdapter/README.md
+++ b/PrebidMobile/PrebidServerAdapter/README.md
@@ -1,10 +1,10 @@
 A sample Open RTB 2.5 spec compliant request that Prebid Server Adapter would send out is as following:
 ```
 {
-  "id": "3d0c6321-9223-4baf-8875-1971c25ff3ce",
+  "id": "1a31e229-9e6f-4a4b-87be-8a19a650bd9b",
   "imp": [
     {
-      "id": "Banner_300x250",
+      "id": "Banner_320x50",
       "secure": 1,
       "ext": {
         "prebid": {
@@ -18,7 +18,6 @@ A sample Open RTB 2.5 spec compliant request that Prebid Server Adapter would se
   "device": {
     "make": "unknown",
     "model": "Android SDK built for x86",
-    "ua": "Mozilla/5.0 (Linux; Android 6.0; Android SDK built for x86 Build/MASTER; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36",
     "w": 360,
     "h": 568,
     "pxratio": 3,
@@ -26,7 +25,6 @@ A sample Open RTB 2.5 spec compliant request that Prebid Server Adapter would se
     "carrier": "Android",
     "connectiontype": 2,
     "lmt": 0,
-    "ifa": "baa7acdc-b7de-48c2-91f7-d0343a74ae68",
     "os": "android",
     "osv": "23",
     "language": "en"
@@ -39,7 +37,13 @@ A sample Open RTB 2.5 spec compliant request that Prebid Server Adapter would se
     "publisher": {
       "id": "bfa84af2-bd16-4d35-96ad-31c6bb888df0"
     },
-    "keywords": "PrebidKeyword1;"
+    "keywords": "PrebidKeyword1;",
+    "ext": {
+      "prebid": {
+        "source": "prebid-mobile",
+        "version": "0.1.0"
+      }
+    }
   },
   "user": {
     "yob": 1992,
@@ -51,9 +55,7 @@ A sample Open RTB 2.5 spec compliant request that Prebid Server Adapter would se
       "targeting": {
         "pricegranularity": "medium",
         "lengthmax": 20
-      },
-      "source": "prebid-mobile",
-      "version": "0.1.0"
+      }
     }
   }
 }

--- a/PrebidMobile/PrebidServerAdapter/README.md
+++ b/PrebidMobile/PrebidServerAdapter/README.md
@@ -1,0 +1,65 @@
+A sample Open RTB 2.5 spec compliant request that Prebid Server Adapter would send out is as following:
+```
+{
+	"id": "3d0c6321-9223-4baf-8875-1971c25ff3ce",
+	"imp": [{
+		"id": "Banner_300x250",
+		"secure": 1,
+		"ext": {
+			"appnexus": {
+				"placementId": 10433394
+			}
+		},
+		"banner": {
+			"format": [{
+				"w": 300,
+				"h": 250
+			}, {
+				"w": 300,
+				"h": 600
+			}]
+		}
+	}],
+	"device": {
+		"make": "unknown",
+		"model": "Android SDK built for x86",
+		"ua": "Mozilla\/5.0 (Linux; Android 6.0; Android SDK built for x86 Build\/MASTER; wv) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Chrome\/44.0.2403.119 Mobile Safari\/537.36",
+		"w": 360,
+		"h": 568,
+		"pxratio": 3,
+		"mccmnc": "310-260",
+		"carrier": "Android",
+		"connectiontype": 2,
+		"lmt": 0,
+		"ifa": "baa7acdc-b7de-48c2-91f7-d0343a74ae68",
+		"os": "android",
+		"osv": "23",
+		"language": "en"
+	},
+	"app": {
+		"bundle": "org.prebid.mobile.demoapp",
+		"ver": "0.1.0",
+		"name": "DemoApp",
+		"privacypolicy": 0,
+		"publisher": {
+			"id": "bfa84af2-bd16-4d35-96ad-31c6bb888df0"
+		},
+		"keywords": "PrebidKeyword1;"
+	},
+	"user": {
+		"yob": 1992,
+		"gender": "F",
+		"keywords": "PrebidKeyword2;"
+	},
+	"ext": {
+		"prebid": {
+			"targeting": {
+				"pricegranularity": "medium",
+				"lengthmax": 20
+			},
+			"source": "prebid-mobile",
+			"version": "0.1.0"
+		}
+	}
+}
+```

--- a/PrebidMobile/PrebidServerAdapter/README.md
+++ b/PrebidMobile/PrebidServerAdapter/README.md
@@ -1,65 +1,60 @@
 A sample Open RTB 2.5 spec compliant request that Prebid Server Adapter would send out is as following:
 ```
 {
-	"id": "3d0c6321-9223-4baf-8875-1971c25ff3ce",
-	"imp": [{
-		"id": "Banner_300x250",
-		"secure": 1,
-		"ext": {
-			"appnexus": {
-				"placementId": 10433394
-			}
-		},
-		"banner": {
-			"format": [{
-				"w": 300,
-				"h": 250
-			}, {
-				"w": 300,
-				"h": 600
-			}]
-		}
-	}],
-	"device": {
-		"make": "unknown",
-		"model": "Android SDK built for x86",
-		"ua": "Mozilla\/5.0 (Linux; Android 6.0; Android SDK built for x86 Build\/MASTER; wv) AppleWebKit\/537.36 (KHTML, like Gecko) Version\/4.0 Chrome\/44.0.2403.119 Mobile Safari\/537.36",
-		"w": 360,
-		"h": 568,
-		"pxratio": 3,
-		"mccmnc": "310-260",
-		"carrier": "Android",
-		"connectiontype": 2,
-		"lmt": 0,
-		"ifa": "baa7acdc-b7de-48c2-91f7-d0343a74ae68",
-		"os": "android",
-		"osv": "23",
-		"language": "en"
-	},
-	"app": {
-		"bundle": "org.prebid.mobile.demoapp",
-		"ver": "0.1.0",
-		"name": "DemoApp",
-		"privacypolicy": 0,
-		"publisher": {
-			"id": "bfa84af2-bd16-4d35-96ad-31c6bb888df0"
-		},
-		"keywords": "PrebidKeyword1;"
-	},
-	"user": {
-		"yob": 1992,
-		"gender": "F",
-		"keywords": "PrebidKeyword2;"
-	},
-	"ext": {
-		"prebid": {
-			"targeting": {
-				"pricegranularity": "medium",
-				"lengthmax": 20
-			},
-			"source": "prebid-mobile",
-			"version": "0.1.0"
-		}
-	}
+  "id": "3d0c6321-9223-4baf-8875-1971c25ff3ce",
+  "imp": [
+    {
+      "id": "Banner_300x250",
+      "secure": 1,
+      "ext": {
+        "prebid": {
+          "storedrequest": {
+            "id": "123456"
+          }
+        }
+      }
+    }
+  ],
+  "device": {
+    "make": "unknown",
+    "model": "Android SDK built for x86",
+    "ua": "Mozilla/5.0 (Linux; Android 6.0; Android SDK built for x86 Build/MASTER; wv) AppleWebKit/537.36 (KHTML, like Gecko) Version/4.0 Chrome/44.0.2403.119 Mobile Safari/537.36",
+    "w": 360,
+    "h": 568,
+    "pxratio": 3,
+    "mccmnc": "310-260",
+    "carrier": "Android",
+    "connectiontype": 2,
+    "lmt": 0,
+    "ifa": "baa7acdc-b7de-48c2-91f7-d0343a74ae68",
+    "os": "android",
+    "osv": "23",
+    "language": "en"
+  },
+  "app": {
+    "bundle": "org.prebid.mobile.demoapp",
+    "ver": "0.1.0",
+    "name": "DemoApp",
+    "privacypolicy": 0,
+    "publisher": {
+      "id": "bfa84af2-bd16-4d35-96ad-31c6bb888df0"
+    },
+    "keywords": "PrebidKeyword1;"
+  },
+  "user": {
+    "yob": 1992,
+    "gender": "F",
+    "keywords": "PrebidKeyword2;"
+  },
+  "ext": {
+    "prebid": {
+      "targeting": {
+        "pricegranularity": "medium",
+        "lengthmax": 20
+      },
+      "source": "prebid-mobile",
+      "version": "0.1.0"
+    }
+  }
 }
 ```

--- a/PrebidMobile/PrebidServerAdapter/README.md
+++ b/PrebidMobile/PrebidServerAdapter/README.md
@@ -2,6 +2,9 @@ A sample Open RTB 2.5 spec compliant request that Prebid Server Adapter would se
 ```
 {
   "id": "1a31e229-9e6f-4a4b-87be-8a19a650bd9b",
+  "source": {
+    "tid": "123"
+  },
   "imp": [
     {
       "id": "Banner_320x50",
@@ -9,9 +12,17 @@ A sample Open RTB 2.5 spec compliant request that Prebid Server Adapter would se
       "ext": {
         "prebid": {
           "storedrequest": {
-            "id": "123456"
+            "id": "eebc307d-7f76-45d6-a7a7-68985169b138"
           }
         }
+      },
+      "banner":{
+        "format":[
+          {
+            "w": 300,
+            "h": 250
+          }
+        ]
       }
     }
   ],
@@ -37,7 +48,7 @@ A sample Open RTB 2.5 spec compliant request that Prebid Server Adapter would se
     "publisher": {
       "id": "bfa84af2-bd16-4d35-96ad-31c6bb888df0"
     },
-    "keywords": "PrebidKeyword1;",
+    "keywords": "PrebidKeyword1,",
     "ext": {
       "prebid": {
         "source": "prebid-mobile",
@@ -48,7 +59,7 @@ A sample Open RTB 2.5 spec compliant request that Prebid Server Adapter would se
   "user": {
     "yob": 1992,
     "gender": "F",
-    "keywords": "PrebidKeyword2;"
+    "keywords": "PrebidKeyword2,"
   },
   "ext": {
     "prebid": {

--- a/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/PrebidServerAdapter.java
+++ b/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/PrebidServerAdapter.java
@@ -94,14 +94,11 @@ public class PrebidServerAdapter implements DemandAdapter, ServerConnector.Serve
                                             Iterator<?> keys = targetingKeywords.keys();
                                             while (keys.hasNext()) {
                                                 String key = (String) keys.next();
-                                                if (key.startsWith("hb_cache_id")) {
-                                                    // todo how to handle cache id saving here since for DFP we don't request for cache?
-                                                    // todo need to see david's implementation on this one.
-                                                    newBid.addCustomKeyword(key, cacheId);
-                                                } else {
-                                                    newBid.addCustomKeyword(key, targetingKeywords.getString(key));
-                                                }
+                                                newBid.addCustomKeyword(key, targetingKeywords.getString(key));
                                             }
+                                            String cacheIdKey = "hb_cache_id_" + bidderName;
+                                            cacheIdKey = cacheIdKey.substring(0, Math.min(cacheIdKey.length(), Settings.REQUEST_KEY_LENGTH_MAX));
+                                            newBid.addCustomKeyword(cacheIdKey, cacheId);
                                         } else {
                                             String cacheId = targetingKeywords.getString(Settings.RESPONSE_CACHE_ID);
                                             newBid = new BidResponse(bidPrice, cacheId);
@@ -151,7 +148,7 @@ public class PrebidServerAdapter implements DemandAdapter, ServerConnector.Serve
         }
         JSONObject postData = new JSONObject();
         try {
-            // todo check ORTB sort bids and cache markup
+            // todo check ORTB cache markup
             postData.put("test", 1);
             postData.put(Settings.REQUEST_SORT_BIDS, 1);
             postData.put("id", generateID()); // random id for the request
@@ -209,7 +206,7 @@ public class PrebidServerAdapter implements DemandAdapter, ServerConnector.Serve
         try {
             JSONObject targeting = new JSONObject();
             targeting.put("pricegranularity", "medium");
-            targeting.put("lengthmax", 40);
+            targeting.put("lengthmax", Settings.REQUEST_KEY_LENGTH_MAX);
             prebid.put("targeting", targeting);
             ext.put("prebid", prebid);
         } catch (JSONException e) {

--- a/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/PrebidServerAdapter.java
+++ b/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/PrebidServerAdapter.java
@@ -147,17 +147,9 @@ public class PrebidServerAdapter implements DemandAdapter, ServerConnector.Serve
         }
         JSONObject postData = new JSONObject();
         try {
-            // todo check ORTB cache markup
             postData.put("test", 1);
-            postData.put(Settings.REQUEST_SORT_BIDS, 1);
             postData.put("id", generateID()); // random id for the request
             postData.put(Settings.REQUEST_ACCOUNT_ID, Prebid.getAccountId());
-            postData.put(Settings.REQUEST_MAX_KEY, 20);
-            if (Prebid.getAdServer() == Prebid.AdServer.DFP) {
-                postData.put(Settings.REQUEST_CACHE_MARKUP, 0);
-            } else {
-                postData.put(Settings.REQUEST_CACHE_MARKUP, 1);
-            }
             // add ad units
             JSONArray imps = getImps(adUnits);
             if (imps != null && imps.length() > 0) {
@@ -207,6 +199,12 @@ public class PrebidServerAdapter implements DemandAdapter, ServerConnector.Serve
             targeting.put("pricegranularity", "medium");
             targeting.put("lengthmax", Settings.REQUEST_KEY_LENGTH_MAX);
             prebid.put("targeting", targeting);
+            if (Prebid.AdServer.MOPUB.equals(Prebid.getAdServer())) {
+                JSONObject bids = new JSONObject();
+                JSONObject cache = new JSONObject();
+                cache.put("bids", bids);
+                prebid.put("cache", cache);
+            }
             ext.put("prebid", prebid);
         } catch (JSONException e) {
             e.printStackTrace();

--- a/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/PrebidServerAdapter.java
+++ b/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/PrebidServerAdapter.java
@@ -147,7 +147,6 @@ public class PrebidServerAdapter implements DemandAdapter, ServerConnector.Serve
         }
         JSONObject postData = new JSONObject();
         try {
-            postData.put("test", 1);
             postData.put("id", generateID()); // random id for the request
             postData.put(Settings.REQUEST_ACCOUNT_ID, Prebid.getAccountId());
             // add ad units

--- a/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/PrebidServerAdapter.java
+++ b/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/PrebidServerAdapter.java
@@ -44,8 +44,7 @@ public class PrebidServerAdapter implements DemandAdapter, ServerConnector.Serve
         this.weakReferenceLisenter = new WeakReference<BidManager.BidResponseListener>(bidResponseListener);
         JSONObject postData = getPostData(context, adUnits);
         if (Prebid.isSecureConnection()) {
-//            new ServerConnector(postData, this, Settings.REQUEST_URL_SECURE, context).execute();
-            new ServerConnector(postData, this, "http://10.0.2.2:8000/openrtb2/auction", context).execute();
+            new ServerConnector(postData, this, Settings.REQUEST_URL_SECURE, context).execute();
         } else {
             new ServerConnector(postData, this, Settings.REQUEST_URL_NON_SECURE, context).execute();
         }

--- a/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/PrebidServerAdapter.java
+++ b/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/PrebidServerAdapter.java
@@ -240,13 +240,13 @@ public class PrebidServerAdapter implements DemandAdapter, ServerConnector.Serve
             try {
                 JSONObject imp = new JSONObject();
                 JSONObject ext = new JSONObject();
+                imp.put("id", adUnit.getCode());
                 imp.put("ext", ext);
                 JSONObject prebid = new JSONObject();
                 ext.put("prebid", prebid);
                 JSONObject storedrequest = new JSONObject();
                 prebid.put("storedrequest", storedrequest);
                 storedrequest.put("id", adUnit.getConfigId());
-                imp.put(Settings.REQUEST_CODE, adUnit.getCode());
                 impConfigs.put(imp);
             } catch (JSONException e) {
             }

--- a/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/PrebidServerAdapter.java
+++ b/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/PrebidServerAdapter.java
@@ -44,7 +44,8 @@ public class PrebidServerAdapter implements DemandAdapter, ServerConnector.Serve
         this.weakReferenceLisenter = new WeakReference<BidManager.BidResponseListener>(bidResponseListener);
         JSONObject postData = getPostData(context, adUnits);
         if (Prebid.isSecureConnection()) {
-            new ServerConnector(postData, this, Settings.REQUEST_URL_SECURE, context).execute();
+//            new ServerConnector(postData, this, Settings.REQUEST_URL_SECURE, context).execute();
+            new ServerConnector(postData, this, "http://10.0.2.2:8000/openrtb2/auction", context).execute();
         } else {
             new ServerConnector(postData, this, Settings.REQUEST_URL_NON_SECURE, context).execute();
         }
@@ -151,8 +152,9 @@ public class PrebidServerAdapter implements DemandAdapter, ServerConnector.Serve
         JSONObject postData = new JSONObject();
         try {
             // todo check ORTB sort bids and cache markup
+            postData.put("test", 1);
             postData.put(Settings.REQUEST_SORT_BIDS, 1);
-            postData.put(Settings.REQUEST_TID, generateTID());
+            postData.put("id", generateID()); // random id for the request
             postData.put(Settings.REQUEST_ACCOUNT_ID, Prebid.getAccountId());
             postData.put(Settings.REQUEST_MAX_KEY, 20);
             if (Prebid.getAdServer() == Prebid.AdServer.DFP) {
@@ -192,9 +194,9 @@ public class PrebidServerAdapter implements DemandAdapter, ServerConnector.Serve
                 postData.put(Settings.REQUEST_SDK, version);
             }
             // add targeting keywords request
-            JSONObject prebid = getRequestExtData();
-            if (prebid != null && prebid.length() > 0) {
-                postData.put("ext", prebid);
+            JSONObject ext = getRequestExtData();
+            if (ext != null && ext.length() > 0) {
+                postData.put("ext", ext);
             }
         } catch (JSONException e) {
         }
@@ -202,21 +204,23 @@ public class PrebidServerAdapter implements DemandAdapter, ServerConnector.Serve
     }
 
     private JSONObject getRequestExtData() {
+        JSONObject ext = new JSONObject();
         JSONObject prebid = new JSONObject();
         try {
             JSONObject targeting = new JSONObject();
             targeting.put("pricegranularity", "medium");
             targeting.put("lengthmax", 40);
             prebid.put("targeting", targeting);
+            ext.put("prebid", prebid);
         } catch (JSONException e) {
             e.printStackTrace();
         }
-        return prebid;
+        return ext;
     }
 
     private String currentTID = null;
 
-    private String generateTID() {
+    private String generateID() {
         currentTID = UUID.randomUUID().toString();
         return currentTID;
     }

--- a/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/PrebidServerAdapter.java
+++ b/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/PrebidServerAdapter.java
@@ -200,7 +200,7 @@ public class PrebidServerAdapter implements DemandAdapter, ServerConnector.Serve
         JSONObject ext = new JSONObject();
         JSONObject prebid = new JSONObject();
         try {
-            if (Prebid.AdServer.MOPUB.equals(Prebid.getAdServer())) {
+            if (!Prebid.useLocalCache()) {
                 JSONObject bids = new JSONObject();
                 JSONObject cache = new JSONObject();
                 cache.put("bids", bids);

--- a/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/PrebidServerAdapter.java
+++ b/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/PrebidServerAdapter.java
@@ -14,7 +14,6 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.prebid.mobile.core.AdSize;
-import org.prebid.mobile.core.AdType;
 import org.prebid.mobile.core.AdUnit;
 import org.prebid.mobile.core.BidManager;
 import org.prebid.mobile.core.BidResponse;
@@ -149,7 +148,11 @@ public class PrebidServerAdapter implements DemandAdapter, ServerConnector.Serve
         }
         JSONObject postData = new JSONObject();
         try {
-            postData.put("id", UUID.randomUUID().toString()); // random id for the request
+            String id = UUID.randomUUID().toString();
+            postData.put("id", id);
+            JSONObject source = new JSONObject();
+            source.put("tid", id);
+            postData.put("source", source);
             // add ad units
             JSONArray imps = getImps(adUnits);
             if (imps != null && imps.length() > 0) {
@@ -222,15 +225,13 @@ public class PrebidServerAdapter implements DemandAdapter, ServerConnector.Serve
                 prebid.put("storedrequest", storedrequest);
                 storedrequest.put("id", adUnit.getConfigId());
                 imp.put("ext", ext);
-                if (adUnit.getAdType().equals(AdType.BANNER)) {
-                    JSONObject banner = new JSONObject();
-                    JSONArray format = new JSONArray();
-                    for (AdSize size : adUnit.getSizes()) {
-                        format.put(new JSONObject().put("w", size.getWidth()).put("h", size.getHeight()));
-                    }
-                    banner.put("format", format);
-                    imp.put("banner", banner);
+                JSONObject banner = new JSONObject();
+                JSONArray format = new JSONArray();
+                for (AdSize size : adUnit.getSizes()) {
+                    format.put(new JSONObject().put("w", size.getWidth()).put("h", size.getHeight()));
                 }
+                banner.put("format", format);
+                imp.put("banner", banner);
                 impConfigs.put(imp);
             } catch (JSONException e) {
             }

--- a/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/PrebidServerAdapter.java
+++ b/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/PrebidServerAdapter.java
@@ -193,8 +193,6 @@ public class PrebidServerAdapter implements DemandAdapter, ServerConnector.Serve
                 cache.put("bids", bids);
                 prebid.put("cache", cache);
             }
-            prebid.put("source", "prebid-mobile");
-            prebid.put("version", Settings.sdk_version);
             ext.put("prebid", prebid);
         } catch (JSONException e) {
             e.printStackTrace();
@@ -438,6 +436,12 @@ public class PrebidServerAdapter implements DemandAdapter, ServerConnector.Serve
             if (!TextUtils.isEmpty(toBeAdded)) {
                 app.put("keywords", toBeAdded);
             }
+            JSONObject prebid = new JSONObject();
+            prebid.put("source", "prebid-mobile");
+            prebid.put("version", Settings.sdk_version);
+            JSONObject ext = new JSONObject();
+            ext.put("prebid", prebid);
+            app.put("ext", ext);
         } catch (JSONException e) {
         }
         return app;

--- a/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/PrebidServerAdapter.java
+++ b/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/PrebidServerAdapter.java
@@ -14,6 +14,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.prebid.mobile.core.AdSize;
+import org.prebid.mobile.core.AdType;
 import org.prebid.mobile.core.AdUnit;
 import org.prebid.mobile.core.BidManager;
 import org.prebid.mobile.core.BidResponse;
@@ -46,16 +47,16 @@ public class PrebidServerAdapter implements DemandAdapter, ServerConnector.Serve
         JSONObject postData = getPostData(context, adUnits);
         new ServerConnector(postData, this, getHost(), context).execute();
     }
-  
+
     private String getHost() {
         String host = null;
         switch (Prebid.getHost()) {
             case APPNEXUS:
-                host = (Prebid.isSecureConnection()) ? Settings.APPNEXUS_REQUEST_URL_SECURE:
-                    Settings.APPNEXUS_REQUEST_URL_NON_SECURE;
+                host = (Prebid.isSecureConnection()) ? Settings.APPNEXUS_REQUEST_URL_SECURE :
+                        Settings.APPNEXUS_REQUEST_URL_NON_SECURE;
                 break;
             case RUBICON:
-                host = (Prebid.isSecureConnection()) ? Settings.RUBICON_REQUEST_URL_SECURE:
+                host = (Prebid.isSecureConnection()) ? Settings.RUBICON_REQUEST_URL_SECURE :
                         Settings.RUBICON_REQUEST_URL_NON_SECURE;
                 break;
         }
@@ -227,6 +228,9 @@ public class PrebidServerAdapter implements DemandAdapter, ServerConnector.Serve
                 imp.put("id", adUnit.getCode());
                 if (Prebid.isSecureConnection()) {
                     imp.put("secure", 1);
+                }
+                if (adUnit.getAdType().equals(AdType.INTERSTITIAL)) {
+                    imp.put("instl", 1);
                 }
                 imp.put("ext", ext);
                 JSONObject prebid = new JSONObject();

--- a/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/PrebidServerAdapter.java
+++ b/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/PrebidServerAdapter.java
@@ -148,7 +148,6 @@ public class PrebidServerAdapter implements DemandAdapter, ServerConnector.Serve
         JSONObject postData = new JSONObject();
         try {
             postData.put("id", generateID()); // random id for the request
-            postData.put(Settings.REQUEST_ACCOUNT_ID, Prebid.getAccountId());
             // add ad units
             JSONArray imps = getImps(adUnits);
             if (imps != null && imps.length() > 0) {
@@ -441,7 +440,9 @@ public class PrebidServerAdapter implements DemandAdapter, ServerConnector.Serve
             app.put(Settings.REQUEST_APP_DOMAIN, Settings.getDomain());
             app.put(Settings.REQUEST_APP_STOREURL, Settings.getStoreUrl());
             app.put(Settings.REQUEST_APP_PRIVACY, Settings.getPrivacyPolicy());
-            // todo get paid, keywords
+            JSONObject publisher = new JSONObject();
+            publisher.put("id", Prebid.getAccountId());
+            app.put("publisher", publisher);
         } catch (JSONException e) {
         }
         return app;

--- a/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/PrebidServerAdapter.java
+++ b/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/PrebidServerAdapter.java
@@ -13,6 +13,8 @@ import android.text.TextUtils;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.prebid.mobile.core.AdSize;
+import org.prebid.mobile.core.AdType;
 import org.prebid.mobile.core.AdUnit;
 import org.prebid.mobile.core.BidManager;
 import org.prebid.mobile.core.BidResponse;
@@ -213,23 +215,22 @@ public class PrebidServerAdapter implements DemandAdapter, ServerConnector.Serve
                 if (Prebid.isSecureConnection()) {
                     imp.put("secure", 1);
                 }
-//                imp.put("ext", ext);
-//                JSONObject prebid = new JSONObject();
-//                ext.put("prebid", prebid);
-//                JSONObject storedrequest = new JSONObject();
-//                prebid.put("storedrequest", storedrequest);
-//                storedrequest.put("id", adUnit.getConfigId());
-                // todo change it back after testing
-                JSONObject banner = new JSONObject();
-                JSONArray format = new JSONArray();
-                format.put(new JSONObject().put("w", 300).put("h", 250));
-                format.put(new JSONObject().put("w", 300).put("h", 600));
-                banner.put("format", format);
                 imp.put("ext", ext);
-                imp.put("banner", banner);
-                JSONObject appnexus = new JSONObject();
-                appnexus.put("placementId", 10433394);
-                ext.put("appnexus", appnexus);
+                JSONObject prebid = new JSONObject();
+                ext.put("prebid", prebid);
+                JSONObject storedrequest = new JSONObject();
+                prebid.put("storedrequest", storedrequest);
+                storedrequest.put("id", adUnit.getConfigId());
+                imp.put("ext", ext);
+                if (adUnit.getAdType().equals(AdType.BANNER)) {
+                    JSONObject banner = new JSONObject();
+                    JSONArray format = new JSONArray();
+                    for (AdSize size : adUnit.getSizes()) {
+                        format.put(new JSONObject().put("w", size.getWidth()).put("h", size.getHeight()));
+                    }
+                    banner.put("format", format);
+                    imp.put("banner", banner);
+                }
                 impConfigs.put(imp);
             } catch (JSONException e) {
             }

--- a/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/PrebidServerAdapter.java
+++ b/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/PrebidServerAdapter.java
@@ -188,16 +188,15 @@ public class PrebidServerAdapter implements DemandAdapter, ServerConnector.Serve
         JSONObject ext = new JSONObject();
         JSONObject prebid = new JSONObject();
         try {
-            JSONObject targeting = new JSONObject();
-            targeting.put("pricegranularity", "medium");
-            targeting.put("lengthmax", Settings.REQUEST_KEY_LENGTH_MAX);
-            prebid.put("targeting", targeting);
             if (Prebid.AdServer.MOPUB.equals(Prebid.getAdServer())) {
                 JSONObject bids = new JSONObject();
                 JSONObject cache = new JSONObject();
                 cache.put("bids", bids);
                 prebid.put("cache", cache);
             }
+            JSONObject storedRequest = new JSONObject();
+            storedRequest.put("id", Prebid.getAccountId());
+            prebid.put("storedrequest", storedRequest);
             ext.put("prebid", prebid);
         } catch (JSONException e) {
             e.printStackTrace();

--- a/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/PrebidServerAdapter.java
+++ b/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/PrebidServerAdapter.java
@@ -44,9 +44,9 @@ public class PrebidServerAdapter implements DemandAdapter, ServerConnector.Serve
         this.weakReferenceLisenter = new WeakReference<BidManager.BidResponseListener>(bidResponseListener);
         JSONObject postData = getPostData(context, adUnits);
         if (Prebid.isSecureConnection()) {
-            new ServerConnector(postData, this, Settings.REQUEST_URL_SECURE, context).execute();
+            new ServerConnector(postData, this, Settings.REQUEST_OPENRTB_ENDPOINT_SECURE, context).execute();
         } else {
-            new ServerConnector(postData, this, Settings.REQUEST_URL_NON_SECURE, context).execute();
+            new ServerConnector(postData, this, Settings.REQUEST_OPENRTB_ENDPOINT_NON_SECURE, context).execute();
         }
     }
 
@@ -238,12 +238,26 @@ public class PrebidServerAdapter implements DemandAdapter, ServerConnector.Serve
                 JSONObject imp = new JSONObject();
                 JSONObject ext = new JSONObject();
                 imp.put("id", adUnit.getCode());
+                if (Prebid.isSecureConnection()) {
+                    imp.put("secure", 1);
+                }
+//                imp.put("ext", ext);
+//                JSONObject prebid = new JSONObject();
+//                ext.put("prebid", prebid);
+//                JSONObject storedrequest = new JSONObject();
+//                prebid.put("storedrequest", storedrequest);
+//                storedrequest.put("id", adUnit.getConfigId());
+                // todo change it back after testing
+                JSONObject banner = new JSONObject();
+                JSONArray format = new JSONArray();
+                format.put(new JSONObject().put("w", 300).put("h", 250));
+                format.put(new JSONObject().put("w", 300).put("h", 600));
+                banner.put("format", format);
                 imp.put("ext", ext);
-                JSONObject prebid = new JSONObject();
-                ext.put("prebid", prebid);
-                JSONObject storedrequest = new JSONObject();
-                prebid.put("storedrequest", storedrequest);
-                storedrequest.put("id", adUnit.getConfigId());
+                imp.put("banner", banner);
+                JSONObject appnexus = new JSONObject();
+                appnexus.put("placementId", 10433394);
+                ext.put("appnexus", appnexus);
                 impConfigs.put(imp);
             } catch (JSONException e) {
             }

--- a/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/PrebidServerAdapter.java
+++ b/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/PrebidServerAdapter.java
@@ -432,7 +432,7 @@ public class PrebidServerAdapter implements DemandAdapter, ServerConnector.Serve
             ArrayList<String> keywords = TargetingParams.getAppKeywords();
             for (String keyword : keywords) {
                 if (!TextUtils.isEmpty(keyword)) {
-                    toBeAdded = toBeAdded + keyword + ";";
+                    toBeAdded = toBeAdded + keyword + ",";
                 }
             }
             if (!TextUtils.isEmpty(toBeAdded)) {
@@ -474,7 +474,7 @@ public class PrebidServerAdapter implements DemandAdapter, ServerConnector.Serve
             ArrayList<String> keywords = TargetingParams.getUserKeywords();
             for (String keyword : keywords) {
                 if (!TextUtils.isEmpty(keyword)) {
-                    toBeAdded = toBeAdded + keyword + ";";
+                    toBeAdded = toBeAdded + keyword + ",";
                 }
             }
             if (!TextUtils.isEmpty(toBeAdded)) {

--- a/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/internal/Settings.java
+++ b/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/internal/Settings.java
@@ -76,7 +76,7 @@ public class Settings {
     public static final String REQUEST_SDK_PLATFORM = "platform";
     public static final String REQUEST_SDK_MOBILE = "prebid-mobile";
     public static final String REQUEST_SDK_ANDROID = "android";
-    public static final int REQUEST_KEY_LENGTH_MAX = 40;
+    public static final int REQUEST_KEY_LENGTH_MAX = 20;
 
     // response
     public static final String RESPONSE_TID = "tid";

--- a/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/internal/Settings.java
+++ b/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/internal/Settings.java
@@ -76,6 +76,7 @@ public class Settings {
     public static final String REQUEST_SDK_PLATFORM = "platform";
     public static final String REQUEST_SDK_MOBILE = "prebid-mobile";
     public static final String REQUEST_SDK_ANDROID = "android";
+    public static final int REQUEST_KEY_LENGTH_MAX = 40;
 
     // response
     public static final String RESPONSE_TID = "tid";

--- a/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/internal/Settings.java
+++ b/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/internal/Settings.java
@@ -23,6 +23,9 @@ public class Settings {
     // connection settings
     public static final String REQUEST_URL_NON_SECURE = "http://prebid.adnxs.com/pbs/v1/auction";
     public static final String REQUEST_URL_SECURE = "https://prebid.adnxs.com/pbs/v1/auction";
+    public static final String REQUEST_OPENRTB_ENDPOINT_NON_SECURE = "http://prebid.adnxs.com/pbs/v1/openrtb2/auction";
+    public static final String REQUEST_OPENRTB_ENDPOINT_SECURE = "https://prebid.adnxs.com/pbs/v1/openrtb2/auction";
+
     public static int connectionTimeOutMillis = 500;
     // request keys
     public static final String REQUEST_CACHE_MARKUP = "cache_markup";

--- a/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/internal/Settings.java
+++ b/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/internal/Settings.java
@@ -28,30 +28,10 @@ public class Settings {
 
     public static int connectionTimeOutMillis = 500;
     // request keys
-    public static final String REQUEST_CACHE_MARKUP = "cache_markup";
-    public static final String REQUEST_SORT_BIDS = "sort_bids";
-    public static final String REQUEST_TID = "tid";
-    public static final String REQUEST_ACCOUNT_ID = "account_id";
-    public static final String REQUEST_MAX_KEY = "max_key_length";
-    public static final String REQUEST_AD_UNITS = "ad_units";
-    public static final String REQUEST_CONFIG_ID = "config_id";
-    public static final String REQUEST_CODE = "code";
-    public static final String REQUEST_WIDTH = "w";
-    public static final String REQUEST_HEIGHT = "h";
-    public static final String REQUEST_SIZES = "sizes";
     public static final String REQUEST_USER = "user";
-    public static final String REQUEST_AGE = "age";
-    public static final String REQUEST_GENDER = "gender";
     public static final String REQUEST_LANGUAGE = "language";
     public static final String REQUEST_DEVICE = "device";
     public static final String REQUEST_APP = "app";
-    public static final String REQUEST_APP_NAME = "name";
-    public static final String REQUEST_APP_BUNDLE = "bundle";
-    public static final String REQUEST_APP_DOMAIN = "domain";
-    public static final String REQUEST_APP_STOREURL = "storeurl";
-    public static final String REQUEST_APP_PRIVACY = "privacypolicy";
-    public static final String REQUEST_APP_VERSION = "ver";
-    public static final String REQUEST_KEYWORDS = "keywords";
     public static final String REQUEST_DEVICE_MAKE = "make";
     public static final String REQUEST_DEVICE_MODEL = "model";
     public static final String REQUEST_DEVICE_WIDTH = "w";
@@ -67,31 +47,10 @@ public class Settings {
     public static final String REQUEST_GEO_LON = "lon";
     public static final String REQEUST_GEO_LAT = "lat";
     public static final String REQUEST_GEO_AGE = "lastfix";
-    public static final String REQUEST_DEVTIME = "devtime";
     public static final String REQUEST_IFA = "ifa";
     public static final String REQUEST_OS = "os";
     public static final String REQUEST_OS_VERSION = "osv";
-    public static final String REQUEST_KEY = "key";
-    public static final String REQUEST_VALUE = "value";
-    public static final String REQUEST_SDK = "sdk";
-    public static final String REQUEST_SDK_SOURCE = "source";
-    public static final String REQUEST_SDK_VERSION = "version";
-    public static final String REQUEST_SDK_PLATFORM = "platform";
-    public static final String REQUEST_SDK_MOBILE = "prebid-mobile";
-    public static final String REQUEST_SDK_ANDROID = "android";
     public static final int REQUEST_KEY_LENGTH_MAX = 20;
-
-    // response
-    public static final String RESPONSE_TID = "tid";
-    public static final String RESPONSE_BIDS = "bids";
-    public static final String RESPONSE_CODE = "code";
-    public static final String RESPONSE_PRICE = "price";
-    public static final String RESPONSE_BIDDER = "bidder";
-    public static final String RESPONSE_STATUS = "status";
-    public static final String RESPONSE_STATUS_OK = "OK";
-    public static final String RESPONSE_TARGETING = "ad_server_targeting";
-    public static final String RESPONSE_CREATIVE = "hb_creative_loadtype";
-    public static final String RESPONSE_CACHE_ID = "hb_cache_id";
 
     // Settings
     public static final String language = Locale.getDefault().getLanguage();
@@ -102,13 +61,10 @@ public class Settings {
     public static String sdk_version = "0.1.0";
     public static String pkgVersion = "";
     public static String appName = "";
-    static int mnc = -1;
-    static int mcc = -1;
-    static String carrierName = null;
-    static String app_id = null;
-    static String domain = "";
-    static String storeUrl = "";
-    static int privacyPolicy = 0;
+    private static int mnc = -1;
+    private static int mcc = -1;
+    private static String carrierName = null;
+
 
     public static synchronized void update(final Context context) {
         if (userAgent == null) {
@@ -176,36 +132,5 @@ public class Settings {
         Settings.carrierName = carrierName;
     }
 
-    public static synchronized String getAppID() {
-        return app_id;
-    }
-
-    public static synchronized void setAppID(String app_id) {
-        Settings.app_id = app_id;
-    }
-
-    public static synchronized void setDomain(String domain) {
-        Settings.domain = domain;
-    }
-
-    public static synchronized String getStoreUrl() {
-        return storeUrl;
-    }
-
-    public static synchronized void setPrivacyPolicy(int privacyPolicy) {
-        Settings.privacyPolicy = privacyPolicy;
-    }
-
-    public static synchronized int getPrivacyPolicy() {
-        return privacyPolicy;
-    }
-
-    public static synchronized void setStoreUrl(String storeUrl) {
-        Settings.storeUrl = storeUrl;
-    }
-
-    public static synchronized String getDomain() {
-        return domain;
-    }
 }
 

--- a/PrebidMobile/PrebidServerAdapter/src/test/java/org/prebid/mobile/prebidserver/PrebidServerAdapterTest.java
+++ b/PrebidMobile/PrebidServerAdapter/src/test/java/org/prebid/mobile/prebidserver/PrebidServerAdapterTest.java
@@ -38,7 +38,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         InterstitialAdUnit interstitialAdUnit = new InterstitialAdUnit("interstitial", "23456");
         adUnits.add(interstitialAdUnit);
         // Test with DFP settings
-        Prebid.setAdServer(Prebid.AdServer.DFP);
+        Prebid.init(activity, adUnits, "34567", Prebid.AdServer.DFP, Prebid.Host.APPNEXUS);
         JSONObject postData = adapter.getPostData(activity, adUnits);
         assertTrue(postData.has(Settings.REQUEST_DEVICE));
         assertTrue(postData.has(Settings.REQUEST_APP));
@@ -48,26 +48,23 @@ public class PrebidServerAdapterTest extends BaseSetup {
         assertTrue("'imp' array should have 2 objects", postData.getJSONArray("imp").length() == 2);
         assertTrue(postData.getJSONArray("imp").getJSONObject(0).get("id").equals("banner"));
         assertTrue(postData.getJSONArray("imp").getJSONObject(0).has("ext"));
-        assertTrue(postData.getJSONArray("imp").getJSONObject(0).has("secure"));
-        // todo add test back after stored request is added in production
-//        assertTrue(postData.getJSONArray("imp").getJSONObject(0).getJSONObject("ext").has("prebid"));
-//        assertTrue(postData.getJSONArray("imp").getJSONObject(0).getJSONObject("ext").getJSONObject("prebid").has("storedrequest"));
-//        assertTrue(postData.getJSONArray("imp").getJSONObject(0).getJSONObject("ext").getJSONObject("prebid").getJSONObject("storedrequest").get("id").equals("12345"));
+        assertTrue(postData.getJSONArray("imp").getJSONObject(1).has("secure"));
+        assertTrue(postData.getJSONArray("imp").getJSONObject(0).getJSONObject("ext").has("prebid"));
+        assertTrue(postData.getJSONArray("imp").getJSONObject(0).getJSONObject("ext").getJSONObject("prebid").has("storedrequest"));
+        assertTrue(postData.getJSONArray("imp").getJSONObject(0).getJSONObject("ext").getJSONObject("prebid").getJSONObject("storedrequest").get("id").equals("12345"));
         assertTrue(postData.getJSONArray("imp").getJSONObject(1).get("id").equals("interstitial"));
         assertTrue(postData.getJSONArray("imp").getJSONObject(1).has("ext"));
         assertTrue(postData.getJSONArray("imp").getJSONObject(1).has("secure"));
-        // todo add test back after stored request is added in production
-//        assertTrue(postData.getJSONArray("imp").getJSONObject(1).getJSONObject("ext").has("prebid"));
-//        assertTrue(postData.getJSONArray("imp").getJSONObject(1).getJSONObject("ext").getJSONObject("prebid").has("storedrequest"));
-//        assertTrue(postData.getJSONArray("imp").getJSONObject(1).getJSONObject("ext").getJSONObject("prebid").getJSONObject("storedrequest").get("id").equals("23456"));
+        assertTrue(postData.getJSONArray("imp").getJSONObject(1).has("instl"));
+        assertTrue(postData.getJSONArray("imp").getJSONObject(1).getJSONObject("ext").has("prebid"));
+        assertTrue(postData.getJSONArray("imp").getJSONObject(1).getJSONObject("ext").getJSONObject("prebid").has("storedrequest"));
+        assertTrue(postData.getJSONArray("imp").getJSONObject(1).getJSONObject("ext").getJSONObject("prebid").getJSONObject("storedrequest").get("id").equals("23456"));
         assertTrue(postData.has("ext"));
         assertTrue(postData.getJSONObject("ext").has("prebid"));
-        assertTrue(postData.getJSONObject("ext").getJSONObject("prebid").has("targeting"));
-        assertTrue(postData.getJSONObject("ext").getJSONObject("prebid").getJSONObject("targeting").getString("pricegranularity").equals("medium"));
-        assertTrue(postData.getJSONObject("ext").getJSONObject("prebid").getJSONObject("targeting").getInt("lengthmax") == Settings.REQUEST_KEY_LENGTH_MAX);
-//        assertTrue(postData.getJSONObject("ext").getJSONObject("prebid").has("cache"));
+        assertTrue(postData.getJSONObject("ext").getJSONObject("prebid").has("storedrequest"));
+        assertTrue(postData.getJSONObject("ext").getJSONObject("prebid").getJSONObject("storedrequest").getString("id").equals(Prebid.getAccountId()));
         // Test with MoPub settings
-        Prebid.setAdServer(Prebid.AdServer.MOPUB);
+        Prebid.init(activity, adUnits, "12345", Prebid.AdServer.MOPUB, Prebid.Host.APPNEXUS);
         Prebid.shouldLoadOverSecureConnection(false);
         postData = adapter.getPostData(activity, adUnits);
         assertTrue(postData.has(Settings.REQUEST_DEVICE));
@@ -79,22 +76,19 @@ public class PrebidServerAdapterTest extends BaseSetup {
         assertTrue(postData.getJSONArray("imp").getJSONObject(0).get("id").equals("banner"));
         assertTrue(postData.getJSONArray("imp").getJSONObject(0).has("ext"));
         assertTrue(!postData.getJSONArray("imp").getJSONObject(0).has("secure"));
-        // todo add test back after stored request is added in production
-//        assertTrue(postData.getJSONArray("imp").getJSONObject(0).getJSONObject("ext").has("prebid"));
-//        assertTrue(postData.getJSONArray("imp").getJSONObject(0).getJSONObject("ext").getJSONObject("prebid").has("storedrequest"));
-//        assertTrue(postData.getJSONArray("imp").getJSONObject(0).getJSONObject("ext").getJSONObject("prebid").getJSONObject("storedrequest").get("id").equals("12345"));
+        assertTrue(postData.getJSONArray("imp").getJSONObject(0).getJSONObject("ext").has("prebid"));
+        assertTrue(postData.getJSONArray("imp").getJSONObject(0).getJSONObject("ext").getJSONObject("prebid").has("storedrequest"));
+        assertTrue(postData.getJSONArray("imp").getJSONObject(0).getJSONObject("ext").getJSONObject("prebid").getJSONObject("storedrequest").get("id").equals("12345"));
         assertTrue(postData.getJSONArray("imp").getJSONObject(1).get("id").equals("interstitial"));
         assertTrue(postData.getJSONArray("imp").getJSONObject(1).has("ext"));
         assertTrue(!postData.getJSONArray("imp").getJSONObject(1).has("secure"));
-        // todo add test back after stored request is added in production
-//        assertTrue(postData.getJSONArray("imp").getJSONObject(1).getJSONObject("ext").has("prebid"));
-//        assertTrue(postData.getJSONArray("imp").getJSONObject(1).getJSONObject("ext").getJSONObject("prebid").has("storedrequest"));
-//        assertTrue(postData.getJSONArray("imp").getJSONObject(1).getJSONObject("ext").getJSONObject("prebid").getJSONObject("storedrequest").get("id").equals("23456"));
+        assertTrue(postData.getJSONArray("imp").getJSONObject(1).getJSONObject("ext").has("prebid"));
+        assertTrue(postData.getJSONArray("imp").getJSONObject(1).getJSONObject("ext").getJSONObject("prebid").has("storedrequest"));
+        assertTrue(postData.getJSONArray("imp").getJSONObject(1).getJSONObject("ext").getJSONObject("prebid").getJSONObject("storedrequest").get("id").equals("23456"));
         assertTrue(postData.has("ext"));
         assertTrue(postData.getJSONObject("ext").has("prebid"));
-        assertTrue(postData.getJSONObject("ext").getJSONObject("prebid").has("targeting"));
-        assertTrue(postData.getJSONObject("ext").getJSONObject("prebid").getJSONObject("targeting").getString("pricegranularity").equals("medium"));
-        assertTrue(postData.getJSONObject("ext").getJSONObject("prebid").getJSONObject("targeting").getInt("lengthmax") == Settings.REQUEST_KEY_LENGTH_MAX);
+        assertTrue(postData.getJSONObject("ext").getJSONObject("prebid").has("storedrequest"));
+        assertTrue(postData.getJSONObject("ext").getJSONObject("prebid").getJSONObject("storedrequest").getString("id").equals(Prebid.getAccountId()));
         assertTrue(postData.getJSONObject("ext").getJSONObject("prebid").has("cache"));
         assertTrue(postData.getJSONObject("ext").getJSONObject("prebid").getJSONObject("cache").has("bids"));
         assertTrue(postData.getJSONObject("ext").getJSONObject("prebid").getJSONObject("cache").getJSONObject("bids").length() == 0);

--- a/PrebidMobile/PrebidServerAdapter/src/test/java/org/prebid/mobile/prebidserver/PrebidServerAdapterTest.java
+++ b/PrebidMobile/PrebidServerAdapter/src/test/java/org/prebid/mobile/prebidserver/PrebidServerAdapterTest.java
@@ -1,12 +1,19 @@
 package org.prebid.mobile.prebidserver;
 
 
+import android.util.Pair;
+
 import org.json.JSONObject;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.prebid.mobile.core.AdUnit;
 import org.prebid.mobile.core.BannerAdUnit;
+import org.prebid.mobile.core.BidManager;
+import org.prebid.mobile.core.BidResponse;
+import org.prebid.mobile.core.CacheManager;
+import org.prebid.mobile.core.ErrorCode;
 import org.prebid.mobile.core.InterstitialAdUnit;
+import org.prebid.mobile.core.Prebid;
 import org.prebid.mobile.prebidserver.internal.Settings;
 import org.prebid.mobile.unittestutils.BaseSetup;
 import org.robolectric.RobolectricTestRunner;
@@ -22,7 +29,7 @@ import static org.junit.Assert.assertTrue;
 public class PrebidServerAdapterTest extends BaseSetup {
 
     @Test
-    public void testPostDataGeneration() {
+    public void testPostDataGeneration() throws Exception {
         PrebidServerAdapter adapter = new PrebidServerAdapter();
         ArrayList<AdUnit> adUnits = new ArrayList<>();
         BannerAdUnit bannerAdUnit = new BannerAdUnit("banner", "12345");
@@ -30,14 +37,148 @@ public class PrebidServerAdapterTest extends BaseSetup {
         adUnits.add(bannerAdUnit);
         InterstitialAdUnit interstitialAdUnit = new InterstitialAdUnit("interstitial", "23456");
         adUnits.add(interstitialAdUnit);
+        // Test with DFP settings
+        Prebid.setAdServer(Prebid.AdServer.DFP);
         JSONObject postData = adapter.getPostData(activity, adUnits);
-        assertTrue(postData.has(Settings.REQUEST_CACHE_MARKUP));
-        assertTrue(postData.has(Settings.REQUEST_SORT_BIDS));
-        assertTrue(postData.has(Settings.REQUEST_TID));
-        assertTrue(postData.has(Settings.REQUEST_AD_UNITS));
         assertTrue(postData.has(Settings.REQUEST_DEVICE));
         assertTrue(postData.has(Settings.REQUEST_APP));
         assertTrue(postData.has(Settings.REQUEST_USER));
+        assertTrue("request data is missing 'id' field", postData.has("id"));
+        assertTrue("request data is missing 'imp' field", postData.has("imp"));
+        assertTrue("'imp' array should have 2 objects", postData.getJSONArray("imp").length() == 2);
+        assertTrue(postData.getJSONArray("imp").getJSONObject(0).get("id").equals("banner"));
+        assertTrue(postData.getJSONArray("imp").getJSONObject(0).has("ext"));
+        assertTrue(postData.getJSONArray("imp").getJSONObject(0).has("secure"));
+        // todo add test back after stored request is added in production
+//        assertTrue(postData.getJSONArray("imp").getJSONObject(0).getJSONObject("ext").has("prebid"));
+//        assertTrue(postData.getJSONArray("imp").getJSONObject(0).getJSONObject("ext").getJSONObject("prebid").has("storedrequest"));
+//        assertTrue(postData.getJSONArray("imp").getJSONObject(0).getJSONObject("ext").getJSONObject("prebid").getJSONObject("storedrequest").get("id").equals("12345"));
+        assertTrue(postData.getJSONArray("imp").getJSONObject(1).get("id").equals("interstitial"));
+        assertTrue(postData.getJSONArray("imp").getJSONObject(1).has("ext"));
+        assertTrue(postData.getJSONArray("imp").getJSONObject(1).has("secure"));
+        // todo add test back after stored request is added in production
+//        assertTrue(postData.getJSONArray("imp").getJSONObject(1).getJSONObject("ext").has("prebid"));
+//        assertTrue(postData.getJSONArray("imp").getJSONObject(1).getJSONObject("ext").getJSONObject("prebid").has("storedrequest"));
+//        assertTrue(postData.getJSONArray("imp").getJSONObject(1).getJSONObject("ext").getJSONObject("prebid").getJSONObject("storedrequest").get("id").equals("23456"));
+        assertTrue(postData.has("ext"));
+        assertTrue(postData.getJSONObject("ext").has("prebid"));
+        assertTrue(postData.getJSONObject("ext").getJSONObject("prebid").has("targeting"));
+        assertTrue(postData.getJSONObject("ext").getJSONObject("prebid").getJSONObject("targeting").getString("pricegranularity").equals("medium"));
+        assertTrue(postData.getJSONObject("ext").getJSONObject("prebid").getJSONObject("targeting").getInt("lengthmax") == Settings.REQUEST_KEY_LENGTH_MAX);
+//        assertTrue(postData.getJSONObject("ext").getJSONObject("prebid").has("cache"));
+        // Test with MoPub settings
+        Prebid.setAdServer(Prebid.AdServer.MOPUB);
+        Prebid.shouldLoadOverSecureConnection(false);
+        postData = adapter.getPostData(activity, adUnits);
+        assertTrue(postData.has(Settings.REQUEST_DEVICE));
+        assertTrue(postData.has(Settings.REQUEST_APP));
+        assertTrue(postData.has(Settings.REQUEST_USER));
+        assertTrue("request data is missing 'id' field", postData.has("id"));
+        assertTrue("request data is missing 'imp' field", postData.has("imp"));
+        assertTrue("'imp' array should have 2 objects", postData.getJSONArray("imp").length() == 2);
+        assertTrue(postData.getJSONArray("imp").getJSONObject(0).get("id").equals("banner"));
+        assertTrue(postData.getJSONArray("imp").getJSONObject(0).has("ext"));
+        assertTrue(!postData.getJSONArray("imp").getJSONObject(0).has("secure"));
+        // todo add test back after stored request is added in production
+//        assertTrue(postData.getJSONArray("imp").getJSONObject(0).getJSONObject("ext").has("prebid"));
+//        assertTrue(postData.getJSONArray("imp").getJSONObject(0).getJSONObject("ext").getJSONObject("prebid").has("storedrequest"));
+//        assertTrue(postData.getJSONArray("imp").getJSONObject(0).getJSONObject("ext").getJSONObject("prebid").getJSONObject("storedrequest").get("id").equals("12345"));
+        assertTrue(postData.getJSONArray("imp").getJSONObject(1).get("id").equals("interstitial"));
+        assertTrue(postData.getJSONArray("imp").getJSONObject(1).has("ext"));
+        assertTrue(!postData.getJSONArray("imp").getJSONObject(1).has("secure"));
+        // todo add test back after stored request is added in production
+//        assertTrue(postData.getJSONArray("imp").getJSONObject(1).getJSONObject("ext").has("prebid"));
+//        assertTrue(postData.getJSONArray("imp").getJSONObject(1).getJSONObject("ext").getJSONObject("prebid").has("storedrequest"));
+//        assertTrue(postData.getJSONArray("imp").getJSONObject(1).getJSONObject("ext").getJSONObject("prebid").getJSONObject("storedrequest").get("id").equals("23456"));
+        assertTrue(postData.has("ext"));
+        assertTrue(postData.getJSONObject("ext").has("prebid"));
+        assertTrue(postData.getJSONObject("ext").getJSONObject("prebid").has("targeting"));
+        assertTrue(postData.getJSONObject("ext").getJSONObject("prebid").getJSONObject("targeting").getString("pricegranularity").equals("medium"));
+        assertTrue(postData.getJSONObject("ext").getJSONObject("prebid").getJSONObject("targeting").getInt("lengthmax") == Settings.REQUEST_KEY_LENGTH_MAX);
+        assertTrue(postData.getJSONObject("ext").getJSONObject("prebid").has("cache"));
+        assertTrue(postData.getJSONObject("ext").getJSONObject("prebid").getJSONObject("cache").has("bids"));
+        assertTrue(postData.getJSONObject("ext").getJSONObject("prebid").getJSONObject("cache").getJSONObject("bids").length() == 0);
+
+
+    }
+
+    @Test
+    public void testResponseProcessingForMoPub() throws Exception {
+        Prebid.setAdServer(Prebid.AdServer.MOPUB);
+        // cached bid response
+        String serverResponse = "{\"id\":\"c7043990-2ac9-4ee5-a3d5-f3c032edeb4f\",\"seatbid\":[{\"bid\":[{\"id\":\"6051533834469542107\",\"impid\":\"Banner_300x250\",\"price\":0.5,\"adm\":\"<script type=\\\"application/javascript\\\" src=\\\"https://nym1-ib.adnxs.com/ab?e=wqT_3QLsB6DsAwAAAwDWAAUBCKHJmdMFEKCGu4213fG-KRi2sNeng8GDl0AqNgkAAAECCOA_EQEHNAAA4D8ZAAAAgOtR4D8hERIAKREJADERG6Aw8ub8BDi-B0C-B0gCUNbLkw5Y4YBIYABokUB4y9EEgAEBigEDVVNEkgUG8FKYAawCoAH6AagBAbABALgBAsABA8gBAtABAtgBAOABAPABAIoCOnVmKCdhJywgNDk0NDcyLCAxNTE2NjU5ODczKTt1ZigncicsIDI5NjgxMTEwLDIeAPCQkgL9ASFvamFvMHdpNjBJY0VFTmJMa3c0WUFDRGhnRWd3QURnQVFBUkl2Z2RROHViOEJGZ0FZTllCYUFCd0pIakdod0dBQVNTSUFjYUhBWkFCQVpnQkFhQUJBYWdCQTdBQkFMa0JLWXVJZ3dBQTREX0JBU21MaUlNQUFPQV95UUZUSEs5RHZNdnhQOWtCQUFBQQEDJDhEX2dBUUQxQVEBDixDWUFnQ2dBZ0MxQWcFEAA5CQjwUERBQWdESUFnRGdBZ0RvQWdENEFnQ0FBd1NRQXdDWUF3R29BN3JRaHdTNkF4RmtaV1poZFd4MEkwNVpUVEk2TXpnek1BLi6aAjkhX2d0c19naTIAAfBMNFlCSUlBUW9BRG9SWkdWbVlYVnNkQ05PV1UweU9qTTRNekEu0gJ2NzcxODkxNSw3ODY5OTM5LDc4OTQzNTEsMTgyMjk1LDIzMzg2OTkFCAg3MDAJCAAyCQgIODAzBRAIODA3BQgEOTQJEAg5NDQJEAA1CSgIOTUyCRAJUGg5MDAz2ALoB-ACx9MB8gIQCgZBRFZfSUQSBjQl_hzyAhEKBkNQRwETHAcxOTc3OTMzAScIBUNQBRPwtzg1MTM1OTSAAwGIAwGQAwCYAxSgAwGqAwDAA6wCyAMA2AMA4AMA6AMC-AMAgAQAkgQJL29wZW5ydGIymAQAogQPMjA3LjIzNy4xNTAuMjQ2qASetA-yBAwIABAAGAAgADAAOAC4BADABADIBADSBBFkZWZhdWx0I05ZTTI6MzgzMNoEAggB4AQA8ATWy5MOggUZb3JnLnByZWJpZC5tb2JpbGUuZGVtb2FwcIgFAZgFAKAF______8BA7ABqgUkYzcwNDM5OTAtMmFjOS00ZWU1LWEzZDUtZjNjMDMyZWRlYjRmwAUAyQVpehTwP9IFCQkJDFAAANgFAeAFAfAFAfoFBAgAEACQBgA.&s=66498e1c32a2420c27f1e24d1d279a9577bdbcde&pp=${AUCTION_PRICE}&\\\"></script>\",\"adid\":\"29681110\",\"adomain\":[\"appnexus.com\"],\"iurl\":\"https://nym1-ib.adnxs.com/cr?id=29681110\",\"cid\":\"958\",\"crid\":\"29681110\",\"w\":300,\"h\":250,\"ext\":{\"prebid\":{\"targeting\":{\"hb_bidder\":\"appnexus\",\"hb_bidder_appnexus\":\"appnexus\",\"hb_cache_id\":\"8d472803-909b-40d9-8dc9-916433c810f0\",\"hb_cache_id_appnexus\":\"8d472803-909b-40d9-8dc9-916433c810f0\",\"hb_creative_loadtype\":\"html\",\"hb_pb\":\"0.50\",\"hb_pb_appnexus\":\"0.50\",\"hb_size\":\"300x250\",\"hb_size_appnexus\":\"300x250\"},\"type\":\"banner\"},\"bidder\":{\"appnexus\":{\"brand_id\":1,\"auction_id\":2989764441633899500,\"bidder_id\":2}}}}],\"seat\":\"appnexus\"}],\"ext\":{\"responsetimemillis\":{\"appnexus\":38}}}";
+        JSONObject serverResponseJson = new JSONObject(serverResponse);
+        PrebidServerAdapter adapter = new PrebidServerAdapter();
+        ArrayList<AdUnit> units = new ArrayList<>();
+        final BannerAdUnit bannerAdUnit = new BannerAdUnit("Banner_300x250", "12345");
+        bannerAdUnit.addSize(300, 250);
+        units.add(bannerAdUnit);
+        BidManager.BidResponseListener listener = new BidManager.BidResponseListener() {
+            @Override
+            public void onBidSuccess(AdUnit bidRequest, ArrayList<BidResponse> bidResponses) {
+                assertTrue(bidRequest.equals(bannerAdUnit));
+                assertTrue(bidResponses.size() == 1);
+                assertTrue(bidResponses.get(0).getCreative().equals("8d472803-909b-40d9-8dc9-916433c810f0"));
+                assertTrue(bidResponses.get(0).getCpm() == 0.50);
+                assertTrue(bidResponses.get(0).getCustomKeywords().size() == 9);
+                assertTrue(bidResponses.get(0).getCustomKeywords().contains(new Pair<String, String>("hb_bidder", "appnexus")));
+                assertTrue(bidResponses.get(0).getCustomKeywords().contains(new Pair<String, String>("hb_bidder_appnexus", "appnexus")));
+                assertTrue(bidResponses.get(0).getCustomKeywords().contains(new Pair<String, String>("hb_cache_id", "8d472803-909b-40d9-8dc9-916433c810f0")));
+                assertTrue(bidResponses.get(0).getCustomKeywords().contains(new Pair<String, String>("hb_cache_id_appnexus", "8d472803-909b-40d9-8dc9-916433c810f0")));
+                assertTrue(bidResponses.get(0).getCustomKeywords().contains(new Pair<String, String>("hb_creative_loadtype", "html")));
+                assertTrue(bidResponses.get(0).getCustomKeywords().contains(new Pair<String, String>("hb_pb", "0.50")));
+                assertTrue(bidResponses.get(0).getCustomKeywords().contains(new Pair<String, String>("hb_pb_appnexus", "0.50")));
+                assertTrue(bidResponses.get(0).getCustomKeywords().contains(new Pair<String, String>("hb_size", "300x250")));
+                assertTrue(bidResponses.get(0).getCustomKeywords().contains(new Pair<String, String>("hb_size_appnexus", "300x250")));
+            }
+
+            @Override
+            public void onBidFailure(AdUnit bidRequest, ErrorCode reason) {
+
+            }
+        };
+        adapter.requestBid(activity, listener, units);
+        adapter.onServerResponded(serverResponseJson);
+    }
+
+    @Test
+    public void testResponseProcessingForDFP() throws Exception {
+        // cached bid response
+        Prebid.setAdServer(Prebid.AdServer.DFP);
+        CacheManager.init(activity);
+        String serverResponse = "{\"id\":\"c7043990-2ac9-4ee5-a3d5-f3c032edeb4f\",\"seatbid\":[{\"bid\":[{\"id\":\"783432982278071921\",\"impid\":\"Banner_300x250\",\"price\":0.5,\"adm\":\"<script type=\\\"application/javascript\\\" src=\\\"https://nym1-ib.adnxs.com/ab?e=wqT_3QLrB6DrAwAAAwDWAAUBCMmnndMFELjCi9vSqcHVPhi2sNeng8GDl0AqNgkAAAECCOA_EQEHNAAA4D8ZAAAAgOtR4D8hERIAKREJADERG6Aw8ub8BDi-B0C-B0gCUNbLkw5Y4YBIYABokUB48c8EgAEBigEDVVNEkgUG8FKYAawCoAH6AagBAbABALgBAsABA8gBAtABAtgBAOABAPABAIoCOnVmKCdhJywgNDk0NDcyLCAxNTE2NzIxMDk3KTt1ZigncicsIDI5NjgxMTEwLDIeAPCQkgL9ASFxelVwZ1FpNjBJY0VFTmJMa3c0WUFDRGhnRWd3QURnQVFBUkl2Z2RROHViOEJGZ0FZTllCYUFCd0pIakFsd0dBQVNTSUFjQ1hBWkFCQVpnQkFhQUJBYWdCQTdBQkFMa0JLWXVJZ3dBQTREX0JBU21MaUlNQUFPQV95UUhXQWhrSXdDZndQOWtCQUFBQQEDJDhEX2dBUUQxQVEBDixDWUFnQ2dBZ0MxQWcFEAA5CQjwUERBQWdESUFnRGdBZ0RvQWdENEFnQ0FBd1NRQXdDWUF3R29BN3JRaHdTNkF4RmtaV1poZFd4MEkwNVpUVEk2TXpnd01RLi6aAjkhX0F0bl9naTIAAfA-NFlCSUlBUW9BRG9SWkdWbVlYVnNkQ05PV1UweU9qTTRNREUu0gJ1MTAwMTIzODQsMTQ2NzE1NywxNzUwNjEzDQh0NCwyMTQ0MjUyLDI1MjA5NywxMDYwMDUsMTQyMzUxAQjwYzM5MTIzLDIxMTcyMjgsNzcxODkxNSw3ODY5OTM5LDc4OTQzNTEsMTgyMjk1LDIzMzg2OTnYAugH4ALH0wHyAhAKBkFEVl9JRBIGNDk0NDcy8gIRCgZDUEdfSUQSBzE5Nzc5MzMBJwgFQ1ABJvC3Bzg1MTM1OTSAAwGIAwGQAwCYAxSgAwGqAwDAA6wCyAMA2AMA4AMA6AMC-AMAgAQAkgQJL29wZW5ydGIymAQAogQPMjA3LjIzNy4xNTAuMjQ2qASavA-yBAwIABAAGAAgADAAOAC4BADABADIBADSBBFkZWZhdWx0I05ZTTI6MzgwMdoEAggB4AQA8ATWy5MOggUZb3JnLnByZWJpZC5tb2JpbGUuZGVtb2FwcIgFAZgFAKAF_____wUDsAGqBSRjNzA0Mzk5MC0yYWM5LTRlZTUtYTNkNS1mM2MwMzJlZGViNGbABQDJBWl5FPA_0gUJCQkMUAAA2AUB4AUB8AUB-gUECAAQAJAGAA..&s=600eb78580716409e28a1a448675a3655a79ca3f&pp=${AUCTION_PRICE}\\\"></script>\",\"adid\":\"29681110\",\"adomain\":[\"appnexus.com\"],\"iurl\":\"https://nym1-ib.adnxs.com/cr?id=29681110\",\"cid\":\"958\",\"crid\":\"29681110\",\"w\":300,\"h\":250,\"ext\":{\"prebid\":{\"targeting\":{\"hb_bidder\":\"appnexus\",\"hb_bidder_appnexus\":\"appnexus\",\"hb_creative_loadtype\":\"html\",\"hb_pb\":\"0.50\",\"hb_pb_appnexus\":\"0.50\",\"hb_size\":\"300x250\",\"hb_size_appnexus\":\"300x250\"},\"type\":\"banner\"},\"bidder\":{\"appnexus\":{\"brand_id\":1,\"auction_id\":4515708880367575600,\"bidder_id\":2}}}}],\"seat\":\"appnexus\"}],\"ext\":{\"responsetimemillis\":{\"appnexus\":36}}}";
+        JSONObject serverResponseJson = new JSONObject(serverResponse);
+        PrebidServerAdapter adapter = new PrebidServerAdapter();
+        ArrayList<AdUnit> units = new ArrayList<>();
+        final BannerAdUnit bannerAdUnit = new BannerAdUnit("Banner_300x250", "12345");
+        bannerAdUnit.addSize(300, 250);
+        units.add(bannerAdUnit);
+        BidManager.BidResponseListener listener = new BidManager.BidResponseListener() {
+            @Override
+            public void onBidSuccess(AdUnit bidRequest, ArrayList<BidResponse> bidResponses) {
+                assertTrue(bidRequest.equals(bannerAdUnit));
+                assertTrue(bidResponses.size() == 1);
+                assertTrue(bidResponses.get(0).getCreative().startsWith("Prebid_"));
+                String creativeId = bidResponses.get(0).getCreative();
+                assertTrue(bidResponses.get(0).getCpm() == 0.50);
+                assertTrue(bidResponses.get(0).getCustomKeywords().size() == 8);
+                assertTrue(bidResponses.get(0).getCustomKeywords().contains(new Pair<String, String>("hb_bidder", "appnexus")));
+                assertTrue(bidResponses.get(0).getCustomKeywords().contains(new Pair<String, String>("hb_bidder_appnexus", "appnexus")));
+                assertTrue(bidResponses.get(0).getCustomKeywords().contains(new Pair<String, String>("hb_cache_id_appnexus", creativeId)));
+                assertTrue(bidResponses.get(0).getCustomKeywords().contains(new Pair<String, String>("hb_creative_loadtype", "html")));
+                assertTrue(bidResponses.get(0).getCustomKeywords().contains(new Pair<String, String>("hb_pb", "0.50")));
+                assertTrue(bidResponses.get(0).getCustomKeywords().contains(new Pair<String, String>("hb_pb_appnexus", "0.50")));
+                assertTrue(bidResponses.get(0).getCustomKeywords().contains(new Pair<String, String>("hb_size", "300x250")));
+                assertTrue(bidResponses.get(0).getCustomKeywords().contains(new Pair<String, String>("hb_size_appnexus", "300x250")));
+            }
+
+            @Override
+            public void onBidFailure(AdUnit bidRequest, ErrorCode reason) {
+
+            }
+        };
+        adapter.requestBid(activity, listener, units);
+        adapter.onServerResponded(serverResponseJson);
     }
 
     @Test

--- a/PrebidMobile/PrebidServerAdapter/src/test/java/org/prebid/mobile/prebidserver/PrebidServerAdapterTest.java
+++ b/PrebidMobile/PrebidServerAdapter/src/test/java/org/prebid/mobile/prebidserver/PrebidServerAdapterTest.java
@@ -19,6 +19,7 @@ import org.prebid.mobile.unittestutils.BaseSetup;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
+import java.lang.reflect.Field;
 import java.util.ArrayList;
 
 import static org.junit.Assert.assertEquals;
@@ -62,6 +63,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         assertTrue(postData.has("ext"));
         assertTrue(postData.getJSONObject("ext").has("prebid"));
         assertTrue(postData.getJSONObject("ext").getJSONObject("prebid").has("storedrequest"));
+        assertTrue(!postData.getJSONObject("ext").getJSONObject("prebid").has("cache"));
         assertTrue(postData.getJSONObject("ext").getJSONObject("prebid").getJSONObject("storedrequest").getString("id").equals(Prebid.getAccountId()));
         // Test with MoPub settings
         Prebid.init(activity, adUnits, "12345", Prebid.AdServer.MOPUB, Prebid.Host.APPNEXUS);
@@ -96,9 +98,19 @@ public class PrebidServerAdapterTest extends BaseSetup {
 
     }
 
+    private void setAdServer(Prebid.AdServer adServer) {
+        try {
+            Field adServerField = Prebid.class.getDeclaredField("adServer");
+            adServerField.setAccessible(true);
+            adServerField.set(null, adServer);
+        } catch (NoSuchFieldException e) {
+        } catch (IllegalAccessException e) {
+        }
+    }
+
     @Test
     public void testResponseProcessingForMoPub() throws Exception {
-        Prebid.setAdServer(Prebid.AdServer.MOPUB);
+        setAdServer(Prebid.AdServer.MOPUB);
         // cached bid response
         String serverResponse = "{\"id\":\"c7043990-2ac9-4ee5-a3d5-f3c032edeb4f\",\"seatbid\":[{\"bid\":[{\"id\":\"6051533834469542107\",\"impid\":\"Banner_300x250\",\"price\":0.5,\"adm\":\"<script type=\\\"application/javascript\\\" src=\\\"https://nym1-ib.adnxs.com/ab?e=wqT_3QLsB6DsAwAAAwDWAAUBCKHJmdMFEKCGu4213fG-KRi2sNeng8GDl0AqNgkAAAECCOA_EQEHNAAA4D8ZAAAAgOtR4D8hERIAKREJADERG6Aw8ub8BDi-B0C-B0gCUNbLkw5Y4YBIYABokUB4y9EEgAEBigEDVVNEkgUG8FKYAawCoAH6AagBAbABALgBAsABA8gBAtABAtgBAOABAPABAIoCOnVmKCdhJywgNDk0NDcyLCAxNTE2NjU5ODczKTt1ZigncicsIDI5NjgxMTEwLDIeAPCQkgL9ASFvamFvMHdpNjBJY0VFTmJMa3c0WUFDRGhnRWd3QURnQVFBUkl2Z2RROHViOEJGZ0FZTllCYUFCd0pIakdod0dBQVNTSUFjYUhBWkFCQVpnQkFhQUJBYWdCQTdBQkFMa0JLWXVJZ3dBQTREX0JBU21MaUlNQUFPQV95UUZUSEs5RHZNdnhQOWtCQUFBQQEDJDhEX2dBUUQxQVEBDixDWUFnQ2dBZ0MxQWcFEAA5CQjwUERBQWdESUFnRGdBZ0RvQWdENEFnQ0FBd1NRQXdDWUF3R29BN3JRaHdTNkF4RmtaV1poZFd4MEkwNVpUVEk2TXpnek1BLi6aAjkhX2d0c19naTIAAfBMNFlCSUlBUW9BRG9SWkdWbVlYVnNkQ05PV1UweU9qTTRNekEu0gJ2NzcxODkxNSw3ODY5OTM5LDc4OTQzNTEsMTgyMjk1LDIzMzg2OTkFCAg3MDAJCAAyCQgIODAzBRAIODA3BQgEOTQJEAg5NDQJEAA1CSgIOTUyCRAJUGg5MDAz2ALoB-ACx9MB8gIQCgZBRFZfSUQSBjQl_hzyAhEKBkNQRwETHAcxOTc3OTMzAScIBUNQBRPwtzg1MTM1OTSAAwGIAwGQAwCYAxSgAwGqAwDAA6wCyAMA2AMA4AMA6AMC-AMAgAQAkgQJL29wZW5ydGIymAQAogQPMjA3LjIzNy4xNTAuMjQ2qASetA-yBAwIABAAGAAgADAAOAC4BADABADIBADSBBFkZWZhdWx0I05ZTTI6MzgzMNoEAggB4AQA8ATWy5MOggUZb3JnLnByZWJpZC5tb2JpbGUuZGVtb2FwcIgFAZgFAKAF______8BA7ABqgUkYzcwNDM5OTAtMmFjOS00ZWU1LWEzZDUtZjNjMDMyZWRlYjRmwAUAyQVpehTwP9IFCQkJDFAAANgFAeAFAfAFAfoFBAgAEACQBgA.&s=66498e1c32a2420c27f1e24d1d279a9577bdbcde&pp=${AUCTION_PRICE}&\\\"></script>\",\"adid\":\"29681110\",\"adomain\":[\"appnexus.com\"],\"iurl\":\"https://nym1-ib.adnxs.com/cr?id=29681110\",\"cid\":\"958\",\"crid\":\"29681110\",\"w\":300,\"h\":250,\"ext\":{\"prebid\":{\"targeting\":{\"hb_bidder\":\"appnexus\",\"hb_bidder_appnexus\":\"appnexus\",\"hb_cache_id\":\"8d472803-909b-40d9-8dc9-916433c810f0\",\"hb_cache_id_appnexus\":\"8d472803-909b-40d9-8dc9-916433c810f0\",\"hb_creative_loadtype\":\"html\",\"hb_pb\":\"0.50\",\"hb_pb_appnexus\":\"0.50\",\"hb_size\":\"300x250\",\"hb_size_appnexus\":\"300x250\"},\"type\":\"banner\"},\"bidder\":{\"appnexus\":{\"brand_id\":1,\"auction_id\":2989764441633899500,\"bidder_id\":2}}}}],\"seat\":\"appnexus\"}],\"ext\":{\"responsetimemillis\":{\"appnexus\":38}}}";
         JSONObject serverResponseJson = new JSONObject(serverResponse);
@@ -138,7 +150,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
     @Test
     public void testResponseProcessingForDFP() throws Exception {
         // cached bid response
-        Prebid.setAdServer(Prebid.AdServer.DFP);
+        setAdServer(Prebid.AdServer.DFP);
         CacheManager.init(activity);
         String serverResponse = "{\"id\":\"c7043990-2ac9-4ee5-a3d5-f3c032edeb4f\",\"seatbid\":[{\"bid\":[{\"id\":\"783432982278071921\",\"impid\":\"Banner_300x250\",\"price\":0.5,\"adm\":\"<script type=\\\"application/javascript\\\" src=\\\"https://nym1-ib.adnxs.com/ab?e=wqT_3QLrB6DrAwAAAwDWAAUBCMmnndMFELjCi9vSqcHVPhi2sNeng8GDl0AqNgkAAAECCOA_EQEHNAAA4D8ZAAAAgOtR4D8hERIAKREJADERG6Aw8ub8BDi-B0C-B0gCUNbLkw5Y4YBIYABokUB48c8EgAEBigEDVVNEkgUG8FKYAawCoAH6AagBAbABALgBAsABA8gBAtABAtgBAOABAPABAIoCOnVmKCdhJywgNDk0NDcyLCAxNTE2NzIxMDk3KTt1ZigncicsIDI5NjgxMTEwLDIeAPCQkgL9ASFxelVwZ1FpNjBJY0VFTmJMa3c0WUFDRGhnRWd3QURnQVFBUkl2Z2RROHViOEJGZ0FZTllCYUFCd0pIakFsd0dBQVNTSUFjQ1hBWkFCQVpnQkFhQUJBYWdCQTdBQkFMa0JLWXVJZ3dBQTREX0JBU21MaUlNQUFPQV95UUhXQWhrSXdDZndQOWtCQUFBQQEDJDhEX2dBUUQxQVEBDixDWUFnQ2dBZ0MxQWcFEAA5CQjwUERBQWdESUFnRGdBZ0RvQWdENEFnQ0FBd1NRQXdDWUF3R29BN3JRaHdTNkF4RmtaV1poZFd4MEkwNVpUVEk2TXpnd01RLi6aAjkhX0F0bl9naTIAAfA-NFlCSUlBUW9BRG9SWkdWbVlYVnNkQ05PV1UweU9qTTRNREUu0gJ1MTAwMTIzODQsMTQ2NzE1NywxNzUwNjEzDQh0NCwyMTQ0MjUyLDI1MjA5NywxMDYwMDUsMTQyMzUxAQjwYzM5MTIzLDIxMTcyMjgsNzcxODkxNSw3ODY5OTM5LDc4OTQzNTEsMTgyMjk1LDIzMzg2OTnYAugH4ALH0wHyAhAKBkFEVl9JRBIGNDk0NDcy8gIRCgZDUEdfSUQSBzE5Nzc5MzMBJwgFQ1ABJvC3Bzg1MTM1OTSAAwGIAwGQAwCYAxSgAwGqAwDAA6wCyAMA2AMA4AMA6AMC-AMAgAQAkgQJL29wZW5ydGIymAQAogQPMjA3LjIzNy4xNTAuMjQ2qASavA-yBAwIABAAGAAgADAAOAC4BADABADIBADSBBFkZWZhdWx0I05ZTTI6MzgwMdoEAggB4AQA8ATWy5MOggUZb3JnLnByZWJpZC5tb2JpbGUuZGVtb2FwcIgFAZgFAKAF_____wUDsAGqBSRjNzA0Mzk5MC0yYWM5LTRlZTUtYTNkNS1mM2MwMzJlZGViNGbABQDJBWl5FPA_0gUJCQkMUAAA2AUB4AUB8AUB-gUECAAQAJAGAA..&s=600eb78580716409e28a1a448675a3655a79ca3f&pp=${AUCTION_PRICE}\\\"></script>\",\"adid\":\"29681110\",\"adomain\":[\"appnexus.com\"],\"iurl\":\"https://nym1-ib.adnxs.com/cr?id=29681110\",\"cid\":\"958\",\"crid\":\"29681110\",\"w\":300,\"h\":250,\"ext\":{\"prebid\":{\"targeting\":{\"hb_bidder\":\"appnexus\",\"hb_bidder_appnexus\":\"appnexus\",\"hb_creative_loadtype\":\"html\",\"hb_pb\":\"0.50\",\"hb_pb_appnexus\":\"0.50\",\"hb_size\":\"300x250\",\"hb_size_appnexus\":\"300x250\"},\"type\":\"banner\"},\"bidder\":{\"appnexus\":{\"brand_id\":1,\"auction_id\":4515708880367575600,\"bidder_id\":2}}}}],\"seat\":\"appnexus\"}],\"ext\":{\"responsetimemillis\":{\"appnexus\":36}}}";
         JSONObject serverResponseJson = new JSONObject(serverResponse);

--- a/PrebidMobile/UnitTestUtils/build.gradle
+++ b/PrebidMobile/UnitTestUtils/build.gradle
@@ -27,6 +27,7 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.pro'
         }
     }
+    buildToolsVersion '26.0.2'
 }
 
 dependencies {

--- a/PrebidMobile/build.gradle
+++ b/PrebidMobile/build.gradle
@@ -14,9 +14,11 @@ ext {
 buildscript {
     repositories {
         jcenter()
+        google()
     }
+
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.3.0'
+        classpath 'com.android.tools.build:gradle:3.0.1'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/PrebidMobile/build.gradle
+++ b/PrebidMobile/build.gradle
@@ -8,7 +8,7 @@ ext {
     minSDKVersion = 16
     targetSDKVersion = 25
     compileSdkVersion = 25
-    buildToolsVersion = "25.0.0"
+    buildToolsVersion = "26.0.2"
 }
 
 buildscript {

--- a/PrebidMobile/gradle/wrapper/gradle-wrapper.properties
+++ b/PrebidMobile/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Fri Mar 24 15:52:34 EDT 2017
+#Thu Jan 25 15:33:51 EST 2018
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-4.1-all.zip

--- a/testprebid.sh
+++ b/testprebid.sh
@@ -1,10 +1,26 @@
 #! /bin/bash
+function echoX {
+echo -e "PREBID TESTLOG: $@"
+}
+
+echoX "start unit tests"
 cd PrebidMobile
 ./gradlew clean test
 
+echoX "assemble debug apk"
 ./gradlew clean assembleDebug
-mkdir -p IntegrationTests/apk && cp DemoApp/build/outputs/apk/DemoApp-debug.apk IntegrationTests/apk/DemoApp.apk
+if [ ! -e DemoApp/build/outputs/apk/debug/DemoApp-debug.apk ];then
+	echoX "apk creation unsuccessful"
+fi
 
+
+echoX "copy debug apk to destination path"
+mkdir -p IntegrationTests/apk && cp DemoApp/build/outputs/apk/debug/DemoApp-debug.apk IntegrationTests/apk/DemoApp.apk
+if [ ! -e IntegrationTests/apk/DemoApp.apk ]; then
+	echoX "file copy unsuccessful"
+fi
+
+echoX "start integration tests"
 cd IntegrationTests
 bundle install
 


### PR DESCRIPTION
This PR includes changes that works with latest Prebid Server openrtb endpoint.

Note that this is tested only with local test server, haven't tested with https request (SSL creatives), and cache function for MoPub builds.

Actual endpoint switch will happen later when Prebid Server fully rolls out its open rtb endpoint. If we use endpoint from AppNexus in the prebid server adapter, we still anticipate the OPEN RTB protocol stays the same.

