### PR TITLE
Change host reference

### DIFF
--- a/PrebidMobile/API1.0/src/main/java/org/prebid/mobile/Host.java
+++ b/PrebidMobile/API1.0/src/main/java/org/prebid/mobile/Host.java
@@ -17,8 +17,17 @@
 package org.prebid.mobile;
 
 public enum Host {
+
+    /**
+     * URL <a href>https://prebid.adnxs.com/pbs/v1/openrtb2/auction</a>
+     */
     APPNEXUS("https://prebid.adnxs.com/pbs/v1/openrtb2/auction"),
+
+    /**
+     * URL <a href>https://prebid-server.rubiconproject.com/openrtb2/auction</a>
+     */
     RUBICON("https://prebid-server.rubiconproject.com/openrtb2/auction"),
+
     CUSTOM("");
 
     private String url;

--- a/PrebidMobile/API1.0/src/main/java/org/prebid/mobile/PrebidMobile.java
+++ b/PrebidMobile/API1.0/src/main/java/org/prebid/mobile/PrebidMobile.java
@@ -40,7 +40,7 @@ public class PrebidMobile {
         return accountId;
     }
 
-    private static Host host = Host.APPNEXUS;
+    private static Host host = Host.CUSTOM;
 
     public static void setPrebidServerHost(Host host) {
         PrebidMobile.host = host;


### PR DESCRIPTION
Default host was changed from Host.APPNEXUS to Host.CUSTOM.
If a publisher does not call setPrebidServerHost() Log error will be printed

<img width="1165" alt="Screen Shot 2019-04-26 at 11 38 33 AM" src="https://user-images.githubusercontent.com/8141931/56795288-d85d2e80-6818-11e9-8242-4b3c3cd68b24.png">


The Doc hint looks like
<img width="970" alt="Screen Shot 2019-04-26 at 11 57 22 AM" src="https://user-images.githubusercontent.com/8141931/56796155-9d5bfa80-681a-11e9-9f8b-da4749593b51.png">
