### PR TITLE
Pass app:content:url property into bid request

### DIFF
--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/AdUnit.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/AdUnit.java
@@ -43,6 +43,7 @@ public abstract class AdUnit {
 
     private final Map<String, Set<String>> contextDataDictionary;
     private final Set<String> contextKeywordsSet;
+    private ContentObject content;
 
     private String pbAdSlot;
 
@@ -170,7 +171,7 @@ public abstract class AdUnit {
 
         if (Util.supportedAdObject(adObj)) {
             fetcher = new DemandFetcher(adObj);
-            RequestParams requestParams = new RequestParams(configId, adType, sizes, contextDataDictionary, contextKeywordsSet, minSizePerc, pbAdSlot, bannerParameters, videoParameters);
+            RequestParams requestParams = new RequestParams(configId, adType, sizes, contextDataDictionary, contextKeywordsSet, minSizePerc, pbAdSlot, bannerParameters, videoParameters, content);
             if (this.adType.equals(AdType.NATIVE)) {
                 requestParams.setNativeRequestParams(((NativeAdUnit) this).params);
             }
@@ -241,6 +242,13 @@ public abstract class AdUnit {
      */
     public void addContextKeywords(Set<String> keywords) {
         contextKeywordsSet.addAll(keywords);
+    }
+
+    /**
+     * This method obtains the content for adunit, content, in which impression will appear
+     */
+    public void addContent(ContentObject content) {
+        this.content = content;
     }
 
     /**

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/ContentObject.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/ContentObject.java
@@ -1,0 +1,13 @@
+package org.prebid.mobile;
+
+public class ContentObject {
+    private String url;
+
+    public void setUrl(String url) {
+        this.url = url;
+    }
+
+    String getUrl() {
+        return this.url;
+    }
+}

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/PrebidServerAdapter.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/PrebidServerAdapter.java
@@ -882,6 +882,10 @@ class PrebidServerAdapter implements DemandAdapter {
                 if (!TextUtils.isEmpty(TargetingParams.getStoreUrl())) {
                     app.put("storeurl", TargetingParams.getStoreUrl());
                 }
+                if (this.requestParams.getContent() != null) {
+                    app.put("content", getContentObject());
+                }
+
                 JSONObject publisher = new JSONObject();
                 publisher.put("id", PrebidMobile.getPrebidServerAccountId());
                 app.put("publisher", publisher);
@@ -898,6 +902,14 @@ class PrebidServerAdapter implements DemandAdapter {
             }
             return app;
 
+        }
+
+        private JSONObject getContentObject() throws JSONException {
+            JSONObject contentJSON = new JSONObject();
+            if (this.requestParams.getContent().getUrl() != null) {
+                contentJSON.put("url", this.requestParams.getContent().getUrl());
+            }
+            return contentJSON;
         }
 
         private JSONObject getUserObject() {

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/RequestParams.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/RequestParams.java
@@ -48,13 +48,16 @@ class RequestParams {
     @Nullable
     private BannerBaseAdUnit.Parameters bannerParameters;
 
+    @Nullable
+    private ContentObject content;
+
     RequestParams(String configId, AdType adType, HashSet<AdSize> sizes) {
         this.configId = configId;
         this.adType = adType;
         this.sizes = sizes; // for Interstitial this will be null, will use screen width & height in the request
     }
 
-    RequestParams(String configId, AdType adType, HashSet<AdSize> sizes, @Nullable Map<String, Set<String>> contextDataDictionary, @Nullable Set<String> contextKeywordsSet, @Nullable AdSize minSizePerc, @Nullable String pbAdSlot , @Nullable BannerBaseAdUnit.Parameters bannerParameters, @Nullable VideoBaseAdUnit.Parameters videoParameters) {
+    RequestParams(String configId, AdType adType, HashSet<AdSize> sizes, @Nullable Map<String, Set<String>> contextDataDictionary, @Nullable Set<String> contextKeywordsSet, @Nullable AdSize minSizePerc, @Nullable String pbAdSlot , @Nullable BannerBaseAdUnit.Parameters bannerParameters, @Nullable VideoBaseAdUnit.Parameters videoParameters, @Nullable ContentObject content) {
         this(configId, adType, sizes);
         this.contextDataDictionary = contextDataDictionary;
         this.contextKeywordsSet = contextKeywordsSet;
@@ -62,6 +65,7 @@ class RequestParams {
         this.pbAdSlot = pbAdSlot;
         this.bannerParameters = bannerParameters;
         this.videoParameters = videoParameters;
+        this.content = content;
     }
 
     void setNativeRequestParams(NativeRequestParams params) {
@@ -102,6 +106,11 @@ class RequestParams {
     @Nullable
     String getPbAdSlot() {
         return pbAdSlot;
+    }
+
+    @Nullable
+    ContentObject getContent() {
+        return content;
     }
 
     @Nullable

--- a/PrebidMobile/src/test/java/org/prebid/mobile/AdUnitContentTest.java
+++ b/PrebidMobile/src/test/java/org/prebid/mobile/AdUnitContentTest.java
@@ -1,0 +1,96 @@
+package org.prebid.mobile;
+
+import android.util.Log;
+
+import org.apache.commons.lang3.reflect.FieldUtils;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.prebid.mobile.tasksmanager.BackgroundThreadExecutor;
+import org.prebid.mobile.tasksmanager.TasksManager;
+import org.prebid.mobile.testutils.BaseSetup;
+import org.prebid.mobile.testutils.MockPrebidServerResponses;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.Shadows;
+import org.robolectric.annotation.Config;
+import org.robolectric.shadows.ShadowLooper;
+
+import java.util.Map;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+
+import okhttp3.HttpUrl;
+import okhttp3.mockwebserver.Dispatcher;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
+
+import static junit.framework.Assert.assertEquals;
+import static junit.framework.Assert.assertTrue;
+import static org.robolectric.Shadows.shadowOf;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = BaseSetup.testSDK)
+public class AdUnitContentTest extends BaseSetup {
+
+    @Override
+    public void setup() {
+        super.setup();
+        ((BackgroundThreadExecutor)TasksManager.getInstance().backgroundThreadExecutor).startThread();
+    }
+
+    @Test
+    public void testAdUnitUsingContentUrl() throws Exception {
+        final String expectedContentUrl = "http://www.something.com/somewhere/here";
+        HttpUrl hostUrl = server.url("/");
+        Host.CUSTOM.setHostUrl(hostUrl.toString());
+        PrebidMobile.setPrebidServerHost(Host.CUSTOM);
+        PrebidMobile.setApplicationContext(activity.getApplicationContext());
+        PrebidMobile.setPrebidServerAccountId("123456");
+        final CompletableFuture<JSONObject> future = new CompletableFuture<>();
+        server.setDispatcher(new Dispatcher() {
+            @Override
+            public MockResponse dispatch(RecordedRequest request) throws InterruptedException {
+                String postData = request.getBody().readUtf8();
+                try {
+                    JSONObject jsonObject = new JSONObject(postData);
+
+                    future.complete(jsonObject);
+                } catch (JSONException err) {
+                    Log.d("Error", err.toString());
+                    future.cancel(true);
+                }
+                return new MockResponse().setResponseCode(200).setBody(MockPrebidServerResponses.noBid());
+            }
+        });
+
+        BannerAdUnit adUnit = new BannerAdUnit("123456", 320, 50);
+        ContentObject contentObject = new ContentObject();
+        contentObject.setUrl(expectedContentUrl);
+        adUnit.addContent(contentObject);
+
+
+        adUnit.fetchDemand(new OnCompleteListener2() {
+            @Override
+            public void onComplete(ResultCode resultCode, Map<String, String> unmodifiableMap) {
+                System.out.println("I am in onComplete " + resultCode.toString());
+                future.cancel(true);
+            }
+        });
+        DemandFetcher fetcher = (DemandFetcher) FieldUtils.readField(adUnit, "fetcher", true);
+        ShadowLooper fetcherLooper = shadowOf(fetcher.getHandler().getLooper());
+        fetcherLooper.runOneTask();
+        ShadowLooper demandLooper = shadowOf(fetcher.getDemandHandler().getLooper());
+        demandLooper.runOneTask();
+
+        ShadowLooper bgLooper = Shadows.shadowOf(((BackgroundThreadExecutor) TasksManager.getInstance().backgroundThreadExecutor).getBackgroundHandler().getLooper());
+        bgLooper.runToEndOfTasks();
+        JSONObject requestBody = future.get(10, TimeUnit.SECONDS);
+
+        JSONObject app = requestBody.getJSONObject("app");
+        assertTrue(app.has("content"));
+        JSONObject content = app.getJSONObject("content");
+        assertTrue(content.has("url"));
+        assertEquals(expectedContentUrl, content.getString("url"));
+    }
+}

--- a/PrebidMobile/src/test/java/org/prebid/mobile/PrebidNativeNativeTest.java
+++ b/PrebidMobile/src/test/java/org/prebid/mobile/PrebidNativeNativeTest.java
@@ -97,7 +97,7 @@ public class PrebidNativeNativeTest extends BaseSetup {
         PrebidMobile.setApplicationContext(activity.getApplicationContext());
         DemandAdapter.DemandAdapterListener mockListener = mock(DemandAdapter.DemandAdapterListener.class);
         PrebidServerAdapter adapter = new PrebidServerAdapter();
-        RequestParams requestParams = new RequestParams(PBS_CONFIG_ID_NATIVE_APPNEXUS, AdType.NATIVE, null, new HashMap<String, Set<String>>(), new HashSet<String>(), null, null, null, null);
+        RequestParams requestParams = new RequestParams(PBS_CONFIG_ID_NATIVE_APPNEXUS, AdType.NATIVE, null, new HashMap<String, Set<String>>(), new HashSet<String>(), null, null, null, null, null);
         requestParams.setNativeRequestParams(new NativeRequestParams());
         String uuid = UUID.randomUUID().toString();
         adapter.requestDemand(requestParams, mockListener, uuid);
@@ -175,7 +175,7 @@ public class PrebidNativeNativeTest extends BaseSetup {
         PrebidMobile.setApplicationContext(activity.getApplicationContext());
         DemandAdapter.DemandAdapterListener mockListener = mock(DemandAdapter.DemandAdapterListener.class);
         PrebidServerAdapter adapter = new PrebidServerAdapter();
-        RequestParams requestParams = new RequestParams(PBS_CONFIG_ID_NATIVE_APPNEXUS, AdType.NATIVE, null, new HashMap<String, Set<String>>(), new HashSet<String>(), null, null, null, null);
+        RequestParams requestParams = new RequestParams(PBS_CONFIG_ID_NATIVE_APPNEXUS, AdType.NATIVE, null, new HashMap<String, Set<String>>(), new HashSet<String>(), null, null, null, null, null);
         requestParams.setNativeRequestParams(new NativeRequestParams());
         String uuid = UUID.randomUUID().toString();
         adapter.requestDemand(requestParams, mockListener, uuid);
@@ -274,7 +274,7 @@ public class PrebidNativeNativeTest extends BaseSetup {
         PrebidMobile.setApplicationContext(activity.getApplicationContext());
         DemandAdapter.DemandAdapterListener mockListener = mock(DemandAdapter.DemandAdapterListener.class);
         PrebidServerAdapter adapter = new PrebidServerAdapter();
-        RequestParams requestParams = new RequestParams(PBS_CONFIG_ID_NATIVE_APPNEXUS, AdType.NATIVE, null, new HashMap<String, Set<String>>(), new HashSet<String>(), null, null, null, null);
+        RequestParams requestParams = new RequestParams(PBS_CONFIG_ID_NATIVE_APPNEXUS, AdType.NATIVE, null, new HashMap<String, Set<String>>(), new HashSet<String>(), null, null, null, null, null);
         requestParams.setNativeRequestParams(new NativeRequestParams());
         String uuid = UUID.randomUUID().toString();
         adapter.requestDemand(requestParams, mockListener, uuid);

--- a/PrebidMobile/src/test/java/org/prebid/mobile/PrebidServerAdapterTest.java
+++ b/PrebidMobile/src/test/java/org/prebid/mobile/PrebidServerAdapterTest.java
@@ -851,6 +851,40 @@ public class PrebidServerAdapterTest extends BaseSetup {
     }
 
     @Test
+    public void testContentUrlInPostData() throws Exception {
+        String expectedContentUrl = "http://www.something.com/item";
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(MockPrebidServerResponses.noBid()));
+        HttpUrl hostUrl = server.url("/");
+        Host.CUSTOM.setHostUrl(hostUrl.toString());
+        PrebidMobile.setPrebidServerHost(Host.CUSTOM);
+        PrebidMobile.setPrebidServerAccountId("12345");
+        PrebidMobile.setShareGeoLocation(true);
+        PrebidMobile.setApplicationContext(activity.getApplicationContext());
+
+        // set content somewhere here
+
+        DemandAdapter.DemandAdapterListener mockListener = mock(DemandAdapter.DemandAdapterListener.class);
+        PrebidServerAdapter adapter = new PrebidServerAdapter();
+        HashSet<AdSize> sizes = new HashSet<>();
+        sizes.add(new AdSize(320, 50));
+        ContentObject contentObject = new ContentObject();
+        contentObject.setUrl(expectedContentUrl);
+        RequestParams requestParams = new RequestParams("67890", AdType.BANNER, sizes, null, null, null, null, null, null, contentObject);
+        String uuid = UUID.randomUUID().toString();
+        adapter.requestDemand(requestParams, mockListener, uuid);
+        @SuppressWarnings("unchecked")
+        ArrayList<PrebidServerAdapter.ServerConnector> connectors = (ArrayList<PrebidServerAdapter.ServerConnector>) FieldUtils.readDeclaredField(adapter, "serverConnectors", true);
+        PrebidServerAdapter.ServerConnector connector = connectors.get(0);
+        JSONObject postData = (JSONObject) MethodUtils.invokeMethod(connector, true, "getPostData");
+
+        JSONObject app = postData.getJSONObject("app");
+        assertTrue(app.has("content"));
+        JSONObject content = app.getJSONObject("content");
+        assertTrue(content.has("url"));
+        assertEquals(expectedContentUrl, content.getString("url"));
+    }
+
+    @Test
     public void testExternalUserIdsInPostData() throws Exception {
         server.enqueue(new MockResponse().setResponseCode(200).setBody(MockPrebidServerResponses.noBid()));
         HttpUrl hostUrl = server.url("/");
@@ -1730,7 +1764,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         HashSet<AdSize> sizes = new HashSet<>();
         sizes.add(new AdSize(500, 700));
 
-        RequestParams requestParams = new RequestParams("67890", AdType.BANNER, sizes, null, null, null, null, parameters, null);
+        RequestParams requestParams = new RequestParams("67890", AdType.BANNER, sizes, null, null, null, null, parameters, null, null);
         String uuid = UUID.randomUUID().toString();
         adapter.requestDemand(requestParams, mockListener, uuid);
         @SuppressWarnings("unchecked")
@@ -1884,7 +1918,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         HashSet<AdSize> sizes = new HashSet<>();
         sizes.add(new AdSize(500, 700));
 
-        RequestParams requestParams = new RequestParams("67890", AdType.VIDEO, sizes, null, null, null, null, null, parameters);
+        RequestParams requestParams = new RequestParams("67890", AdType.VIDEO, sizes, null, null, null, null, null, parameters, null);
         String uuid = UUID.randomUUID().toString();
         adapter.requestDemand(requestParams, mockListener, uuid);
         @SuppressWarnings("unchecked")
@@ -2360,7 +2394,7 @@ public class PrebidServerAdapterTest extends BaseSetup {
         HashSet<AdSize> sizes = new HashSet<>();
         sizes.add(new AdSize(300, 250));
 
-        RequestParams requestParams = new RequestParams("67890", adType, sizes, contextDataDictionary, contextKeywordsSet, minSizePerc, adSlot, bannerParameters, videoParameters);
+        RequestParams requestParams = new RequestParams("67890", adType, sizes, contextDataDictionary, contextKeywordsSet, minSizePerc, adSlot, bannerParameters, videoParameters, null);
         String uuid = UUID.randomUUID().toString();
         adapter.requestDemand(requestParams, mockListener, uuid);
         @SuppressWarnings("unchecked")

--- a/PrebidMobile/src/test/java/org/prebid/mobile/RequestParamsTest.java
+++ b/PrebidMobile/src/test/java/org/prebid/mobile/RequestParamsTest.java
@@ -115,7 +115,7 @@ public class RequestParamsTest {
 
         AdSize minSizePerc = new AdSize(50, 70);
 
-        RequestParams requestParams = new RequestParams("123456", AdType.INTERSTITIAL, sizes, null, null, minSizePerc, null, null, null);
+        RequestParams requestParams = new RequestParams("123456", AdType.INTERSTITIAL, sizes, null, null, minSizePerc, null, null, null, null);
 
         AdSize minAdSizePerc = requestParams.getMinSizePerc();
         assertNotNull(minAdSizePerc);

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 ext {
-    prebidVersionName = "1.13-stroeer"
+    prebidVersionName = "1.12"
     prebidVersionCode = 1
     minSDKVersion = 16
     targetSDKVersion = 28

--- a/build.gradle
+++ b/build.gradle
@@ -1,7 +1,7 @@
 // Top-level build file where you can add configuration options common to all sub-projects/modules.
 
 ext {
-    prebidVersionName = "1.12"
+    prebidVersionName = "1.13-stroeer"
     prebidVersionCode = 1
     minSDKVersion = 16
     targetSDKVersion = 28


### PR DESCRIPTION
This PR aims to provide more precise targeting information with bid request. When PBS asks for bids for an ad slot, bidders have very little information about the user. This is caused by latest developments where users choose to opt-out of sharing their AAID and such.

We can at least supply bidders with some context, like what content the user is looking at when they see an ad. Google ad manager calls this technique content mapping: https://support.google.com/admanager/answer/11050896?hl=en

Publishers roughly map views in their apps to pages on their websites. Then the targeting information already collected for pages on publisher’s website can be used to better target ad slots that appear in the apps. For this to work bidders needs to receive information which page would this ad slot appear on if this was a website and not an app. This page’s URL is set into ContentUrl property. Google’s ad manager has already implemented this property: https://developers.google.com/ad-manager/mobile-ads-sdk/android/targeting#content_url

Our Prebid server is connected to a couple DSPs that are able to target their bids based on contentUrl. We identified an OpenRTB property that could carry this data. See Bid request -> App -> Content -> Url in https://www.iab.com/wp-content/uploads/2016/03/OpenRTB-API-Specification-Version-2-5-FINAL.pdf

Unfortunately we could not find a way to pass this property to the PBS using the SDK. This PR is an attempt to fix it. We would like to be able to pass this from the SDK because it would allow to re-use the same ad slot on different views with different content within an app.

We did the same thing on iOS, see: https://github.com/prebid/prebid-mobile-ios/pull/403