### PR TITLE
Video signals improvement

### DIFF
--- a/Example/PrebidDemoJava/src/main/java/org/prebid/mobile/app/DemoActivity.java
+++ b/Example/PrebidDemoJava/src/main/java/org/prebid/mobile/app/DemoActivity.java
@@ -455,8 +455,9 @@ public class DemoActivity extends AppCompatActivity implements MoPubRewardedVide
         parameters.setMimes(Arrays.asList("video/mp4"));
         parameters.setProtocols(Arrays.asList(Signals.Protocols.VAST_2_0));
         parameters.setPlaybackMethod(Arrays.asList(Signals.PlaybackMethod.AutoPlaySoundOff));
+        parameters.setPlacement(Signals.Placement.InBanner);
 
-        VideoAdUnit adUnit = new VideoAdUnit("1001-1", 300, 250, VideoAdUnit.PlacementType.IN_BANNER);
+        VideoAdUnit adUnit = new VideoAdUnit("1001-1", 300, 250);
         adUnit.setParameters(parameters);
 
         this.adUnit = adUnit;

--- a/Example/PrebidDemoJava/src/main/java/org/prebid/mobile/app/DemoActivity.java
+++ b/Example/PrebidDemoJava/src/main/java/org/prebid/mobile/app/DemoActivity.java
@@ -464,7 +464,6 @@ public class DemoActivity extends AppCompatActivity implements MoPubRewardedVide
         // parameters.setPlacement(new Signals.Placement(2));
 
         VideoAdUnit adUnit = new VideoAdUnit("1001-1", 300, 250);
-
         adUnit.setParameters(parameters);
 
         this.adUnit = adUnit;

--- a/Example/PrebidDemoJava/src/main/java/org/prebid/mobile/app/DemoActivity.java
+++ b/Example/PrebidDemoJava/src/main/java/org/prebid/mobile/app/DemoActivity.java
@@ -453,9 +453,15 @@ public class DemoActivity extends AppCompatActivity implements MoPubRewardedVide
 
         VideoBaseAdUnit.Parameters parameters = new VideoBaseAdUnit.Parameters();
         parameters.setMimes(Arrays.asList("video/mp4"));
+
         parameters.setProtocols(Arrays.asList(Signals.Protocols.VAST_2_0));
+        // parameters.setProtocols(Arrays.asList(new Signals.Protocols(2)));
+
         parameters.setPlaybackMethod(Arrays.asList(Signals.PlaybackMethod.AutoPlaySoundOff));
+        // parameters.setPlaybackMethod(Arrays.asList(new Signals.PlaybackMethod(2)));
+
         parameters.setPlacement(Signals.Placement.InBanner);
+        // parameters.setPlacement(new Signals.Placement(2));
 
         VideoAdUnit adUnit = new VideoAdUnit("1001-1", 300, 250);
         adUnit.setParameters(parameters);
@@ -534,8 +540,12 @@ public class DemoActivity extends AppCompatActivity implements MoPubRewardedVide
 
         VideoBaseAdUnit.Parameters parameters = new VideoBaseAdUnit.Parameters();
         parameters.setMimes(Arrays.asList("video/mp4"));
+
         parameters.setProtocols(Arrays.asList(Signals.Protocols.VAST_2_0));
+        // parameters.setProtocols(Arrays.asList(new Signals.Protocols(2)));
+
         parameters.setPlaybackMethod(Arrays.asList(Signals.PlaybackMethod.AutoPlaySoundOff));
+        // parameters.setPlaybackMethod(Arrays.asList(new Signals.PlaybackMethod(2)));
 
         VideoInterstitialAdUnit adUnit = new VideoInterstitialAdUnit("1001-1");
         adUnit.setParameters(parameters);
@@ -686,8 +696,12 @@ public class DemoActivity extends AppCompatActivity implements MoPubRewardedVide
 
         VideoBaseAdUnit.Parameters parameters = new VideoBaseAdUnit.Parameters();
         parameters.setMimes(Arrays.asList("video/mp4"));
+
         parameters.setProtocols(Arrays.asList(Signals.Protocols.VAST_2_0));
+        // parameters.setProtocols(Arrays.asList(new Signals.Protocols(2)));
+
         parameters.setPlaybackMethod(Arrays.asList(Signals.PlaybackMethod.AutoPlaySoundOff));
