### PR TITLE
[Feature Request] fetchBids with PublisherAdRequest$Builder

### DIFF
--- a/Example/PrebidDemoKotlin/src/main/java/org/prebid/mobile/prebidkotlindemo/DemoActivity.kt
+++ b/Example/PrebidDemoKotlin/src/main/java/org/prebid/mobile/prebidkotlindemo/DemoActivity.kt
@@ -105,15 +105,13 @@ class DemoActivity : AppCompatActivity() {
         adFrame.addView(dfpAdView)
         val builder = PublisherAdRequest.Builder()
 
-        val request = builder.build()
-
         //region PrebidMobile Mobile API 1.0 usage
         val millis = intent.getIntExtra(Constants.AUTO_REFRESH_NAME, 0)
         adUnit!!.setAutoRefreshPeriodMillis(millis)
-        adUnit!!.fetchDemand(request, object : OnCompleteListener {
+        adUnit!!.fetchDemand(builder, object : OnCompleteListener {
             override fun onComplete(resultCode: ResultCode) {
                 this@DemoActivity.resultCode = resultCode
-                dfpAdView.loadAd(request)
+                dfpAdView.loadAd(builder.build())
                 refreshCount++
             }
         })

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/Util.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/Util.java
@@ -474,7 +474,6 @@ public class Util {
     }
 
     private static void handleDFPBuilderCustomTargetingUpdate(HashMap<String, String> bids, Object adObj) {
-        removeUsedCustomTargetingForDFPBuilder(adObj);
         if (bids != null && !bids.isEmpty()) {
             for (String key : bids.keySet()) {
                 Util.callMethodOnObject(adObj, "addCustomTargeting", key, bids.get(key));
@@ -519,10 +518,6 @@ public class Util {
                 bundle.remove(key);
             }
         }
-    }
-
-    private static void removeUsedCustomTargetingForDFPBuilder(Object adRequestObj) {
-        // TODO: How to remove stuff from the custom targeting map?
     }
 
     static <E, U> void addValue(Map<E, Set<U>> map, E key, U value) {


### PR DESCRIPTION
# Preface

This PR is a proof of concept in combination with a feature request.
I also included some open question about the inner working of this Android library and some architectural choices that were made.

# Current problem

Currently (v1.6) when fetching bids via the `AdUnit#fetchDemand` method it allows for any object to be passed.
This object is then checked in the code to see if it is of a known type.

The current supported types are:

    static final String MOPUB_BANNER_VIEW_CLASS = "com.mopub.mobileads.MoPubView";
    static final String MOPUB_INTERSTITIAL_CLASS = "com.mopub.mobileads.MoPubInterstitial";
    static final String DFP_AD_REQUEST_CLASS = "com.google.android.gms.ads.doubleclick.PublisherAdRequest";

We would like to add one more object namely the `PublisherAdRequest$Builder`. 
 
This allows us to manipulate the request after the specific parameters are added for Prebid.  
The way we implemented it in this PR is a non breaking change, but ideally this should be the only way of fetching bids. 
That is because Google's `PublisherAdRequest$Builder` library offers no convenient `copyFrom` method that can take an already existing `PublisherAdRequest` to a builder and therefore Prebid currently blocks us from adding extra values **AFTER** bids were fetched.

# Extra questions

## Reflection
We were a little beetje stumped to see the usage of reflection for adding simple key values in the custom targeting.
Using reflection on mobile is severely bad for performance and should be avoided at ALL costs.

There is probably a good reason why you are not declaring a dependency on the `com.google.android.gms:play-services-ads` lib.
We would love to hear the reasoning.

## Util#removeUsedCustomTargetingForDFP
This method is removing reserved keys from the custom targeting map.
However the map is only allocated after the initial load.
So the first time this method does not remove anything.
The second time a `fetchDemand` call is triggered the `PublisherAdRequest` is a new object so the custom targeting is not even filled in.
Did we miss something here? If not this method seems useless.

Thanks in advance

From your friends at TAR.GET() @ DPG Media ❤️


