### PR TITLE
Fix Price Granularity

### DIFF
--- a/PrebidMobile/PrebidMobileCore/src/main/java/org/prebid/mobile/core/Prebid.java
+++ b/PrebidMobile/PrebidMobileCore/src/main/java/org/prebid/mobile/core/Prebid.java
@@ -54,7 +54,9 @@ public class Prebid {
 
     public enum PriceGranularity {
         LOW,
-        MEDIUM,
+        MED,
+        HIGH,
+        AUTO,
         DENSE,
         UNKNOWN,
         SERVER

--- a/PrebidMobile/PrebidMobileCore/src/main/java/org/prebid/mobile/core/Prebid.java
+++ b/PrebidMobile/PrebidMobileCore/src/main/java/org/prebid/mobile/core/Prebid.java
@@ -51,6 +51,14 @@ public class Prebid {
         UNKNOWN
     }
 
+    public enum PriceGranularity {
+        LOW,
+        MEDIUM,
+        DENSE,
+        UNKNOWN,
+        SERVER
+    }
+    
     public enum Host {
         APPNEXUS,
         RUBICON
@@ -77,7 +85,11 @@ public class Prebid {
     public static Host getHost() {
         return host;
     }
-
+    
+    public static PriceGranularity getPriceGranularity() {
+        return priceGranularity;
+    }
+    
     public static boolean useLocalCache() {
         return useLocalCache;
     }
@@ -88,14 +100,15 @@ public class Prebid {
      * - Validate the setup of the demand adapter
      * - Start the bid manager
      *
-     * @param context   Application context
-     * @param adUnits   List of Ad Slot Configurations to register
-     * @param accountId Prebid Server account
-     * @param adServer  Primary AdServer you're using for your app
-     * @param host      Host you're using for your app
+     * @param context               Application context
+     * @param adUnits               List of Ad Slot Configurations to register
+     * @param accountId             Prebid Server account
+     * @param adServer              Primary AdServer you're using for your app
+     * @param host                  Host you're using for your app
+     * @param priceGranularity      Price granulairty you're using for your app
      * @throws PrebidException
      */
-    public static void init(Context context, ArrayList<AdUnit> adUnits, String accountId, AdServer adServer, Host host) throws PrebidException {
+    public static void init(Context context, ArrayList<AdUnit> adUnits, String accountId, AdServer adServer, Host host, PriceGranularity priceGranularity) throws PrebidException {
         LogUtil.i("Initializing with a list of AdUnits");
         // validate context
         if (context == null) {
@@ -113,6 +126,10 @@ public class Prebid {
         if (host == null)
             throw new PrebidException(PrebidException.PrebidError.NULL_HOST);
         Prebid.host = host;
+        if (priceGranularity == null) {
+            throw new PrebidException(PrebidException.PrebidError.NULL_PRICE_GRANULARITY);
+        }
+        Prebid.priceGranularity = priceGranularity;
         // validate ad units and register them
         if (adUnits == null || adUnits.isEmpty()) {
             throw new PrebidException(PrebidException.PrebidError.EMPTY_ADUNITS);
@@ -148,6 +165,10 @@ public class Prebid {
         BidManager.requestBidsForAdUnits(context, adUnits);
     }
 
+    public static void init(Context context, ArrayList<AdUnit> adUnits, String accountId, AdServer adServer, Host host) throws PrebidException {
+        init(context, adUnits, accountId, adServer, host, PriceGranularity.UNKNOWN);
+    }
+    
     public static void attachBids(Object adObj, String adUnitCode, Context context) {
         if (adObj == null) {
             //LogUtil.e(TAG, "Request is null, unable to set keywords");

--- a/PrebidMobile/PrebidMobileCore/src/main/java/org/prebid/mobile/core/Prebid.java
+++ b/PrebidMobile/PrebidMobileCore/src/main/java/org/prebid/mobile/core/Prebid.java
@@ -43,6 +43,7 @@ public class Prebid {
     private static final int kMoPubQueryStringLimit = 4000;
     private static boolean useLocalCache = true;
     private static Host host = Host.APPNEXUS;
+    private static PriceGranularity priceGranularity = PriceGranularity.UNKNOWN;
     private static AdServer adServer = AdServer.UNKNOWN;
 
     public enum AdServer {

--- a/PrebidMobile/PrebidMobileCore/src/main/java/org/prebid/mobile/core/PrebidException.java
+++ b/PrebidMobile/PrebidMobileCore/src/main/java/org/prebid/mobile/core/PrebidException.java
@@ -24,7 +24,8 @@ public class PrebidException extends Exception {
         NULL_HOST("Null host passed in."),
         BANNER_AD_UNIT_NO_SIZE("BannerAdUnit requires size information to check the price for the impression."),
         UNABLE_TO_INITIALIZE_DEMAND_SOURCE("Unable to instantiating the adapter."),
-        INVALID_ACCOUNT_ID("Invalid input of account id.");
+        INVALID_ACCOUNT_ID("Invalid input of account id."),
+        NULL_PRICE_GRANULARITY("Invalid granularity");
 
         private String error;
 

--- a/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/PrebidServerAdapter.java
+++ b/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/PrebidServerAdapter.java
@@ -178,7 +178,7 @@ public class PrebidServerAdapter implements DemandAdapter, ServerConnector.Serve
             }
             for (AdUnit adUnit : adUnits) {
                 ArrayList<BidResponse> results = responses.get(adUnit);
-                LogUtil.d(Settings.TAG, "Prebid Mobile receive for the adUnit " + adUnit.getCode() + " the response: " + String.valueOf(results));
+                LogUtil.d(Settings.TAG, "Prebid Mobile receive for the adUnit " + adUnit.getCode() + " the following responses: " + String.valueOf(results));
                 if (results != null && !results.isEmpty()) {
                     // save the bids sorted
                     if (Prebid.useLocalCache()) {

--- a/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/PrebidServerAdapter.java
+++ b/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/PrebidServerAdapter.java
@@ -300,14 +300,13 @@ public class PrebidServerAdapter implements DemandAdapter, ServerConnector.Serve
         String keyTargeting = "targeting";
         String keyLengthMax = "lengthmax";
         String keyPriceGranularity = "pricegranularity";
-
+        JSONObject storedRequest = new JSONObject();
+        storedRequest.put(keyId, Prebid.getAccountId());
+        prebid.put(keyStoredRequest, storedRequest);
+        
         Prebid.PriceGranularity priceGranularity = Prebid.getPriceGranularity();
         switch (priceGranularity) {
             case UNKNOWN:
-                JSONObject storedRequest = new JSONObject();
-                storedRequest.put(keyId, Prebid.getAccountId());
-                prebid.put(keyStoredRequest, storedRequest);
-                break;
             case SERVER:
                 JSONObject targetingEmpty = new JSONObject();
                 prebid.put(keyTargeting, targetingEmpty);

--- a/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/PrebidServerAdapter.java
+++ b/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/PrebidServerAdapter.java
@@ -285,9 +285,7 @@ public class PrebidServerAdapter implements DemandAdapter, ServerConnector.Serve
                 cache.put("bids", bids);
                 prebid.put("cache", cache);
             }
-
             parseAndAppendPriceGranularity(prebid);
-
             ext.put("prebid", prebid);
         } catch (JSONException e) {
             e.printStackTrace();
@@ -304,28 +302,21 @@ public class PrebidServerAdapter implements DemandAdapter, ServerConnector.Serve
         String keyPriceGranularity = "pricegranularity";
 
         Prebid.PriceGranularity priceGranularity = Prebid.getPriceGranularity();
-
         switch (priceGranularity) {
-
             case UNKNOWN:
                 JSONObject storedRequest = new JSONObject();
                 storedRequest.put(keyId, Prebid.getAccountId());
                 prebid.put(keyStoredRequest, storedRequest);
-
                 break;
-
             case SERVER:
                 JSONObject targetingEmpty = new JSONObject();
                 prebid.put(keyTargeting, targetingEmpty);
-
                 break;
-
             default:
                 JSONObject targeting = new JSONObject();
                 targeting.put(keyLengthMax, 20);
                 targeting.put(keyPriceGranularity, priceGranularity.toString().toLowerCase());
                 prebid.put(keyTargeting, targeting);
-
                 break;
         }
     }

--- a/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/PrebidServerAdapter.java
+++ b/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/PrebidServerAdapter.java
@@ -284,9 +284,20 @@ public class PrebidServerAdapter implements DemandAdapter, ServerConnector.Serve
                 cache.put("bids", bids);
                 prebid.put("cache", cache);
             }
-            JSONObject storedRequest = new JSONObject();
-            storedRequest.put("id", Prebid.getAccountId());
-            prebid.put("storedrequest", storedRequest);
+            String _priceGranularity = Prebid.getPriceGranularity().toString();
+            if (_priceGranularity == "SERVER") {
+                JSONObject targeting = new JSONObject();
+                prebid.put("targeting", targeting);
+            } else if (_priceGranularity != "UNKNOWN") {
+                JSONObject targeting = new JSONObject();
+                targeting.put("lengthmax", 20);
+                targeting.put("pricegranularity", _priceGranularity.toLowerCase());
+                prebid.put("targeting", targeting);
+            } else {
+                JSONObject storedRequest = new JSONObject();
+                storedRequest.put("id", Prebid.getAccountId());
+                prebid.put("storedrequest", storedRequest);
+            }
             ext.put("prebid", prebid);
         } catch (JSONException e) {
             e.printStackTrace();

--- a/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/PrebidServerAdapter.java
+++ b/PrebidMobile/PrebidServerAdapter/src/main/java/org/prebid/mobile/prebidserver/PrebidServerAdapter.java
@@ -178,6 +178,7 @@ public class PrebidServerAdapter implements DemandAdapter, ServerConnector.Serve
             }
             for (AdUnit adUnit : adUnits) {
                 ArrayList<BidResponse> results = responses.get(adUnit);
+                LogUtil.d(Settings.TAG, "Prebid Mobile receive for the adUnit " + adUnit.getCode() + " the response: " + String.valueOf(results));
                 if (results != null && !results.isEmpty()) {
                     // save the bids sorted
                     if (Prebid.useLocalCache()) {


### PR DESCRIPTION
For Android the request is always passed with:
"ext": { "prebid": { "storedrequest": { "id": "stored-request"}}}

It should be able to check if the price granularity is hardcode in the application and pass the above string if only nothing is declared. 