### PR TITLE
Move to new devices for integration tests

### DIFF
--- a/PrebidMobile/IntegrationTests/features/step_definitions/calabash_steps.rb
+++ b/PrebidMobile/IntegrationTests/features/step_definitions/calabash_steps.rb
@@ -20,14 +20,14 @@ Then(/^I should see AppNexus creative in PublisherAdView number (\d+)$/) do |arg
 end
 
 Then(/^I should see AppNexus creative in HTMLBannerWebView$/) do
-    @query_results = query("HTMLBannerWebView css:'div'")
+    @query_results = query("HTMLBannerWebView css:'*'")
     contains_header_bidding_ad = false
     len = @query_results.length
     for counter in 0..len-1
-        contains_header_bidding_ad = contains_header_bidding_ad || @query_results[counter]['textContent'].include?("A Header Bidding Ad.")
+        contains_header_bidding_ad = contains_header_bidding_ad || @query_results[counter]['html'].include?("A Header Bidding Ad.")
     end
     unless contains_header_bidding_ad
-        raise "Prebid creative was not served"
+        raise "Prebid creative was not served, acutal content is : " + @query_results.to_s
     end
 end
 

--- a/testprebid.sh
+++ b/testprebid.sh
@@ -10,4 +10,5 @@ bundle install
 
 bundle exec calabash-android resign apk/DemoApp.apk
 bundle exec calabash-android build apk/DemoApp.apk
-bundle exec test-cloud submit apk/DemoApp.apk 435c130f3f6ff5256d19a790c21dd653 --devices 2ae0b5a0 --series "master" --locale "en_US" --app-name "DemoApp" --user nhedley@appnexus.com
+#bundle exec test-cloud submit apk/DemoApp.apk 435c130f3f6ff5256d19a790c21dd653 --devices 2ae0b5a0 --series "master" --locale "en_US" --app-name "DemoApp" --user nhedley@appnexus.com
+bundle exec test-cloud submit apk/DemoApp.apk 435c130f3f6ff5256d19a790c21dd653 --devices b2a05af9 --series "master" --locale "en_US" --app-name "DemoApp" --user wzhang@appnexus.com


### PR DESCRIPTION
The old device of the tests were not rendering the ad properly, updating to two new devices and modified the tests to be more robust.