### PR TITLE
PrebidServerAdapter errors

### DIFF
--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/PrebidServerAdapter.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/PrebidServerAdapter.java
@@ -40,6 +40,7 @@ import org.prebid.mobile.http.TaskResult;
 
 import java.lang.ref.WeakReference;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
@@ -48,10 +49,10 @@ import java.util.Map;
 import java.util.UUID;
 
 class PrebidServerAdapter implements DemandAdapter {
-    private ArrayList<ServerConnector> serverConnectors;
+    private final List<ServerConnector> serverConnectors;
 
     PrebidServerAdapter() {
-        serverConnectors = new ArrayList<>();
+        serverConnectors = Collections.synchronizedList(new ArrayList<ServerConnector>());
     }
 
     @Override
@@ -64,10 +65,13 @@ class PrebidServerAdapter implements DemandAdapter {
     @Override
     public void stopRequest(String auctionId) {
         ArrayList<ServerConnector> toRemove = new ArrayList<>();
-        for (ServerConnector connector : serverConnectors) {
-            if (connector.getAuctionId().equals(auctionId)) {
-                connector.destroy();
-                toRemove.add(connector);
+
+        synchronized (serverConnectors) {
+            for (ServerConnector connector : serverConnectors) {
+                if (connector.getAuctionId().equals(auctionId)) {
+                    connector.destroy();
+                    toRemove.add(connector);
+                }
             }
         }
         serverConnectors.removeAll(toRemove);

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/Util.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/Util.java
@@ -24,7 +24,6 @@ import android.support.annotation.CheckResult;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
 import android.text.TextUtils;
-import android.view.View;
 import android.view.ViewGroup;
 import android.webkit.ValueCallback;
 import android.webkit.WebView;
@@ -34,7 +33,6 @@ import android.widget.ImageView;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
-import org.prebid.mobile.addendum.AdViewUtils;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -528,7 +526,9 @@ public class Util {
         Bundle bundle = (Bundle) Util.callMethodOnObject(publisherAdRequest, "getCustomTargeting");
         if (bundle != null && reservedKeys != null) {
             for (String key : reservedKeys) {
-                bundle.remove(key);
+                synchronized (reservedKeys) {
+                    bundle.remove(key);
+                }
             }
         }
     }

--- a/PrebidMobile/src/test/java/org/prebid/mobile/PrebidServerAdapterTest.java
+++ b/PrebidMobile/src/test/java/org/prebid/mobile/PrebidServerAdapterTest.java
@@ -34,7 +34,6 @@ import org.junit.Test;
 import org.junit.rules.ErrorCollector;
 import org.junit.runner.RunWith;
 import org.prebid.mobile.tasksmanager.BackgroundThreadExecutor;
-import org.prebid.mobile.tasksmanager.MainThreadExecutor;
 import org.prebid.mobile.tasksmanager.TasksManager;
 import org.prebid.mobile.testutils.BaseSetup;
 import org.prebid.mobile.testutils.MockPrebidServerResponses;
@@ -794,7 +793,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         String uuid = UUID.randomUUID().toString();
         adapter.requestDemand(requestParams, mockListener, uuid);
         @SuppressWarnings("unchecked")
-        ArrayList<PrebidServerAdapter.ServerConnector> connectors = (ArrayList<PrebidServerAdapter.ServerConnector>) FieldUtils.readDeclaredField(adapter, "serverConnectors", true);
+        List<PrebidServerAdapter.ServerConnector> connectors = (List<PrebidServerAdapter.ServerConnector>) FieldUtils.readDeclaredField(adapter, "serverConnectors", true);
         PrebidServerAdapter.ServerConnector connector = connectors.get(0);
         assertEquals(uuid, connector.getAuctionId());
         JSONObject postData = (JSONObject) MethodUtils.invokeMethod(connector, true, "getPostData");
@@ -1209,7 +1208,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         String uuid = UUID.randomUUID().toString();
         adapter.requestDemand(requestParams, mockListener, uuid);
         @SuppressWarnings("unchecked")
-        ArrayList<PrebidServerAdapter.ServerConnector> connectors = (ArrayList<PrebidServerAdapter.ServerConnector>) FieldUtils.readDeclaredField(adapter, "serverConnectors", true);
+        List<PrebidServerAdapter.ServerConnector> connectors = (List<PrebidServerAdapter.ServerConnector>) FieldUtils.readDeclaredField(adapter, "serverConnectors", true);
         PrebidServerAdapter.ServerConnector connector = connectors.get(0);
 
         JSONObject postData = (JSONObject) MethodUtils.invokeMethod(connector, true, "getPostData");
@@ -1308,7 +1307,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         String uuid = UUID.randomUUID().toString();
         adapter.requestDemand(requestParams, mockListener, uuid);
         @SuppressWarnings("unchecked")
-        ArrayList<PrebidServerAdapter.ServerConnector> connectors = (ArrayList<PrebidServerAdapter.ServerConnector>) FieldUtils.readDeclaredField(adapter, "serverConnectors", true);
+        List<PrebidServerAdapter.ServerConnector> connectors = (List<PrebidServerAdapter.ServerConnector>) FieldUtils.readDeclaredField(adapter, "serverConnectors", true);
         PrebidServerAdapter.ServerConnector connector = connectors.get(0);
 
         JSONObject postData = (JSONObject) MethodUtils.invokeMethod(connector, true, "getPostData");
@@ -1339,7 +1338,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         String uuid = UUID.randomUUID().toString();
         adapter.requestDemand(requestParams, mockListener, uuid);
         @SuppressWarnings("unchecked")
-        ArrayList<PrebidServerAdapter.ServerConnector> connectors = (ArrayList<PrebidServerAdapter.ServerConnector>) FieldUtils.readDeclaredField(adapter, "serverConnectors", true);
+        List<PrebidServerAdapter.ServerConnector> connectors = (List<PrebidServerAdapter.ServerConnector>) FieldUtils.readDeclaredField(adapter, "serverConnectors", true);
         PrebidServerAdapter.ServerConnector connector = connectors.get(0);
 
         JSONObject postData = (JSONObject) MethodUtils.invokeMethod(connector, true, "getPostData");
@@ -1370,7 +1369,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         String uuid = UUID.randomUUID().toString();
         adapter.requestDemand(requestParams, mockListener, uuid);
         @SuppressWarnings("unchecked")
-        ArrayList<PrebidServerAdapter.ServerConnector> connectors = (ArrayList<PrebidServerAdapter.ServerConnector>) FieldUtils.readDeclaredField(adapter, "serverConnectors", true);
+        List<PrebidServerAdapter.ServerConnector> connectors = (List<PrebidServerAdapter.ServerConnector>) FieldUtils.readDeclaredField(adapter, "serverConnectors", true);
         PrebidServerAdapter.ServerConnector connector = connectors.get(0);
 
         JSONObject postData = (JSONObject) MethodUtils.invokeMethod(connector, true, "getPostData");
@@ -1406,7 +1405,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         String uuid = UUID.randomUUID().toString();
         adapter.requestDemand(requestParams, mockListener, uuid);
         @SuppressWarnings("unchecked")
-        ArrayList<PrebidServerAdapter.ServerConnector> connectors = (ArrayList<PrebidServerAdapter.ServerConnector>) FieldUtils.readDeclaredField(adapter, "serverConnectors", true);
+        List<PrebidServerAdapter.ServerConnector> connectors = (List<PrebidServerAdapter.ServerConnector>) FieldUtils.readDeclaredField(adapter, "serverConnectors", true);
         PrebidServerAdapter.ServerConnector connector = connectors.get(0);
 
         JSONObject postData = (JSONObject) MethodUtils.invokeMethod(connector, true, "getPostData");
@@ -1442,7 +1441,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         String uuid = UUID.randomUUID().toString();
         adapter.requestDemand(requestParams, mockListener, uuid);
         @SuppressWarnings("unchecked")
-        ArrayList<PrebidServerAdapter.ServerConnector> connectors = (ArrayList<PrebidServerAdapter.ServerConnector>) FieldUtils.readDeclaredField(adapter, "serverConnectors", true);
+        List<PrebidServerAdapter.ServerConnector> connectors = (List<PrebidServerAdapter.ServerConnector>) FieldUtils.readDeclaredField(adapter, "serverConnectors", true);
         PrebidServerAdapter.ServerConnector connector = connectors.get(0);
 
         JSONObject postData = (JSONObject) MethodUtils.invokeMethod(connector, true, "getPostData");
@@ -1493,7 +1492,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         String uuid = UUID.randomUUID().toString();
         adapter.requestDemand(requestParams, mockListener, uuid);
         @SuppressWarnings("unchecked")
-        ArrayList<PrebidServerAdapter.ServerConnector> connectors = (ArrayList<PrebidServerAdapter.ServerConnector>) FieldUtils.readDeclaredField(adapter, "serverConnectors", true);
+        List<PrebidServerAdapter.ServerConnector> connectors = (List<PrebidServerAdapter.ServerConnector>) FieldUtils.readDeclaredField(adapter, "serverConnectors", true);
         PrebidServerAdapter.ServerConnector connector = connectors.get(0);
 
         JSONObject postData = (JSONObject) MethodUtils.invokeMethod(connector, true, "getPostData");
@@ -1969,7 +1968,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         String uuid = UUID.randomUUID().toString();
         adapter.requestDemand(requestParams, mockListener, uuid);
         @SuppressWarnings("unchecked")
-        ArrayList<PrebidServerAdapter.ServerConnector> connectors = (ArrayList<PrebidServerAdapter.ServerConnector>) FieldUtils.readDeclaredField(adapter, "serverConnectors", true);
+        List<PrebidServerAdapter.ServerConnector> connectors = (List<PrebidServerAdapter.ServerConnector>) FieldUtils.readDeclaredField(adapter, "serverConnectors", true);
         PrebidServerAdapter.ServerConnector connector = connectors.get(0);
 
         JSONObject postData = (JSONObject) MethodUtils.invokeMethod(connector, true, "getPostData");

--- a/PrebidMobile/src/test/java/org/prebid/mobile/ResultCodeTest.java
+++ b/PrebidMobile/src/test/java/org/prebid/mobile/ResultCodeTest.java
@@ -27,7 +27,6 @@ import org.apache.commons.lang3.reflect.FieldUtils;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.prebid.mobile.tasksmanager.BackgroundThreadExecutor;
-import org.prebid.mobile.tasksmanager.MainThreadExecutor;
 import org.prebid.mobile.tasksmanager.TasksManager;
 import org.prebid.mobile.testutils.BaseSetup;
 import org.prebid.mobile.testutils.MockPrebidServerResponses;
@@ -38,8 +37,8 @@ import org.robolectric.annotation.Config;
 import org.robolectric.shadows.ShadowLooper;
 import org.robolectric.shadows.ShadowNetworkInfo;
 
-import java.util.ArrayList;
 import java.util.HashSet;
+import java.util.List;
 import java.util.UUID;
 
 import okhttp3.HttpUrl;
@@ -276,7 +275,7 @@ public class ResultCodeTest extends BaseSetup {
         adapter.requestDemand(requestParams, mockListener, uuid);
 
         @SuppressWarnings("unchecked")
-        ArrayList<PrebidServerAdapter.ServerConnector> connectors = (ArrayList<PrebidServerAdapter.ServerConnector>) FieldUtils.readDeclaredField(adapter, "serverConnectors", true);
+        List<PrebidServerAdapter.ServerConnector> connectors = (List<PrebidServerAdapter.ServerConnector>) FieldUtils.readDeclaredField(adapter, "serverConnectors", true);
         PrebidServerAdapter.ServerConnector connector = connectors.get(0);
         PrebidServerAdapter.ServerConnector.TimeoutCountDownTimer timeoutCountDownTimer = (PrebidServerAdapter.ServerConnector.TimeoutCountDownTimer) FieldUtils.readDeclaredField(connector, "timeoutCountDownTimer", true);
         shadowOf(timeoutCountDownTimer).invokeFinish();


### PR DESCRIPTION
Based on several crash reports #243, #244, #246, #247 this PR was created

I could not reproduce these force closes but all issues has the same root - `serverConnectors` field which throws `ArrayIndexOutOfBoundsException` during remove(`serverConnectors.remove()` and `serverConnectors.removeAll()`)

It seems that several  threads access to `serverConnectors` and modify  it. I propose to use synchronized collection(a lot of list modifications) to protect this behavior