### PR TITLE
Introduce consistent refresh policy

### DIFF
--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/AdUnit.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/AdUnit.java
@@ -67,11 +67,17 @@ public abstract class AdUnit {
         }
     }
 
+    public void resumeAutoRefresh() {
+        LogUtil.v("Resuming auto refresh...");
+        if (fetcher != null) {
+            fetcher.start();
+        }
+    }
+
     public void stopAutoRefresh() {
         LogUtil.v("Stopping auto refresh...");
         if (fetcher != null) {
-            fetcher.destroy();
-            fetcher = null;
+            fetcher.stop();
         }
     }
 

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/DemandFetcher.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/DemandFetcher.java
@@ -73,7 +73,7 @@ class DemandFetcher {
         }
     }
 
-    private void stop() {
+    void stop() {
         this.requestRunnable.cancelRequest();
         this.fetcherHandler.removeCallbacks(requestRunnable);
         // cancel existing requests
@@ -98,7 +98,7 @@ class DemandFetcher {
                     } else {
                         stall = 0;
                     }
-                    fetcherHandler.postDelayed(requestRunnable, stall * 1000);
+                    fetcherHandler.postDelayed(requestRunnable, stall);
                 }
                 state = STATE.RUNNING;
                 break;

--- a/PrebidMobile/build.gradle
+++ b/PrebidMobile/build.gradle
@@ -48,8 +48,8 @@ dependencies {
     testImplementation 'com.squareup.okhttp3:mockwebserver:3.2.0'
     testImplementation 'junit:junit:4.12'
     testImplementation 'org.assertj:assertj-core:1.7.0'
-    testImplementation 'org.robolectric:robolectric:3.2.2'
-    testImplementation 'org.robolectric:shadows-httpclient:3.2.2'
+    testImplementation 'org.robolectric:robolectric:4.3.1'
+    testImplementation 'org.robolectric:shadows-httpclient:4.3.1'
     testImplementation 'org.skyscreamer:jsonassert:1.5.0'
 }
 

--- a/PrebidMobile/src/test/java/org/prebid/mobile/AdUnitSuccessorTest.java
+++ b/PrebidMobile/src/test/java/org/prebid/mobile/AdUnitSuccessorTest.java
@@ -18,8 +18,12 @@
 package org.prebid.mobile;
 
 import org.apache.commons.lang3.reflect.FieldUtils;
+import org.codehaus.plexus.util.ReflectionUtils;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
 import org.prebid.mobile.testutils.BaseSetup;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
@@ -30,10 +34,40 @@ import java.util.List;
 import static junit.framework.Assert.assertEquals;
 import static junit.framework.Assert.assertNotNull;
 import static junit.framework.Assert.assertTrue;
+import static org.mockito.Mockito.verify;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = BaseSetup.testSDK)
 public class AdUnitSuccessorTest {
+
+    @Mock
+    DemandFetcher mockDemandFetcher;
+
+    @Before
+    public void setup() {
+        MockitoAnnotations.initMocks(this);
+    }
+
+    //Base AdUnit
+    @Test
+    public void testResumeAutoRefresh() throws IllegalAccessException {
+        AdUnit adUnit = new BannerAdUnit("123456", 320, 50);
+        ReflectionUtils.setVariableValueInObject(adUnit, "fetcher", mockDemandFetcher);
+
+        adUnit.resumeAutoRefresh();
+
+        verify(mockDemandFetcher).start();
+    }
+
+    @Test
+    public void testStopAutoRefresh() throws IllegalAccessException {
+        AdUnit adUnit = new BannerAdUnit("123456", 320, 50);
+        ReflectionUtils.setVariableValueInObject(adUnit, "fetcher", mockDemandFetcher);
+
+        adUnit.stopAutoRefresh();
+
+        verify(mockDemandFetcher).stop();
+    }
 
     //Banner AdUnit
     @Test

--- a/PrebidMobile/src/test/java/org/prebid/mobile/PrebidServerAdapterTest.java
+++ b/PrebidMobile/src/test/java/org/prebid/mobile/PrebidServerAdapterTest.java
@@ -824,7 +824,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         assertEquals(Locale.getDefault().getLanguage(), device.getString("language"));
         assertEquals(String.valueOf(BaseSetup.testSDK), device.getString("osv"));
         assertEquals(320, device.getInt("w"));
-        assertEquals(0, device.getInt("h"));
+        assertEquals(470, device.getInt("h"));
         assertEquals(1, device.getInt("pxratio"));
         assertEquals(2, device.getInt("connectiontype"));
         JSONObject app = postData.getJSONObject("app");

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ ext {
     prebidVersionCode = 1
     minSDKVersion = 16
     targetSDKVersion = 28
-    compileSdkVersion = 28
+    compileSdkVersion = 30
     buildToolsVersion = "28.0.3"
 }
 


### PR DESCRIPTION
This PR introduces changes described in the following issue: 
https://github.com/prebid/prebid-mobile-ios/issues/393

chore(build.gradle):
- Updated compile version to 30
- Updated robolectric version to 4.3.1

feat(AdUnit):
- Added ability to resume autorefresh
- Added unit tests