### PR TITLE
Add Start Auto Refresh support

### DIFF
--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/AdUnit.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/AdUnit.java
@@ -67,11 +67,17 @@ public abstract class AdUnit {
         }
     }
 
+    public void startAutoRefresh() {
+        LogUtil.v("Starting auto refresh...");
+        if (fetcher != null) {
+            fetcher.start();
+        }
+    }
+
     public void stopAutoRefresh() {
         LogUtil.v("Stopping auto refresh...");
         if (fetcher != null) {
-            fetcher.destroy();
-            fetcher = null;
+            fetcher.stop();
         }
     }
 

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/AdUnit.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/AdUnit.java
@@ -67,17 +67,25 @@ public abstract class AdUnit {
         }
     }
 
-    public void startAutoRefresh() {
-        LogUtil.v("Starting auto refresh...");
+    public void resumeAutoRefresh() {
+        LogUtil.v("Resuming auto refresh...");
         if (fetcher != null) {
             fetcher.start();
+        }
+    }
+
+    public void pauseAutoRefresh() {
+        LogUtil.v("Pausing auto refresh...");
+        if (fetcher != null) {
+            fetcher.stop();
         }
     }
 
     public void stopAutoRefresh() {
         LogUtil.v("Stopping auto refresh...");
         if (fetcher != null) {
-            fetcher.stop();
+            fetcher.destroy();
+            fetcher = null;
         }
     }
 

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/DemandFetcher.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/DemandFetcher.java
@@ -73,7 +73,7 @@ class DemandFetcher {
         }
     }
 
-    private void stop() {
+    void stop() {
         this.requestRunnable.cancelRequest();
         this.fetcherHandler.removeCallbacks(requestRunnable);
         // cancel existing requests

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/DemandFetcher.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/DemandFetcher.java
@@ -98,7 +98,7 @@ class DemandFetcher {
                     } else {
                         stall = 0;
                     }
-                    fetcherHandler.postDelayed(requestRunnable, stall * 1000);
+                    fetcherHandler.postDelayed(requestRunnable, stall);
                 }
                 state = STATE.RUNNING;
                 break;


### PR DESCRIPTION
Prebid documentation mentions startAutoRefresh [here](https://docs.prebid.org/prebid-mobile/pbm-api/android/pbm-adunit-android.html#startautorefresh), however it is not implemented.

We require the ability to start and stop auto refreshing of ads, for cases where the app is backgrounded or in landscape mode and ads are not visible, we do not want to be making empty requests.