### PR TITLE
reduce dependency only to commons-lang3 and use implementation instead of deprecated compile in gradle

### DIFF
--- a/Maven/pom.xml
+++ b/Maven/pom.xml
@@ -31,8 +31,8 @@
     <dependencies>
         <dependency>
             <groupId>org.apache.commons</groupId>
-            <artifactId>commons-text</artifactId>
-            <version>1.1</version>
+            <artifactId>commons-lang3</artifactId>
+            <version>3.7</version>
         </dependency>
     </dependencies>
 </project>

--- a/PrebidMobile/PrebidMobileCore/build.gradle
+++ b/PrebidMobile/PrebidMobileCore/build.gradle
@@ -25,7 +25,7 @@ android {
 }
 
 dependencies {
-    compile 'com.android.support:support-annotations:25.2.0'
-    compile 'org.apache.commons:commons-text:1.1'
+    implementation 'com.android.support:support-annotations:25.2.0'
+    implementation 'org.apache.commons:commons-lang3:3.7'
     testCompile project(':UnitTestUtils')
 }


### PR DESCRIPTION
This will help with the integration in other projects, when pulling more code can be a potential problem due to the DEX limitations in android.