### PR TITLE
Update resize function

### DIFF
--- a/PrebidMobile/API1.0/src/main/java/org/prebid/mobile/Util.java
+++ b/PrebidMobile/API1.0/src/main/java/org/prebid/mobile/Util.java
@@ -52,7 +52,7 @@ public class Util {
     }
 
     /**
-     *@deprecated Please migrate to - Util.findPrebidCreativeSize(View, CreativeSizeResultHandler)
+     *@deprecated Please migrate to - AdViewUtils.findPrebidCreativeSize(View, AdViewUtils.PbFindSizeListener)
      *@see AdViewUtils#findPrebidCreativeSize(View, AdViewUtils.PbFindSizeListener)
      */
     @Deprecated

--- a/PrebidMobile/API1.0/src/main/java/org/prebid/mobile/Util.java
+++ b/PrebidMobile/API1.0/src/main/java/org/prebid/mobile/Util.java
@@ -63,6 +63,7 @@ public class Util {
         recursivelyFindWebView(adView, webViewList);
         if (webViewList.size() == 0) {
             LogUtil.w("adView doesn't include WebView");
+            completionHandler.onSize(null);
             return;
         }
 

--- a/PrebidMobile/API1.0/src/main/java/org/prebid/mobile/Util.java
+++ b/PrebidMobile/API1.0/src/main/java/org/prebid/mobile/Util.java
@@ -57,7 +57,26 @@ public class Util {
 
     }
 
-    public static void findPrebidCreativeSize(View adView, CreativeSizeCompletionHandler completionHandler) {
+    @SuppressWarnings("deprecation")
+    public static void findPrebidCreativeSize(@NonNull View adView, final CreativeSizeResultHandler handler) {
+        findPrebidCreativeSize(adView, new CreativeSizeCompletionHandler() {
+            @Override
+            public void onSize(@Nullable CreativeSize size) {
+                if (size == null) {
+                    handler.failure(new CreativeSizeError(0, "Can not get size"));
+                } else {
+                    handler.success(size);
+                }
+            }
+        });
+    }
+
+    /**
+     *@deprecated Please migrate to - Util.findPrebidCreativeSize(View, CreativeSizeResultHandler)
+     *@see Util#findPrebidCreativeSize(View, CreativeSizeResultHandler)
+     */
+    @Deprecated
+    public static void findPrebidCreativeSize(@Nullable View adView, CreativeSizeCompletionHandler completionHandler) {
 
         List<WebView> webViewList = new ArrayList<>(2);
         recursivelyFindWebView(adView, webViewList);
@@ -71,7 +90,7 @@ public class Util {
     }
 
     @Nullable
-    static void recursivelyFindWebView(View view, List<WebView> webViewList) {
+    static void recursivelyFindWebView(@Nullable View view, List<WebView> webViewList) {
         if (view instanceof ViewGroup) {
             //ViewGroup
             ViewGroup viewGroup = (ViewGroup) view;
@@ -491,6 +510,11 @@ public class Util {
         }
     }
 
+    public interface CreativeSizeResultHandler {
+        void success(@NonNull CreativeSize size);
+        void failure(@NonNull CreativeSizeError error);
+    }
+
     public interface CreativeSizeCompletionHandler {
         void onSize(@Nullable CreativeSize size);
     }
@@ -501,6 +525,26 @@ public class Util {
         void failure();
     }
 
+    /**
+     * Utility error class
+     */
+    public static class CreativeSizeError {
+        private final int code;
+        private final String message;
+
+        public CreativeSizeError(int code, String message) {
+            this.code = code;
+            this.message = message;
+        }
+
+        public int getCode() {
+            return code;
+        }
+
+        public String getMessage() {
+            return message;
+        }
+    }
     /**
      * Utility Size class
      */

--- a/PrebidMobile/API1.0/src/main/java/org/prebid/mobile/addendum/AdViewUtils.java
+++ b/PrebidMobile/API1.0/src/main/java/org/prebid/mobile/addendum/AdViewUtils.java
@@ -1,0 +1,356 @@
+/*
+ *    Copyright 2018-2019 Prebid.org, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.prebid.mobile.addendum;
+
+import android.annotation.TargetApi;
+import android.os.Build;
+import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
+import android.support.annotation.Size;
+import android.text.TextUtils;
+import android.view.View;
+import android.view.ViewGroup;
+import android.webkit.ValueCallback;
+import android.webkit.WebView;
+
+import org.prebid.mobile.LogUtil;
+
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+public final class AdViewUtils {
+
+    private static final String INNER_HTML_SCRIPT = "document.body.innerHTML";
+    private static final String SIZE_VALUE_REGEX_EXPRESSION = "[0-9]+x[0-9]+";
+    private static final String SIZE_OBJECT_REGEX_EXPRESSION = "hb_size\\W+" + SIZE_VALUE_REGEX_EXPRESSION; //"hb_size\\W+[0-9]+x[0-9]+"
+
+    private AdViewUtils() { }
+
+    @SuppressWarnings("deprecation")
+    public static void findPrebidCreativeSize(@Nullable View adView, final PbFindSizeListener handler) {
+
+        if (adView == null) {
+            warnAndTriggerFailure(PbFindSizeErrorFactory.NO_WEB_VIEW, handler);
+            return;
+        }
+
+        List<WebView> webViewList = new ArrayList<>(2);
+        recursivelyFindWebViewList(adView, webViewList);
+        if (webViewList.size() == 0) {
+            warnAndTriggerFailure(PbFindSizeErrorFactory.NO_WEB_VIEW, handler);
+            return;
+        }
+
+        findSizeInWebViewListAsync(webViewList, handler);
+    }
+
+    static void triggerSuccess(final WebView webView, Pair<Integer, Integer> adSize, PbFindSizeListener handler) {
+        int width = adSize.first;
+        int height = adSize.second;
+
+        handler.success(width, height);
+
+        //a fix of strange bug on Android with image scaling up
+        webView.post(new Runnable() {
+            @Override
+            public void run() {
+                webView.getSettings().setLoadWithOverviewMode(true);
+            }
+        });
+    }
+
+    static void warnAndTriggerFailure(Set<Pair<WebView, PbFindSizeError>> webViewErrorSet, PbFindSizeListener handler) {
+
+        warnAndTriggerFailure(PbFindSizeErrorFactory.getCompositeFailureError(webViewErrorSet), handler);
+    }
+
+    static void warnAndTriggerFailure(PbFindSizeError error, PbFindSizeListener handler) {
+
+        String description = error.getDescription();
+        LogUtil.w(description);
+
+        handler.failure(error);
+    }
+
+    @Nullable
+    static void recursivelyFindWebViewList(@Nullable View view, List<WebView> webViewList) {
+        if (view instanceof ViewGroup) {
+            //ViewGroup
+            ViewGroup viewGroup = (ViewGroup) view;
+
+            if (viewGroup instanceof WebView) {
+                //WebView
+                final WebView webView = (WebView) viewGroup;
+                webViewList.add(webView);
+            } else {
+                for (int i = 0; i < viewGroup.getChildCount(); i++) {
+                    recursivelyFindWebViewList(viewGroup.getChildAt(i), webViewList);
+                }
+            }
+        }
+    }
+
+    static void findSizeInWebViewListAsync(@Size(min = 1) final List<WebView> webViewList, final PbFindSizeListener handler) {
+
+        int currentAndroidApi = Build.VERSION.SDK_INT;
+        int necessaryAndroidApi = Build.VERSION_CODES.KITKAT;
+
+        if (currentAndroidApi >= necessaryAndroidApi) {
+            LogUtil.d("webViewList size:" + webViewList.size());
+
+            int lastIndex = webViewList.size() - 1;
+            iterateWebViewListAsync(webViewList, lastIndex, handler);
+
+
+        } else {
+            warnAndTriggerFailure(PbFindSizeErrorFactory.getUnsupportedAndroidIpiError(currentAndroidApi, necessaryAndroidApi), handler);
+        }
+
+    }
+
+    /**
+     * {@link PbFindSizeListener} will be called only once.
+     * {@link PbFindSizeListener#success(int, int)} when size is found
+     * and {@link PbFindSizeListener#failure(PbFindSizeError)} when size is not found inside passed WebView list
+     */
+    @TargetApi(Build.VERSION_CODES.KITKAT)
+    static void iterateWebViewListAsync(@Size(min = 1) final List<WebView> webViewList, final int index, final PbFindSizeListener handler) {
+
+        final WebView webView = webViewList.get(index);
+
+        webView.evaluateJavascript(INNER_HTML_SCRIPT, new ValueCallback<String>() {
+
+            private Set<Pair<WebView, PbFindSizeError>> errorSet = new LinkedHashSet<>();
+
+            private void processNextWebViewOrFail(PbFindSizeError error) {
+
+                errorSet.add(new Pair<>(webView, error));
+
+                int nextIndex = index - 1;
+
+                if (nextIndex >= 0) {
+                    iterateWebViewListAsync(webViewList, nextIndex, handler);
+                } else {
+                    warnAndTriggerFailure(errorSet, handler);
+                }
+            }
+
+            @Override
+            public void onReceiveValue(@Nullable String html) {
+
+                Pair<Pair<Integer, Integer>, PbFindSizeError> pair = findSizeInHtml(html);
+
+                @Nullable
+                Pair<Integer, Integer> size = pair.first;
+                @Nullable
+                PbFindSizeError error = pair.second;
+
+                if (size != null) {
+                    triggerSuccess(webView, size, handler);
+                } else {
+                    processNextWebViewOrFail(error);
+                }
+            }
+        });
+    }
+
+    @NonNull
+    static Pair<Pair<Integer, Integer>, PbFindSizeError> findSizeInHtml(@Nullable String html) {
+
+        if (TextUtils.isEmpty(html)) {
+            return new Pair<>(null, PbFindSizeErrorFactory.NO_HTML);
+        }
+
+        String hbSizeObject = findHbSizeObject(html);
+        if (hbSizeObject == null) {
+            return new Pair<>(null, PbFindSizeErrorFactory.NO_SIZE_OBJECT);
+        }
+
+        String hbSizeValue = findHbSizeValue(hbSizeObject);
+        if (hbSizeValue == null) {
+            return new Pair<>(null, PbFindSizeErrorFactory.NO_SIZE_VALUE);
+        }
+
+        Pair<Integer, Integer> size = stringToSize(hbSizeValue);
+        if (size == null) {
+            return new Pair<>(null, PbFindSizeErrorFactory.SIZE_UNPARSED);
+        } else {
+            return new Pair<>(size, null);
+        }
+
+    }
+
+    @Nullable
+    static String findHbSizeObject(String text) {
+        return matchAndCheck(SIZE_OBJECT_REGEX_EXPRESSION, text);
+    }
+
+    @Nullable
+    static String findHbSizeValue(String text) {
+        return matchAndCheck(SIZE_VALUE_REGEX_EXPRESSION, text);
+    }
+
+    @NonNull
+    static String[] matches(String regex, String text) {
+
+        Pattern pattern = Pattern.compile(regex);
+        Matcher matcher = pattern.matcher(text);
+
+        List<String> allMatches = new ArrayList<>();
+        while (matcher.find()) {
+            allMatches.add(matcher.group());
+        }
+
+        return allMatches.toArray(new String[0]);
+    }
+
+    @Nullable
+    static String matchAndCheck(String regex, String text) {
+
+        String[] matched = matches(regex, text);
+
+        if (matched.length == 0) {
+            return null;
+        }
+
+        String firstResult = matched[0];
+        return firstResult;
+    }
+
+    @Nullable
+    static Pair<Integer, Integer> stringToSize(String size) {
+        String[] sizeArr = size.split("x");
+
+        if (sizeArr.length != 2) {
+            LogUtil.w(size + " has a wrong format");
+            return null;
+        }
+
+        String widthString = sizeArr[0];
+        String heightString = sizeArr[1];
+
+        int width;
+        int height;
+        try {
+            width = Integer.parseInt(widthString);
+        } catch (NumberFormatException e) {
+            LogUtil.w(size + "can not be converted to Size");
+            return null;
+        }
+
+        try {
+            height = Integer.parseInt(heightString);
+        } catch (NumberFormatException e) {
+            LogUtil.w(size + "can not be converted to Size");
+            return null;
+        }
+
+        return new Pair<>(width, height);
+    }
+
+    public interface PbFindSizeListener {
+        void success(int width, int height);
+
+        void failure(@NonNull PbFindSizeError error);
+    }
+
+}
+
+//It is not possible to use Enum because we should have a possibility to pass additional information
+final class PbFindSizeErrorFactory {
+
+    private PbFindSizeErrorFactory() { }
+
+    //common errors
+    static final int UNSPECIFIED_CODE = 201;
+    static final int UNSUPPORTED_ANDROID_IPI_CODE = 202;
+    static final int COMPOSITE_FAILURE_CODE = 203;
+
+    //Platform's errors
+    static final int NO_WEBVIEW_CODE = 210;
+    static final int WEBVIEW_FAILED_CODE = 220;
+    static final int NO_HTML_CODE = 230;
+    static final int NO_SIZE_OBJECT_CODE = 240;
+    static final int NO_SIZE_VALUE_CODE = 250;
+    static final int SIZE_UNPARSED_CODE = 260;
+
+    //factory's objects
+    static final PbFindSizeError UNSPECIFIED = getUnspecifiedError();
+
+    static final PbFindSizeError NO_WEB_VIEW = getNoWebViewError();
+    static final PbFindSizeError NO_HTML = getNoHtmlError();
+    static final PbFindSizeError NO_SIZE_OBJECT = getNoSizeObjectError();
+    static final PbFindSizeError NO_SIZE_VALUE = getNoSizeValueError();
+    static final PbFindSizeError SIZE_UNPARSED = getSizeUnparsedError();
+
+    private static PbFindSizeError getUnspecifiedError() {
+        return getError(UNSPECIFIED_CODE, "Unspecified error");
+    }
+
+    static PbFindSizeError getUnsupportedAndroidIpiError(int currentAndroidApi, int necessaryAndroidApi) {
+        return getError(UNSUPPORTED_ANDROID_IPI_CODE, "AndroidAPI:" + currentAndroidApi + " doesn't support the functionality. Minimum AndroidAPI is:" + necessaryAndroidApi);
+    }
+
+    static PbFindSizeError getCompositeFailureError(Set<Pair<WebView, PbFindSizeError>> errorSet) {
+        StringBuilder result = new StringBuilder();
+        result.append("There is a set of errors:\n");
+
+        for (Pair<WebView, PbFindSizeError> webViewFindSizeError : errorSet) {
+
+            result.append("    WebView:").append(webViewFindSizeError.first)
+                    .append(" errorCode:").append(webViewFindSizeError.second.getCode())
+                    .append(" errorDescription:").append(webViewFindSizeError.second.getDescription())
+                    .append("\n");
+        }
+
+        return getError(COMPOSITE_FAILURE_CODE, result.toString());
+    }
+
+    //private zone
+    private static PbFindSizeError getNoWebViewError() {
+        return getError(NO_WEBVIEW_CODE, "The view doesn't include WebView");
+    }
+
+    private static PbFindSizeError getWebViewFailedError() {
+        return getError(WEBVIEW_FAILED_CODE, "The view doesn't include WebView");
+    }
+
+    private static PbFindSizeError getNoHtmlError() {
+        return getError(NO_HTML_CODE, "The WebView doesn't have HTML");
+    }
+
+    private static PbFindSizeError getNoSizeObjectError() {
+        return getError(NO_SIZE_OBJECT_CODE, "The HTML doesn't contain a size object");
+    }
+
+    private static PbFindSizeError getNoSizeValueError() {
+        return getError(NO_SIZE_VALUE_CODE, "The size object doesn't contain a value");
+    }
+
+    private static PbFindSizeError getSizeUnparsedError() {
+        return getError(SIZE_UNPARSED_CODE, "The size value has a wrong format");
+    }
+
+    private static PbFindSizeError getError(final int code, final String description) {
+
+        return new PbFindSizeError(code, description);
+    }
+}

--- a/PrebidMobile/API1.0/src/main/java/org/prebid/mobile/addendum/Pair.java
+++ b/PrebidMobile/API1.0/src/main/java/org/prebid/mobile/addendum/Pair.java
@@ -1,0 +1,47 @@
+/*
+ *    Copyright 2018-2019 Prebid.org, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.prebid.mobile.addendum;
+
+class Pair<U, V> {
+    U first;
+    V second;
+
+    public Pair(U first, V second) {
+
+        this.first = first;
+        this.second = second;
+    }
+
+    @SuppressWarnings("EqualsReplaceableByObjectsCall")
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof Pair)) return false;
+
+        Pair<?, ?> pair = (Pair<?, ?>) o;
+
+        if (first != null ? !first.equals(pair.first) : pair.first != null) return false;
+        return second != null ? second.equals(pair.second) : pair.second == null;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = first != null ? first.hashCode() : 0;
+        result = 31 * result + (second != null ? second.hashCode() : 0);
+        return result;
+    }
+}

--- a/PrebidMobile/API1.0/src/main/java/org/prebid/mobile/addendum/PbError.java
+++ b/PrebidMobile/API1.0/src/main/java/org/prebid/mobile/addendum/PbError.java
@@ -1,0 +1,65 @@
+/*
+ *    Copyright 2018-2019 Prebid.org, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.prebid.mobile.addendum;
+
+class PbError {
+
+    private final String domain = "com.prebidmobile.android";
+    private final int code;
+    private final String description;
+
+    PbError(int code, String description) {
+        this.code = code;
+        this.description = description;
+    }
+
+    public final String getDomain() {
+        return domain;
+    }
+
+    public final int getCode() {
+        return code;
+    }
+
+    public final String getDescription() {
+        return description;
+    }
+
+    @Override
+    public int hashCode() {
+        return code;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (!(o instanceof PbError)) return false;
+
+        PbError pbError = (PbError) o;
+
+        return code == pbError.code;
+    }
+
+    @Override
+    public String toString() {
+        return "PbError{" +
+                "domain='" + domain + '\'' +
+                ", code=" + code +
+                ", description='" + description + '\'' +
+                '}';
+    }
+}

--- a/PrebidMobile/API1.0/src/main/java/org/prebid/mobile/addendum/PbFindSizeError.java
+++ b/PrebidMobile/API1.0/src/main/java/org/prebid/mobile/addendum/PbFindSizeError.java
@@ -1,0 +1,25 @@
+/*
+ *    Copyright 2018-2019 Prebid.org, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.prebid.mobile.addendum;
+
+
+public final class PbFindSizeError extends PbError {
+
+    PbFindSizeError(int code, String description) {
+        super(code, description);
+    }
+}

--- a/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/UtilTest.java
+++ b/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/UtilTest.java
@@ -30,9 +30,7 @@ import java.util.HashMap;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
-import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertTrue;
-import static org.junit.Assert.assertNull;
 
 
 @RunWith(RobolectricTestRunner.class)
@@ -112,88 +110,6 @@ public class UtilTest extends BaseSetup {
         assertTrue(Util.supportedAdObject(request));
         Object object = new Object();
         assertFalse(Util.supportedAdObject(object));
-    }
-
-    @Test
-    public void testRegexMatches() {
-        String[] result = Util.matches("^a", "aaa aaa");
-        assertEquals(1, result.length);
-        assertEquals("a", result[0]);
-
-        result = Util.matches("^b", "aaa aaa");
-        assertEquals(0, result.length);
-
-        result = Util.matches("aaa aaa", "^a");
-        assertEquals(0, result.length);
-
-        result = Util.matches("[0-9]+x[0-9]+", "{ \n adManagerResponse:\"hb_size\":[\"728x90\"],\"hb_size_rubicon\":[\"1x1\"],moPubResponse:\"hb_size:300x250\" \n }");
-        assertEquals(3, result.length);
-        assertEquals("728x90", result[0]);
-        assertEquals("1x1", result[1]);
-        assertEquals("300x250", result[2]);
-
-        result = Util.matches("hb_size\\W+[0-9]+x[0-9]+", "{ \n adManagerResponse:\"hb_size\":[\"728x90\"],\"hb_size_rubicon\":[\"1x1\"],moPubResponse:\"hb_size:300x250\" \n }");
-        assertEquals(2, result.length);
-        assertEquals("hb_size\":[\"728x90", result[0]);
-        assertEquals("hb_size:300x250", result[1]);
-    }
-
-    @Test
-    public void testRegexMatchAndCheck() {
-        String result = Util.matchAndCheck("^a", "aaa aaa");
-
-        assertNotNull(result);
-        assertEquals("a", result);
-
-        result = Util.matchAndCheck("^b", "aaa aaa");
-        assertNull(result);
-    }
-
-
-    @Test
-    public void testFindHbSizeValue() {
-        String result = Util.findHbSizeValue("{ \n adManagerResponse:\"hb_size\":[\"728x90\"],\"hb_size_rubicon\":[\"728x90\"],moPubResponse:\"hb_size:300x250\" \n }");
-        assertNotNull(result);
-        assertEquals("728x90", result);
-    }
-
-    @Test
-    public void testFindHbSizeKeyValue() {
-        String result = Util.findHbSizeKeyValue("{ \n adManagerResponse:\"hb_size\":[\"728x90\"],\"hb_size_rubicon\":[\"728x90\"],moPubResponse:\"hb_size:300x250\" \n }");
-        assertNotNull(result);
-        assertEquals("hb_size\":[\"728x90", result);
-    }
-
-    @Test
-    public void testStringToCGSize() {
-        Util.CreativeSize result = Util.stringToSize("300x250");
-        assertNotNull(result);
-        assertEquals(new Util.CreativeSize(300, 250), result);
-
-        result = Util.stringToSize("300x250x1");
-        assertNull(result);
-
-        result = Util.stringToSize("ERROR");
-        assertNull(result);
-
-        result = Util.stringToSize("300x250ERROR");
-        assertNull(result);
-    }
-
-    @Test
-    public void testFindSizeInJavaScript() {
-        Util.CreativeSize result = Util.findSizeInJavaScript(null);
-        assertNull(result);
-
-        result = Util.findSizeInJavaScript("<script> \n </script>");
-        assertNull(result);
-
-        result = Util.findSizeInJavaScript("<script> \n \"hb_size\":ERROR \n </script>");
-        assertNull(result);
-
-        result = Util.findSizeInJavaScript("<script> \n \"hb_size\":[\"728x90\"] \n </script>");
-        assertNotNull(result);
-        assertEquals(new Util.CreativeSize(728, 90), result);
     }
 
 }

--- a/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/addendum/AdViewUtilsTest.java
+++ b/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/addendum/AdViewUtilsTest.java
@@ -1,0 +1,153 @@
+/*
+ *    Copyright 2018-2019 Prebid.org, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.prebid.mobile.addendum;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.prebid.mobile.testutils.BaseSetup;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = BaseSetup.testSDK)
+public class AdViewUtilsTest {
+
+    @Test
+    public void testRegexMatches() {
+        String[] result = AdViewUtils.matches("^a", "aaa aaa");
+        assertEquals(1, result.length);
+        assertEquals("a", result[0]);
+
+        result = AdViewUtils.matches("^b", "aaa aaa");
+        assertEquals(0, result.length);
+
+        result = AdViewUtils.matches("aaa aaa", "^a");
+        assertEquals(0, result.length);
+
+        result = AdViewUtils.matches("[0-9]+x[0-9]+", "{ \n adManagerResponse:\"hb_size\":[\"728x90\"],\"hb_size_rubicon\":[\"1x1\"],moPubResponse:\"hb_size:300x250\" \n }");
+        assertEquals(3, result.length);
+        assertEquals("728x90", result[0]);
+        assertEquals("1x1", result[1]);
+        assertEquals("300x250", result[2]);
+
+        result = AdViewUtils.matches("hb_size\\W+[0-9]+x[0-9]+", "{ \n adManagerResponse:\"hb_size\":[\"728x90\"],\"hb_size_rubicon\":[\"1x1\"],moPubResponse:\"hb_size:300x250\" \n }");
+        assertEquals(2, result.length);
+        assertEquals("hb_size\":[\"728x90", result[0]);
+        assertEquals("hb_size:300x250", result[1]);
+    }
+
+    @Test
+    public void testRegexMatchAndCheck() {
+        String result = AdViewUtils.matchAndCheck("^a", "aaa aaa");
+
+        assertNotNull(result);
+        assertEquals("a", result);
+
+        result = AdViewUtils.matchAndCheck("^b", "aaa aaa");
+        assertNull(result);
+    }
+
+
+    @Test
+    public void testFindHbSizeValue() {
+        String result = AdViewUtils.findHbSizeValue("{ \n adManagerResponse:\"hb_size\":[\"728x90\"],\"hb_size_rubicon\":[\"728x90\"],moPubResponse:\"hb_size:300x250\" \n }");
+        assertNotNull(result);
+        assertEquals("728x90", result);
+    }
+
+    @Test
+    public void testFindHbSizeKeyValue() {
+        String result = AdViewUtils.findHbSizeObject("{ \n adManagerResponse:\"hb_size\":[\"728x90\"],\"hb_size_rubicon\":[\"728x90\"],moPubResponse:\"hb_size:300x250\" \n }");
+        assertNotNull(result);
+        assertEquals("hb_size\":[\"728x90", result);
+    }
+
+    @Test
+    public void testStringToCGSize() {
+        Pair<Integer, Integer> result = AdViewUtils.stringToSize("300x250");
+        assertNotNull(result);
+        assertTrue(result.first == 300 && result.second == 250);
+
+        result = AdViewUtils.stringToSize("300x250x1");
+        assertNull(result);
+
+        result = AdViewUtils.stringToSize("ERROR");
+        assertNull(result);
+
+        result = AdViewUtils.stringToSize("300x250ERROR");
+        assertNull(result);
+    }
+
+    @Test
+    public void testFailureFindASizeInNilHtmlCode() {
+        findSizeInHtmlErrorHelper(null, PbFindSizeErrorFactory.NO_HTML_CODE);
+    }
+
+    @Test
+    public void testFailureFindASizeIfItIsNotPresent() {
+        findSizeInHtmlErrorHelper("<script> \n </script>", PbFindSizeErrorFactory.NO_SIZE_OBJECT_CODE);
+    }
+
+    @Test
+    public void testFailureFindASizeIfItHasTheWrongType() {
+        findSizeInHtmlErrorHelper("<script> \n \"hb_size\":\"1ERROR1\" \n </script>", PbFindSizeErrorFactory.NO_SIZE_OBJECT_CODE);
+    }
+
+    @Test
+    public void testSuccessFindASizeIfProperlyFormatted() {
+        findSizeInHtmlSuccessHelper("<script> \n \"hb_size\":[\"728x90\"] \n </script>", 728, 90);
+    }
+
+    void findSizeInHtmlErrorHelper(String htmlBody, int expectedErrorCode) {
+
+        // given
+        Pair<Integer, Integer> size;
+        PbFindSizeError error;
+
+        // when
+        Pair<Pair<Integer, Integer>, PbFindSizeError> result = AdViewUtils.findSizeInHtml(htmlBody);
+        size = result.first;
+        error = result.second;
+
+        // then
+        assertNull(size);
+        assertNotNull(error);
+        assertEquals(expectedErrorCode, error.getCode());
+    }
+
+    void findSizeInHtmlSuccessHelper(String htmlBody, int expectedWidth, int expectedHeight) {
+        // given
+        Pair<Integer, Integer> size;
+        PbFindSizeError error;
+
+        // when
+        Pair<Pair<Integer, Integer>, PbFindSizeError> result = AdViewUtils.findSizeInHtml(htmlBody);
+        size = result.first;
+        error = result.second;
+
+        // then
+        assertNotNull(size);
+        assertTrue(expectedWidth == size.first && expectedHeight == size.second);
+        assertNull(error);
+    }
+
+}

--- a/PrebidMobile/API1.0Demo/src/main/java/org/prebid/mobile/app/DemoActivity.java
+++ b/PrebidMobile/API1.0Demo/src/main/java/org/prebid/mobile/app/DemoActivity.java
@@ -20,9 +20,11 @@ package org.prebid.mobile.app;
 import android.content.Intent;
 import android.os.Build;
 import android.os.Bundle;
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.support.v7.app.AlertDialog;
 import android.support.v7.app.AppCompatActivity;
+import android.util.Log;
 import android.widget.FrameLayout;
 
 import com.google.android.gms.ads.AdListener;
@@ -89,12 +91,15 @@ public class DemoActivity extends AppCompatActivity {
             public void onAdLoaded() {
                 super.onAdLoaded();
 
-                Util.findPrebidCreativeSize(dfpAdView, new Util.CreativeSizeCompletionHandler() {
+                Util.findPrebidCreativeSize(dfpAdView, new Util.CreativeSizeResultHandler() {
                     @Override
-                    public void onSize(final Util.CreativeSize size) {
-                        if (size != null) {
-                            dfpAdView.setAdSizes(new AdSize(size.getWidth(), size.getHeight()));
-                        }
+                    public void success(@NonNull Util.CreativeSize size) {
+                        dfpAdView.setAdSizes(new AdSize(size.getWidth(), size.getHeight()));
+                    }
+
+                    @Override
+                    public void failure(@NonNull Util.CreativeSizeError error) {
+                        Log.d("MyTag", "error: " + error.getMessage());
                     }
                 });
 

--- a/PrebidMobile/API1.0Demo/src/main/java/org/prebid/mobile/app/DemoActivity.java
+++ b/PrebidMobile/API1.0Demo/src/main/java/org/prebid/mobile/app/DemoActivity.java
@@ -41,7 +41,8 @@ import org.prebid.mobile.BannerAdUnit;
 import org.prebid.mobile.InterstitialAdUnit;
 import org.prebid.mobile.OnCompleteListener;
 import org.prebid.mobile.ResultCode;
-import org.prebid.mobile.Util;
+import org.prebid.mobile.addendum.AdViewUtils;
+import org.prebid.mobile.addendum.PbFindSizeError;
 
 import static org.prebid.mobile.app.Constants.MOPUB_BANNER_ADUNIT_ID_300x250;
 import static org.prebid.mobile.app.Constants.MOPUB_BANNER_ADUNIT_ID_320x50;
@@ -76,10 +77,10 @@ public class DemoActivity extends AppCompatActivity {
         int width = Integer.valueOf(wAndH[0]);
         int height = Integer.valueOf(wAndH[1]);
         if (width == 300 && height == 250) {
-            dfpAdView.setAdUnitId(Constants.DFP_BANNER_ADUNIT_ID_300x250);
+            dfpAdView.setAdUnitId(Constants.DFP_BANNER_ADUNIT_ID_ALL_SIZES);
             adUnit = new BannerAdUnit(Constants.PBS_CONFIG_ID_300x250, width, height);
         } else if (width == 320 && height == 50) {
-            dfpAdView.setAdUnitId(Constants.DFP_BANNER_ADUNIT_ID_300x250);
+            dfpAdView.setAdUnitId(Constants.DFP_BANNER_ADUNIT_ID_ALL_SIZES);
             adUnit = new BannerAdUnit(Constants.PBS_CONFIG_ID_320x50, width, height);
         } else {
             dfpAdView.setAdUnitId(Constants.DFP_BANNER_ADUNIT_ID_ALL_SIZES);
@@ -91,15 +92,16 @@ public class DemoActivity extends AppCompatActivity {
             public void onAdLoaded() {
                 super.onAdLoaded();
 
-                Util.findPrebidCreativeSize(dfpAdView, new Util.CreativeSizeResultHandler() {
+                AdViewUtils.findPrebidCreativeSize(dfpAdView, new AdViewUtils.PbFindSizeListener() {
                     @Override
-                    public void success(@NonNull Util.CreativeSize size) {
-                        dfpAdView.setAdSizes(new AdSize(size.getWidth(), size.getHeight()));
+                    public void success(int width, int height) {
+                        dfpAdView.setAdSizes(new AdSize(width, height));
+
                     }
 
                     @Override
-                    public void failure(@NonNull Util.CreativeSizeError error) {
-                        Log.d("MyTag", "error: " + error.getMessage());
+                    public void failure(@NonNull PbFindSizeError error) {
+                        Log.d("MyTag", "error: " + error);
                     }
                 });
 


### PR DESCRIPTION
GitHub issue #124 

What were changed:
1. Fixed bug when a callback is not being called on a client side
2. A new method `AdViewUtils.findPrebidCreativeSize()` was created to support success and failure handlers 
3. The old resize function(`findPrebidCreativeSize(View, CreativeSizeCompletionHandler)`) was marked as deprecated and it's still possible to use it (to support compatibility)

<img width="672" alt="Screen Shot 2019-07-04 at 6 57 56 PM 1" src="https://user-images.githubusercontent.com/8141931/60678586-a6f28600-9e8d-11e9-853c-39d8f1720431.png">

The latest API for resize function looks like

```
        dfpAdView.setAdListener(new AdListener() {
            @Override
            public void onAdLoaded() {
                super.onAdLoaded();

                AdViewUtils.findPrebidCreativeSize(dfpAdView, new AdViewUtils.PbFindSizeListener() {
                    @Override
                    public void success(int width, int height) {
                        dfpAdView.setAdSizes(new AdSize(width, height));

                    }

                    @Override
                    public void failure(@NonNull PbFindSizeError error) {
                        Log.d("MyTag", "error: " + error);
                    }
                });

            }
        });
```

Error codes:
```
UNSPECIFIED_CODE = 201;
UNSUPPORTED_ANDROID_IPI_CODE = 202;
COMPOSITE_FAILURE_CODE = 203;
NO_WEBVIEW_CODE = 210;
WEBVIEW_FAILED_CODE = 220;
NO_HTML_CODE = 230;
NO_SIZE_OBJECT_CODE = 240;
NO_SIZE_VALUE_CODE = 250;
SIZE_UNPARSED_CODE = 260;
```

What to do:
1. Update docs