+        // parameters.setPlaybackMethod(Arrays.asList(new Signals.PlaybackMethod(2)));
 
         RewardedVideoAdUnit adUnit = new RewardedVideoAdUnit("1001-1");
         adUnit.setParameters(parameters);

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/AdUnit.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/AdUnit.java
@@ -143,9 +143,7 @@ public abstract class AdUnit {
 
         if (Util.supportedAdObject(adObj)) {
             fetcher = new DemandFetcher(adObj);
-
             RequestParams requestParams = new RequestParams(configId, adType, sizes, contextDataDictionary, contextKeywordsSet, minSizePerc, parameters);
-
             if (this.adType.equals(AdType.NATIVE)) {
                 requestParams.setNativeRequestParams(((NativeAdUnit) this).params);
             }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/AdUnit.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/AdUnit.java
@@ -90,7 +90,6 @@ public abstract class AdUnit {
             }
         }
 
-        Integer videoPlacement = null;
         HashSet<AdSize> sizes = null;
         if (adType == AdType.BANNER) {
             sizes = ((BannerAdUnit) this).getSizes();
@@ -113,7 +112,6 @@ public abstract class AdUnit {
                 }
             }
 
-            videoPlacement = videoAdUnit.getType().getValue();
         }
         AdSize minSizePerc = null;
         if (this instanceof InterstitialAdUnit) {
@@ -145,7 +143,7 @@ public abstract class AdUnit {
 
         if (Util.supportedAdObject(adObj)) {
             fetcher = new DemandFetcher(adObj);
-            RequestParams requestParams = new RequestParams(configId, adType, sizes, contextDataDictionary, contextKeywordsSet, minSizePerc, videoPlacement, parameters);
+            RequestParams requestParams = new RequestParams(configId, adType, sizes, contextDataDictionary, contextKeywordsSet, minSizePerc, parameters);
             if (this.adType.equals(AdType.NATIVE)) {
                 requestParams.setNativeRequestParams(((NativeAdUnit) this).params);
             }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/PrebidServerAdapter.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/PrebidServerAdapter.java
@@ -557,7 +557,6 @@ class PrebidServerAdapter implements DemandAdapter {
                 }
 
                 if (adType.equals(AdType.INTERSTITIAL)) {
-                    imp.put("instl", 1);
                     JSONObject banner = new JSONObject();
                     JSONArray format = new JSONArray();
                     Context context = PrebidMobile.getApplicationContext();
@@ -686,6 +685,7 @@ class PrebidServerAdapter implements DemandAdapter {
                 } else if (adType.equals(AdType.VIDEO) || adType.equals(AdType.VIDEO_INTERSTITIAL) || adType.equals(AdType.REWARDED_VIDEO)) {
 
                     JSONObject video = new JSONObject();
+                    Integer placementValue = null;
 
                     VideoBaseAdUnit.Parameters parameters = requestParams.getVideoParameters();
                     if (parameters != null) {
@@ -717,6 +717,11 @@ class PrebidServerAdapter implements DemandAdapter {
                             startDelayValue = startDelay.value;
                         }
 
+                        Signals.Placement placement = parameters.getPlacement();
+                        if (placement != null) {
+                            placementValue = placement.value;
+                        }
+
                         video.put("api", new JSONArray(apiList));
                         video.put("maxbitrate", parameters.getMaxBitrate());
                         video.put("minbitrate", parameters.getMinBitrate());
@@ -728,14 +733,12 @@ class PrebidServerAdapter implements DemandAdapter {
                         video.put("startdelay", startDelayValue);
                     }
 
-                    Integer placement = null;
+                    Integer placementValueDefault = null;
                     if (adType.equals(AdType.VIDEO)) {
                         for (AdSize size : requestParams.getAdSizes()) {
                             video.put("w", size.getWidth());
                             video.put("h", size.getHeight());
                         }
-
-                        placement = requestParams.getVideoPlacement();
 
                     } else if (adType.equals(AdType.VIDEO_INTERSTITIAL) || adType.equals(AdType.REWARDED_VIDEO)) {
                         Context context = PrebidMobile.getApplicationContext();
@@ -745,10 +748,14 @@ class PrebidServerAdapter implements DemandAdapter {
                             video.put("h", context.getResources().getConfiguration().screenHeightDp);
                         }
 
-                        placement = 5;
+                        placementValueDefault = 5;
                     }
 
-                    video.put("placement", placement);
+                    if (placementValue == null) {
+                        placementValue = placementValueDefault;
+                    }
+
+                    video.put("placement", placementValue);
 
                     video.put("linearity", 1);
 

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/PrebidServerAdapter.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/PrebidServerAdapter.java
@@ -685,7 +685,6 @@ class PrebidServerAdapter implements DemandAdapter {
                 } else if (adType.equals(AdType.VIDEO) || adType.equals(AdType.VIDEO_INTERSTITIAL) || adType.equals(AdType.REWARDED_VIDEO)) {
 
                     JSONObject video = new JSONObject();
-
                     Integer placementValue = null;
 
                     VideoBaseAdUnit.Parameters parameters = requestParams.getVideoParameters();
@@ -735,7 +734,6 @@ class PrebidServerAdapter implements DemandAdapter {
                     }
 
                     Integer placementValueDefault = null;
-
                     if (adType.equals(AdType.VIDEO)) {
                         for (AdSize size : requestParams.getAdSizes()) {
                             video.put("w", size.getWidth());
@@ -758,8 +756,6 @@ class PrebidServerAdapter implements DemandAdapter {
                     }
 
                     video.put("placement", placementValue);
-
-                    video.put("linearity", 1);
 
                     video.put("linearity", 1);
 

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/RequestParams.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/RequestParams.java
@@ -49,7 +49,6 @@ class RequestParams {
     }
 
     RequestParams(String configId, AdType adType, HashSet<AdSize> sizes, @Nullable Map<String, Set<String>> contextDataDictionary, @Nullable Set<String> contextKeywordsSet, @Nullable AdSize minSizePerc, @Nullable VideoBaseAdUnit.Parameters parameters) {
-
         this(configId, adType, sizes);
         this.contextDataDictionary = contextDataDictionary;
         this.contextKeywordsSet = contextKeywordsSet;

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/RequestParams.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/RequestParams.java
@@ -40,9 +40,6 @@ class RequestParams {
     private AdSize minSizePerc; //non null only for InterstitialAdUnit(String, int, int)
 
     @Nullable
-    private Integer videoPlacement;
-
-    @Nullable
     private VideoBaseAdUnit.Parameters parameters;
 
     RequestParams(String configId, AdType adType, HashSet<AdSize> sizes) {
@@ -51,12 +48,11 @@ class RequestParams {
         this.sizes = sizes; // for Interstitial this will be null, will use screen width & height in the request
     }
 
-    RequestParams(String configId, AdType adType, HashSet<AdSize> sizes, @Nullable Map<String, Set<String>> contextDataDictionary, @Nullable Set<String> contextKeywordsSet, @Nullable AdSize minSizePerc, @Nullable Integer videoPlacement, @Nullable VideoBaseAdUnit.Parameters parameters) {
+    RequestParams(String configId, AdType adType, HashSet<AdSize> sizes, @Nullable Map<String, Set<String>> contextDataDictionary, @Nullable Set<String> contextKeywordsSet, @Nullable AdSize minSizePerc, @Nullable VideoBaseAdUnit.Parameters parameters) {
         this(configId, adType, sizes);
         this.contextDataDictionary = contextDataDictionary;
         this.contextKeywordsSet = contextKeywordsSet;
         this.minSizePerc = minSizePerc;
-        this.videoPlacement = videoPlacement;
         this.parameters = parameters;
     }
 
@@ -82,12 +78,12 @@ class RequestParams {
     }
 
     @NonNull
-    public Map<String, Set<String>> getContextDataDictionary() {
+    Map<String, Set<String>> getContextDataDictionary() {
         return contextDataDictionary != null ? contextDataDictionary : new HashMap<String, Set<String>>();
     }
 
     @NonNull
-    public Set<String> getContextKeywordsSet() {
+    Set<String> getContextKeywordsSet() {
         return contextKeywordsSet != null ? contextKeywordsSet : new HashSet<String>();
     }
 
@@ -97,12 +93,7 @@ class RequestParams {
     }
 
     @Nullable
-    public Integer getVideoPlacement() {
-        return videoPlacement;
-    }
-
-    @Nullable
-    public VideoBaseAdUnit.Parameters getVideoParameters() {
+    VideoBaseAdUnit.Parameters getVideoParameters() {
         return parameters;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/RequestParams.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/RequestParams.java
@@ -42,9 +42,6 @@ class RequestParams {
     @Nullable
     private VideoBaseAdUnit.Parameters parameters;
 
-    @Nullable
-    private VideoBaseAdUnit.Parameters parameters;
-
     RequestParams(String configId, AdType adType, HashSet<AdSize> sizes) {
         this.configId = configId;
         this.adType = adType;
@@ -98,11 +95,6 @@ class RequestParams {
 
     @Nullable
     VideoBaseAdUnit.Parameters getVideoParameters() {
-        return parameters;
-    }
-
-    @Nullable
-    public VideoBaseAdUnit.Parameters getVideoParameters() {
         return parameters;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/Signals.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/Signals.java
@@ -219,10 +219,10 @@ public class Signals {
         public static Placement InBanner = new Placement(2);
 
         /** In-Article */
-        public static Placement inArticle = new Placement(3);
+        public static Placement InArticle = new Placement(3);
 
         /** In-Feed */
-        public static Placement inFeed = new Placement(4);
+        public static Placement InFeed = new Placement(4);
 
         /** Interstitial */
         public static Placement Interstitial = new Placement(5);

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/Signals.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/Signals.java
@@ -237,4 +237,5 @@ public class Signals {
             super(value);
         }
     }
+
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/Signals.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/Signals.java
@@ -184,17 +184,58 @@ public class Signals {
      */
     public static class StartDelay extends SingleContainerInt {
 
-        /** Pre-Roll  */
+        /** Pre-Roll */
         public static StartDelay PreRoll = new StartDelay(0);
 
-        /** Generic Mid-Roll  */
+        /** Generic Mid-Roll */
         public static StartDelay GenericMidRoll = new StartDelay(-1);
 
-        /** Generic Post-Roll  */
+        /** Generic Post-Roll */
         public static StartDelay GenericPostRoll = new StartDelay(-2);
 
         public StartDelay(int value) {
             super(value);
         }
     }
+
+    /**
+     OpenRTB - Video Placement Types
+     * <pre>
+     | Value | Description                  |
+     |-------|------------------------------|
+     | 1     | In-Stream                    |
+     | 2     | In-Banner                    |
+     | 3     | In-Article                   |
+     | 4     | In-Feed                      |
+     | 5     | Interstitial/Slider/Floating |
+     *</pre>
+     */
+    public static class Placement extends SingleContainerInt {
+
+        /** In-Stream */
+        public static Placement InStream = new Placement(1);
+
+        /** In-Banner */
+        public static Placement InBanner = new Placement(2);
+
+        /** In-Article */
+        public static Placement inArticle = new Placement(3);
+
+        /** In-Feed */
+        public static Placement inFeed = new Placement(4);
+
+        /** Interstitial */
+        public static Placement Interstitial = new Placement(5);
+
+        /** Slider */
+        public static Placement Slider = new Placement(5);
+
+        /** Floating */
+        public static Placement Floating = new Placement(5);
+
+        public Placement(int value) {
+            super(value);
+        }
+    }
+
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/VideoAdUnit.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/VideoAdUnit.java
@@ -17,15 +17,27 @@
 package org.prebid.mobile;
 
 import android.support.annotation.NonNull;
+import android.support.annotation.Nullable;
 
 public class VideoAdUnit extends VideoBaseAdUnit {
 
     private final AdSize adSize;
-    private final PlacementType type;
 
-    public VideoAdUnit(@NonNull String configId, int width, int height, PlacementType type) {
+    @Deprecated
+    @Nullable
+    private PlacementType type;
+
+    public VideoAdUnit(@NonNull String configId, int width, int height) {
         super(configId, AdType.VIDEO);
         adSize = new AdSize(width, height);
+    }
+
+    /**
+     * @deprecated Replaced by {@link #VideoAdUnit(String, int, int)}}
+     */
+    @Deprecated
+    public VideoAdUnit(@NonNull String configId, int width, int height, PlacementType type) {
+        this(configId, width, height);
         this.type = type;
     }
 
@@ -33,21 +45,31 @@ public class VideoAdUnit extends VideoBaseAdUnit {
         return adSize;
     }
 
+    @Deprecated
     public PlacementType getType() {
         return type;
     }
 
+    /**
+     * @deprecated Replaced by {@link Signals.Placement}
+     */
+    @Deprecated
     public enum PlacementType {
+        @Deprecated
         IN_BANNER(2),
+        @Deprecated
         IN_ARTICLE(3),
+        @Deprecated
         IN_FEED(4);
 
         private final int value;
 
+        @Deprecated
         PlacementType(int value) {
             this.value = value;
         }
 
+        @Deprecated
         public int getValue() {
             return value;
         }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/VideoBaseAdUnit.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/VideoBaseAdUnit.java
@@ -101,6 +101,12 @@ public abstract class VideoBaseAdUnit extends AdUnit {
         @Nullable
         private Signals.StartDelay startDelay;
 
+        /**
+         Placement type for the impression.
+         */
+        @Nullable
+        private Signals.Placement placement;
+
         //Getters and setters
         @Nullable
         public List<Signals.Api> getApi() {
@@ -181,6 +187,15 @@ public abstract class VideoBaseAdUnit extends AdUnit {
 
         public void setStartDelay(@Nullable Signals.StartDelay startDelay) {
             this.startDelay = startDelay;
+        }
+
+        @Nullable
+        public Signals.Placement getPlacement() {
+            return placement;
+        }
+
+        public void setPlacement(@Nullable Signals.Placement placement) {
+            this.placement = placement;
         }
     }
 }

--- a/PrebidMobile/src/test/java/org/prebid/mobile/AdUnitSuccessorTest.java
+++ b/PrebidMobile/src/test/java/org/prebid/mobile/AdUnitSuccessorTest.java
@@ -17,6 +17,8 @@
 
 package org.prebid.mobile;
 
+import android.support.annotation.RequiresApi;
+
 import org.apache.commons.lang3.reflect.FieldUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -73,8 +75,18 @@ public class AdUnitSuccessorTest {
     }
 
     //Video AdUnit
+    @RequiresApi
     @Test
     public void testVideoAdUnitCreation() throws Exception {
+        VideoAdUnit adUnit = new VideoAdUnit("123456", 320, 50);
+        assertEquals(new AdSize(320, 50), adUnit.getAdSize());
+        assertEquals("123456", FieldUtils.readField(adUnit, "configId", true));
+        assertEquals(AdType.VIDEO, FieldUtils.readField(adUnit, "adType", true));
+    }
+
+    @Test
+    @Deprecated
+    public void testVideoAdUnitCreationDeprecated() throws Exception {
         VideoAdUnit adUnit = new VideoAdUnit("123456", 320, 50, VideoAdUnit.PlacementType.IN_BANNER);
         assertEquals(new AdSize(320, 50), adUnit.getAdSize());
         assertEquals("123456", FieldUtils.readField(adUnit, "configId", true));
@@ -103,19 +115,19 @@ public class AdUnitSuccessorTest {
     public void testVideoParametersCreation() {
 
         //given
-        VideoAdUnit videoAdUnit = new VideoAdUnit("123456", 320, 50, VideoAdUnit.PlacementType.IN_BANNER);
+        VideoAdUnit videoAdUnit = new VideoAdUnit("123456", 320, 50);
         VideoInterstitialAdUnit videoInterstitialAdUnit = new VideoInterstitialAdUnit("123456");
         RewardedVideoAdUnit rewardedVideoAdUnit = new RewardedVideoAdUnit("123456");
 
         List<VideoBaseAdUnit> videoBaseAdUnitList = Arrays.asList(videoAdUnit, videoInterstitialAdUnit, rewardedVideoAdUnit);
 
         for (VideoBaseAdUnit videoBaseAdUnit : videoBaseAdUnitList) {
-            checkVideoParametersHelper(videoBaseAdUnit);
+            setupAndCheckVideoParametersHelper(videoBaseAdUnit);
         }
 
     }
 
-    private void checkVideoParametersHelper(VideoBaseAdUnit videoBaseAdUnit) {
+    private void setupAndCheckVideoParametersHelper(VideoBaseAdUnit videoBaseAdUnit) {
 
         VideoAdUnit.Parameters parameters = new VideoAdUnit.Parameters();
 
@@ -128,13 +140,13 @@ public class AdUnitSuccessorTest {
         parameters.setPlaybackMethod(Arrays.asList(Signals.PlaybackMethod.AutoPlaySoundOn, Signals.PlaybackMethod.ClickToPlay));
         parameters.setProtocols(Arrays.asList(Signals.Protocols.VAST_2_0, Signals.Protocols.VAST_3_0));
         parameters.setStartDelay(Signals.StartDelay.PreRoll);
+        parameters.setPlacement(Signals.Placement.InBanner);
 
         videoBaseAdUnit.parameters = parameters;
 
         //when
         VideoAdUnit.Parameters testedVideoParameters = videoBaseAdUnit.parameters;
 
-        //then
         List<Signals.Api> api = testedVideoParameters.getApi();
         Integer maxBitrate = testedVideoParameters.getMaxBitrate();
         Integer minBitrate = testedVideoParameters.getMinBitrate();
@@ -144,7 +156,9 @@ public class AdUnitSuccessorTest {
         List<Signals.PlaybackMethod> playbackMethod = testedVideoParameters.getPlaybackMethod();
         List<Signals.Protocols> protocols = testedVideoParameters.getProtocols();
         Signals.StartDelay startDelay = testedVideoParameters.getStartDelay();
+        Signals.Placement placement = testedVideoParameters.getPlacement();
 
+        //then
         assertEquals(2, api.size());
         assertTrue(api.contains(new Signals.Api(1)) && api.contains(new Signals.Api(2)));
         assertEquals(new Integer(1500), maxBitrate);
@@ -158,5 +172,6 @@ public class AdUnitSuccessorTest {
         assertEquals(2, protocols.size());
         assertTrue(protocols.contains(new Signals.Protocols(2)) && protocols.contains(new Signals.Protocols(3)));
         assertEquals(new Signals.StartDelay(0), startDelay);
+        assertEquals(new Signals.Placement(2), placement);
     }
 }

--- a/PrebidMobile/src/test/java/org/prebid/mobile/DemandFetcherTest.java
+++ b/PrebidMobile/src/test/java/org/prebid/mobile/DemandFetcherTest.java
@@ -73,6 +73,7 @@ public class DemandFetcherTest extends BaseSetup {
     @Test
     public void testSingleRequestNoBidsResponse() throws Exception {
         HttpUrl httpUrl = server.url("/");
+        PrebidMobile.setApplicationContext(activity);
         Host.CUSTOM.setHostUrl(httpUrl.toString());
         PrebidMobile.setPrebidServerHost(Host.CUSTOM);
         server.enqueue(new MockResponse().setResponseCode(200).setBody(MockPrebidServerResponses.noBid()));
@@ -103,6 +104,7 @@ public class DemandFetcherTest extends BaseSetup {
     @Test
     public void testDestroyAutoRefresh() throws Exception {
         HttpUrl httpUrl = server.url("/");
+        PrebidMobile.setApplicationContext(activity);
         Host.CUSTOM.setHostUrl(httpUrl.toString());
         PrebidMobile.setPrebidServerHost(Host.CUSTOM);
         server.enqueue(new MockResponse().setResponseCode(200).setBody(MockPrebidServerResponses.noBid()));
@@ -139,6 +141,7 @@ public class DemandFetcherTest extends BaseSetup {
     @Test
     public void testSingleRequestOneBidResponseForDFPAdObject() throws Exception {
         HttpUrl httpUrl = server.url("/");
+        PrebidMobile.setApplicationContext(activity);
         Host.CUSTOM.setHostUrl(httpUrl.toString());
         PrebidMobile.setPrebidServerHost(Host.CUSTOM);
         server.enqueue(new MockResponse().setResponseCode(200).setBody(MockPrebidServerResponses.oneBidFromAppNexus()));
@@ -191,9 +194,9 @@ public class DemandFetcherTest extends BaseSetup {
     @Test
     public void testSingleRequestOneBidRubiconResponseForDFPAdObject() throws Exception {
         HttpUrl httpUrl = server.url("/");
+        PrebidMobile.setApplicationContext(activity);
         Host.CUSTOM.setHostUrl(httpUrl.toString());
         PrebidMobile.setPrebidServerHost(Host.CUSTOM);
-        PrebidMobile.setApplicationContext(activity);
         server.enqueue(new MockResponse().setResponseCode(200).setBody(MockPrebidServerResponses.oneBidFromRubicon()));
         PublisherAdRequest.Builder builder = new PublisherAdRequest.Builder();
         PublisherAdRequest request = builder.build();
@@ -275,6 +278,7 @@ public class DemandFetcherTest extends BaseSetup {
     public void testSingleRequestOneBidResponseForMoPubAdObject() throws Exception {
 
         HttpUrl httpUrl = server.url("/");
+        PrebidMobile.setApplicationContext(activity);
         Host.CUSTOM.setHostUrl(httpUrl.toString());
         PrebidMobile.setPrebidServerHost(Host.CUSTOM);
         server.enqueue(new MockResponse().setResponseCode(200).setBody(MockPrebidServerResponses.oneBidFromAppNexus()));
@@ -307,9 +311,9 @@ public class DemandFetcherTest extends BaseSetup {
     @Test
     public void testSingleRequestOneBidRubiconResponseForMoPubAdObject() throws Exception {
         HttpUrl httpUrl = server.url("/");
+        PrebidMobile.setApplicationContext(activity);
         Host.CUSTOM.setHostUrl(httpUrl.toString());
         PrebidMobile.setPrebidServerHost(Host.CUSTOM);
-        PrebidMobile.setApplicationContext(activity.getApplicationContext());
         server.enqueue(new MockResponse().setResponseCode(200).setBody(MockPrebidServerResponses.oneBidFromRubicon()));
         MoPubView adView = new MoPubView(activity);
         adView.setAdUnitId("123456789");
@@ -340,6 +344,7 @@ public class DemandFetcherTest extends BaseSetup {
     @Test
     public void testAutoRefreshForMoPubAdObject() throws Exception {
         HttpUrl httpUrl = server.url("/");
+        PrebidMobile.setApplicationContext(activity);
         Host.CUSTOM.setHostUrl(httpUrl.toString());
         PrebidMobile.setPrebidServerHost(Host.CUSTOM);
         server.enqueue(new MockResponse().setResponseCode(200).setBody(MockPrebidServerResponses.oneBidFromAppNexus()));
@@ -381,6 +386,7 @@ public class DemandFetcherTest extends BaseSetup {
     @Test
     public void testAutoRefreshForDFPAdObject() throws Exception {
         HttpUrl httpUrl = server.url("/");
+        PrebidMobile.setApplicationContext(activity);
         Host.CUSTOM.setHostUrl(httpUrl.toString());
         PrebidMobile.setPrebidServerHost(Host.CUSTOM);
         server.enqueue(new MockResponse().setResponseCode(200).setBody(MockPrebidServerResponses.oneBidFromAppNexus()));

--- a/PrebidMobile/src/test/java/org/prebid/mobile/PrebidServerAdapterTest.java
+++ b/PrebidMobile/src/test/java/org/prebid/mobile/PrebidServerAdapterTest.java
@@ -786,7 +786,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
 
         Integer gdprSubject = null;
         //when
-        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null, null);
+        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null);
         try {
             gdprSubject = postData.getJSONObject("regs").getJSONObject("ext").getInt("gdpr");
         } catch (Exception ex) {
@@ -806,7 +806,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
 
         Object gdprSubject = null;
         //when
-        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null, null);
+        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null);
         try {
             gdprSubject = postData.opt("regs");
         } catch (Exception ex) {
@@ -826,7 +826,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
 
         Object gdprSubject = null;
         //when
-        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null, null);
+        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null);
         try {
             gdprSubject = postData.optJSONObject("regs");
         } catch (Exception ex) {
@@ -849,7 +849,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         Integer gdprSubject = null;
         String gdprConsent = null;
         //when
-        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null, null);
+        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null);
         try {
             gdprSubject = postData.getJSONObject("regs").getJSONObject("ext").getInt("gdpr");
             gdprConsent = postData.getJSONObject("user").getJSONObject("ext").getString("consent");
@@ -873,7 +873,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         Object gdprSubject = null;
         Object gdprConsent = null;
         //when
-        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null, null);
+        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null);
         try {
             gdprSubject = postData.opt("regs");
             gdprConsent = postData.getJSONObject("user").opt("ext");
@@ -903,7 +903,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
 
         String ifa = null;
         //when
-        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null, null);
+        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null);
         try {
             ifa = postData.getJSONObject("device").getString("ifa");
 
@@ -962,7 +962,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         JSONObject device = null;
         Object ifa = null;
         //when
-        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null, null);
+        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null);
         try {
             device = postData.optJSONObject("device");
 
@@ -992,7 +992,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         int coppa = 0;
 
         //when
-        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null, null);
+        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null);
         try {
             coppa = postData.getJSONObject("regs").getInt("coppa");
         } catch (Exception ex) {
@@ -1011,7 +1011,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         Object coppa = null;
 
         //when
-        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null, null);
+        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null);
         try {
             coppa = postData.opt("regs");
         } catch (Exception ex) {
@@ -1036,7 +1036,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         String ccpa = null;
 
         //when
-        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null, null);
+        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null);
         try {
             ccpa = postData.getJSONObject("regs").getJSONObject("ext").getString("us_privacy");
         } catch (Exception ex) {
@@ -1059,7 +1059,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         Object ccpa = null;
 
         //when
-        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null, null);
+        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null);
         try {
             ccpa = postData.opt("regs");
         } catch (Exception ex) {
@@ -1084,7 +1084,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         Object ccpa = null;
 
         //when
-        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null, null);
+        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null);
         try {
             ccpa = postData.opt("regs");
         } catch (Exception ex) {
@@ -1201,10 +1201,9 @@ public class PrebidServerAdapterTest extends BaseSetup {
         int instl = postData.getJSONArray("imp").getJSONObject(0).getInt("instl");
 
         //then
+        assertEquals(5, video.getInt("placement"));
         assertEquals(1, video.getInt("linearity"));
-
         assertEquals(1, instl);
-
         assertNotNull(vastxml);
     }
 
@@ -1240,12 +1239,10 @@ public class PrebidServerAdapterTest extends BaseSetup {
         int isRewarded = postData.getJSONArray("imp").getJSONObject(0).getJSONObject("ext").getJSONObject("prebid").getInt("is_rewarded_inventory");
 
         //then
+        assertEquals(5, video.getInt("placement"));
         assertEquals(1, video.getInt("linearity"));
-
         assertEquals(1, instl);
-
         assertEquals(1, isRewarded);
-
         assertNotNull(vastxml);
     }
 
@@ -1274,7 +1271,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         HashSet<AdSize> sizes = new HashSet<>();
         sizes.add(new AdSize(500, 700));
 
-        RequestParams requestParams = new RequestParams("67890", AdType.VIDEO, sizes, null, null, null, null, parameters);
+        RequestParams requestParams = new RequestParams("67890", AdType.VIDEO, sizes, null, null, null, parameters);
         String uuid = UUID.randomUUID().toString();
         adapter.requestDemand(requestParams, mockListener, uuid);
         @SuppressWarnings("unchecked")
@@ -1331,7 +1328,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         int instl = 0;
 
         //when
-        JSONObject postData = getPostDataHelper(AdType.INTERSTITIAL, null, null, minSizePerc, null, null);
+        JSONObject postData = getPostDataHelper(AdType.INTERSTITIAL, null, null, minSizePerc, null);
 
         try {
             extInterstitial = postData.getJSONObject("device").getJSONObject("ext").getJSONObject("prebid").getJSONObject("interstitial");
@@ -1370,7 +1367,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         int instl = 0;
 
         //when
-        JSONObject postData = getPostDataHelper(AdType.INTERSTITIAL, null, null, null, null, null);
+        JSONObject postData = getPostDataHelper(AdType.INTERSTITIAL, null, null, null, null);
 
         try {
             instl = postData.getJSONArray("imp").getJSONObject(0).getInt("instl");
@@ -1396,7 +1393,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         int instl = 0;
 
         //when
-        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, minSizePerc, null, null);
+        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, minSizePerc, null);
 
         try {
             extInterstitial = postData.getJSONObject("device").getJSONObject("ext").getJSONObject("prebid").getJSONObject("interstitial");
@@ -1420,7 +1417,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         TargetingParams.addUserKeyword("value10");
 
         //when
-        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null, null);
+        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null);
 
         String keywords = null;
         try {
@@ -1441,7 +1438,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         TargetingParams.addContextKeyword("value10");
 
         //when
-        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null, null);
+        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null);
 
         String keywords = null;
         try {
@@ -1463,7 +1460,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         TargetingParams.addBidderToAccessControlList(TargetingParams.BIDDER_NAME_RUBICON_PROJECT);
 
         //when
-        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null, null);
+        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null);
 
         JSONArray biddersJsonArray = null;
         try {
@@ -1488,7 +1485,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         TargetingParams.addUserData("key2", "value21");
 
         //when
-        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null, null);
+        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null);
 
         JSONObject dataJsonObject = null;
         try {
@@ -1521,7 +1518,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         TargetingParams.addContextData("key2", "value21");
 
         //when
-        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null, null);
+        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null);
 
         JSONObject dataJsonObject = null;
         try {
@@ -1553,7 +1550,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         contextKeywordsSet.add("value10");
 
         //when
-        JSONObject postData = getPostDataHelper(AdType.BANNER, null, contextKeywordsSet, null, null, null);
+        JSONObject postData = getPostDataHelper(AdType.BANNER, null, contextKeywordsSet, null, null);
 
         String keywords = null;
 
@@ -1577,7 +1574,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         contextDataDictionary.put("key2", new HashSet<>(Arrays.asList("value20", "value21")));
 
         //when
-        JSONObject postData = getPostDataHelper(AdType.BANNER, contextDataDictionary, null, null, null, null);
+        JSONObject postData = getPostDataHelper(AdType.BANNER, contextDataDictionary, null, null, null);
 
         JSONObject dataJsonObject = null;
         try {
@@ -1717,7 +1714,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         nativeAdUnit.fetchDemand(testView, mockListener);
     }
 
-    private JSONObject getPostDataHelper(AdType adType, @Nullable Map<String, Set<String>> contextDataDictionary, @Nullable Set<String> contextKeywordsSet, @Nullable AdSize minSizePerc, @Nullable Integer videoPlacement, @Nullable VideoBaseAdUnit.Parameters parameters) throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
+    private JSONObject getPostDataHelper(AdType adType, @Nullable Map<String, Set<String>> contextDataDictionary, @Nullable Set<String> contextKeywordsSet, @Nullable AdSize minSizePerc, @Nullable VideoBaseAdUnit.Parameters parameters) throws NoSuchMethodException, IllegalAccessException, InvocationTargetException {
 
         PrebidMobile.setApplicationContext(activity.getApplicationContext());
 
@@ -1728,7 +1725,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         HashSet<AdSize> sizes = new HashSet<>();
         sizes.add(new AdSize(300, 250));
 
-        RequestParams requestParams = new RequestParams("67890", adType, sizes, contextDataDictionary, contextKeywordsSet, minSizePerc, videoPlacement, parameters);
+        RequestParams requestParams = new RequestParams("67890", adType, sizes, contextDataDictionary, contextKeywordsSet, minSizePerc, parameters);
         String uuid = UUID.randomUUID().toString();
         adapter.requestDemand(requestParams, mockListener, uuid);
         @SuppressWarnings("unchecked")

--- a/PrebidMobile/src/test/java/org/prebid/mobile/PrebidServerAdapterTest.java
+++ b/PrebidMobile/src/test/java/org/prebid/mobile/PrebidServerAdapterTest.java
@@ -786,7 +786,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
 
         Integer gdprSubject = null;
         //when
-        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null, null);
+        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null);
         try {
             gdprSubject = postData.getJSONObject("regs").getJSONObject("ext").getInt("gdpr");
         } catch (Exception ex) {
@@ -806,7 +806,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
 
         Object gdprSubject = null;
         //when
-        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null, null);
+        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null);
         try {
             gdprSubject = postData.opt("regs");
         } catch (Exception ex) {
@@ -826,7 +826,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
 
         Object gdprSubject = null;
         //when
-        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null, null);
+        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null);
         try {
             gdprSubject = postData.optJSONObject("regs");
         } catch (Exception ex) {
@@ -849,7 +849,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         Integer gdprSubject = null;
         String gdprConsent = null;
         //when
-        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null, null);
+        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null);
         try {
             gdprSubject = postData.getJSONObject("regs").getJSONObject("ext").getInt("gdpr");
             gdprConsent = postData.getJSONObject("user").getJSONObject("ext").getString("consent");
@@ -873,7 +873,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         Object gdprSubject = null;
         Object gdprConsent = null;
         //when
-        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null, null);
+        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null);
         try {
             gdprSubject = postData.opt("regs");
             gdprConsent = postData.getJSONObject("user").opt("ext");
@@ -903,7 +903,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
 
         String ifa = null;
         //when
-        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null, null);
+        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null);
         try {
             ifa = postData.getJSONObject("device").getString("ifa");
 
@@ -962,7 +962,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         JSONObject device = null;
         Object ifa = null;
         //when
-        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null, null);
+        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null);
         try {
             device = postData.optJSONObject("device");
 
@@ -992,7 +992,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         int coppa = 0;
 
         //when
-        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null, null);
+        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null);
         try {
             coppa = postData.getJSONObject("regs").getInt("coppa");
         } catch (Exception ex) {
@@ -1011,7 +1011,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         Object coppa = null;
 
         //when
-        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null, null);
+        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null);
         try {
             coppa = postData.opt("regs");
         } catch (Exception ex) {
@@ -1036,7 +1036,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         String ccpa = null;
 
         //when
-        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null, null);
+        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null);
         try {
             ccpa = postData.getJSONObject("regs").getJSONObject("ext").getString("us_privacy");
         } catch (Exception ex) {
@@ -1059,7 +1059,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         Object ccpa = null;
 
         //when
-        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null, null);
+        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null);
         try {
             ccpa = postData.opt("regs");
         } catch (Exception ex) {
@@ -1084,7 +1084,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         Object ccpa = null;
 
         //when
-        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null, null);
+        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null);
         try {
             ccpa = postData.opt("regs");
         } catch (Exception ex) {
@@ -1318,77 +1318,6 @@ public class PrebidServerAdapterTest extends BaseSetup {
     }
 
     @Test
-    public void testVideoBaseAdUnit() throws Exception {
-        PrebidMobile.setPrebidServerAccountId("12345");
-
-        //given
-        VideoAdUnit.Parameters parameters = new VideoAdUnit.Parameters();
-
-        parameters.setApi(Arrays.asList(Signals.Api.VPAID_1, Signals.Api.VPAID_2));
-        parameters.setMaxBitrate(1500);
-        parameters.setMinBitrate(300);
-        parameters.setMaxDuration(30);
-        parameters.setMinDuration(5);
-        parameters.setMimes(Arrays.asList("video/x-flv", "video/mp4"));
-        parameters.setPlaybackMethod(Arrays.asList(Signals.PlaybackMethod.AutoPlaySoundOn, Signals.PlaybackMethod.ClickToPlay));
-        parameters.setProtocols(Arrays.asList(Signals.Protocols.VAST_2_0, Signals.Protocols.VAST_3_0));
-        parameters.setStartDelay(Signals.StartDelay.PreRoll);
-
-        //when
-        PrebidMobile.setApplicationContext(activity.getApplicationContext());
-        server.enqueue(new MockResponse().setResponseCode(200).setBody(MockPrebidServerResponses.noBid()));
-        DemandAdapter.DemandAdapterListener mockListener = mock(DemandAdapter.DemandAdapterListener.class);
-        PrebidServerAdapter adapter = new PrebidServerAdapter();
-        HashSet<AdSize> sizes = new HashSet<>();
-        sizes.add(new AdSize(500, 700));
-
-        RequestParams requestParams = new RequestParams("67890", AdType.VIDEO, sizes, null, null, null, null, parameters);
-        String uuid = UUID.randomUUID().toString();
-        adapter.requestDemand(requestParams, mockListener, uuid);
-        @SuppressWarnings("unchecked")
-        ArrayList<PrebidServerAdapter.ServerConnector> connectors = (ArrayList<PrebidServerAdapter.ServerConnector>) FieldUtils.readDeclaredField(adapter, "serverConnectors", true);
-        PrebidServerAdapter.ServerConnector connector = connectors.get(0);
-
-        JSONObject postData = (JSONObject) MethodUtils.invokeMethod(connector, true, "getPostData");
-
-        JSONObject video = postData.getJSONArray("imp").getJSONObject(0).getJSONObject("video");
-
-        //then
-        List<Integer> apiList = Util.convertJSONArray(video.getJSONArray("api"));
-        assertEquals(2, apiList.size());
-        assertTrue(apiList.contains(1) && apiList.contains(2));
-
-        int maxBitrate = video.getInt("maxbitrate");
-        assertEquals(1500, maxBitrate);
-
-        int minBitrate = video.getInt("minbitrate");
-        assertEquals(300, minBitrate);
-
-        int maxDuration = video.getInt("maxduration");
-        assertEquals(30, maxDuration);
-
-        int minDuration = video.getInt("minduration");
-        assertEquals(5, minDuration);
-
-        List<String> mimeList = Util.convertJSONArray(video.getJSONArray("mimes"));
-
-        assertEquals(2, mimeList.size());
-        assertTrue(mimeList.contains("video/x-flv") && mimeList.contains("video/mp4"));
-
-        List<Integer> playbackList = Util.convertJSONArray(video.getJSONArray("playbackmethod"));
-        assertEquals(2, playbackList.size());
-        assertTrue(playbackList.contains(1) && playbackList.contains(3));
-
-        List<Integer> protocolList = Util.convertJSONArray(video.getJSONArray("protocols"));
-        assertEquals(2, protocolList.size());
-        assertTrue(protocolList.contains(2) && protocolList.contains(3));
-
-        int startDelay = video.getInt("startdelay");
-        assertEquals(0, startDelay);
-
-    }
-
-    @Test
     public void testPostDataWithAdvancedInterstitial() throws Exception {
 
         //given
@@ -1399,7 +1328,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         int instl = 0;
 
         //when
-        JSONObject postData = getPostDataHelper(AdType.INTERSTITIAL, null, null, minSizePerc, null, null);
+        JSONObject postData = getPostDataHelper(AdType.INTERSTITIAL, null, null, minSizePerc, null);
 
         try {
             extInterstitial = postData.getJSONObject("device").getJSONObject("ext").getJSONObject("prebid").getJSONObject("interstitial");
@@ -1438,7 +1367,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         int instl = 0;
 
         //when
-        JSONObject postData = getPostDataHelper(AdType.INTERSTITIAL, null, null, null, null, null);
+        JSONObject postData = getPostDataHelper(AdType.INTERSTITIAL, null, null, null, null);
 
         try {
             instl = postData.getJSONArray("imp").getJSONObject(0).getInt("instl");
@@ -1464,7 +1393,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         int instl = 0;
 
         //when
-        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, minSizePerc, null, null);
+        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, minSizePerc, null);
 
         try {
             extInterstitial = postData.getJSONObject("device").getJSONObject("ext").getJSONObject("prebid").getJSONObject("interstitial");
@@ -1488,7 +1417,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         TargetingParams.addUserKeyword("value10");
 
         //when
-        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null, null);
+        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null);
 
         String keywords = null;
         try {
@@ -1509,7 +1438,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         TargetingParams.addContextKeyword("value10");
 
         //when
-        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null, null);
+        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null);
 
         String keywords = null;
         try {
@@ -1531,7 +1460,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         TargetingParams.addBidderToAccessControlList(TargetingParams.BIDDER_NAME_RUBICON_PROJECT);
 
         //when
-        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null, null);
+        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null);
 
         JSONArray biddersJsonArray = null;
         try {
@@ -1556,7 +1485,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         TargetingParams.addUserData("key2", "value21");
 
         //when
-        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null, null);
+        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null);
 
         JSONObject dataJsonObject = null;
         try {
@@ -1589,7 +1518,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         TargetingParams.addContextData("key2", "value21");
 
         //when
-        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null, null);
+        JSONObject postData = getPostDataHelper(AdType.BANNER, null, null, null, null);
 
         JSONObject dataJsonObject = null;
         try {
@@ -1621,7 +1550,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         contextKeywordsSet.add("value10");
 
         //when
-        JSONObject postData = getPostDataHelper(AdType.BANNER, null, contextKeywordsSet, null, null, null);
+        JSONObject postData = getPostDataHelper(AdType.BANNER, null, contextKeywordsSet, null, null);
 
         String keywords = null;
 
@@ -1645,7 +1574,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         contextDataDictionary.put("key2", new HashSet<>(Arrays.asList("value20", "value21")));
 
         //when
-        JSONObject postData = getPostDataHelper(AdType.BANNER, contextDataDictionary, null, null, null, null);
+        JSONObject postData = getPostDataHelper(AdType.BANNER, contextDataDictionary, null, null, null);
 
         JSONObject dataJsonObject = null;
         try {
@@ -1797,7 +1726,6 @@ public class PrebidServerAdapterTest extends BaseSetup {
         sizes.add(new AdSize(300, 250));
 
         RequestParams requestParams = new RequestParams("67890", adType, sizes, contextDataDictionary, contextKeywordsSet, minSizePerc, parameters);
-
         String uuid = UUID.randomUUID().toString();
         adapter.requestDemand(requestParams, mockListener, uuid);
         @SuppressWarnings("unchecked")

--- a/PrebidMobile/src/test/java/org/prebid/mobile/RequestParamsTest.java
+++ b/PrebidMobile/src/test/java/org/prebid/mobile/RequestParamsTest.java
@@ -115,7 +115,7 @@ public class RequestParamsTest {
 
         AdSize minSizePerc = new AdSize(50, 70);
 
-        RequestParams requestParams = new RequestParams("123456", AdType.INTERSTITIAL, sizes, null, null, minSizePerc, null, null);
+        RequestParams requestParams = new RequestParams("123456", AdType.INTERSTITIAL, sizes, null, null, minSizePerc, null);
 
         AdSize minAdSizePerc = requestParams.getMinSizePerc();
         assertNotNull(minAdSizePerc);


### PR DESCRIPTION
**Changes**
`Signals.Placement` class was added to replace `PlacementType`

**API**
There are two ways to create a `Signal` object:
1. Use predefined constants
2. Manually construct a new instance

``` Java
//Interstitial
Signals.Placement interstitial = Signals.Placement.Interstitial;
Signals.Placement interstitial = new Signals.Placement(5);
```

Example
``` Java
VideoBaseAdUnit.Parameters parameters = new VideoBaseAdUnit.Parameters();
parameters.setPlacement(Signals.Placement.Interstitial);

VideoInterstitialAdUnit adUnit = new VideoInterstitialAdUnit("1001-1");
adUnit.setParameters(parameters);
```

**Notes:**
If publisher does not set `placement` for `VideoInterstitialAdUnit` or `RewardedVideoAdUnit`, value `5` is used by default

**Deprecated**
``` Java
//Enums
VideoAdUnit.PlacementType

//Constructors
VideoAdUnit(String, int, int, PlacementType)

//Methods
VideoAdUnit.getType()
```