### PR TITLE
Support for COPPA

### DIFF
--- a/PrebidMobile/API1.0/src/main/java/org/prebid/mobile/PrebidServerAdapter.java
+++ b/PrebidMobile/API1.0/src/main/java/org/prebid/mobile/PrebidServerAdapter.java
@@ -745,14 +745,17 @@ class PrebidServerAdapter implements DemandAdapter {
             JSONObject regs = new JSONObject();
             try {
                 JSONObject ext = new JSONObject();
-                if (TargetingParams.isSubjectToGDPR() != null) {
-                    if (TargetingParams.isSubjectToGDPR()) {
-                        ext.put("gdpr", 1);
-                    } else {
-                        ext.put("gdpr", 0);
-                    }
+                Boolean isSubjectToGDPR = TargetingParams.isSubjectToGDPR();
+
+                if (isSubjectToGDPR != null && isSubjectToGDPR) {
+                    ext.put("gdpr", 1);
+                    regs.put("ext", ext);
                 }
-                regs.put("ext", ext);
+
+                if (TargetingParams.isSubjectToCOPPA()) {
+                    regs.put("coppa", 1);
+                }
+
             } catch (JSONException e) {
                 LogUtil.d("PrebidServerAdapter getRegsObject() " + e.getMessage());
             }

--- a/PrebidMobile/API1.0/src/main/java/org/prebid/mobile/TargetingParams.java
+++ b/PrebidMobile/API1.0/src/main/java/org/prebid/mobile/TargetingParams.java
@@ -38,6 +38,7 @@ public class TargetingParams {
     private static String bundleName = null;
     private static final String PREBID_CONSENT_STRING_KEY = "Prebid_GDPR_consent_strings";
     private static final String IABConsent_ConsentString = "IABConsent_ConsentString";
+    private static final String PREBID_COPPA_KEY = "Prebid_COPPA";
     private static final String PREBID_GDPR_KEY = "Prebid_GDPR";
     private static final String IABConsent_SubjectToGDPR = "IABConsent_SubjectToGDPR";
     //endregion
@@ -70,6 +71,28 @@ public class TargetingParams {
             }
         }
         return null;
+    }
+
+    public static void setSubjectToCOPPA(boolean consent) {
+        Context context = PrebidMobile.getApplicationContext();
+        if (context != null) {
+            SharedPreferences pref = PreferenceManager.getDefaultSharedPreferences(context);
+            SharedPreferences.Editor editor = pref.edit();
+            editor.putBoolean(PREBID_COPPA_KEY, consent);
+            editor.apply();
+        }
+    }
+
+    public static boolean isSubjectToCOPPA() {
+        boolean result = false;
+        Context context = PrebidMobile.getApplicationContext();
+        if (context != null) {
+            SharedPreferences pref = PreferenceManager.getDefaultSharedPreferences(context);
+            if (pref.contains(PREBID_COPPA_KEY)) {
+                result = pref.getBoolean(PREBID_COPPA_KEY, false);
+            }
+        }
+        return result;
     }
 
     public static void setSubjectToGDPR(boolean consent) {

--- a/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/PrebidServerAdapterTest.java
+++ b/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/PrebidServerAdapterTest.java
@@ -771,57 +771,56 @@ public class PrebidServerAdapterTest extends BaseSetup {
 
     @Test
     public void testPostDataWithCOPPA() throws Exception {
-
-        if (successfulMockServerStarted) {
-            PrebidMobile.setApplicationContext(activity.getApplicationContext());
-
-            server.enqueue(new MockResponse().setResponseCode(200).setBody(MockPrebidServerResponses.noBid()));
-            TargetingParams.setSubjectToCOPPA(true);
-
-            DemandAdapter.DemandAdapterListener mockListener = mock(DemandAdapter.DemandAdapterListener.class);
-            PrebidServerAdapter adapter = new PrebidServerAdapter();
-            HashSet<AdSize> sizes = new HashSet<>();
-            sizes.add(new AdSize(320, 50));
-            RequestParams requestParams = new RequestParams("67890", AdType.BANNER, sizes, new ArrayList<String>());
-            String uuid = UUID.randomUUID().toString();
-            adapter.requestDemand(requestParams, mockListener, uuid);
-            @SuppressWarnings("unchecked")
-            ArrayList<PrebidServerAdapter.ServerConnector> connectors = (ArrayList<PrebidServerAdapter.ServerConnector>) FieldUtils.readDeclaredField(adapter, "serverConnectors", true);
-            PrebidServerAdapter.ServerConnector connector = connectors.get(0);
-
-            JSONObject postData = (JSONObject) MethodUtils.invokeMethod(connector, true, "getPostData");
-            assertTrue(postData.has("regs"));
-            JSONObject regs = postData.getJSONObject("regs");
-            assertEquals(1, regs.getInt("coppa"));
-        } else {
+        if (!successfulMockServerStarted) {
             fail("Server failed to start, unable to test.");
         }
+
+        PrebidMobile.setApplicationContext(activity.getApplicationContext());
+
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(MockPrebidServerResponses.noBid()));
+        TargetingParams.setSubjectToCOPPA(true);
+
+        DemandAdapter.DemandAdapterListener mockListener = mock(DemandAdapter.DemandAdapterListener.class);
+        PrebidServerAdapter adapter = new PrebidServerAdapter();
+        HashSet<AdSize> sizes = new HashSet<>();
+        sizes.add(new AdSize(320, 50));
+        RequestParams requestParams = new RequestParams("67890", AdType.BANNER, sizes, new ArrayList<String>());
+        String uuid = UUID.randomUUID().toString();
+        adapter.requestDemand(requestParams, mockListener, uuid);
+        @SuppressWarnings("unchecked")
+        ArrayList<PrebidServerAdapter.ServerConnector> connectors = (ArrayList<PrebidServerAdapter.ServerConnector>) FieldUtils.readDeclaredField(adapter, "serverConnectors", true);
+        PrebidServerAdapter.ServerConnector connector = connectors.get(0);
+
+        JSONObject postData = (JSONObject) MethodUtils.invokeMethod(connector, true, "getPostData");
+        assertTrue(postData.has("regs"));
+        JSONObject regs = postData.getJSONObject("regs");
+        assertEquals(1, regs.getInt("coppa"));
+
     }
 
     @Test
     public void testPostDataWithoutCOPPA() throws Exception {
-
-        if (successfulMockServerStarted) {
-            PrebidMobile.setApplicationContext(activity.getApplicationContext());
-
-            server.enqueue(new MockResponse().setResponseCode(200).setBody(MockPrebidServerResponses.noBid()));
-            TargetingParams.setSubjectToCOPPA(false);
-
-            DemandAdapter.DemandAdapterListener mockListener = mock(DemandAdapter.DemandAdapterListener.class);
-            PrebidServerAdapter adapter = new PrebidServerAdapter();
-            HashSet<AdSize> sizes = new HashSet<>();
-            sizes.add(new AdSize(320, 50));
-            RequestParams requestParams = new RequestParams("67890", AdType.BANNER, sizes, new ArrayList<String>());
-            String uuid = UUID.randomUUID().toString();
-            adapter.requestDemand(requestParams, mockListener, uuid);
-            @SuppressWarnings("unchecked")
-            ArrayList<PrebidServerAdapter.ServerConnector> connectors = (ArrayList<PrebidServerAdapter.ServerConnector>) FieldUtils.readDeclaredField(adapter, "serverConnectors", true);
-            PrebidServerAdapter.ServerConnector connector = connectors.get(0);
-
-            JSONObject postData = (JSONObject) MethodUtils.invokeMethod(connector, true, "getPostData");
-            assertFalse(postData.has("regs"));
-        } else {
+        if (!successfulMockServerStarted) {
             fail("Server failed to start, unable to test.");
         }
+
+        PrebidMobile.setApplicationContext(activity.getApplicationContext());
+
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(MockPrebidServerResponses.noBid()));
+        TargetingParams.setSubjectToCOPPA(false);
+
+        DemandAdapter.DemandAdapterListener mockListener = mock(DemandAdapter.DemandAdapterListener.class);
+        PrebidServerAdapter adapter = new PrebidServerAdapter();
+        HashSet<AdSize> sizes = new HashSet<>();
+        sizes.add(new AdSize(320, 50));
+        RequestParams requestParams = new RequestParams("67890", AdType.BANNER, sizes, new ArrayList<String>());
+        String uuid = UUID.randomUUID().toString();
+        adapter.requestDemand(requestParams, mockListener, uuid);
+        @SuppressWarnings("unchecked")
+        ArrayList<PrebidServerAdapter.ServerConnector> connectors = (ArrayList<PrebidServerAdapter.ServerConnector>) FieldUtils.readDeclaredField(adapter, "serverConnectors", true);
+        PrebidServerAdapter.ServerConnector connector = connectors.get(0);
+
+        JSONObject postData = (JSONObject) MethodUtils.invokeMethod(connector, true, "getPostData");
+        assertFalse(postData.has("regs"));
     }
 }

--- a/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/TargetingParamsTest.java
+++ b/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/TargetingParamsTest.java
@@ -89,6 +89,15 @@ public class TargetingParamsTest extends BaseSetup {
     }
 
     @Test
+    public void testCOPPAFlag() throws Exception {
+        PrebidMobile.setApplicationContext(activity.getApplicationContext());
+        TargetingParams.setSubjectToCOPPA(true);
+        assertTrue(TargetingParams.isSubjectToCOPPA());
+        TargetingParams.setSubjectToCOPPA(false);
+        assertTrue(!TargetingParams.isSubjectToCOPPA());
+    }
+
+    @Test
     public void testGDPRFlag() throws Exception {
         PrebidMobile.setApplicationContext(activity.getApplicationContext());
         TargetingParams.setSubjectToGDPR(true);


### PR DESCRIPTION
GitHub issue #110

1. COPPA support was added
The `PreferenceManager`is being used for saving flag

API:
```
TargetingParams.setSubjectToCOPPA(true);
```

OpenRTB:
```
"request.regs.coppa": 1
```

2. Unit test tests were added