### PR TITLE
Support for First Party Data

### DIFF
--- a/PrebidMobile/API1.0/src/main/java/org/prebid/mobile/AdUnit.java
+++ b/PrebidMobile/API1.0/src/main/java/org/prebid/mobile/AdUnit.java
@@ -24,7 +24,7 @@ import android.support.annotation.IntRange;
 import android.support.annotation.NonNull;
 import android.text.TextUtils;
 
-import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -36,8 +36,6 @@ public abstract class AdUnit {
     private String configId;
     private AdType adType;
 
-    @Deprecated
-    private ArrayList<String> userKeywords;
     private DemandFetcher fetcher;
     private int periodMillis;
 
@@ -49,8 +47,6 @@ public abstract class AdUnit {
         this.adType = adType;
         this.periodMillis = 0; // by default no auto refresh
         
-        this.userKeywords = new ArrayList<>();
-
         this.contextDataDictionary = new HashMap<>();
         this.contextKeywordsSet = new HashSet<>();
 
@@ -74,7 +70,6 @@ public abstract class AdUnit {
             fetcher = null;
         }
     }
-
 
     public void fetchDemand(@NonNull Object adObj, @NonNull OnCompleteListener listener) {
         if (TextUtils.isEmpty(PrebidMobile.getPrebidServerAccountId())) {
@@ -128,7 +123,7 @@ public abstract class AdUnit {
         if (Util.supportedAdObject(adObj)) {
             fetcher = new DemandFetcher(adObj);
 
-            RequestParams requestParams = new RequestParams(configId, adType, sizes, userKeywords, contextDataDictionary, contextKeywordsSet, minSizePerc);
+            RequestParams requestParams = new RequestParams(configId, adType, sizes, contextDataDictionary, contextKeywordsSet, minSizePerc);
             fetcher.setPeriodMillis(periodMillis);
             fetcher.setRequestParams(requestParams);
             fetcher.setListener(listener);
@@ -148,30 +143,26 @@ public abstract class AdUnit {
     /**
      *@deprecated Please migrate to - TargetingParams.addUserKeyword(String)
      *@see TargetingParams#addUserKeyword(String)
+     *
+     * @param key parameter will be omitted
      */
     @Deprecated
-    public void addUserKeyword(String key, String value) {
-        if (!TextUtils.isEmpty(key) && !TextUtils.isEmpty(value)) {
-            userKeywords.add(key + "=" + value);
-        } else if (!TextUtils.isEmpty(key)) {
-            userKeywords.add(key);
+    public void addUserKeyword(String key, String keyword) {
+        if (!TextUtils.isEmpty(keyword)) {
+            TargetingParams.addUserKeyword(keyword);
         }
     }
 
     /**
      *@deprecated Please migrate to - TargetingParams.addUserKeywords(Set)
      *@see TargetingParams#addUserKeywords(Set)
+     *
+     * @param key parameter will be omitted
      */
     @Deprecated
-    public void addUserKeywords(String key, String[] values) {
-        if (!TextUtils.isEmpty(key) && values.length > 0) {
-            userKeywords.clear();
-            for (String value : values) {
-                userKeywords.add(key + "=" + value);
-            }
-        } else if (!TextUtils.isEmpty(key)) {
-            userKeywords.clear();
-            userKeywords.add(key);
+    public void addUserKeywords(String key, String[] keywords) {
+        if (keywords.length > 0) {
+            TargetingParams.addUserKeywords(new HashSet<>(Arrays.asList(keywords)));
         }
     }
 
@@ -180,19 +171,8 @@ public abstract class AdUnit {
      *@see TargetingParams#removeUserKeyword(String)
      */
     @Deprecated
-    public void removeUserKeyword(String key) {
-        ArrayList<String> toBeRemoved = new ArrayList<>();
-        for (String keyword : userKeywords) {
-            if (keyword.equals(key)) {
-                toBeRemoved.add(keyword);
-            } else {
-                String[] keyValuePair = keyword.split("=");
-                if (keyValuePair[0].equals(key)) {
-                    toBeRemoved.add(keyword);
-                }
-            }
-        }
-        userKeywords.removeAll(toBeRemoved);
+    public void removeUserKeyword(String keyword) {
+        TargetingParams.removeUserKeyword(keyword);
     }
 
     /**
@@ -201,7 +181,7 @@ public abstract class AdUnit {
      */
     @Deprecated
     public void clearUserKeywords() {
-        userKeywords.clear();
+        TargetingParams.clearUserKeywords();
     }
 
     // MARK: - adunit context data aka inventory data (imp[].ext.context.data)

--- a/PrebidMobile/API1.0/src/main/java/org/prebid/mobile/PrebidServerAdapter.java
+++ b/PrebidMobile/API1.0/src/main/java/org/prebid/mobile/PrebidServerAdapter.java
@@ -469,24 +469,36 @@ class PrebidServerAdapter implements DemandAdapter {
                 if (ext != null && ext.length() > 0) {
                     postData.put("ext", ext);
                 }
+
+                JSONObject objectWithoutEmptyValues = Util.getObjectWithoutEmptyValues(postData);
+
+                if (objectWithoutEmptyValues != null) {
+                    postData = objectWithoutEmptyValues;
+
+                    JSONObject prebid = postData.getJSONObject("ext").getJSONObject("prebid");
+
+                    JSONObject cache = new JSONObject();
+                    JSONObject bids = new JSONObject();
+                    cache.put("bids", bids);
+                    prebid.put("cache", cache);
+
+                    JSONObject targetingEmpty = new JSONObject();
+                    prebid.put("targeting", targetingEmpty);
+                }
+
             } catch (JSONException e) {
             }
-            return Util.getObjectWithoutEmptyValues(postData);
+
+            return postData;
         }
 
         private JSONObject getRequestExtData() {
             JSONObject ext = new JSONObject();
             JSONObject prebid = new JSONObject();
             try {
-                JSONObject cache = new JSONObject();
-                JSONObject bids = new JSONObject();
-                cache.put("bids", bids);
-                prebid.put("cache", cache);
                 JSONObject storedRequest = new JSONObject();
                 storedRequest.put("id", PrebidMobile.getPrebidServerAccountId());
                 prebid.put("storedrequest", storedRequest);
-                JSONObject targetingEmpty = new JSONObject();
-                prebid.put("targeting", targetingEmpty);
 
                 JSONObject data = new JSONObject().put("bidders", new JSONArray(TargetingParams.getAccessControlList()));
                 prebid.put("data", data);

--- a/PrebidMobile/API1.0/src/main/java/org/prebid/mobile/PrebidServerAdapter.java
+++ b/PrebidMobile/API1.0/src/main/java/org/prebid/mobile/PrebidServerAdapter.java
@@ -471,7 +471,7 @@ class PrebidServerAdapter implements DemandAdapter {
                 }
             } catch (JSONException e) {
             }
-            return postData;
+            return Util.getObjectWithoutEmptyValues(postData);
         }
 
         private JSONObject getRequestExtData() {
@@ -487,6 +487,9 @@ class PrebidServerAdapter implements DemandAdapter {
                 prebid.put("storedrequest", storedRequest);
                 JSONObject targetingEmpty = new JSONObject();
                 prebid.put("targeting", targetingEmpty);
+
+                JSONObject data = new JSONObject().put("bidders", new JSONArray(TargetingParams.getAccessControlList()));
+                prebid.put("data", data);
                 ext.put("prebid", prebid);
             } catch (JSONException e) {
                 e.printStackTrace();
@@ -525,9 +528,13 @@ class PrebidServerAdapter implements DemandAdapter {
                     banner.put("format", format);
                     imp.put("banner", banner);
                 }
-                imp.put("ext", ext);
+
                 JSONObject prebid = new JSONObject();
                 ext.put("prebid", prebid);
+                JSONObject context = new JSONObject();
+                context.put("data", Util.toJson(requestParams.getContextDataDictionary()));
+                context.put("keywords", TextUtils.join(",", requestParams.getContextKeywordsSet()));
+                ext.put("context", context);
                 JSONObject storedrequest = new JSONObject();
                 prebid.put("storedrequest", storedrequest);
                 storedrequest.put("id", requestParams.getConfigId());
@@ -590,8 +597,7 @@ class PrebidServerAdapter implements DemandAdapter {
                     deviceExtPrebidInstl.put("minwidthperc", minSizePercWidth);
                     deviceExtPrebidInstl.put("minheightperc", minSizePercHeight);
 
-                    JSONObject deviceExtWithoutEmptyValues = Util.getObjectWithoutEmptyValues(deviceExt);
-                    device.put("ext", deviceExtWithoutEmptyValues);
+                    device.put("ext", deviceExt);
                 }
 
                 // POST data that requires context
@@ -723,7 +729,9 @@ class PrebidServerAdapter implements DemandAdapter {
                 prebid.put("version", PrebidServerSettings.sdk_version);
                 JSONObject ext = new JSONObject();
                 ext.put("prebid", prebid);
+                ext.put("data", Util.toJson(TargetingParams.getContextDataDictionary()));
                 app.put("ext", ext);
+                app.put("keywords", TextUtils.join(",", TargetingParams.getContextKeywordsSet()));
             } catch (JSONException e) {
                 LogUtil.d("PrebidServerAdapter getAppObject() " + e.getMessage());
             }
@@ -751,20 +759,20 @@ class PrebidServerAdapter implements DemandAdapter {
                         break;
                 }
                 user.put("gender", g);
-                StringBuilder builder = new StringBuilder();
-                ArrayList<String> keywords = this.requestParams.getKeywords();
-                for (String key : keywords) {
-                    builder.append(key).append(",");
+
+                String globalUserKeywordString = TextUtils.join(",", TargetingParams.getUserKeywordsSet());
+                String adunitUserKeywordString = TextUtils.join(",", requestParams.getUserKeywords());
+                if (!TextUtils.isEmpty(globalUserKeywordString))  {
+                    user.put("keywords", globalUserKeywordString);
+                } else if (!TextUtils.isEmpty(adunitUserKeywordString))  {
+                    user.put("keywords", adunitUserKeywordString);
                 }
-                String finalKeywords = builder.toString();
-                if (!TextUtils.isEmpty(finalKeywords)) {
-                    user.put("keywords", finalKeywords);
-                }
-                if (TargetingParams.isSubjectToGDPR() != null) {
-                    JSONObject ext = new JSONObject();
-                    ext.put("consent", TargetingParams.getGDPRConsentString());
-                    user.put("ext", ext);
-                }
+
+                JSONObject ext = new JSONObject();
+                ext.put("consent", TargetingParams.getGDPRConsentString());
+                ext.put("data", Util.toJson(TargetingParams.getUserDataDictionary()));
+                user.put("ext", ext);
+
             } catch (JSONException e) {
                 LogUtil.d("PrebidServerAdapter getUserObject() " + e.getMessage());
             }

--- a/PrebidMobile/API1.0/src/main/java/org/prebid/mobile/PrebidServerAdapter.java
+++ b/PrebidMobile/API1.0/src/main/java/org/prebid/mobile/PrebidServerAdapter.java
@@ -773,12 +773,7 @@ class PrebidServerAdapter implements DemandAdapter {
                 user.put("gender", g);
 
                 String globalUserKeywordString = TextUtils.join(",", TargetingParams.getUserKeywordsSet());
-                String adunitUserKeywordString = TextUtils.join(",", requestParams.getUserKeywords());
-                if (!TextUtils.isEmpty(globalUserKeywordString))  {
-                    user.put("keywords", globalUserKeywordString);
-                } else if (!TextUtils.isEmpty(adunitUserKeywordString))  {
-                    user.put("keywords", adunitUserKeywordString);
-                }
+                user.put("keywords", globalUserKeywordString);
 
                 JSONObject ext = new JSONObject();
                 ext.put("consent", TargetingParams.getGDPRConsentString());

--- a/PrebidMobile/API1.0/src/main/java/org/prebid/mobile/RequestParams.java
+++ b/PrebidMobile/API1.0/src/main/java/org/prebid/mobile/RequestParams.java
@@ -19,7 +19,6 @@ package org.prebid.mobile;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Map;
@@ -31,8 +30,6 @@ class RequestParams {
     private AdType adType = AdType.BANNER;
     private HashSet<AdSize> sizes = new HashSet<>();
 
-    @Deprecated
-    private final ArrayList<String> userKeywords;
     @Nullable
     private Map<String, Set<String>> contextDataDictionary;
     @Nullable
@@ -41,15 +38,14 @@ class RequestParams {
     @Nullable
     private AdSize minSizePerc; //non null only for InterstitialAdUnit(String, int, int)
 
-    RequestParams(String configId, AdType adType, HashSet<AdSize> sizes, ArrayList<String> userKeywords) {
+    RequestParams(String configId, AdType adType, HashSet<AdSize> sizes) {
         this.configId = configId;
         this.adType = adType;
         this.sizes = sizes; // for Interstitial this will be null, will use screen width & height in the request
-        this.userKeywords = userKeywords;
     }
 
-    RequestParams(String configId, AdType adType, HashSet<AdSize> sizes, ArrayList<String> userKeywords, @Nullable Map<String, Set<String>> contextDataDictionary, @Nullable Set<String> contextKeywordsSet, @Nullable AdSize minSizePerc) {
-        this(configId, adType, sizes, userKeywords);
+    RequestParams(String configId, AdType adType, HashSet<AdSize> sizes, @Nullable Map<String, Set<String>> contextDataDictionary, @Nullable Set<String> contextKeywordsSet, @Nullable AdSize minSizePerc) {
+        this(configId, adType, sizes);
         this.contextDataDictionary = contextDataDictionary;
         this.contextKeywordsSet = contextKeywordsSet;
         this.minSizePerc = minSizePerc;
@@ -65,10 +61,6 @@ class RequestParams {
 
     HashSet<AdSize> getAdSizes() {
         return this.sizes;
-    }
-
-    ArrayList<String> getUserKeywords() {
-        return userKeywords;
     }
 
     @NonNull

--- a/PrebidMobile/API1.0/src/main/java/org/prebid/mobile/RequestParams.java
+++ b/PrebidMobile/API1.0/src/main/java/org/prebid/mobile/RequestParams.java
@@ -16,29 +16,42 @@
 
 package org.prebid.mobile;
 
+import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 class RequestParams {
 
     private String configId = "";
     private AdType adType = AdType.BANNER;
     private HashSet<AdSize> sizes = new HashSet<>();
-    private ArrayList<String> keywords;
+
+    @Deprecated
+    private final ArrayList<String> userKeywords;
+    @Nullable
+    private Map<String, Set<String>> contextDataDictionary;
+    @Nullable
+    private Set<String> contextKeywordsSet;
+
     @Nullable
     private AdSize minSizePerc; //non null only for InterstitialAdUnit(String, int, int)
 
-    RequestParams(String configId, AdType adType, HashSet<AdSize> sizes, ArrayList<String> keywords) {
+    RequestParams(String configId, AdType adType, HashSet<AdSize> sizes, ArrayList<String> userKeywords) {
         this.configId = configId;
         this.adType = adType;
         this.sizes = sizes; // for Interstitial this will be null, will use screen width & height in the request
-        this.keywords = keywords;
+        this.userKeywords = userKeywords;
     }
 
-    RequestParams(String configId, AdType adType, HashSet<AdSize> sizes, ArrayList<String> keywords, @Nullable AdSize minSizePerc) {
-        this(configId, adType, sizes, keywords);
+    RequestParams(String configId, AdType adType, HashSet<AdSize> sizes, ArrayList<String> userKeywords, @Nullable Map<String, Set<String>> contextDataDictionary, @Nullable Set<String> contextKeywordsSet, @Nullable AdSize minSizePerc) {
+        this(configId, adType, sizes, userKeywords);
+        this.contextDataDictionary = contextDataDictionary;
+        this.contextKeywordsSet = contextKeywordsSet;
         this.minSizePerc = minSizePerc;
     }
 
@@ -54,8 +67,18 @@ class RequestParams {
         return this.sizes;
     }
 
-    ArrayList<String> getKeywords() {
-        return keywords;
+    ArrayList<String> getUserKeywords() {
+        return userKeywords;
+    }
+
+    @NonNull
+    public Map<String, Set<String>> getContextDataDictionary() {
+        return contextDataDictionary != null ? contextDataDictionary : new HashMap<String, Set<String>>();
+    }
+
+    @NonNull
+    public Set<String> getContextKeywordsSet() {
+        return contextKeywordsSet != null ? contextKeywordsSet : new HashSet<String>();
     }
 
     @Nullable

--- a/PrebidMobile/API1.0/src/main/java/org/prebid/mobile/TargetingParams.java
+++ b/PrebidMobile/API1.0/src/main/java/org/prebid/mobile/TargetingParams.java
@@ -23,6 +23,10 @@ import android.preference.PreferenceManager;
 import android.text.TextUtils;
 
 import java.util.Calendar;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.Map;
+import java.util.Set;
 
 
 /**
@@ -41,6 +45,16 @@ public class TargetingParams {
     private static final String PREBID_COPPA_KEY = "Prebid_COPPA";
     private static final String PREBID_GDPR_KEY = "Prebid_GDPR";
     private static final String IABConsent_SubjectToGDPR = "IABConsent_SubjectToGDPR";
+
+    public static final String BIDDER_NAME_APP_NEXUS = "appnexus";
+    public static final String BIDDER_NAME_RUBICON_PROJECT = "rubicon";
+
+    private static final Set<String> accessControlList = new HashSet<>();
+    private static final Map<String, Set<String>> userDataMap = new HashMap<>();
+    private static final Set<String> userKeywordsSet = new HashSet<>();
+    private static final Map<String, Set<String>> contextDataDictionary = new HashMap<>();
+    private static final Set<String> contextKeywordsSet = new HashSet<>();
+
     //endregion
 
     //region Private Constructor
@@ -229,6 +243,179 @@ public class TargetingParams {
         return storeUrl;
     }
 
+
+    // MARK: - access control list (ext.prebid.data)
+
+    /**
+     * This method obtains a bidder name allowed to receive global targeting
+     */
+    public static void addBidderToAccessControlList(String bidderName) {
+        accessControlList.add(bidderName);
+    }
+
+    /**
+     * This method allows to remove specific bidder name
+     */
+    public static void removeBidderFromAccessControlList(String bidderName) {
+        accessControlList.remove(bidderName);
+    }
+
+    /**
+     * This method allows to remove all the bidder name set
+     */
+    public static void clearAccessControlList() {
+        accessControlList.clear();
+    }
+
+    static Set<String> getAccessControlList() {
+        return accessControlList;
+    }
+
+    // MARK: - global user data aka visitor data (user.ext.data)
+
+    /**
+     * This method obtains the user data keyword & value for global user targeting
+     * if the key already exists the value will be appended to the list. No duplicates will be added
+     */
+    public static void addUserData(String key, String value) {
+
+        Util.addValue(userDataMap, key, value);
+
+    }
+
+    /**
+     * This method obtains the user data keyword & values set for global user targeting
+     * the values if the key already exist will be replaced with the new set of values
+     */
+    public static void updateUserData(String key, Set<String> value) {
+        userDataMap.put(key, value);
+    }
+
+    /**
+     * This method allows to remove specific user data keyword & value set from global user targeting
+     */
+    public static void removeUserData(String key) {
+        userDataMap.remove(key);
+    }
+
+    /**
+     * This method allows to remove all user data set from global user targeting
+     */
+    public static void clearUserData() {
+        userDataMap.clear();
+    }
+
+    static Map<String, Set<String>> getUserDataDictionary() {
+        return userDataMap;
+    }
+
+    // MARK: - global user keywords (user.keywords)
+
+    /**
+     * This method obtains the user keyword for global user targeting
+     * Inserts the given element in the set if it is not already present.
+     */
+    public static void addUserKeyword(String keyword) {
+        userKeywordsSet.add(keyword);
+    }
+
+    /**
+     * This method obtains the user keyword set for global user targeting
+     * Adds the elements of the given set to the set.
+     */
+    public static void addUserKeywords(Set<String> keywords) {
+        userKeywordsSet.addAll(keywords);
+    }
+
+    /**
+     * This method allows to remove specific user keyword from global user targeting
+     */
+    public static void removeUserKeyword(String keyword) {
+        userKeywordsSet.remove(keyword);
+    }
+
+    /**
+     * This method allows to remove all keywords from the set of global user targeting
+     */
+    public static void clearUserKeywords() {
+        userKeywordsSet.clear();
+    }
+
+    static Set<String> getUserKeywordsSet() {
+        return userKeywordsSet;
+    }
+
+    // MARK: - global context data aka inventory data (app.ext.data)
+
+    /**
+     * This method obtains the context data keyword & value context for global context targeting
+     * if the key already exists the value will be appended to the list. No duplicates will be added
+     */
+    public static void addContextData(String key, String value) {
+        Util.addValue(contextDataDictionary, key, value);
+    }
+
+    /**
+     * This method obtains the context data keyword & values set for global context targeting.
+     * the values if the key already exist will be replaced with the new set of values
+     */
+    public static void updateContextData(String key, Set<String> value) {
+        contextDataDictionary.put(key, value);
+    }
+
+    /**
+     * This method allows to remove specific context data keyword & values set from global context targeting
+     */
+    public static void removeContextData(String key) {
+        contextDataDictionary.remove(key);
+    }
+
+    /**
+     * This method allows to remove all context data set from global context targeting
+     */
+    public static void clearContextData() {
+        contextDataDictionary.clear();
+    }
+
+    static Map<String, Set<String>> getContextDataDictionary() {
+        return contextDataDictionary;
+    }
+
+    // MARK: - adunit context keywords (imp[].ext.context.keywords)
+
+    /**
+     * This method obtains the context keyword for adunit context targeting
+     * Inserts the given element in the set if it is not already present.
+     */
+    public static void addContextKeyword(String keyword) {
+        contextKeywordsSet.add(keyword);
+    }
+
+    /**
+     * This method obtains the context keyword set for adunit context targeting
+     * Adds the elements of the given set to the set.
+     */
+    public static void addContextKeywords(Set<String> keywords) {
+        contextKeywordsSet.addAll(keywords);
+    }
+
+    /**
+     * This method allows to remove specific context keyword from adunit context targeting
+     */
+    public static void removeContextKeyword(String keyword) {
+        contextKeywordsSet.remove(keyword);
+    }
+
+    /**
+     * This method allows to remove all keywords from the set of adunit context targeting
+     */
+    public static void clearContextKeywords() {
+        contextKeywordsSet.clear();
+    }
+
+    static Set<String> getContextKeywordsSet()  {
+        return contextKeywordsSet;
+    }
 
 //endregion
 }

--- a/PrebidMobile/API1.0/src/main/java/org/prebid/mobile/Util.java
+++ b/PrebidMobile/API1.0/src/main/java/org/prebid/mobile/Util.java
@@ -23,22 +23,24 @@ import android.support.annotation.Nullable;
 import android.text.TextUtils;
 import android.view.View;
 
-import org.prebid.mobile.addendum.AdViewUtils;
-import org.prebid.mobile.addendum.PbFindSizeError;
-
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.prebid.mobile.addendum.AdViewUtils;
+import org.prebid.mobile.addendum.PbFindSizeError;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.LinkedList;
+import java.util.Map;
 import java.util.Random;
+import java.util.Set;
 
 public class Util {
 
@@ -125,6 +127,12 @@ public class Util {
                     if (arrayValue.length() == 0) {
                         iterator.remove();
                     }
+                } else if (value instanceof String) {
+                    String stringValue = (String) value;
+
+                    if (stringValue.length() == 0) {
+                        iterator.remove();
+                    }
                 }
             }
         }
@@ -153,6 +161,12 @@ public class Util {
                     array.put(i, arrayValue);
 
                     if (arrayValue.length() == 0) {
+                        array = getJsonArrayWithoutEntryByIndex(array, i);
+                    }
+                } else if (value instanceof String) {
+                    String stringValue = (String) value;
+
+                    if (stringValue.length() == 0) {
                         array = getJsonArrayWithoutEntryByIndex(array, i);
                     }
                 }
@@ -411,6 +425,33 @@ public class Util {
                 bundle.remove(key);
             }
         }
+    }
+
+    static <E, U> void addValue(Map<E, Set<U>> map, E key, U value) {
+        Set<U> valueSet = map.get(key);
+
+        if (valueSet == null) {
+            valueSet = new HashSet<>();
+            map.put(key, valueSet);
+        }
+
+        valueSet.add(value);
+    }
+
+    @NonNull
+    static <E, U> JSONObject toJson(@Nullable Map<E, ? extends Collection<U>> map) throws JSONException {
+
+        JSONObject jsonObject = new JSONObject();
+        if (map == null) {
+            return jsonObject;
+        }
+
+        for (Map.Entry<E, ? extends Collection<U>> entry : map.entrySet()) {
+
+            jsonObject.put(entry.getKey().toString(), new JSONArray(entry.getValue()));
+        }
+
+        return jsonObject;
     }
 
     public interface CreativeSizeCompletionHandler {

--- a/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/AdUnitTest.java
+++ b/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/AdUnitTest.java
@@ -1,0 +1,66 @@
+/*
+ *    Copyright 2018-2019 Prebid.org, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.prebid.mobile;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.prebid.mobile.testutils.BaseSetup;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.Set;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = BaseSetup.testSDK)
+public class AdUnitTest {
+
+    @Test
+    public void testSetUserKeyword() throws Exception {
+        AdUnit adUnit = new BannerAdUnit("123456", 320, 50);
+        adUnit.addUserKeyword("key", "value");
+        adUnit.addUserKeyword("key1", null);
+        @SuppressWarnings("unchecked")
+        Set<String> keywords = TargetingParams.getUserKeywordsSet();
+        assertEquals(1, keywords.size());
+        assertTrue(keywords.contains("value"));
+        adUnit.addUserKeyword("key", "value2");
+        assertEquals(2, keywords.size());
+        assertTrue(keywords.contains("value") && keywords.contains("value2"));
+        adUnit.removeUserKeyword("value");
+        assertEquals(1, keywords.size());
+        adUnit.clearUserKeywords();
+        assertEquals(0, keywords.size());
+    }
+
+    @Test
+    public void testSetUserKeywords() throws Exception {
+        AdUnit adUnit = new BannerAdUnit("123456", 320, 50);
+        adUnit.addUserKeyword("key1", "value1");
+        String[] values = {"value1", "value2"};
+        adUnit.addUserKeywords("key2", values);
+        @SuppressWarnings("unchecked")
+        Set<String> keywords = TargetingParams.getUserKeywordsSet();
+        assertEquals(2, keywords.size());
+        assertTrue(keywords.contains("value1") && keywords.contains("value2"));
+        adUnit.addUserKeywords("key1", values);
+        assertEquals(2, keywords.size());
+        assertTrue(keywords.contains("value1") && keywords.contains("value2"));
+    }
+}

--- a/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/BannerAdUnitTest.java
+++ b/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/BannerAdUnitTest.java
@@ -23,8 +23,6 @@ import org.prebid.mobile.testutils.BaseSetup;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-import java.util.ArrayList;
-
 import static junit.framework.Assert.assertEquals;
 
 @RunWith(RobolectricTestRunner.class)
@@ -46,44 +44,5 @@ public class BannerAdUnitTest {
         assertEquals(2, adUnit.getSizes().size());
         adUnit.addAdditionalSize(320, 50);
         assertEquals(2, adUnit.getSizes().size());
-    }
-
-    @Test
-    public void testSetUserKeyword() throws Exception {
-        BannerAdUnit adUnit = new BannerAdUnit("123456", 320, 50);
-        adUnit.addUserKeyword("key", "value");
-        adUnit.addUserKeyword("key1", null);
-        @SuppressWarnings("unchecked")
-        ArrayList<String> keywords = (ArrayList<String>) FieldUtils.readField(adUnit, "userKeywords", true);
-        assertEquals(2, keywords.size());
-        assertEquals("key=value", keywords.get(0));
-        assertEquals("key1", keywords.get(1));
-        adUnit.addUserKeyword("key", "value2");
-        assertEquals(3, keywords.size());
-        assertEquals("key=value", keywords.get(0));
-        assertEquals("key1", keywords.get(1));
-        assertEquals("key=value2", keywords.get(2));
-        adUnit.removeUserKeyword("key");
-        assertEquals(1, keywords.size());
-        assertEquals("key1", keywords.get(0));
-        adUnit.clearUserKeywords();
-        assertEquals(0, keywords.size());
-    }
-
-    @Test
-    public void testSetUserKeywords() throws Exception {
-        BannerAdUnit adUnit = new BannerAdUnit("123456", 320, 50);
-        adUnit.addUserKeyword("key1", "value1");
-        String[] values = {"value1", "value2"};
-        adUnit.addUserKeywords("key2", values);
-        @SuppressWarnings("unchecked")
-        ArrayList<String> keywords = (ArrayList<String>) FieldUtils.readField(adUnit, "userKeywords", true);
-        assertEquals(2, keywords.size());
-        assertEquals("key2=value1", keywords.get(0));
-        assertEquals("key2=value2", keywords.get(1));
-        adUnit.addUserKeywords("key1", values);
-        assertEquals(2, keywords.size());
-        assertEquals("key1=value1", keywords.get(0));
-        assertEquals("key1=value2", keywords.get(1));
     }
 }

--- a/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/BannerAdUnitTest.java
+++ b/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/BannerAdUnitTest.java
@@ -54,7 +54,7 @@ public class BannerAdUnitTest {
         adUnit.addUserKeyword("key", "value");
         adUnit.addUserKeyword("key1", null);
         @SuppressWarnings("unchecked")
-        ArrayList<String> keywords = (ArrayList<String>) FieldUtils.readField(adUnit, "keywords", true);
+        ArrayList<String> keywords = (ArrayList<String>) FieldUtils.readField(adUnit, "userKeywords", true);
         assertEquals(2, keywords.size());
         assertEquals("key=value", keywords.get(0));
         assertEquals("key1", keywords.get(1));
@@ -77,7 +77,7 @@ public class BannerAdUnitTest {
         String[] values = {"value1", "value2"};
         adUnit.addUserKeywords("key2", values);
         @SuppressWarnings("unchecked")
-        ArrayList<String> keywords = (ArrayList<String>) FieldUtils.readField(adUnit, "keywords", true);
+        ArrayList<String> keywords = (ArrayList<String>) FieldUtils.readField(adUnit, "userKeywords", true);
         assertEquals(2, keywords.size());
         assertEquals("key2=value1", keywords.get(0));
         assertEquals("key2=value2", keywords.get(1));

--- a/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/DemandFetcherTest.java
+++ b/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/DemandFetcherTest.java
@@ -35,7 +35,6 @@ import org.robolectric.Shadows;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowLooper;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 
 import okhttp3.HttpUrl;
@@ -61,8 +60,7 @@ public class DemandFetcherTest extends BaseSetup {
             demandFetcher.setPeriodMillis(0);
             HashSet<AdSize> sizes = new HashSet<>();
             sizes.add(new AdSize(300, 250));
-            ArrayList<String> keywords = new ArrayList<>();
-            RequestParams requestParams = new RequestParams("12345", AdType.BANNER, sizes, keywords);
+            RequestParams requestParams = new RequestParams("12345", AdType.BANNER, sizes);
             demandFetcher.setRequestParams(requestParams);
             assertEquals(DemandFetcher.STATE.STOPPED, FieldUtils.readField(demandFetcher, "state", true));
             demandFetcher.start();
@@ -92,8 +90,7 @@ public class DemandFetcherTest extends BaseSetup {
             demandFetcher.setPeriodMillis(0);
             HashSet<AdSize> sizes = new HashSet<>();
             sizes.add(new AdSize(300, 250));
-            ArrayList<String> keywords = new ArrayList<>();
-            RequestParams requestParams = new RequestParams("12345", AdType.BANNER, sizes, keywords);
+            RequestParams requestParams = new RequestParams("12345", AdType.BANNER, sizes);
             demandFetcher.setRequestParams(requestParams);
             OnCompleteListener mockListener = mock(OnCompleteListener.class);
             demandFetcher.setListener(mockListener);
@@ -130,8 +127,7 @@ public class DemandFetcherTest extends BaseSetup {
             demandFetcher.setPeriodMillis(30);
             HashSet<AdSize> sizes = new HashSet<>();
             sizes.add(new AdSize(300, 250));
-            ArrayList<String> keywords = new ArrayList<>();
-            RequestParams requestParams = new RequestParams("12345", AdType.BANNER, sizes, keywords);
+            RequestParams requestParams = new RequestParams("12345", AdType.BANNER, sizes);
             demandFetcher.setRequestParams(requestParams);
             OnCompleteListener mockListener = mock(OnCompleteListener.class);
             demandFetcher.setListener(mockListener);
@@ -169,8 +165,7 @@ public class DemandFetcherTest extends BaseSetup {
             demandFetcher.setPeriodMillis(0);
             HashSet<AdSize> sizes = new HashSet<>();
             sizes.add(new AdSize(300, 250));
-            ArrayList<String> keywords = new ArrayList<>();
-            RequestParams requestParams = new RequestParams("12345", AdType.BANNER, sizes, keywords);
+            RequestParams requestParams = new RequestParams("12345", AdType.BANNER, sizes);
             demandFetcher.setRequestParams(requestParams);
             OnCompleteListener mockListener = mock(OnCompleteListener.class);
             demandFetcher.setListener(mockListener);
@@ -229,8 +224,7 @@ public class DemandFetcherTest extends BaseSetup {
         demandFetcher.setPeriodMillis(0);
         HashSet<AdSize> sizes = new HashSet<>();
         sizes.add(new AdSize(300, 250));
-        ArrayList<String> keywords = new ArrayList<>();
-        RequestParams requestParams = new RequestParams("12345", AdType.BANNER, sizes, keywords);
+        RequestParams requestParams = new RequestParams("12345", AdType.BANNER, sizes);
         demandFetcher.setRequestParams(requestParams);
         OnCompleteListener mockListener = mock(OnCompleteListener.class);
         demandFetcher.setListener(mockListener);
@@ -313,8 +307,7 @@ public class DemandFetcherTest extends BaseSetup {
             demandFetcher.setPeriodMillis(0);
             HashSet<AdSize> sizes = new HashSet<>();
             sizes.add(new AdSize(300, 250));
-            ArrayList<String> keywords = new ArrayList<>();
-            RequestParams requestParams = new RequestParams("12345", AdType.BANNER, sizes, keywords);
+            RequestParams requestParams = new RequestParams("12345", AdType.BANNER, sizes);
             demandFetcher.setRequestParams(requestParams);
             OnCompleteListener mockListener = mock(OnCompleteListener.class);
             demandFetcher.setListener(mockListener);
@@ -353,8 +346,7 @@ public class DemandFetcherTest extends BaseSetup {
         demandFetcher.setPeriodMillis(0);
         HashSet<AdSize> sizes = new HashSet<>();
         sizes.add(new AdSize(300, 250));
-        ArrayList<String> keywords = new ArrayList<>();
-        RequestParams requestParams = new RequestParams("12345", AdType.BANNER, sizes, keywords);
+        RequestParams requestParams = new RequestParams("12345", AdType.BANNER, sizes);
         demandFetcher.setRequestParams(requestParams);
         OnCompleteListener mockListener = mock(OnCompleteListener.class);
         demandFetcher.setListener(mockListener);
@@ -388,8 +380,7 @@ public class DemandFetcherTest extends BaseSetup {
             demandFetcher.setPeriodMillis(2000);
             HashSet<AdSize> sizes = new HashSet<>();
             sizes.add(new AdSize(300, 250));
-            ArrayList<String> keywords = new ArrayList<>();
-            RequestParams requestParams = new RequestParams("12345", AdType.BANNER, sizes, keywords);
+            RequestParams requestParams = new RequestParams("12345", AdType.BANNER, sizes);
             demandFetcher.setRequestParams(requestParams);
             OnCompleteListener mockListener = mock(OnCompleteListener.class);
             demandFetcher.setListener(mockListener);
@@ -434,8 +425,7 @@ public class DemandFetcherTest extends BaseSetup {
             demandFetcher.setPeriodMillis(2000);
             HashSet<AdSize> sizes = new HashSet<>();
             sizes.add(new AdSize(300, 250));
-            ArrayList<String> keywords = new ArrayList<>();
-            RequestParams requestParams = new RequestParams("12345", AdType.BANNER, sizes, keywords);
+            RequestParams requestParams = new RequestParams("12345", AdType.BANNER, sizes);
             demandFetcher.setRequestParams(requestParams);
             OnCompleteListener mockListener = mock(OnCompleteListener.class);
             demandFetcher.setListener(mockListener);

--- a/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/InterstItialAdUnitTest.java
+++ b/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/InterstItialAdUnitTest.java
@@ -55,7 +55,7 @@ public class InterstItialAdUnitTest {
         adUnit.addUserKeyword("key", "value");
         adUnit.addUserKeyword("key1", null);
         @SuppressWarnings("unchecked")
-        ArrayList<String> keywords = (ArrayList<String>) FieldUtils.readField(adUnit, "keywords", true);
+        ArrayList<String> keywords = (ArrayList<String>) FieldUtils.readField(adUnit, "userKeywords", true);
         assertEquals(2, keywords.size());
         assertEquals("key=value", keywords.get(0));
         assertEquals("key1", keywords.get(1));
@@ -78,7 +78,7 @@ public class InterstItialAdUnitTest {
         String[] values = {"value1", "value2"};
         adUnit.addUserKeywords("key2", values);
         @SuppressWarnings("unchecked")
-        ArrayList<String> keywords = (ArrayList<String>) FieldUtils.readField(adUnit, "keywords", true);
+        ArrayList<String> keywords = (ArrayList<String>) FieldUtils.readField(adUnit, "userKeywords", true);
         assertEquals(2, keywords.size());
         assertEquals("key2=value1", keywords.get(0));
         assertEquals("key2=value2", keywords.get(1));

--- a/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/InterstItialAdUnitTest.java
+++ b/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/InterstItialAdUnitTest.java
@@ -23,8 +23,6 @@ import org.prebid.mobile.testutils.BaseSetup;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-import java.util.ArrayList;
-
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertTrue;
@@ -47,45 +45,6 @@ public class InterstItialAdUnitTest {
 
         assertNotNull(adUnit.getMinSizePerc());
         assertTrue(adUnit.getMinSizePerc().getWidth() == 50 && adUnit.getMinSizePerc().getHeight() == 70);
-    }
-
-    @Test
-    public void testSetUserKeyword() throws Exception {
-        InterstitialAdUnit adUnit = new InterstitialAdUnit("12345");
-        adUnit.addUserKeyword("key", "value");
-        adUnit.addUserKeyword("key1", null);
-        @SuppressWarnings("unchecked")
-        ArrayList<String> keywords = (ArrayList<String>) FieldUtils.readField(adUnit, "userKeywords", true);
-        assertEquals(2, keywords.size());
-        assertEquals("key=value", keywords.get(0));
-        assertEquals("key1", keywords.get(1));
-        adUnit.addUserKeyword("key", "value2");
-        assertEquals(3, keywords.size());
-        assertEquals("key=value", keywords.get(0));
-        assertEquals("key1", keywords.get(1));
-        assertEquals("key=value2", keywords.get(2));
-        adUnit.removeUserKeyword("key");
-        assertEquals(1, keywords.size());
-        assertEquals("key1", keywords.get(0));
-        adUnit.clearUserKeywords();
-        assertEquals(0, keywords.size());
-    }
-
-    @Test
-    public void testSetUserKeywords() throws Exception {
-        InterstitialAdUnit adUnit = new InterstitialAdUnit("123456");
-        adUnit.addUserKeyword("key1", "value1");
-        String[] values = {"value1", "value2"};
-        adUnit.addUserKeywords("key2", values);
-        @SuppressWarnings("unchecked")
-        ArrayList<String> keywords = (ArrayList<String>) FieldUtils.readField(adUnit, "userKeywords", true);
-        assertEquals(2, keywords.size());
-        assertEquals("key2=value1", keywords.get(0));
-        assertEquals("key2=value2", keywords.get(1));
-        adUnit.addUserKeywords("key1", values);
-        assertEquals(2, keywords.size());
-        assertEquals("key1=value1", keywords.get(0));
-        assertEquals("key1=value2", keywords.get(1));
     }
 
 }

--- a/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/PrebidServerAdapterTest.java
+++ b/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/PrebidServerAdapterTest.java
@@ -810,7 +810,11 @@ public class PrebidServerAdapterTest extends BaseSetup {
             assertEquals(1, regs.getInt("coppa"));
             assertEquals(1, regs.getJSONObject("ext").getInt("gdpr"));
             JSONObject ext = postData.getJSONObject("ext");
+            assertTrue(ext.getJSONObject("prebid").has("cache"));
+            assertTrue(ext.getJSONObject("prebid").getJSONObject("cache").has("bids"));
+            assertEquals(0, ext.getJSONObject("prebid").getJSONObject("cache").getJSONObject("bids").length());
             assertEquals("12345", ext.getJSONObject("prebid").getJSONObject("storedrequest").getString("id"));
+            assertTrue(ext.getJSONObject("prebid").has("targeting"));
         } else {
             assertTrue("Server failed to start, unable to test.", false);
         }

--- a/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/PrebidServerAdapterTest.java
+++ b/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/PrebidServerAdapterTest.java
@@ -16,25 +16,37 @@
 
 package org.prebid.mobile;
 
+import android.support.annotation.Nullable;
+
 import com.mopub.mobileads.MoPubView;
 
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.apache.commons.lang3.reflect.MethodUtils;
+import org.json.JSONArray;
+import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Assert;
+import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.ErrorCollector;
 import org.junit.runner.RunWith;
 import org.prebid.mobile.testutils.BaseSetup;
 import org.prebid.mobile.testutils.MockPrebidServerResponses;
+import org.prebid.mobile.testutils.Utils;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowLooper;
 
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import java.util.regex.Matcher;
@@ -47,8 +59,14 @@ import okhttp3.mockwebserver.RecordedRequest;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
+import static junit.framework.Assert.assertNotNull;
+import static junit.framework.Assert.assertNull;
 import static junit.framework.Assert.assertTrue;
 import static junit.framework.Assert.fail;
+import static org.hamcrest.CoreMatchers.containsString;
+import static org.hamcrest.CoreMatchers.not;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
@@ -58,6 +76,21 @@ import static org.robolectric.Shadows.shadowOf;
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = BaseSetup.testSDK, manifest = Config.NONE)
 public class PrebidServerAdapterTest extends BaseSetup {
+
+    @Rule
+    public ErrorCollector errorCollector = new ErrorCollector();
+
+    @Override
+    public void tearDown() {
+        super.tearDown();
+
+        TargetingParams.clearAccessControlList();
+        TargetingParams.clearUserData();
+        TargetingParams.clearContextData();
+        TargetingParams.clearContextKeywords();
+        TargetingParams.clearUserKeywords();
+    }
+
     @Test
     public void testRegexMatch() {
         Pattern p = Pattern.compile("^Invalid request: Stored Request with ID=\".*\" not found.");
@@ -652,10 +685,10 @@ public class PrebidServerAdapterTest extends BaseSetup {
             public MockResponse dispatch(RecordedRequest request) throws InterruptedException {
                 if (request.getPath().equals("/withKeywords")) {
                     String postData = request.getBody().readUtf8();
-                    Assert.assertTrue("Post data does not contain key values: " + postData, postData.contains("key1=value1,key1=value2,key2=value1,key2=value2,key3=value1,key3=value2,key4=value1,key4=value2,key5=value1,key5=value2,"));
+                    errorCollector.checkThat("Post data does not contain key values: " + postData, postData, containsString("key1=value1,key1=value2,key2=value1,key2=value2,key3=value1,key3=value2,key4=value1,key4=value2,key5=value1,key5=value2"));
                 } else if (request.getPath().equals("/clearKeywords")) {
                     String postData = request.getBody().readUtf8();
-                    Assert.assertTrue("Post data should not contain key values: " + postData, !postData.contains("key1=value1,key1=value2,key2=value1,key2=value2,key3=value1,key3=value2,key4=value1,key4=value2,key5=value1,key5=value2,"));
+                    errorCollector.checkThat("Post data should not contain key values: " + postData, postData, not(containsString("key1=value1,key1=value2,key2=value1,key2=value2,key3=value1,key3=value2,key4=value1,key4=value2,key5=value1,key5=value2")));
                 }
                 return new MockResponse().setResponseCode(200).setBody(MockPrebidServerResponses.noBid());
             }
@@ -777,11 +810,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
             assertEquals(1, regs.getInt("coppa"));
             assertEquals(1, regs.getJSONObject("ext").getInt("gdpr"));
             JSONObject ext = postData.getJSONObject("ext");
-            assertTrue(ext.getJSONObject("prebid").has("cache"));
-            assertTrue(ext.getJSONObject("prebid").getJSONObject("cache").has("bids"));
-            assertEquals(0, ext.getJSONObject("prebid").getJSONObject("cache").getJSONObject("bids").length());
             assertEquals("12345", ext.getJSONObject("prebid").getJSONObject("storedrequest").getString("id"));
-            assertTrue(ext.getJSONObject("prebid").has("targeting"));
         } else {
             assertTrue("Server failed to start, unable to test.", false);
         }
@@ -814,133 +843,354 @@ public class PrebidServerAdapterTest extends BaseSetup {
 
     @Test
     public void testPostDataWithCOPPA() throws Exception {
-        if (!successfulMockServerStarted) {
-            fail("Server failed to start, unable to test.");
+
+        //given
+        PrebidMobile.setApplicationContext(activity.getApplicationContext());
+        TargetingParams.setSubjectToCOPPA(true);
+        int coppa = 0;
+
+        //when
+        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null);
+        try {
+            coppa = postData.getJSONObject("regs").getInt("coppa");
+        } catch (Exception ex) {
         }
 
-        PrebidMobile.setApplicationContext(activity.getApplicationContext());
-
-        server.enqueue(new MockResponse().setResponseCode(200).setBody(MockPrebidServerResponses.noBid()));
-        TargetingParams.setSubjectToCOPPA(true);
-
-        DemandAdapter.DemandAdapterListener mockListener = mock(DemandAdapter.DemandAdapterListener.class);
-        PrebidServerAdapter adapter = new PrebidServerAdapter();
-        HashSet<AdSize> sizes = new HashSet<>();
-        sizes.add(new AdSize(320, 50));
-        RequestParams requestParams = new RequestParams("67890", AdType.BANNER, sizes, new ArrayList<String>());
-        String uuid = UUID.randomUUID().toString();
-        adapter.requestDemand(requestParams, mockListener, uuid);
-        @SuppressWarnings("unchecked")
-        ArrayList<PrebidServerAdapter.ServerConnector> connectors = (ArrayList<PrebidServerAdapter.ServerConnector>) FieldUtils.readDeclaredField(adapter, "serverConnectors", true);
-        PrebidServerAdapter.ServerConnector connector = connectors.get(0);
-
-        JSONObject postData = (JSONObject) MethodUtils.invokeMethod(connector, true, "getPostData");
-        assertTrue(postData.has("regs"));
-        JSONObject regs = postData.getJSONObject("regs");
-        assertEquals(1, regs.getInt("coppa"));
-
+        //then
+        assertEquals(1, coppa);
     }
 
     @Test
     public void testPostDataWithoutCOPPA() throws Exception {
-        if (!successfulMockServerStarted) {
-            fail("Server failed to start, unable to test.");
+
+        //given
+        TargetingParams.setSubjectToCOPPA(false);
+        int coppa = 0;
+
+        //when
+        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null);
+        try {
+            coppa = postData.getJSONObject("regs").getInt("coppa");
+        } catch (Exception ex) {
         }
 
-        PrebidMobile.setApplicationContext(activity.getApplicationContext());
-
-        server.enqueue(new MockResponse().setResponseCode(200).setBody(MockPrebidServerResponses.noBid()));
-        TargetingParams.setSubjectToCOPPA(false);
-
-        DemandAdapter.DemandAdapterListener mockListener = mock(DemandAdapter.DemandAdapterListener.class);
-        PrebidServerAdapter adapter = new PrebidServerAdapter();
-        HashSet<AdSize> sizes = new HashSet<>();
-        sizes.add(new AdSize(320, 50));
-        RequestParams requestParams = new RequestParams("67890", AdType.BANNER, sizes, new ArrayList<String>());
-        String uuid = UUID.randomUUID().toString();
-        adapter.requestDemand(requestParams, mockListener, uuid);
-        @SuppressWarnings("unchecked")
-        ArrayList<PrebidServerAdapter.ServerConnector> connectors = (ArrayList<PrebidServerAdapter.ServerConnector>) FieldUtils.readDeclaredField(adapter, "serverConnectors", true);
-        PrebidServerAdapter.ServerConnector connector = connectors.get(0);
-
-        JSONObject postData = (JSONObject) MethodUtils.invokeMethod(connector, true, "getPostData");
-        assertFalse(postData.has("regs"));
+        //then
+        assertEquals(0, coppa);
     }
 
     @Test
     public void testPostDataWithAdvancedInterstitial() throws Exception {
-        if (!successfulMockServerStarted) {
-            fail("Server failed to start, unable to test.");
-        }
 
-        PrebidMobile.setApplicationContext(activity.getApplicationContext());
-
-        server.enqueue(new MockResponse().setResponseCode(200).setBody(MockPrebidServerResponses.noBid()));
-
-        DemandAdapter.DemandAdapterListener mockListener = mock(DemandAdapter.DemandAdapterListener.class);
-        PrebidServerAdapter adapter = new PrebidServerAdapter();
-        HashSet<AdSize> sizes = new HashSet<>();
-        sizes.add(new AdSize(500, 700));
+        //given
         AdSize minSizePerc = new AdSize(50, 70);
 
-        RequestParams requestParams = new RequestParams("67890", AdType.INTERSTITIAL, sizes, new ArrayList<String>(), minSizePerc);
-        String uuid = UUID.randomUUID().toString();
-        adapter.requestDemand(requestParams, mockListener, uuid);
-        @SuppressWarnings("unchecked")
-        ArrayList<PrebidServerAdapter.ServerConnector> connectors = (ArrayList<PrebidServerAdapter.ServerConnector>) FieldUtils.readDeclaredField(adapter, "serverConnectors", true);
-        PrebidServerAdapter.ServerConnector connector = connectors.get(0);
+        JSONObject extInterstitial = null;
+        JSONObject banner = null;
+        int instl = 0;
 
-        JSONObject postData = (JSONObject) MethodUtils.invokeMethod(connector, true, "getPostData");
-        JSONObject interstitial = postData.getJSONObject("device").getJSONObject("ext").getJSONObject("prebid").getJSONObject("interstitial");
-        assertTrue(interstitial.getInt("minwidthperc") == 50 && interstitial.getInt("minheightperc") == 70);
+        //when
+        JSONObject postData = getPostDataHelper(AdType.INTERSTITIAL, null, null, minSizePerc);
 
-        JSONObject banner = postData.getJSONArray("imp").getJSONObject(0).getJSONObject("banner").getJSONArray("format").getJSONObject(0);
+        try {
+            extInterstitial = postData.getJSONObject("device").getJSONObject("ext").getJSONObject("prebid").getJSONObject("interstitial");
+        } catch (Exception ex) {
+            fail("extInterstitial parsing fail");
+        }
 
+        try {
+            banner = postData.getJSONArray("imp").getJSONObject(0).getJSONObject("banner").getJSONArray("format").getJSONObject(0);
+        } catch (Exception ex) {
+            fail("banner parsing fail");
+        }
+
+        try {
+            instl = postData.getJSONArray("imp").getJSONObject(0).getInt("instl");
+        } catch (Exception ex) {
+            fail("instl parsing fail");
+        }
+
+        //then
+        Assert.assertNotNull(extInterstitial);
+        assertTrue(extInterstitial.getInt("minwidthperc") == 50 && extInterstitial.getInt("minheightperc") == 70);
+
+        Assert.assertNotNull(banner);
         assertTrue(banner.has("w"));
         assertTrue(banner.has("h"));
 
-        assertEquals(1, postData.getJSONArray("imp").getJSONObject(0).getInt("instl"));
-
+        assertEquals(1, instl);
     }
 
     @Test
     public void testPostDataWithoutAdvancedInterstitial() throws Exception {
-        if (!successfulMockServerStarted) {
-            fail("Server failed to start, unable to test.");
-        }
 
-        PrebidMobile.setApplicationContext(activity.getApplicationContext());
+        //given
+        JSONObject extInterstitial = null;
+        int instl = 0;
 
-        server.enqueue(new MockResponse().setResponseCode(200).setBody(MockPrebidServerResponses.noBid()));
-
-        DemandAdapter.DemandAdapterListener mockListener = mock(DemandAdapter.DemandAdapterListener.class);
-        PrebidServerAdapter adapter = new PrebidServerAdapter();
-        HashSet<AdSize> sizes = new HashSet<>();
-        sizes.add(new AdSize(500, 700));
-
-        RequestParams requestParams = new RequestParams("67890", AdType.INTERSTITIAL, sizes, new ArrayList<String>());
-        String uuid = UUID.randomUUID().toString();
-        adapter.requestDemand(requestParams, mockListener, uuid);
-        @SuppressWarnings("unchecked")
-        ArrayList<PrebidServerAdapter.ServerConnector> connectors = (ArrayList<PrebidServerAdapter.ServerConnector>) FieldUtils.readDeclaredField(adapter, "serverConnectors", true);
-        PrebidServerAdapter.ServerConnector connector = connectors.get(0);
-
-        JSONObject postData = (JSONObject) MethodUtils.invokeMethod(connector, true, "getPostData");
+        //when
+        JSONObject postData = getPostDataHelper(AdType.INTERSTITIAL, null, null, null);
 
         try {
-            JSONObject interstitial = postData.getJSONObject("device").getJSONObject("ext").getJSONObject("prebid").getJSONObject("interstitial");
-            assertFalse(interstitial.has("minwidthperc"));
-            assertFalse(interstitial.has("minheightperc"));
+            instl = postData.getJSONArray("imp").getJSONObject(0).getInt("instl");
         } catch (Exception ex) {
-
         }
 
-        assertEquals(1, postData.getJSONArray("imp").getJSONObject(0).getInt("instl"));
+        try {
+            extInterstitial = postData.getJSONObject("device").getJSONObject("ext").getJSONObject("prebid").getJSONObject("interstitial");
+        } catch (Exception ex) {
+        }
+
+        //then
+        assertEquals(1, instl);
+        assertNull(extInterstitial);
+    }
+
+    @Test
+    public void testPostDataBannerWithAdvancedInterstitial() throws Exception {
+
+        //given
+        AdSize minSizePerc = new AdSize(50, 70);
+        JSONObject extInterstitial = null;
+        int instl = 0;
+
+        //when
+        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, minSizePerc);
+
+        try {
+            extInterstitial = postData.getJSONObject("device").getJSONObject("ext").getJSONObject("prebid").getJSONObject("interstitial");
+        } catch (Exception ex) {
+        }
+
+        try {
+            instl = postData.getJSONArray("imp").getJSONObject(0).getInt("instl");
+        } catch (Exception ex) {
+        }
+
+        //then
+        assertNull(extInterstitial);
+        assertEquals(0, instl);
+    }
+
+    @Test
+    public void testPostDataWithGlobalUserKeyword() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+
+        //given
+        TargetingParams.addUserKeyword("value10");
+
+        //when
+        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null);
+
+        String keywords = null;
+        try {
+            keywords = postData.getJSONObject("user").optString("keywords", null);
+        } catch (Exception ex) {
+            fail("keywords parsing fail");
+        }
+
+        //then
+        assertNotNull(keywords);
+        assertEquals("value10", keywords);
+    }
+
+    @Test
+    public void testPostDataWithGlobalContextKeyword() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+
+        //given
+        TargetingParams.addContextKeyword("value10");
+
+        //when
+        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null);
+
+        String keywords = null;
+        try {
+            keywords = postData.getJSONObject("app").optString("keywords", null);
+        } catch (Exception ex) {
+            fail("keywords parsing fail");
+        }
+
+        //then
+        assertNotNull(keywords);
+        assertEquals("value10", keywords);
 
     }
 
     @Test
-    public void testPostDataWithoutAdvancedBannerInterstitial() throws Exception {
+    public void testPostDataWithAccessControlList() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException, JSONException {
+
+        //given
+        TargetingParams.addBidderToAccessControlList(TargetingParams.BIDDER_NAME_RUBICON_PROJECT);
+
+        //when
+        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null);
+
+        JSONArray biddersJsonArray = null;
+        try {
+            biddersJsonArray = postData.getJSONObject("ext").getJSONObject("prebid").getJSONObject("data").getJSONArray("bidders");
+        } catch (Exception ex) {
+            fail("keywords parsing fail");
+        }
+
+        //then
+        assertNotNull(biddersJsonArray);
+        assertEquals(1, biddersJsonArray.length());
+        assertEquals(TargetingParams.BIDDER_NAME_RUBICON_PROJECT, biddersJsonArray.get(0).toString());
+
+    }
+
+    @Test
+    public void testPostDataWithGlobalUserData() throws Exception {
+
+        //given
+        TargetingParams.addUserData("key1", "value10");
+        TargetingParams.addUserData("key2", "value20");
+        TargetingParams.addUserData("key2", "value21");
+
+        //when
+        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null);
+
+        JSONObject dataJsonObject = null;
+        try {
+            dataJsonObject = postData.getJSONObject("user").getJSONObject("ext").getJSONObject("data");
+        } catch (Exception ex) {
+            fail("keywords parsing fail");
+        }
+
+        List<String> listKey1 = Utils.getList(dataJsonObject.getJSONArray("key1"), new Utils.ParseCallable<String>() {
+            @Override
+            public String call(JSONArray jsonArray, int index) throws JSONException {
+                return jsonArray.getString(index);
+            }
+        });
+
+        List<String> listKey2 = Utils.getList(dataJsonObject.getJSONArray("key2"), new Utils.ParseCallable<String>() {
+            @Override
+            public String call(JSONArray jsonArray, int index) throws JSONException {
+                return jsonArray.getString(index);
+            }
+        });
+
+        //then
+        assertNotNull(dataJsonObject);
+        assertEquals(2, dataJsonObject.length());
+
+        assertEquals(listKey1.size(), 1);
+        assertThat(listKey1, containsInAnyOrder("value10"));
+
+        assertEquals(listKey2.size(), 2);
+        assertThat(listKey2, containsInAnyOrder("value20", "value21"));
+    }
+
+    @Test
+    public void testPostDataWithGlobalContextData() throws Exception {
+
+        //given
+        TargetingParams.addContextData("key1", "value10");
+        TargetingParams.addContextData("key2", "value20");
+        TargetingParams.addContextData("key2", "value21");
+
+        //when
+        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null);
+
+        JSONObject dataJsonObject = null;
+        try {
+            dataJsonObject = postData.getJSONObject("app").getJSONObject("ext").getJSONObject("data");
+        } catch (Exception ex) {
+            fail("keywords parsing fail");
+        }
+
+        List<String> listKey1 = Utils.getList(dataJsonObject.getJSONArray("key1"), new Utils.ParseCallable<String>() {
+            @Override
+            public String call(JSONArray jsonArray, int index) throws JSONException {
+                return jsonArray.getString(index);
+            }
+        });
+
+        List<String> listKey2 = Utils.getList(dataJsonObject.getJSONArray("key2"), new Utils.ParseCallable<String>() {
+            @Override
+            public String call(JSONArray jsonArray, int index) throws JSONException {
+                return jsonArray.getString(index);
+            }
+        });
+
+        //then
+        assertNotNull(dataJsonObject);
+        assertEquals(2, dataJsonObject.length());
+
+        assertEquals(listKey1.size(), 1);
+        assertThat(listKey1, containsInAnyOrder("value10"));
+
+        assertEquals(listKey2.size(), 2);
+        assertThat(listKey2, containsInAnyOrder("value20", "value21"));
+    }
+
+    @Test
+    public void testPostDataWithAdunitContextKeyword() throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+
+        //given
+        HashSet<String> contextKeywordsSet = new HashSet<>(1);
+        contextKeywordsSet.add("value10");
+
+        //when
+        JSONObject postData = getPostDataHelper(AdType.BANNER, null, contextKeywordsSet, null);
+
+        String keywords = null;
+
+        try {
+            keywords = postData.getJSONArray("imp").getJSONObject(0).getJSONObject("ext").getJSONObject("context").getString("keywords");
+        } catch (Exception ex) {
+            fail("keywords parsing fail");
+        }
+
+        //then
+        assertNotNull(keywords);
+        assertEquals("value10", keywords);
+    }
+
+    @Test
+    public void testPostDataWithAdunitContextData() throws Exception {
+
+        //given
+        Map<String, Set<String>> contextDataDictionary = new HashMap<>(2);
+        contextDataDictionary.put("key1", new HashSet<>(Arrays.asList("value10")));
+        contextDataDictionary.put("key2", new HashSet<>(Arrays.asList("value20", "value21")));
+
+        //when
+        JSONObject postData = getPostDataHelper(AdType.BANNER, contextDataDictionary, null, null);
+
+        JSONObject dataJsonObject = null;
+        try {
+            dataJsonObject = postData.getJSONArray("imp").getJSONObject(0).getJSONObject("ext").getJSONObject("context").getJSONObject("data");
+        } catch (Exception ex) {
+            fail("keywords parsing fail");
+        }
+
+        List<String> listKey1 = Utils.getList(dataJsonObject.getJSONArray("key1"), new Utils.ParseCallable<String>() {
+            @Override
+            public String call(JSONArray jsonArray, int index) throws JSONException {
+                return jsonArray.getString(index);
+            }
+        });
+
+        List<String> listKey2 = Utils.getList(dataJsonObject.getJSONArray("key2"), new Utils.ParseCallable<String>() {
+            @Override
+            public String call(JSONArray jsonArray, int index) throws JSONException {
+                return jsonArray.getString(index);
+            }
+        });
+
+        //then
+        assertNotNull(dataJsonObject);
+        assertEquals(2, dataJsonObject.length());
+
+        assertEquals(listKey1.size(), 1);
+        assertThat(listKey1, containsInAnyOrder("value10"));
+
+        assertEquals(listKey2.size(), 2);
+        assertThat(listKey2, containsInAnyOrder("value20", "value21"));
+
+    }
+
+    private JSONObject getPostDataHelper(AdType adType, @Nullable Map<String, Set<String>> contextDataDictionary, @Nullable Set<String> contextKeywordsSet, @Nullable AdSize minSizePerc) throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
         if (!successfulMockServerStarted) {
             fail("Server failed to start, unable to test.");
         }
@@ -953,9 +1203,8 @@ public class PrebidServerAdapterTest extends BaseSetup {
         PrebidServerAdapter adapter = new PrebidServerAdapter();
         HashSet<AdSize> sizes = new HashSet<>();
         sizes.add(new AdSize(300, 250));
-        AdSize minSizePerc = new AdSize(50, 70);
 
-        RequestParams requestParams = new RequestParams("67890", AdType.BANNER, sizes, new ArrayList<String>(), minSizePerc);
+        RequestParams requestParams = new RequestParams("67890", adType, sizes, new ArrayList<String>(), contextDataDictionary, contextKeywordsSet, minSizePerc);
         String uuid = UUID.randomUUID().toString();
         adapter.requestDemand(requestParams, mockListener, uuid);
         @SuppressWarnings("unchecked")
@@ -963,20 +1212,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         PrebidServerAdapter.ServerConnector connector = connectors.get(0);
 
         JSONObject postData = (JSONObject) MethodUtils.invokeMethod(connector, true, "getPostData");
-
-        try {
-            JSONObject interstitial = postData.getJSONObject("device").getJSONObject("ext").getJSONObject("prebid").getJSONObject("interstitial");
-            assertFalse(interstitial.has("minwidthperc"));
-            assertFalse(interstitial.has("minheightperc"));
-        } catch (Exception ex) {
-
-        }
-
-        try {
-            assertEquals(0, postData.getJSONArray("imp").getJSONObject(0).getInt("instl"));
-        } catch (Exception ex) {
-
-        }
+        return postData;
 
     }
 }

--- a/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/PrebidServerAdapterTest.java
+++ b/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/PrebidServerAdapterTest.java
@@ -122,7 +122,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         PrebidServerAdapter adapter = new PrebidServerAdapter();
         HashSet<AdSize> sizes = new HashSet<>();
         sizes.add(new AdSize(320, 50));
-        RequestParams requestParams = new RequestParams("6ace8c7d-88c0-4623-8117-75bc3f0a2e45", AdType.BANNER, sizes, new ArrayList<String>());
+        RequestParams requestParams = new RequestParams("6ace8c7d-88c0-4623-8117-75bc3f0a2e45", AdType.BANNER, sizes);
         String uuid = UUID.randomUUID().toString();
         adapter.requestDemand(requestParams, mockListener, uuid);
         Robolectric.flushBackgroundThreadScheduler();
@@ -147,7 +147,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         PrebidServerAdapter adapter = new PrebidServerAdapter();
         HashSet<AdSize> sizes = new HashSet<>();
         sizes.add(new AdSize(300, 250));
-        RequestParams requestParams = new RequestParams("1001-1", AdType.BANNER, sizes, new ArrayList<String>());
+        RequestParams requestParams = new RequestParams("1001-1", AdType.BANNER, sizes);
         String uuid = UUID.randomUUID().toString();
         adapter.requestDemand(requestParams, mockListener, uuid);
         Robolectric.flushBackgroundThreadScheduler();
@@ -167,7 +167,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         PrebidServerAdapter adapter = new PrebidServerAdapter();
         HashSet<AdSize> sizes = new HashSet<>();
         sizes.add(new AdSize(320, 50));
-        RequestParams requestParams = new RequestParams("6ace8c7d-88c0-4623-8117-ffffffffffff", AdType.BANNER, sizes, new ArrayList<String>());
+        RequestParams requestParams = new RequestParams("6ace8c7d-88c0-4623-8117-ffffffffffff", AdType.BANNER, sizes);
         String uuid = UUID.randomUUID().toString();
         adapter.requestDemand(requestParams, mockListener, uuid);
         Robolectric.flushBackgroundThreadScheduler();
@@ -193,7 +193,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         PrebidServerAdapter adapter = new PrebidServerAdapter();
         HashSet<AdSize> sizes = new HashSet<>();
         sizes.add(new AdSize(300, 250));
-        RequestParams requestParams = new RequestParams("1001-1_INVALID_CONFIG_ID", AdType.BANNER, sizes, new ArrayList<String>());
+        RequestParams requestParams = new RequestParams("1001-1_INVALID_CONFIG_ID", AdType.BANNER, sizes);
         String uuid = UUID.randomUUID().toString();
         adapter.requestDemand(requestParams, mockListener, uuid);
         Robolectric.flushBackgroundThreadScheduler();
@@ -212,7 +212,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         PrebidServerAdapter adapter = new PrebidServerAdapter();
         HashSet<AdSize> sizes = new HashSet<>();
         sizes.add(new AdSize(320, 50));
-        RequestParams requestParams = new RequestParams("6ace8c7d-88c0-4623-8117-75bc3f0a2e45", AdType.BANNER, sizes, new ArrayList<String>());
+        RequestParams requestParams = new RequestParams("6ace8c7d-88c0-4623-8117-75bc3f0a2e45", AdType.BANNER, sizes);
         String uuid = UUID.randomUUID().toString();
         adapter.requestDemand(requestParams, mockListener, uuid);
         Robolectric.flushBackgroundThreadScheduler();
@@ -230,7 +230,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         PrebidServerAdapter adapter = new PrebidServerAdapter();
         HashSet<AdSize> sizes = new HashSet<>();
         sizes.add(new AdSize(320, 50));
-        RequestParams requestParams = new RequestParams("6ace8c7d-88c0-4623-8117-75bc3f0a2e", AdType.BANNER, sizes, new ArrayList<String>());
+        RequestParams requestParams = new RequestParams("6ace8c7d-88c0-4623-8117-75bc3f0a2e", AdType.BANNER, sizes);
         String uuid = UUID.randomUUID().toString();
         adapter.requestDemand(requestParams, mockListener, uuid);
         Robolectric.flushBackgroundThreadScheduler();
@@ -250,7 +250,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         PrebidServerAdapter adapter = new PrebidServerAdapter();
         HashSet<AdSize> sizes = new HashSet<>();
         sizes.add(new AdSize(300, 250));
-        RequestParams requestParams = new RequestParams("e2edc23f-0b3b-4203-81b5-7cc97132f418", AdType.BANNER, sizes, new ArrayList<String>());
+        RequestParams requestParams = new RequestParams("e2edc23f-0b3b-4203-81b5-7cc97132f418", AdType.BANNER, sizes);
         String uuid = UUID.randomUUID().toString();
         adapter.requestDemand(requestParams, mockListener, uuid);
         Robolectric.flushBackgroundThreadScheduler();
@@ -275,7 +275,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
             PrebidServerAdapter adapter = new PrebidServerAdapter();
             HashSet<AdSize> sizes = new HashSet<>();
             sizes.add(new AdSize(300, 250));
-            RequestParams requestParams = new RequestParams("67890", AdType.BANNER, sizes, new ArrayList<String>());
+            RequestParams requestParams = new RequestParams("67890", AdType.BANNER, sizes);
             String uuid = UUID.randomUUID().toString();
             adapter.requestDemand(requestParams, mockListener, uuid);
             Robolectric.flushBackgroundThreadScheduler();
@@ -306,7 +306,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
             PrebidServerAdapter adapter = new PrebidServerAdapter();
             HashSet<AdSize> sizes = new HashSet<>();
             sizes.add(new AdSize(320, 50));
-            RequestParams requestParams = new RequestParams("67890", AdType.BANNER, sizes, new ArrayList<String>());
+            RequestParams requestParams = new RequestParams("67890", AdType.BANNER, sizes);
             String uuid = UUID.randomUUID().toString();
             adapter.requestDemand(requestParams, mockListener, uuid);
             Robolectric.flushBackgroundThreadScheduler();
@@ -334,7 +334,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         PrebidServerAdapter adapter = new PrebidServerAdapter();
         HashSet<AdSize> sizes = new HashSet<>();
         sizes.add(new AdSize(320, 50));
-        RequestParams requestParams = new RequestParams("67890", AdType.BANNER, sizes, new ArrayList<String>());
+        RequestParams requestParams = new RequestParams("67890", AdType.BANNER, sizes);
         String uuid = UUID.randomUUID().toString();
         adapter.requestDemand(requestParams, mockListener, uuid);
         Robolectric.flushBackgroundThreadScheduler();
@@ -357,7 +357,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
             PrebidServerAdapter adapter = new PrebidServerAdapter();
             HashSet<AdSize> sizes = new HashSet<>();
             sizes.add(new AdSize(300, 250));
-            RequestParams requestParams = new RequestParams("67890", AdType.BANNER, sizes, new ArrayList<String>());
+            RequestParams requestParams = new RequestParams("67890", AdType.BANNER, sizes);
             String uuid = UUID.randomUUID().toString();
             adapter.requestDemand(requestParams, mockListener, uuid);
             Robolectric.flushBackgroundThreadScheduler();
@@ -396,7 +396,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         PrebidServerAdapter adapter = new PrebidServerAdapter();
         HashSet<AdSize> sizes = new HashSet<>();
         sizes.add(new AdSize(300, 250));
-        RequestParams requestParams = new RequestParams("67890", AdType.BANNER, sizes, new ArrayList<String>());
+        RequestParams requestParams = new RequestParams("67890", AdType.BANNER, sizes);
         String uuid = UUID.randomUUID().toString();
         adapter.requestDemand(requestParams, mockListener, uuid);
         Robolectric.flushBackgroundThreadScheduler();
@@ -437,7 +437,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
             PrebidServerAdapter adapter = new PrebidServerAdapter();
             HashSet<AdSize> sizes = new HashSet<>();
             sizes.add(new AdSize(300, 250));
-            RequestParams requestParams = new RequestParams("67890", AdType.BANNER, sizes, new ArrayList<String>());
+            RequestParams requestParams = new RequestParams("67890", AdType.BANNER, sizes);
             String uuid = UUID.randomUUID().toString();
             adapter.requestDemand(requestParams, mockListener, uuid);
             Robolectric.flushBackgroundThreadScheduler();
@@ -465,7 +465,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         PrebidServerAdapter adapter = new PrebidServerAdapter();
         HashSet<AdSize> sizes = new HashSet<>();
         sizes.add(new AdSize(300, 250));
-        RequestParams requestParams = new RequestParams("67890", AdType.BANNER, sizes, new ArrayList<String>());
+        RequestParams requestParams = new RequestParams("67890", AdType.BANNER, sizes);
         String uuid = UUID.randomUUID().toString();
         adapter.requestDemand(requestParams, mockListener, uuid);
         Robolectric.flushBackgroundThreadScheduler();
@@ -487,7 +487,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
             PrebidServerAdapter adapter = new PrebidServerAdapter();
             HashSet<AdSize> sizes = new HashSet<>();
             sizes.add(new AdSize(300, 250));
-            RequestParams requestParams = new RequestParams("67890", AdType.BANNER, sizes, new ArrayList<String>());
+            RequestParams requestParams = new RequestParams("67890", AdType.BANNER, sizes);
             String uuid = UUID.randomUUID().toString();
             adapter.requestDemand(requestParams, mockListener, uuid);
             Robolectric.flushBackgroundThreadScheduler();
@@ -523,7 +523,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
             PrebidServerAdapter adapter = new PrebidServerAdapter();
             HashSet<AdSize> sizes = new HashSet<>();
             sizes.add(new AdSize(300, 250));
-            RequestParams requestParams = new RequestParams("67890", AdType.BANNER, sizes, new ArrayList<String>());
+            RequestParams requestParams = new RequestParams("67890", AdType.BANNER, sizes);
             String uuid = UUID.randomUUID().toString();
             adapter.requestDemand(requestParams, mockListener, uuid);
             Robolectric.flushBackgroundThreadScheduler();
@@ -559,7 +559,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
             PrebidServerAdapter adapter = new PrebidServerAdapter();
             HashSet<AdSize> sizes = new HashSet<>();
             sizes.add(new AdSize(300, 250));
-            RequestParams requestParams = new RequestParams("67890", AdType.BANNER, sizes, new ArrayList<String>());
+            RequestParams requestParams = new RequestParams("67890", AdType.BANNER, sizes);
             String uuid = UUID.randomUUID().toString();
             adapter.requestDemand(requestParams, mockListener, uuid);
             Robolectric.flushBackgroundThreadScheduler();
@@ -584,7 +584,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
             PrebidServerAdapter adapter = new PrebidServerAdapter();
             HashSet<AdSize> sizes = new HashSet<>();
             sizes.add(new AdSize(300, 250));
-            RequestParams requestParams = new RequestParams("67890", AdType.BANNER, sizes, new ArrayList<String>());
+            RequestParams requestParams = new RequestParams("67890", AdType.BANNER, sizes);
             String uuid = UUID.randomUUID().toString();
             adapter.requestDemand(requestParams, mockListener, uuid);
             Robolectric.flushBackgroundThreadScheduler();
@@ -629,7 +629,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
             PrebidServerAdapter adapter = new PrebidServerAdapter();
             HashSet<AdSize> sizes = new HashSet<>();
             sizes.add(new AdSize(320, 50));
-            RequestParams requestParams = new RequestParams("67890", AdType.BANNER, sizes, new ArrayList<String>());
+            RequestParams requestParams = new RequestParams("67890", AdType.BANNER, sizes);
             String uuid1 = UUID.randomUUID().toString();
             String uuid2 = UUID.randomUUID().toString();
             adapter.requestDemand(requestParams, mockListener1, uuid1);
@@ -662,7 +662,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
             final PrebidServerAdapter adapter = new PrebidServerAdapter();
             HashSet<AdSize> sizes = new HashSet<>();
             sizes.add(new AdSize(320, 50));
-            final RequestParams requestParams = new RequestParams("67890", AdType.BANNER, sizes, new ArrayList<String>());
+            final RequestParams requestParams = new RequestParams("67890", AdType.BANNER, sizes);
             final String uuid = UUID.randomUUID().toString();
             adapter.requestDemand(requestParams, mockListener, uuid);
             bgScheduler.runOneTask();
@@ -685,10 +685,10 @@ public class PrebidServerAdapterTest extends BaseSetup {
             public MockResponse dispatch(RecordedRequest request) throws InterruptedException {
                 if (request.getPath().equals("/withKeywords")) {
                     String postData = request.getBody().readUtf8();
-                    errorCollector.checkThat("Post data does not contain key values: " + postData, postData, containsString("key1=value1,key1=value2,key2=value1,key2=value2,key3=value1,key3=value2,key4=value1,key4=value2,key5=value1,key5=value2"));
+                    errorCollector.checkThat("Post data does not contain key values: " + postData, postData, containsString("value2,value1"));
                 } else if (request.getPath().equals("/clearKeywords")) {
                     String postData = request.getBody().readUtf8();
-                    errorCollector.checkThat("Post data should not contain key values: " + postData, postData, not(containsString("key1=value1,key1=value2,key2=value1,key2=value2,key3=value1,key3=value2,key4=value1,key4=value2,key5=value1,key5=value2")));
+                    errorCollector.checkThat("Post data should not contain key values: " + postData, postData, not(containsString("value2,value1")));
                 }
                 return new MockResponse().setResponseCode(200).setBody(MockPrebidServerResponses.noBid());
             }
@@ -759,7 +759,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
             PrebidServerAdapter adapter = new PrebidServerAdapter();
             HashSet<AdSize> sizes = new HashSet<>();
             sizes.add(new AdSize(320, 50));
-            RequestParams requestParams = new RequestParams("67890", AdType.BANNER, sizes, new ArrayList<String>());
+            RequestParams requestParams = new RequestParams("67890", AdType.BANNER, sizes);
             String uuid = UUID.randomUUID().toString();
             adapter.requestDemand(requestParams, mockListener, uuid);
             @SuppressWarnings("unchecked")
@@ -836,7 +836,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         PrebidServerAdapter adapter = new PrebidServerAdapter();
         HashSet<AdSize> sizes = new HashSet<>();
         sizes.add(new AdSize(320, 50));
-        RequestParams requestParams = new RequestParams("67890", AdType.BANNER, sizes, new ArrayList<String>());
+        RequestParams requestParams = new RequestParams("67890", AdType.BANNER, sizes);
         String uuid = UUID.randomUUID().toString();
         adapter.requestDemand(requestParams, mockListener, uuid);
         Robolectric.flushBackgroundThreadScheduler();
@@ -1208,7 +1208,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         HashSet<AdSize> sizes = new HashSet<>();
         sizes.add(new AdSize(300, 250));
 
-        RequestParams requestParams = new RequestParams("67890", adType, sizes, new ArrayList<String>(), contextDataDictionary, contextKeywordsSet, minSizePerc);
+        RequestParams requestParams = new RequestParams("67890", adType, sizes, contextDataDictionary, contextKeywordsSet, minSizePerc);
         String uuid = UUID.randomUUID().toString();
         adapter.requestDemand(requestParams, mockListener, uuid);
         @SuppressWarnings("unchecked")

--- a/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/RequestParamsTest.java
+++ b/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/RequestParamsTest.java
@@ -23,7 +23,6 @@ import org.prebid.mobile.testutils.BaseSetup;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 
 import static junit.framework.Assert.assertEquals;
@@ -37,30 +36,24 @@ public class RequestParamsTest {
     public void testCreation() throws Exception {
         HashSet<AdSize> sizes = new HashSet<>();
         sizes.add(new AdSize(320, 50));
-        ArrayList<String> keywords = new ArrayList<>();
-        keywords.add("test=1");
-        RequestParams requestParams = new RequestParams("123456", AdType.BANNER, sizes, keywords);
+        RequestParams requestParams = new RequestParams("123456", AdType.BANNER, sizes);
         assertEquals("123456", FieldUtils.readField(requestParams, "configId", true));
         assertEquals(AdType.BANNER, FieldUtils.readField(requestParams, "adType", true));
         assertEquals(sizes, FieldUtils.readField(requestParams, "sizes", true));
-        assertEquals(keywords, FieldUtils.readField(requestParams, "userKeywords", true));
-        requestParams = new RequestParams("123456", AdType.INTERSTITIAL, null, keywords);
+        requestParams = new RequestParams("123456", AdType.INTERSTITIAL, null);
         assertEquals("123456", FieldUtils.readField(requestParams, "configId", true));
         assertEquals(AdType.INTERSTITIAL, FieldUtils.readField(requestParams, "adType", true));
         assertEquals(null, FieldUtils.readField(requestParams, "sizes", true));
-        assertEquals(keywords, FieldUtils.readField(requestParams, "userKeywords", true));
     }
 
     @Test
     public void testCreationWithAdditionalMap() throws Exception {
         HashSet<AdSize> sizes = new HashSet<>();
         sizes.add(new AdSize(500, 700));
-        ArrayList<String> keywords = new ArrayList<>();
-        keywords.add("test=1");
 
         AdSize minSizePerc = new AdSize(50, 70);
 
-        RequestParams requestParams = new RequestParams("123456", AdType.INTERSTITIAL, sizes, keywords, null, null, minSizePerc);
+        RequestParams requestParams = new RequestParams("123456", AdType.INTERSTITIAL, sizes, null, null, minSizePerc);
 
         AdSize minAdSizePerc = requestParams.getMinSizePerc();
         assertNotNull(minAdSizePerc);

--- a/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/RequestParamsTest.java
+++ b/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/RequestParamsTest.java
@@ -43,12 +43,12 @@ public class RequestParamsTest {
         assertEquals("123456", FieldUtils.readField(requestParams, "configId", true));
         assertEquals(AdType.BANNER, FieldUtils.readField(requestParams, "adType", true));
         assertEquals(sizes, FieldUtils.readField(requestParams, "sizes", true));
-        assertEquals(keywords, FieldUtils.readField(requestParams, "keywords", true));
+        assertEquals(keywords, FieldUtils.readField(requestParams, "userKeywords", true));
         requestParams = new RequestParams("123456", AdType.INTERSTITIAL, null, keywords);
         assertEquals("123456", FieldUtils.readField(requestParams, "configId", true));
         assertEquals(AdType.INTERSTITIAL, FieldUtils.readField(requestParams, "adType", true));
         assertEquals(null, FieldUtils.readField(requestParams, "sizes", true));
-        assertEquals(keywords, FieldUtils.readField(requestParams, "keywords", true));
+        assertEquals(keywords, FieldUtils.readField(requestParams, "userKeywords", true));
     }
 
     @Test
@@ -60,7 +60,7 @@ public class RequestParamsTest {
 
         AdSize minSizePerc = new AdSize(50, 70);
 
-        RequestParams requestParams = new RequestParams("123456", AdType.INTERSTITIAL, sizes, keywords, minSizePerc);
+        RequestParams requestParams = new RequestParams("123456", AdType.INTERSTITIAL, sizes, keywords, null, null, minSizePerc);
 
         AdSize minAdSizePerc = requestParams.getMinSizePerc();
         assertNotNull(minAdSizePerc);

--- a/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/ResultCodeTest.java
+++ b/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/ResultCodeTest.java
@@ -256,7 +256,7 @@ public class ResultCodeTest extends BaseSetup {
         PrebidServerAdapter adapter = new PrebidServerAdapter();
         HashSet<AdSize> sizes = new HashSet<>();
         sizes.add(new AdSize(0, 250));
-        RequestParams requestParams = new RequestParams("e2edc23f-0b3b-4203-81b5-7cc97132f418", AdType.BANNER, sizes, new ArrayList<String>());
+        RequestParams requestParams = new RequestParams("e2edc23f-0b3b-4203-81b5-7cc97132f418", AdType.BANNER, sizes);
         String uuid = UUID.randomUUID().toString();
         adapter.requestDemand(requestParams, mockListener, uuid);
 
@@ -392,7 +392,7 @@ public class ResultCodeTest extends BaseSetup {
         PrebidServerAdapter adapter = new PrebidServerAdapter();
         HashSet<AdSize> sizes = new HashSet<>();
         sizes.add(new AdSize(0, 250));
-        RequestParams requestParams = new RequestParams("e2edc23f-0b3b-4203-81b5-7cc97132f418", AdType.BANNER, sizes, new ArrayList<String>());
+        RequestParams requestParams = new RequestParams("e2edc23f-0b3b-4203-81b5-7cc97132f418", AdType.BANNER, sizes);
         String uuid = UUID.randomUUID().toString();
         adapter.requestDemand(requestParams, mockListener, uuid);
         Robolectric.flushBackgroundThreadScheduler();

--- a/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/TargetingParamsTest.java
+++ b/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/TargetingParamsTest.java
@@ -17,6 +17,7 @@
 package org.prebid.mobile;
 
 import org.apache.commons.lang3.reflect.FieldUtils;
+import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.prebid.mobile.testutils.BaseSetup;
@@ -24,13 +25,29 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import java.util.Calendar;
+import java.util.Map;
+import java.util.Set;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertTrue;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = BaseSetup.testSDK)
 public class TargetingParamsTest extends BaseSetup {
+
+    @Override
+    public void tearDown() {
+        super.tearDown();
+
+        TargetingParams.clearAccessControlList();
+        TargetingParams.clearUserData();
+        TargetingParams.clearContextData();
+        TargetingParams.clearContextKeywords();
+        TargetingParams.clearUserKeywords();
+    }
+
     @Test
     public void testYearOfBirth() throws Exception {
         // force initial state since it's static might be changed from other tests
@@ -111,5 +128,64 @@ public class TargetingParamsTest extends BaseSetup {
         PrebidMobile.setApplicationContext(activity.getApplicationContext());
         TargetingParams.setGDPRConsentString("testString");
         assertEquals("testString", TargetingParams.getGDPRConsentString());
+    }
+
+    @Test
+    public void testContextData() {
+        // given
+        TargetingParams.addContextData("key1", "value10");
+
+        //when
+        Map<String, Set<String>> dictionary = TargetingParams.getContextDataDictionary();
+        Set<String> set = dictionary.get("key1");
+
+        //then
+        Assert.assertEquals(1, dictionary.size());
+
+        Assert.assertEquals(1, set.size());
+        assertThat(set, containsInAnyOrder("value10"));
+    }
+
+    @Test
+    public void testUserData() {
+        // given
+        TargetingParams.addUserData("key1", "value10");
+
+        //when
+        Map<String, Set<String>> dictionary = TargetingParams.getUserDataDictionary();
+        Set<String> set = dictionary.get("key1");
+
+        //then
+        Assert.assertEquals(1, dictionary.size());
+
+        Assert.assertEquals(1, set.size());
+        assertThat(set, containsInAnyOrder("value10"));
+    }
+
+    @Test
+    public void testContextKeyword() {
+        // given
+        TargetingParams.addContextKeyword("value10");
+
+        //when
+        Set<String> set = TargetingParams.getContextKeywordsSet();
+
+        //then
+        Assert.assertEquals(1, set.size());
+        assertThat(set, containsInAnyOrder("value10"));
+    }
+
+    @Test
+    public void testUserKeyword() {
+
+        //given
+        TargetingParams.addUserKeyword("value10");
+
+        //when
+        Set<String>  set = TargetingParams.getUserKeywordsSet();
+
+        //then
+        Assert.assertEquals(1, set.size());
+        assertThat(set, containsInAnyOrder("value10"));
     }
 }

--- a/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/UtilTest.java
+++ b/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/UtilTest.java
@@ -30,7 +30,9 @@ import org.prebid.mobile.testutils.BaseSetup;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
@@ -130,6 +132,11 @@ public class UtilTest extends BaseSetup {
 
         JSONObject node1 = new JSONObject();
         node1.put("key1", node11);
+
+        node1.put("emptyObject", "");
+        List<String> array = new ArrayList<>();
+        array.add("");
+        node1.put("emptyArray", new JSONArray(array));
 
         JSONObject result1 = Util.getObjectWithoutEmptyValues(node1);
 

--- a/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/UtilTest.java
+++ b/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/UtilTest.java
@@ -32,7 +32,10 @@ import org.robolectric.annotation.Config;
 
 import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertFalse;
@@ -208,6 +211,93 @@ public class UtilTest extends BaseSetup {
         node31.put(node313);
         JSONObject result10 = Util.getObjectWithoutEmptyValues(node1);
         Assert.assertEquals("{\"key3\":[{\"key312\":\"value312\"},[{\"key3131\":\"value3131\"}]]}", result10.toString());
+    }
+
+    @Test
+    public void testAddValue() {
+
+        //given
+        Map<String, Set<String>> map = new HashMap<>();
+
+        //when
+        //add key1/value10
+        Util.addValue(map, "key1", "value10");
+
+        //then
+        Assert.assertEquals(1, map.size());
+        Assert.assertEquals(1, map.get("key1").size());
+        Assert.assertTrue(map.get("key1").contains("value10"));
+
+        //when
+        //add key2/value20
+        Util.addValue(map, "key2", "value20");
+
+        //then
+        Assert.assertEquals(2, map.size());
+        Assert.assertEquals(1, map.get("key2").size());
+        Assert.assertTrue(map.get("key2").contains("value20"));
+
+        //when
+        //add key1/value11
+        Util.addValue(map, "key1", "value11");
+
+        //then
+        Assert.assertEquals(2, map.size());
+        Assert.assertEquals(2, map.get("key1").size());
+        Assert.assertTrue(map.get("key2").contains("value10") && map.get("key2").contains("value11"));
+    }
+
+    @Test
+    public void testToJson() throws JSONException {
+
+        //given
+        Map<String, Set<String>> map = new HashMap<>();
+        Set<String> set1 = new HashSet<>();
+        Set<String> set2 = new HashSet<>();
+
+        //when
+        JSONObject jsonObject = Util.toJson(map);
+
+        //then
+        Assert.assertNotNull(jsonObject);
+        Assert.assertEquals("{}", jsonObject.toString());
+
+        //given
+        map.put("key1", set1);
+
+        //when
+        JSONObject jsonObject2 = Util.toJson(map);
+
+        //then
+        Assert.assertEquals("{\"key1\":[]}", jsonObject2.toString());
+
+        //given
+        set1.add("value11");
+
+        //when
+        JSONObject jsonObject3 = Util.toJson(map);
+
+        //then
+        Assert.assertEquals("{\"key1\":[\"value11\"]}", jsonObject3.toString());
+
+        //given
+        set1.add("value12");
+
+        //when
+        JSONObject jsonObject4 = Util.toJson(map);
+
+        //then
+        Assert.assertEquals("{\"key1\":[\"value11\",\"value12\"]}", jsonObject4.toString());
+
+        //given
+        set2.add("value21");
+        map.put("key2", set2);
+
+        //when
+        JSONObject jsonObject5 = Util.toJson(map);
+
+        //then
+        Assert.assertEquals("{\"key1\":[\"value11\",\"value12\"],\"key2\":[\"value21\"]}", jsonObject5.toString());
     }
 
 }

--- a/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/UtilTest.java
+++ b/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/UtilTest.java
@@ -244,7 +244,8 @@ public class UtilTest extends BaseSetup {
         //then
         Assert.assertEquals(2, map.size());
         Assert.assertEquals(2, map.get("key1").size());
-        Assert.assertTrue(map.get("key2").contains("value10") && map.get("key2").contains("value11"));
+        Assert.assertTrue(map.get("key1").contains("value10") && map.get("key1").contains("value11"));
+        Assert.assertTrue(map.get("key2").contains("value20"));
     }
 
     @Test

--- a/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/testutils/Utils.java
+++ b/PrebidMobile/API1.0/src/test/java/org/prebid/mobile/testutils/Utils.java
@@ -1,0 +1,27 @@
+package org.prebid.mobile.testutils;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+
+import java.util.ArrayList;
+import java.util.List;
+
+public class Utils {
+
+    public interface ParseCallable<T> {
+        T call(JSONArray jsonArray, int index) throws JSONException;
+    }
+
+    public static <T> List<T> getList(JSONArray jsonArray, ParseCallable<T> callable) throws Exception {
+
+        List<T> list = new ArrayList<>(jsonArray.length());
+
+        for (int i = 0; i < jsonArray.length(); i++) {
+            T t = callable.call(jsonArray, i);
+            list.add(t);
+        }
+
+        return list;
+
+    }
+}


### PR DESCRIPTION
GitHub issue #131 

//ACL block
1. `Access Control List` 

`TargetingParams` API:
``` Java
void addBidderToAccessControlList(String bidderName)
void removeBidderFromAccessControlList(String bidderName)
void clearAccessControlList()
```

Example:
``` Java
TargetingParams.addBidderToAccessControlList(TargetingParams.BIDDER_NAME_RUBICON_PROJECT);
```

OpenRTB request:
``` JSON
"ext": {
	"prebid": {
		"data": {
			"bidders": [
				"rubicon"]
		}
	}
}
```

//data block
2. `global user data`

`TargetingParams` API:
``` Java
void addUserData(String key, String value)
void updateUserData(String key, Set<String> value)
void removeUserData(String key)
void clearUserData()
```

Example:
``` Java
TargetingParams.addUserData("globalUserDataKey1", "globalUserDataValue1")
```

OpenRTB request:
``` JSON
"user": {
	"ext": {
		"data": {
			"globalUserDataKey1": [
				"globalUserDataValue1"]
		}
	}
}
```

3. `global context data`

`TargetingParams` API:
``` Java
void addContextData(String key, String value)
void updateContextData(String key, Set<String> value)
void removeContextData(String key)
void clearContextData()
```

Example:
``` Java
TargetingParams.addContextData("globalContextDataKey1", "globalContextDataValue1")
```

OpenRTB request:
``` JSON
"app": {
	"ext": {
		"data": {
			"globalContextDataKey1": [
				"globalContextDataValue1"]
		}
	}
}
```

4. `adunit context data`

`AdUnit` API:
``` Java
void addContextData(String key, String value)
void updateContextData(String key, Set<String> value)
void removeContextData(String key)
void clearContextData()
```

Example:
``` Java
adUnit.addContextData("adunitContextDataKey1", "adunitContextDataValue1")
```

OpenRTB request:
``` JSON
"imp": [{
	"ext": {
		"context": {
			"data": {
				"adunitContextDataKey1": [
					"adunitContextDataValue1"]
			}
		}
	}
}]
```

5. `global context keywords`

`TargetingParams` API:
``` Java
void addContextKeyword(String keyword)
void addContextKeywords(Set<String> keywords)
void removeContextKeyword(String keyword)
void clearContextKeywords()
```

Example:
``` Java
TargetingParams.addContextKeyword("globalContextKeywordValue1")
TargetingParams.addContextKeyword("globalContextKeywordValue2")
TargetingParams.addContextKeyword("globalContextKeywordValue3")
```

OpenRTB request:
``` JSON
"app": {
    "keywords": "globalContextKeywordValue1,globalContextKeywordValue2,globalContextKeywordValue3"
}

```
6. `global user keywords`

`TargetingParams` API:
``` Java
void addUserKeyword(String keyword)
void addUserKeywords(Set<String> keywords)
void removeUserKeyword(String keyword)
void clearUserKeywords()
```

Example:
``` Java
TargetingParams.addUserKeyword("globalUserKeywordValue1")
TargetingParams.addUserKeyword("globalUserKeywordValue2")
TargetingParams.addUserKeyword("globalUserKeywordValue3")
```

OpenRTB request:
``` JSON
"user": {
    "keywords": "globalUserKeywordValue1,globalUserKeywordValue2,globalUserKeywordValue3"
}
```

7. `adunit context keywords`

`AdUnit` API:
``` Java
void addContextKeyword(String keyword)
void addContextKeywords(Set<String> keywords)
void removeContextKeyword(String keyword)
void clearContextKeywords()
```

Example:
``` Java
adUnit.addContextKeyword("adunitContextKeywordValue1")
adUnit.addContextKeyword("adunitContextKeywordValue2")
adUnit.addContextKeyword("adunitContextKeywordValue3")
```
    
OpenRTB request:
``` JSON
"imp": [{
    "ext": {
        "context": {
            "keywords": "adunitContextKeywordValue1,adunitContextKeywordValue2,adunitContextKeywordValue3"
        }
    }
}]
```

Deprecated API
`AdUnit. userKeywords` was marked as deprecated, because this parameter creates `user.keywords` object.
Since `global user keywords` API has been added in this PR and it brings the functionality to work with `userKeywords` on `global` level  hence I have added a compatibility function to create `user.keywords` object.
`AdUnit.UserKeyword` uses `TargetingParams.UserKeyword` inside. The parameter `key` will be omitted 


[android_all_cahnges.zip](https://github.com/prebid/prebid-mobile-android/files/3510124/android_all_cahnges.zip)

