### PR TITLE
CacheManager no longer leaks Contexts and refactors

### DIFF
--- a/PrebidMobile/PrebidMobileCore/src/main/java/org/prebid/mobile/core/CacheManager.java
+++ b/PrebidMobile/PrebidMobileCore/src/main/java/org/prebid/mobile/core/CacheManager.java
@@ -159,12 +159,16 @@ public class CacheManager {
                 return;
             }
 
-            cacheManager.dfpWebCache = new WebView(context);
-            WebSettings webSettings = cacheManager.dfpWebCache.getSettings();
-
-            if (webSettings != null) {
-                webSettings.setDomStorageEnabled(true);
-                webSettings.setJavaScriptEnabled(true);
+            try {
+                cacheManager.dfpWebCache = new WebView(context);
+                WebSettings webSettings = cacheManager.dfpWebCache.getSettings();
+                if (webSettings != null) {
+                    webSettings.setDomStorageEnabled(true);
+                    webSettings.setJavaScriptEnabled(true);
+                }
+            } catch (Throwable t) {
+                // possible AndroidRuntime thrown at android.webkit.WebViewFactory.getFactoryClass
+                // stemming from WebView's constructor, manifests itself in Android 5.0 and 5.1.
             }
         }
     }


### PR DESCRIPTION
- No more anonymous runnables with implicit outer references to CacheManager and its Context referencing WebView property
- Reuse Handler instance for setupBidCleanUpRunnable (and its inner Runnable), setupWebCache
- Reuse WebSettings reference when initializing the dfpWebCache settings, Dalvik isn't too good at code optimization
- Removed unnecessary 'long now' instance, only used once when cleaning up the cache
- Suggestion as a next refactor: get rid of one liner methods setupWebCache, setupBidCleanUpRunnable, just invoke the handler.post calls on the constructor