### PR TITLE
Modify custom targeting after the auction happened

### DIFF
--- a/Example/PrebidDemoJava/src/androidTest/java/org/prebid/mobile/app/AdManagerComplexTest.java
+++ b/Example/PrebidDemoJava/src/androidTest/java/org/prebid/mobile/app/AdManagerComplexTest.java
@@ -269,6 +269,30 @@ public class AdManagerComplexTest {
     }
 
     @Test
+    public void testPublisherAdRequest() throws Exception {
+        PublisherAdRequest.Builder builder = new PublisherAdRequest.Builder();
+        builder.addCustomTargeting("key1", "value1");
+        builder.addCustomTargeting("key2", "value2");
+
+        PublisherAdRequest publisherAdRequest1 = builder.build();
+        Bundle bundle1 = publisherAdRequest1.getCustomTargeting();
+
+        assertEquals(2, bundle1.keySet().size());
+        assertEquals("value1", bundle1.getString("key1"));
+        assertEquals("value2", bundle1.getString("key2"));
+
+        bundle1.remove("key2");
+        assertEquals(1, bundle1.keySet().size());
+        assertEquals("value1", bundle1.getString("key1"));
+
+        PublisherAdRequest publisherAdRequest2 = builder.build();
+        Bundle bundle2 = publisherAdRequest2.getCustomTargeting();
+        assertEquals(1, bundle2.keySet().size());
+        assertEquals("value1", bundle2.getString("key1"));
+
+    }
+
+    @Test
     public void testPublisherAdRequestBuilderUseCase() throws Exception {
         //given
 

--- a/Example/PrebidDemoJava/src/main/java/org/prebid/mobile/app/DemoActivity.java
+++ b/Example/PrebidDemoJava/src/main/java/org/prebid/mobile/app/DemoActivity.java
@@ -83,6 +83,7 @@ public class DemoActivity extends AppCompatActivity implements MoPubRewardedVide
     AdUnit adUnit;
     ResultCode resultCode;
 
+    //Used by UI tests
     PublisherAdRequest request;
     MoPubView adView;
 
@@ -278,7 +279,6 @@ public class DemoActivity extends AppCompatActivity implements MoPubRewardedVide
         nativeAdView.setAdSizes(AdSize.FLUID);
         adFrame.addView(nativeAdView);
         final PublisherAdRequest.Builder builder = new PublisherAdRequest.Builder();
-        request = builder.build();
         NativeAdUnit nativeAdUnit = (NativeAdUnit) adUnit;
         nativeAdUnit.setContextType(NativeAdUnit.CONTEXT_TYPE.SOCIAL_CENTRIC);
         nativeAdUnit.setPlacementType(NativeAdUnit.PLACEMENTTYPE.CONTENT_FEED);
@@ -324,12 +324,13 @@ public class DemoActivity extends AppCompatActivity implements MoPubRewardedVide
         nativeAdUnit.addAsset(cta);
         int millis = getIntent().getIntExtra(Constants.AUTO_REFRESH_NAME, 0);
         nativeAdUnit.setAutoRefreshPeriodMillis(millis);
-        nativeAdUnit.fetchDemand(request, new OnCompleteListener() {
+        nativeAdUnit.fetchDemand(builder, new OnCompleteListener() {
             @Override
             public void onComplete(ResultCode resultCode) {
                 DemoActivity.this.resultCode = resultCode;
+
+                request = builder.build();
                 nativeAdView.loadAd(request);
-                DemoActivity.this.request = request;
                 refreshCount++;
             }
         });
@@ -445,14 +446,17 @@ public class DemoActivity extends AppCompatActivity implements MoPubRewardedVide
         });
 
         final PublisherAdRequest.Builder builder = new PublisherAdRequest.Builder();
-        final PublisherAdRequest request = builder.build();
+
         //region PrebidMobile Mobile API 1.0 usage
         int millis = getIntent().getIntExtra(Constants.AUTO_REFRESH_NAME, 0);
         adUnit.setAutoRefreshPeriodMillis(millis);
-        adUnit.fetchDemand(request, new OnCompleteListener() {
+        adUnit.fetchDemand(builder, new OnCompleteListener() {
             @Override
             public void onComplete(ResultCode resultCode) {
+
                 DemoActivity.this.resultCode = resultCode;
+
+                PublisherAdRequest request = builder.build();
                 amBanner.loadAd(request);
                 refreshCount++;
             }
@@ -622,12 +626,13 @@ public class DemoActivity extends AppCompatActivity implements MoPubRewardedVide
     private void loadAMInterstitial() {
         int millis = getIntent().getIntExtra(Constants.AUTO_REFRESH_NAME, 0);
         adUnit.setAutoRefreshPeriodMillis(millis);
-        PublisherAdRequest.Builder builder = new PublisherAdRequest.Builder();
-        request = builder.build();
-        adUnit.fetchDemand(request, new OnCompleteListener() {
+        final PublisherAdRequest.Builder builder = new PublisherAdRequest.Builder();
+        adUnit.fetchDemand(builder, new OnCompleteListener() {
             @Override
             public void onComplete(ResultCode resultCode) {
                 DemoActivity.this.resultCode = resultCode;
+
+                PublisherAdRequest request = builder.build();
                 amInterstitial.loadAd(request);
                 refreshCount++;
             }
@@ -738,12 +743,13 @@ public class DemoActivity extends AppCompatActivity implements MoPubRewardedVide
     //Load
     private void loadAMRewardedVideo() {
 
-        PublisherAdRequest.Builder builder = new PublisherAdRequest.Builder();
-        request = builder.build();
-        adUnit.fetchDemand(request, new OnCompleteListener() {
+        final PublisherAdRequest.Builder builder = new PublisherAdRequest.Builder();
+        adUnit.fetchDemand(builder, new OnCompleteListener() {
             @Override
             public void onComplete(ResultCode resultCode) {
                 DemoActivity.this.resultCode = resultCode;
+
+                PublisherAdRequest request = builder.build();
                 amRewardedAd.loadAd(request, new RewardedAdLoadCallback() {
                     @Override
                     public void onRewardedAdLoaded() {

--- a/Example/PrebidDemoKotlin/src/main/java/org/prebid/mobile/prebidkotlindemo/DemoActivity.kt
+++ b/Example/PrebidDemoKotlin/src/main/java/org/prebid/mobile/prebidkotlindemo/DemoActivity.kt
@@ -105,15 +105,13 @@ class DemoActivity : AppCompatActivity() {
         adFrame.addView(dfpAdView)
         val builder = PublisherAdRequest.Builder()
 
-        val request = builder.build()
-
         //region PrebidMobile Mobile API 1.0 usage
         val millis = intent.getIntExtra(Constants.AUTO_REFRESH_NAME, 0)
         adUnit!!.setAutoRefreshPeriodMillis(millis)
-        adUnit!!.fetchDemand(request, object : OnCompleteListener {
+        adUnit!!.fetchDemand(builder, object : OnCompleteListener {
             override fun onComplete(resultCode: ResultCode) {
                 this@DemoActivity.resultCode = resultCode
-                dfpAdView.loadAd(request)
+                dfpAdView.loadAd(builder.build())
                 refreshCount++
             }
         })

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/Util.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/Util.java
@@ -54,8 +54,8 @@ public class Util {
 
     static final String MOPUB_BANNER_VIEW_CLASS = "com.mopub.mobileads.MoPubView";
     static final String MOPUB_INTERSTITIAL_CLASS = "com.mopub.mobileads.MoPubInterstitial";
-    static final String DFP_AD_REQUEST_CLASS = "com.google.android.gms.ads.doubleclick.PublisherAdRequest";
-    static final String DFP_AD_REQUEST_BUILDER_CLASS = "com.google.android.gms.ads.doubleclick.PublisherAdRequest$Builder";
+    static final String AD_MANAGER_REQUEST_CLASS = "com.google.android.gms.ads.doubleclick.PublisherAdRequest";
+    static final String AD_MANAGER_REQUEST_BUILDER_CLASS = "com.google.android.gms.ads.doubleclick.PublisherAdRequest$Builder";
     private static final Random RANDOM = new Random();
     private static final HashSet<String> reservedKeys;
     private static final int MoPubQueryStringLimit = 4000;
@@ -412,8 +412,8 @@ public class Util {
         if (adObj == null) return false;
         if (adObj.getClass() == getClassFromString(MOPUB_BANNER_VIEW_CLASS)
                 || adObj.getClass() == getClassFromString(MOPUB_INTERSTITIAL_CLASS)
-                || adObj.getClass() == getClassFromString(DFP_AD_REQUEST_CLASS)
-                || adObj.getClass() == getClassFromString(DFP_AD_REQUEST_BUILDER_CLASS)
+                || adObj.getClass() == getClassFromString(AD_MANAGER_REQUEST_CLASS)
+                || adObj.getClass() == getClassFromString(AD_MANAGER_REQUEST_BUILDER_CLASS)
                 || adObj.getClass() == HashMap.class)
             return true;
         return false;
@@ -424,10 +424,10 @@ public class Util {
         if (adObj.getClass() == getClassFromString(MOPUB_BANNER_VIEW_CLASS)
                 || adObj.getClass() == getClassFromString(MOPUB_INTERSTITIAL_CLASS)) {
             handleMoPubKeywordsUpdate(bids, adObj);
-        } else if (adObj.getClass() == getClassFromString(DFP_AD_REQUEST_CLASS)) {
-            handleDFPCustomTargetingUpdate(bids, adObj);
-        } else if (adObj.getClass() == getClassFromString(DFP_AD_REQUEST_BUILDER_CLASS)) {
-            handleDFPBuilderCustomTargetingUpdate(bids, adObj);
+        } else if (adObj.getClass() == getClassFromString(AD_MANAGER_REQUEST_CLASS)) {
+            handleAdManagerCustomTargeting(bids, adObj);
+        } else if (adObj.getClass() == getClassFromString(AD_MANAGER_REQUEST_BUILDER_CLASS)) {
+            handleAdManagerBuilderCustomTargeting(bids, adObj);
         }
         else if (adObj.getClass() == HashMap.class) {
             if (bids != null && !bids.isEmpty()) {
@@ -458,10 +458,10 @@ public class Util {
         }
     }
 
-    private static void handleDFPCustomTargetingUpdate(HashMap<String, String> bids, Object adObj) {
-        removeUsedCustomTargetingForDFP(adObj);
+    private static void handleAdManagerCustomTargeting(HashMap<String, String> bids, Object publisherAdRequest) {
+        removeUsedCustomTargetingForDFP(publisherAdRequest);
         if (bids != null && !bids.isEmpty()) {
-            Bundle bundle = (Bundle) Util.callMethodOnObject(adObj, "getCustomTargeting");
+            Bundle bundle = (Bundle) Util.callMethodOnObject(publisherAdRequest, "getCustomTargeting");
             if (bundle != null) {
                 // retrieve keywords from mopub adview
                 for (String key : bids.keySet()) {
@@ -472,13 +472,13 @@ public class Util {
         }
     }
 
-    private static void handleDFPBuilderCustomTargetingUpdate(HashMap<String, String> bids, Object adObj) {
-        Object publisherAdRequest = Util.callMethodOnObject(adObj, "build");
+    private static void handleAdManagerBuilderCustomTargeting(HashMap<String, String> bids, Object publisherAdRequestBuilder) {
+        Object publisherAdRequest = Util.callMethodOnObject(publisherAdRequestBuilder, "build");
         removeUsedCustomTargetingForDFP(publisherAdRequest);
 
         if (bids != null && !bids.isEmpty()) {
             for (String key : bids.keySet()) {
-                Util.callMethodOnObject(adObj, "addCustomTargeting", key, bids.get(key));
+                Util.callMethodOnObject(publisherAdRequestBuilder, "addCustomTargeting", key, bids.get(key));
                 addReservedKeys(key);
             }
         }
@@ -514,8 +514,8 @@ public class Util {
         }
     }
 
-    private static void removeUsedCustomTargetingForDFP(Object adRequestObj) {
-        Bundle bundle = (Bundle) Util.callMethodOnObject(adRequestObj, "getCustomTargeting");
+    private static void removeUsedCustomTargetingForDFP(Object publisherAdRequest) {
+        Bundle bundle = (Bundle) Util.callMethodOnObject(publisherAdRequest, "getCustomTargeting");
         if (bundle != null && reservedKeys != null) {
             for (String key : reservedKeys) {
                 bundle.remove(key);

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/Util.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/Util.java
@@ -24,7 +24,6 @@ import android.support.annotation.CheckResult;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
-import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 import android.webkit.ValueCallback;
@@ -474,9 +473,11 @@ public class Util {
     }
 
     private static void handleDFPBuilderCustomTargetingUpdate(HashMap<String, String> bids, Object adObj) {
+        removeUsedCustomTargetingForDFP(adObj);
         if (bids != null && !bids.isEmpty()) {
             for (String key : bids.keySet()) {
                 Util.callMethodOnObject(adObj, "addCustomTargeting", key, bids.get(key));
+                addReservedKeys(key);
             }
         }
     }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/Util.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/Util.java
@@ -473,7 +473,9 @@ public class Util {
     }
 
     private static void handleDFPBuilderCustomTargetingUpdate(HashMap<String, String> bids, Object adObj) {
-        removeUsedCustomTargetingForDFP(adObj);
+        Object publisherAdRequest = Util.callMethodOnObject(adObj, "build");
+        removeUsedCustomTargetingForDFP(publisherAdRequest);
+
         if (bids != null && !bids.isEmpty()) {
             for (String key : bids.keySet()) {
                 Util.callMethodOnObject(adObj, "addCustomTargeting", key, bids.get(key));

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/Util.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/Util.java
@@ -474,7 +474,6 @@ public class Util {
     }
 
     private static void handleDFPBuilderCustomTargetingUpdate(HashMap<String, String> bids, Object adObj) {
-        removeUsedCustomTargetingForDFPBuilder(adObj);
         if (bids != null && !bids.isEmpty()) {
             for (String key : bids.keySet()) {
                 Util.callMethodOnObject(adObj, "addCustomTargeting", key, bids.get(key));
@@ -519,10 +518,6 @@ public class Util {
                 bundle.remove(key);
             }
         }
-    }
-
-    private static void removeUsedCustomTargetingForDFPBuilder(Object adRequestObj) {
-        // TODO: How to remove stuff from the custom targeting map?
     }
 
     static <E, U> void addValue(Map<E, Set<U>> map, E key, U value) {

--- a/PrebidMobile/src/test/java/org/prebid/mobile/UtilTest.java
+++ b/PrebidMobile/src/test/java/org/prebid/mobile/UtilTest.java
@@ -63,7 +63,8 @@ public class UtilTest extends BaseSetup {
     public void testGetClassFromString() throws Exception {
         assertEquals(MoPubView.class, Util.getClassFromString(Util.MOPUB_BANNER_VIEW_CLASS));
         assertEquals(MoPubInterstitial.class, Util.getClassFromString(Util.MOPUB_INTERSTITIAL_CLASS));
-        assertEquals(PublisherAdRequest.class, Util.getClassFromString(Util.DFP_AD_REQUEST_CLASS));
+        assertEquals(PublisherAdRequest.class, Util.getClassFromString(Util.AD_MANAGER_REQUEST_CLASS));
+        assertEquals(PublisherAdRequest.Builder.class, Util.getClassFromString(Util.AD_MANAGER_REQUEST_BUILDER_CLASS));
     }
 
     @Test
@@ -93,18 +94,22 @@ public class UtilTest extends BaseSetup {
         HashMap<String, String> bids = new HashMap<>();
         bids.put("hb_pb", "0.50");
         bids.put("hb_cache_id", "123456");
+
+        Util.apply(bids, builder);
         PublisherAdRequest request = builder.build();
+        assertEquals(3, request.getCustomTargeting().size());
+        assertEquals("Value", request.getCustomTargeting().get("Key"));
+        assertEquals("0.50", request.getCustomTargeting().get("hb_pb"));
+        assertEquals("123456", request.getCustomTargeting().get("hb_cache_id"));
+
         Util.apply(bids, request);
         assertEquals(3, request.getCustomTargeting().size());
-        assertTrue(request.getCustomTargeting().containsKey("Key"));
         assertEquals("Value", request.getCustomTargeting().get("Key"));
-        assertTrue(request.getCustomTargeting().containsKey("hb_pb"));
         assertEquals("0.50", request.getCustomTargeting().get("hb_pb"));
-        assertTrue(request.getCustomTargeting().containsKey("hb_cache_id"));
         assertEquals("123456", request.getCustomTargeting().get("hb_cache_id"));
+
         Util.apply(null, request);
         assertEquals(1, request.getCustomTargeting().size());
-        assertTrue(request.getCustomTargeting().containsKey("Key"));
         assertEquals("Value", request.getCustomTargeting().get("Key"));
     }
 
@@ -117,6 +122,8 @@ public class UtilTest extends BaseSetup {
         assertTrue(Util.supportedAdObject(interstitial));
         PublisherAdRequest request = new PublisherAdRequest.Builder().build();
         assertTrue(Util.supportedAdObject(request));
+        PublisherAdRequest.Builder requestBuilder = new PublisherAdRequest.Builder();
+        assertTrue(Util.supportedAdObject(requestBuilder));
         Object object = new Object();
         assertFalse(Util.supportedAdObject(object));
     }


### PR DESCRIPTION
Description and the main idea #198

As a developer I want to have a possibility to add extra `custom targeting` **after** bids were retrieved

Now publisher can pass an `PublisherAdRequest.Builder`

``` Java
final PublisherAdRequest.Builder builder = new PublisherAdRequest.Builder();

adUnit.fetchDemand(builder, new OnCompleteListener() {
    @Override
    public void onComplete(ResultCode resultCode) {
        builder.addCustomTargeting("key1", "value1");
        PublisherAdRequest request = builder.build();
        amBanner.loadAd(request);
    }
});
```