### PR TITLE
Fix issue #156: FetcherThreads and DemandThreads persist after task completion

### DIFF
--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/DemandFetcher.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/DemandFetcher.java
@@ -118,7 +118,9 @@ class DemandFetcher {
             this.requestRunnable.cancelRequest();
             this.requestRunnable.destroy();
             this.fetcherHandler.removeCallbacks(requestRunnable);
-            this.fetcherHandler.getLooper().quit();
+            if (this.fetcherHandler.getLooper() != null) {
+                this.fetcherHandler.getLooper().quit();
+            }
             this.requestRunnable = null;
             state = STATE.DESTROYED;
         }
@@ -159,7 +161,9 @@ class DemandFetcher {
         void destroy() {
             cancelRequest();
             demandHandler.removeCallbacksAndMessages(null);
-            demandHandler.getLooper().quit();
+            if (demandHandler.getLooper() != null) {
+                demandHandler.getLooper().quit();
+            }
         }
 
         @Override

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/DemandFetcher.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/DemandFetcher.java
@@ -116,7 +116,9 @@ class DemandFetcher {
             this.adObject = null;
             this.listener = null;
             this.requestRunnable.cancelRequest();
+            this.requestRunnable.destroy();
             this.fetcherHandler.removeCallbacks(requestRunnable);
+            this.fetcherHandler.getLooper().quit();
             this.requestRunnable = null;
             state = STATE.DESTROYED;
         }
@@ -152,6 +154,12 @@ class DemandFetcher {
 
         void cancelRequest() {
             this.demandAdapter.stopRequest(auctionId);
+        }
+
+        void destroy() {
+            cancelRequest();
+            demandHandler.removeCallbacksAndMessages(null);
+            demandHandler.getLooper().quit();
         }
 
         @Override


### PR DESCRIPTION
https://github.com/prebid/prebid-mobile-android/issues/156

FetcherThreads and DemandThreads persist and new threads seem to be created for each fetch. If the app is used long enough, there are too many threads, causing a crash.

 With this fix or one like it, I believe existing applications using this library won't have to make any updates in their own code unless they use autoRefresh, in which case they need to make sure to stopAutoRefresh on the adUnits when destroying an ad (which would already been good practice).