### PR TITLE
Fix prebid timeout editable

### DIFF
--- a/PrebidMobile/API1.0/src/main/java/org/prebid/mobile/PrebidMobile.java
+++ b/PrebidMobile/API1.0/src/main/java/org/prebid/mobile/PrebidMobile.java
@@ -22,9 +22,9 @@ import java.lang.ref.WeakReference;
 
 public class PrebidMobile {
 
-    public static final int TIMEOUT_MILLIS = 2_000;
+    static final int TIMEOUT_MILLIS = 2_000;
 
-    static int timeoutMillis = TIMEOUT_MILLIS; // by default use 10000 milliseconds as timeout
+    public static int timeoutMillis = TIMEOUT_MILLIS; // by default use 10000 milliseconds as timeout
     static boolean timeoutMillisUpdated = false;
 
     private PrebidMobile() {

--- a/PrebidMobile/API1.0/src/main/java/org/prebid/mobile/PrebidMobile.java
+++ b/PrebidMobile/API1.0/src/main/java/org/prebid/mobile/PrebidMobile.java
@@ -24,8 +24,16 @@ public class PrebidMobile {
 
     private static final int TIMEOUT_MILLIS = 2_000;
 
-    public static int timeoutMillis = TIMEOUT_MILLIS; // by default use 10000 milliseconds as timeout
+    private static int timeoutMillis = TIMEOUT_MILLIS; // by default use 2000 milliseconds as timeout
     static boolean timeoutMillisUpdated = false;
+
+    public static int getTimeoutMillis() {
+        return timeoutMillis;
+    }
+
+    public static void setTimeoutMillis(int timeoutMillis) {
+        PrebidMobile.timeoutMillis = timeoutMillis;
+    }
 
     private PrebidMobile() {
     }

--- a/PrebidMobile/API1.0/src/main/java/org/prebid/mobile/PrebidMobile.java
+++ b/PrebidMobile/API1.0/src/main/java/org/prebid/mobile/PrebidMobile.java
@@ -22,7 +22,7 @@ import java.lang.ref.WeakReference;
 
 public class PrebidMobile {
 
-    static final int TIMEOUT_MILLIS = 2_000;
+    private static final int TIMEOUT_MILLIS = 2_000;
 
     public static int timeoutMillis = TIMEOUT_MILLIS; // by default use 10000 milliseconds as timeout
     static boolean timeoutMillisUpdated = false;

--- a/PrebidMobile/API1.0/src/main/java/org/prebid/mobile/PrebidServerAdapter.java
+++ b/PrebidMobile/API1.0/src/main/java/org/prebid/mobile/PrebidServerAdapter.java
@@ -103,7 +103,7 @@ class PrebidServerAdapter implements DemandAdapter {
             this.listener = listener;
             this.requestParams = requestParams;
             this.auctionId = auctionId;
-            timeoutCountDownTimer = new TimeoutCountDownTimer(PrebidMobile.timeoutMillis, TIMEOUT_COUNT_DOWN_INTERVAL);
+            timeoutCountDownTimer = new TimeoutCountDownTimer(PrebidMobile.getTimeoutMillis(), TIMEOUT_COUNT_DOWN_INTERVAL);
         }
 
         @Override
@@ -130,7 +130,7 @@ class PrebidServerAdapter implements DemandAdapter {
                 } // todo still pass cookie if limit ad tracking?
 
                 conn.setRequestMethod("POST");
-                conn.setConnectTimeout(PrebidMobile.timeoutMillis);
+                conn.setConnectTimeout(PrebidMobile.getTimeoutMillis());
 
                 // Add post data
                 OutputStreamWriter wr = new OutputStreamWriter(conn.getOutputStream(), "UTF-8");
@@ -167,7 +167,7 @@ class PrebidServerAdapter implements DemandAdapter {
                             // ignore this
                         }
                         if (tmaxRequest >= 0) {
-                            PrebidMobile.timeoutMillis = Math.min((int) (demandFetchEndTime - demandFetchStartTime) + tmaxRequest + 200, 2000); // adding 200ms as safe time
+                            PrebidMobile.setTimeoutMillis(Math.min((int) (demandFetchEndTime - demandFetchStartTime) + tmaxRequest + 200, 2000)); // adding 200ms as safe time
                             PrebidMobile.timeoutMillisUpdated = true;
                         }
                     }

--- a/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/DemandFetcherTest.java
+++ b/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/DemandFetcherTest.java
@@ -88,7 +88,7 @@ public class DemandFetcherTest extends BaseSetup {
             PublisherAdRequest.Builder builder = new PublisherAdRequest.Builder();
             PublisherAdRequest request = builder.build();
             DemandFetcher demandFetcher = new DemandFetcher(request);
-            PrebidMobile.timeoutMillis = Integer.MAX_VALUE;
+            PrebidMobile.setTimeoutMillis(Integer.MAX_VALUE);
             demandFetcher.setPeriodMillis(0);
             HashSet<AdSize> sizes = new HashSet<>();
             sizes.add(new AdSize(300, 250));
@@ -126,7 +126,7 @@ public class DemandFetcherTest extends BaseSetup {
             PublisherAdRequest.Builder builder = new PublisherAdRequest.Builder();
             PublisherAdRequest request = builder.build();
             DemandFetcher demandFetcher = new DemandFetcher(request);
-            PrebidMobile.timeoutMillis = Integer.MAX_VALUE;
+            PrebidMobile.setTimeoutMillis(Integer.MAX_VALUE);
             demandFetcher.setPeriodMillis(30);
             HashSet<AdSize> sizes = new HashSet<>();
             sizes.add(new AdSize(300, 250));
@@ -165,7 +165,7 @@ public class DemandFetcherTest extends BaseSetup {
             PublisherAdRequest.Builder builder = new PublisherAdRequest.Builder();
             PublisherAdRequest request = builder.build();
             DemandFetcher demandFetcher = new DemandFetcher(request);
-            PrebidMobile.timeoutMillis = Integer.MAX_VALUE;
+            PrebidMobile.setTimeoutMillis(Integer.MAX_VALUE);
             demandFetcher.setPeriodMillis(0);
             HashSet<AdSize> sizes = new HashSet<>();
             sizes.add(new AdSize(300, 250));
@@ -309,7 +309,7 @@ public class DemandFetcherTest extends BaseSetup {
             MoPubView adView = new MoPubView(activity);
             adView.setAdUnitId("123456789");
             DemandFetcher demandFetcher = new DemandFetcher(adView);
-            PrebidMobile.timeoutMillis = Integer.MAX_VALUE;
+            PrebidMobile.setTimeoutMillis(Integer.MAX_VALUE);
             demandFetcher.setPeriodMillis(0);
             HashSet<AdSize> sizes = new HashSet<>();
             sizes.add(new AdSize(300, 250));
@@ -349,7 +349,7 @@ public class DemandFetcherTest extends BaseSetup {
         MoPubView adView = new MoPubView(activity);
         adView.setAdUnitId("123456789");
         DemandFetcher demandFetcher = new DemandFetcher(adView);
-        PrebidMobile.timeoutMillis = Integer.MAX_VALUE;
+        PrebidMobile.setTimeoutMillis(Integer.MAX_VALUE);
         demandFetcher.setPeriodMillis(0);
         HashSet<AdSize> sizes = new HashSet<>();
         sizes.add(new AdSize(300, 250));

--- a/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/DemandFetcherTest.java
+++ b/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/DemandFetcherTest.java
@@ -225,7 +225,7 @@ public class DemandFetcherTest extends BaseSetup {
         PublisherAdRequest.Builder builder = new PublisherAdRequest.Builder();
         PublisherAdRequest request = builder.build();
         DemandFetcher demandFetcher = new DemandFetcher(request);
-        PrebidMobile.timeoutMillis = Integer.MAX_VALUE;
+        PrebidMobile.setTimeoutMillis(Integer.MAX_VALUE);
         demandFetcher.setPeriodMillis(0);
         HashSet<AdSize> sizes = new HashSet<>();
         sizes.add(new AdSize(300, 250));

--- a/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/DemandFetcherTest.java
+++ b/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/DemandFetcherTest.java
@@ -384,7 +384,7 @@ public class DemandFetcherTest extends BaseSetup {
             MoPubView adView = new MoPubView(activity);
             adView.setAdUnitId("123456789");
             DemandFetcher demandFetcher = new DemandFetcher(adView);
-            PrebidMobile.timeoutMillis = Integer.MAX_VALUE;
+            PrebidMobile.setTimeoutMillis(Integer.MAX_VALUE);
             demandFetcher.setPeriodMillis(2000);
             HashSet<AdSize> sizes = new HashSet<>();
             sizes.add(new AdSize(300, 250));
@@ -430,7 +430,7 @@ public class DemandFetcherTest extends BaseSetup {
             PublisherAdRequest.Builder builder = new PublisherAdRequest.Builder();
             PublisherAdRequest request = builder.build();
             DemandFetcher demandFetcher = new DemandFetcher(request);
-            PrebidMobile.timeoutMillis = Integer.MAX_VALUE;
+            PrebidMobile.setTimeoutMillis(Integer.MAX_VALUE);
             demandFetcher.setPeriodMillis(2000);
             HashSet<AdSize> sizes = new HashSet<>();
             sizes.add(new AdSize(300, 250));

--- a/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/PrebidMobileTest.java
+++ b/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/PrebidMobileTest.java
@@ -33,7 +33,7 @@ public class PrebidMobileTest extends BaseSetup {
         PrebidMobile.setPrebidServerAccountId("123456");
         assertEquals("123456", PrebidMobile.getPrebidServerAccountId());
         PrebidMobile.setTimeoutMillis(2500);
-        assertEquals(2500, PrebidMobile.getTimeoutMillis());        
+        assertEquals(2500, PrebidMobile.getTimeoutMillis());
         PrebidMobile.setApplicationContext(activity.getApplicationContext());
         assertEquals(activity.getApplicationContext(), PrebidMobile.getApplicationContext());
         PrebidMobile.setShareGeoLocation(true);

--- a/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/PrebidMobileTest.java
+++ b/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/PrebidMobileTest.java
@@ -32,6 +32,8 @@ public class PrebidMobileTest extends BaseSetup {
     public void testPrebidMobileSettings() {
         PrebidMobile.setPrebidServerAccountId("123456");
         assertEquals("123456", PrebidMobile.getPrebidServerAccountId());
+        PrebidMobile.setTimeoutMillis(2500);
+        assertEquals(2500, PrebidMobile.getTimeoutMillis());        
         PrebidMobile.setApplicationContext(activity.getApplicationContext());
         assertEquals(activity.getApplicationContext(), PrebidMobile.getApplicationContext());
         PrebidMobile.setShareGeoLocation(true);

--- a/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/PrebidServerAdapterTest.java
+++ b/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/PrebidServerAdapterTest.java
@@ -190,7 +190,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
     @Test
     public void testUpdateTimeoutMillis() {
         PrebidMobile.setPrebidServerHost(Host.APPNEXUS);
-        assertEquals(2000, PrebidMobile.timeoutMillis);
+        assertEquals(2000, PrebidMobile.getTimeoutMillis());
         assertFalse(PrebidMobile.timeoutMillisUpdated);
         PrebidMobile.setPrebidServerAccountId("b7adad2c-e042-4126-8ca1-b3caac7d3e5c");
         PrebidMobile.setShareGeoLocation(true);
@@ -205,7 +205,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         Robolectric.flushBackgroundThreadScheduler();
         Robolectric.flushForegroundThreadScheduler();
         verify(mockListener).onDemandFailed(ResultCode.NO_BIDS, uuid);
-        assertTrue("Actual Prebid Mobile timeout is " + PrebidMobile.timeoutMillis, PrebidMobile.timeoutMillis <= 2000 && PrebidMobile.timeoutMillis > 700);
+        assertTrue("Actual Prebid Mobile timeout is " + PrebidMobile.getTimeoutMillis(), PrebidMobile.getTimeoutMillis() <= 2000 && PrebidMobile.getTimeoutMillis() > 700);
         assertTrue(PrebidMobile.timeoutMillisUpdated);
     }
 
@@ -229,12 +229,12 @@ public class PrebidServerAdapterTest extends BaseSetup {
             adapter.requestDemand(requestParams, mockListener, uuid);
             Robolectric.flushBackgroundThreadScheduler();
             Robolectric.flushForegroundThreadScheduler();
-            assertEquals("Actual Prebid Mobile timeout is " + PrebidMobile.timeoutMillis, 2000, PrebidMobile.timeoutMillis);
+            assertEquals("Actual Prebid Mobile timeout is " + PrebidMobile.getTimeoutMillis(), 2000, PrebidMobile.getTimeoutMillis());
             assertTrue(!PrebidMobile.timeoutMillisUpdated);
             adapter.requestDemand(requestParams, mockListener, uuid);
             Robolectric.flushBackgroundThreadScheduler();
             Robolectric.flushForegroundThreadScheduler();
-            assertEquals("Actual Prebid Mobile timeout is " + PrebidMobile.timeoutMillis, 2000, PrebidMobile.timeoutMillis);
+            assertEquals("Actual Prebid Mobile timeout is " + PrebidMobile.getTimeoutMillis(), 2000, PrebidMobile.getTimeoutMillis());
             assertTrue(PrebidMobile.timeoutMillisUpdated);
         } else {
             assertTrue("Server failed to start, unable to test.", false);
@@ -662,7 +662,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         OnCompleteListener mockListener = mock(OnCompleteListener.class);
         adUnit.fetchDemand(testView, mockListener);
         DemandFetcher fetcher = (DemandFetcher) FieldUtils.readField(adUnit, "fetcher", true);
-        PrebidMobile.timeoutMillis = Integer.MAX_VALUE;
+        PrebidMobile.setTimeoutMillis(Integer.MAX_VALUE);
         ShadowLooper fetcherLooper = shadowOf(fetcher.getHandler().getLooper());
         fetcherLooper.runOneTask();
         ShadowLooper demandLooper = shadowOf(fetcher.getDemandHandler().getLooper());
@@ -675,7 +675,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         OnCompleteListener mockListenerNoKV = mock(OnCompleteListener.class);
         adUnit.fetchDemand(testView, mockListenerNoKV);
         fetcher = (DemandFetcher) FieldUtils.readField(adUnit, "fetcher", true);
-        PrebidMobile.timeoutMillis = Integer.MAX_VALUE;
+        PrebidMobile.setTimeoutMillis(Integer.MAX_VALUE);
         fetcherLooper = shadowOf(fetcher.getHandler().getLooper());
         fetcherLooper.runOneTask();
         demandLooper = shadowOf(fetcher.getDemandHandler().getLooper());

--- a/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/ResultCodeTest.java
+++ b/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/ResultCodeTest.java
@@ -86,7 +86,7 @@ public class ResultCodeTest extends BaseSetup {
             OnCompleteListener mockListener = mock(OnCompleteListener.class);
             adUnit.fetchDemand(testView, mockListener);
             DemandFetcher fetcher = (DemandFetcher) FieldUtils.readField(adUnit, "fetcher", true);
-            PrebidMobile.timeoutMillis = Integer.MAX_VALUE;
+            PrebidMobile.setTimeoutMillis(Integer.MAX_VALUE);
             ShadowLooper fetcherLooper = shadowOf(fetcher.getHandler().getLooper());
             fetcherLooper.runOneTask();
             ShadowLooper demandLooper = shadowOf(fetcher.getDemandHandler().getLooper());
@@ -114,7 +114,7 @@ public class ResultCodeTest extends BaseSetup {
             OnCompleteListener mockListener = mock(OnCompleteListener.class);
             adUnit.fetchDemand(testRequest, mockListener);
             DemandFetcher fetcher = (DemandFetcher) FieldUtils.readField(adUnit, "fetcher", true);
-            PrebidMobile.timeoutMillis = Integer.MAX_VALUE;
+            PrebidMobile.setTimeoutMillis(Integer.MAX_VALUE);
             ShadowLooper fetcherLooper = shadowOf(fetcher.getHandler().getLooper());
             fetcherLooper.runOneTask();
             ShadowLooper demandLooper = shadowOf(fetcher.getDemandHandler().getLooper());
@@ -167,7 +167,7 @@ public class ResultCodeTest extends BaseSetup {
         OnCompleteListener mockListener = mock(OnCompleteListener.class);
         adUnit.fetchDemand(testRequest, mockListener);
         DemandFetcher fetcher = (DemandFetcher) FieldUtils.readField(adUnit, "fetcher", true);
-        PrebidMobile.timeoutMillis = Integer.MAX_VALUE;
+        PrebidMobile.setTimeoutMillis(Integer.MAX_VALUE);
         ShadowLooper fetcherLooper = shadowOf(fetcher.getHandler().getLooper());
         fetcherLooper.runOneTask();
         ShadowLooper demandLooper = shadowOf(fetcher.getDemandHandler().getLooper());
@@ -248,7 +248,7 @@ public class ResultCodeTest extends BaseSetup {
     @Test
     public void testTimeOut() throws Exception {
         PrebidMobile.setPrebidServerHost(Host.APPNEXUS);
-        PrebidMobile.timeoutMillis = 30;
+        PrebidMobile.setTimeoutMillis(30);
         PrebidMobile.setPrebidServerAccountId("b7adad2c-e042-4126-8ca1-b3caac7d3e5c");
         PrebidMobile.setShareGeoLocation(true);
         PrebidMobile.setApplicationContext(activity.getApplicationContext());
@@ -285,7 +285,7 @@ public class ResultCodeTest extends BaseSetup {
             OnCompleteListener mockListener = mock(OnCompleteListener.class);
             adUnit.fetchDemand(testView, mockListener);
             DemandFetcher fetcher = (DemandFetcher) FieldUtils.readField(adUnit, "fetcher", true);
-            PrebidMobile.timeoutMillis = Integer.MAX_VALUE;
+            PrebidMobile.setTimeoutMillis(Integer.MAX_VALUE);
             ShadowLooper fetcherLooper = shadowOf(fetcher.getHandler().getLooper());
             fetcherLooper.runOneTask();
             ShadowLooper demandLooper = shadowOf(fetcher.getDemandHandler().getLooper());
@@ -316,7 +316,7 @@ public class ResultCodeTest extends BaseSetup {
         OnCompleteListener mockListener = mock(OnCompleteListener.class);
         adUnit.fetchDemand(testView, mockListener);
         DemandFetcher fetcher = (DemandFetcher) FieldUtils.readField(adUnit, "fetcher", true);
-        PrebidMobile.timeoutMillis = Integer.MAX_VALUE;
+        PrebidMobile.setTimeoutMillis(Integer.MAX_VALUE);
         ShadowLooper fetcherLooper = shadowOf(fetcher.getHandler().getLooper());
         fetcherLooper.runOneTask();
         ShadowLooper demandLooper = shadowOf(fetcher.getDemandHandler().getLooper());


### PR DESCRIPTION
public should be the field timeoutMillis so it could be changed if needed from the publisher code when integrating the SDK:
"PrebidMobile.timeoutMillis = 1000;"

I removed public for the var "TIMEOUT_MILLIS" which is final so public is useless.
Issue   #111  