### PR TITLE
PrebidServerAdapter errors alternative solution

### DIFF
--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/PrebidServerAdapter.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/PrebidServerAdapter.java
@@ -98,13 +98,13 @@ class PrebidServerAdapter implements DemandAdapter {
             adType = requestParams.getAdType();
         }
 
+        @MainThread
         @Override
         protected void onPostExecute(TaskResult<JSONObject> response) {
             processResult(response);
-
         }
 
-         public void execute() {
+        public void execute() {
             timeoutCountDownTimer.start();
             super.execute();
         }

--- a/PrebidMobile/src/test/java/org/prebid/mobile/PrebidNativeNativeTest.java
+++ b/PrebidMobile/src/test/java/org/prebid/mobile/PrebidNativeNativeTest.java
@@ -28,6 +28,7 @@ import org.junit.runner.RunWith;
 import org.mockito.Mockito;
 import org.prebid.mobile.addendum.AdViewUtils;
 import org.prebid.mobile.tasksmanager.BackgroundThreadExecutor;
+import org.prebid.mobile.tasksmanager.MainThreadExecutor;
 import org.prebid.mobile.tasksmanager.TasksManager;
 import org.prebid.mobile.testutils.BaseSetup;
 import org.prebid.mobile.testutils.MockPrebidServerResponses;
@@ -104,6 +105,8 @@ public class PrebidNativeNativeTest extends BaseSetup {
         bgLooper.runOneTask();
         bgLooper.runOneTask();
 
+        runAllMainThreadExecutorTasks();
+
         Robolectric.getBackgroundThreadScheduler().runOneTask();
         Robolectric.getBackgroundThreadScheduler().runOneTask();
         String cacheId = "";
@@ -179,6 +182,8 @@ public class PrebidNativeNativeTest extends BaseSetup {
         ShadowLooper bgLooper = Shadows.shadowOf(((BackgroundThreadExecutor) TasksManager.getInstance().backgroundThreadExecutor).getBackgroundHandler().getLooper());
         bgLooper.runOneTask();
         bgLooper.runOneTask();
+
+        runAllMainThreadExecutorTasks();
 
         Robolectric.getBackgroundThreadScheduler().runOneTask();
         Robolectric.getBackgroundThreadScheduler().runOneTask();
@@ -277,6 +282,8 @@ public class PrebidNativeNativeTest extends BaseSetup {
         bgLooper.runOneTask();
         bgLooper.runOneTask();
 
+        runAllMainThreadExecutorTasks();
+
         Robolectric.getBackgroundThreadScheduler().runOneTask();
         Robolectric.getBackgroundThreadScheduler().runOneTask();
         String cacheId = "";
@@ -356,4 +363,9 @@ public class PrebidNativeNativeTest extends BaseSetup {
         });
     }
 
+    private void runAllMainThreadExecutorTasks() {
+        ShadowLooper mainLooper = Shadows.shadowOf(((MainThreadExecutor) TasksManager.getInstance().mainThreadExecutor)
+                .getMainExecutor().getLooper());
+        mainLooper.runToEndOfTasks();
+    }
 }


### PR DESCRIPTION
This PR shows an alternative way to fix the concurrency issue mentioned in next issues: https://github.com/prebid/prebid-mobile-android/issues/243, https://github.com/prebid/prebid-mobile-android/issues/244, https://github.com/prebid/prebid-mobile-android/issues/246, https://github.com/prebid/prebid-mobile-android/issues/247, https://github.com/prebid/prebid-mobile-android/issues/248, https://github.com/prebid/prebid-mobile-android/issues/249
Original PR which also has the concurrency fixes: https://github.com/prebid/prebid-mobile-android/pull/245

The reason for this alternative PR is that `HttpPost.onPostExecute` (and all future processing in `PrebidServerAdapter`) was initially executed on the main thread. Some of the methods in `PrebidServerAdapter` are marked with `@MainThread`  annotation, but after debugging you'll see that they are no longer executed on main thread (more detailed description and debugging screenshots can be found in the original PR discussion). 
I believe that the above changes lead to concurrency issues in version `1.10`, because these changes were introduced in the following PR: https://github.com/prebid/prebid-mobile-android/pull/231 (AsyncTask.onPostExecute was previously executed on the main thread). This PR should fix the reason of concurrency issues in PrebidServerAdapter.

CC: @yoalex5 @avohraa @bszekely1 

**Commit details**
fix(HttpPost):
- Posting result from HTTPPost on MainThread
- Marked onPostExecute with main thread annotation
- Removed unused methods

test(PrebidNativeNativeTest):
- Applied changed to execute mainThread executor tasks instantly