### PR TITLE
catch AndroidRuntimeException when getting the device WebView userAgent

### DIFF
--- a/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/internal/Settings.java
+++ b/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/internal/Settings.java
@@ -8,6 +8,7 @@ import android.os.Build;
 import android.os.Handler;
 import android.os.Looper;
 import android.text.TextUtils;
+import android.util.AndroidRuntimeException;
 import android.webkit.WebView;
 
 import java.util.Locale;
@@ -72,10 +73,12 @@ public class Settings {
             handler.post(new Runnable() {
                 @Override
                 public void run() {
-
-                    WebView wv = new WebView(context);
-                    userAgent = wv.getSettings().getUserAgentString();
-
+                    try {
+                        WebView wv = new WebView(context);
+                        userAgent = wv.getSettings().getUserAgentString();
+                    } catch (AndroidRuntimeException e) {
+                        userAgent = "unavailable";
+                    }
                 }
             });
         }


### PR DESCRIPTION
We are getting this crash report
```
android.util.AndroidRuntimeException: 
  at android.webkit.WebViewFactory.getFactoryClass (WebViewFactory.java:174)
  at android.webkit.WebViewFactory.getProvider (WebViewFactory.java:109)
  at android.webkit.WebView.getFactory (WebView.java:2194)
  at android.webkit.WebView.ensureProviderCreated (WebView.java:2189)
  at android.webkit.WebView.setOverScrollMode (WebView.java:2248)
  at android.view.View.<init> (View.java:3701)
  at android.view.View.<init> (View.java:3797)
  at android.view.ViewGroup.<init> (ViewGroup.java:503)
  at android.widget.AbsoluteLayout.<init> (AbsoluteLayout.java:55)
  at android.webkit.WebView.<init> (WebView.java:544)
  at android.webkit.WebView.<init> (WebView.java:489)
  at android.webkit.WebView.<init> (WebView.java:472)
  at android.webkit.WebView.<init> (WebView.java:459)
  at android.webkit.WebView.<init> (WebView.java:449)
  at org.prebid.mobile.prebidserver.internal.Settings$1.run (Settings.java:76)
  at android.os.Handler.handleCallback (Handler.java:739)
  at android.os.Handler.dispatchMessage (Handler.java:95)
  at android.os.Looper.loop (Looper.java:135)
  at android.app.ActivityThread.main (ActivityThread.java:5912)
  at java.lang.reflect.Method.invoke (Native Method)
  at java.lang.reflect.Method.invoke (Method.java:372)
  at com.android.internal.os.ZygoteInit$MethodAndArgsCaller.run (ZygoteInit.java:1405)
  at com.android.internal.os.ZygoteInit.main (ZygoteInit.java:1200)
Caused by: android.content.pm.PackageManager$NameNotFoundException: 
  at android.app.ApplicationPackageManager.getPackageInfo (ApplicationPackageManager.java:163)
  at android.webkit.WebViewFactory.getFactoryClass (WebViewFactory.java:146)
```