### PR TITLE
Make private native ad from rendering. 

### DIFF
--- a/Example/PrebidInternalTestApp/src/androidTest/java/org/prebid/mobile/renderingtestapp/uiAutomator/tests/gam/GamNativeTests.java
+++ b/Example/PrebidInternalTestApp/src/androidTest/java/org/prebid/mobile/renderingtestapp/uiAutomator/tests/gam/GamNativeTests.java
@@ -70,7 +70,8 @@ public class GamNativeTests extends BaseUiAutomatorTest {
                 .sdkEventShouldBePresent(AdBasePage.SdkEvent.onAdFailed);
     }
 
-    @Test
+    // TODO: Merge Native engine from original SDK and rendering codebase
+//    @Test
     public void testGamNativeCustomFormatPrebidWin() throws InterruptedException {
         final GamNativePage gamNativePage =
             homePage.getNativePageFactory()
@@ -79,7 +80,8 @@ public class GamNativeTests extends BaseUiAutomatorTest {
         verifyGamNativeAdPrebidWin(gamNativePage, AdBasePage.SdkEvent.customAdRequestSuccess);
     }
 
-    @Test
+    // TODO: Merge Native engine from original SDK and rendering codebase
+//    @Test
     public void testGamNativeNativeAdPrebidWin() throws InterruptedException {
         final GamNativePage gamNativePage =
             homePage.getNativePageFactory()
@@ -88,7 +90,8 @@ public class GamNativeTests extends BaseUiAutomatorTest {
         verifyGamNativeAdPrebidWin(gamNativePage, AdBasePage.SdkEvent.nativeAdRequestSuccess);
     }
 
-    @Test
+    // TODO: Merge Native engine from original SDK and rendering codebase
+//    @Test
     public void testGamNativeCustomFormatGamWin() throws InterruptedException {
         homePage.getNativePageFactory()
                 .goToGamNative(getStringResource(R.string.demo_bidding_gam_native_custom_templates_no_bids))
@@ -110,7 +113,8 @@ public class GamNativeTests extends BaseUiAutomatorTest {
                 .sdkEventShouldNotBePresent(AdBasePage.SdkEvent.video50Event);
     }
 
-    @Test
+    // TODO: Merge Native engine from original SDK and rendering codebase
+//    @Test
     public void testGamNativeAdGamWin() throws InterruptedException {
         homePage.getNativePageFactory()
                 .goToGamNative(getStringResource(R.string.demo_bidding_gam_native_unified_ads_no_bids))

--- a/Example/PrebidInternalTestApp/src/androidTest/java/org/prebid/mobile/renderingtestapp/uiAutomator/tests/ppm/PpmNativeTests.java
+++ b/Example/PrebidInternalTestApp/src/androidTest/java/org/prebid/mobile/renderingtestapp/uiAutomator/tests/ppm/PpmNativeTests.java
@@ -57,7 +57,8 @@ public class PpmNativeTests extends BaseUiAutomatorTest {
                 .sdkEventShouldBePresent(AdBasePage.SdkEvent.onAdFailed);
     }
 
-    @Test
+    // TODO: Uncomment when native module will be merged
+//    @Test
     public void testPpmNative() {
         homePage.getNativePageFactory()
                 .goToPpmNativeStyles(getStringResource(R.string.demo_bidding_in_app_native))
@@ -75,7 +76,8 @@ public class PpmNativeTests extends BaseUiAutomatorTest {
                 .sdkEventShouldNotBePresent(AdBasePage.SdkEvent.video50Event);
     }
 
-    @Test
+    // TODO: Uncomment when native module will be merged
+//    @Test
     public void testPpmNativeVideo() throws InterruptedException {
         homePage.getNativePageFactory()
                 .goToPpmNative(getStringResource(R.string.demo_bidding_in_app_native_video))

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/gam/GamNativeFeedFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/gam/GamNativeFeedFragment.kt
@@ -16,25 +16,26 @@
 
 package org.prebid.mobile.renderingtestapp.plugplay.bidding.gam
 
-import com.google.android.gms.ads.AdLoader
-import org.prebid.mobile.rendering.bidding.display.NativeAdUnit
-import org.prebid.mobile.renderingtestapp.plugplay.bidding.base.BaseFeedFragment
-import org.prebid.mobile.renderingtestapp.utils.adapters.BaseFeedAdapter
-import org.prebid.mobile.renderingtestapp.utils.adapters.NativeGamFeedAdapter
-
-
-class GamNativeFeedFragment : BaseFeedFragment() {
-    override fun initFeedAdapter(): BaseFeedAdapter {
-        val nativeAdUnit = NativeAdUnit(context, configId, getNativeAdConfig()!!)
-        val customFormatId = arguments?.getString(GamNativeFragment.ARG_CUSTOM_FORMAT_ID, "") ?: ""
-        val adLoader = createCustomFormatAdLoader(customFormatId)
-
-        return NativeGamFeedAdapter(requireContext(), nativeAdUnit, adLoader)
-    }
-
-    private fun createCustomFormatAdLoader(customFormatId: String) = AdLoader.Builder(requireContext(), adUnitId)
-            .forCustomFormatAd(customFormatId, { formatAd ->
-                (getAdapter() as? NativeGamFeedAdapter)?.handleCustomFormatAd(formatAd)
-            }, null)
-            .build()
-}
+// TODO: Uncomment when native module will be merged
+//import com.google.android.gms.ads.AdLoader
+//import org.prebid.mobile.rendering.bidding.display.NativeAdUnit
+//import org.prebid.mobile.renderingtestapp.plugplay.bidding.base.BaseFeedFragment
+//import org.prebid.mobile.renderingtestapp.utils.adapters.BaseFeedAdapter
+//import org.prebid.mobile.renderingtestapp.utils.adapters.NativeGamFeedAdapter
+//
+//
+//class GamNativeFeedFragment : BaseFeedFragment() {
+//    override fun initFeedAdapter(): BaseFeedAdapter {
+//        val nativeAdUnit = NativeAdUnit(context, configId, getNativeAdConfig()!!)
+//        val customFormatId = arguments?.getString(GamNativeFragment.ARG_CUSTOM_FORMAT_ID, "") ?: ""
+//        val adLoader = createCustomFormatAdLoader(customFormatId)
+//
+//        return NativeGamFeedAdapter(requireContext(), nativeAdUnit, adLoader)
+//    }
+//
+//    private fun createCustomFormatAdLoader(customFormatId: String) = AdLoader.Builder(requireContext(), adUnitId)
+//            .forCustomFormatAd(customFormatId, { formatAd ->
+//                (getAdapter() as? NativeGamFeedAdapter)?.handleCustomFormatAd(formatAd)
+//            }, null)
+//            .build()
+//}

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/gam/GamNativeFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/gam/GamNativeFragment.kt
@@ -16,235 +16,236 @@
 
 package org.prebid.mobile.renderingtestapp.plugplay.bidding.gam
 
-import android.os.Bundle
-import android.text.TextUtils
-import android.view.LayoutInflater
-import android.view.View
-import android.widget.Button
-import android.widget.ImageView
-import android.widget.TextView
-import com.google.android.gms.ads.AdListener
-import com.google.android.gms.ads.AdLoader
-import com.google.android.gms.ads.LoadAdError
-import com.google.android.gms.ads.admanager.AdManagerAdRequest
-import com.google.android.gms.ads.nativead.NativeAd
-import com.google.android.gms.ads.nativead.NativeAdView
-import com.google.android.gms.ads.nativead.NativeCustomFormatAd
-import kotlinx.android.synthetic.main.lyt_native_ad.*
-import kotlinx.android.synthetic.main.lyt_native_gam_events.*
-import org.prebid.mobile.eventhandlers.utils.GamUtils
-import org.prebid.mobile.rendering.bidding.data.FetchDemandResult
-import org.prebid.mobile.renderingtestapp.R
-import org.prebid.mobile.renderingtestapp.plugplay.bidding.ppm.PpmNativeFragment
-import org.prebid.mobile.renderingtestapp.plugplay.config.AdConfiguratorDialogFragment
-import org.prebid.mobile.renderingtestapp.utils.SourcePicker
-import org.prebid.mobile.renderingtestapp.utils.loadImage
-
-class GamNativeFragment(override val layoutRes: Int = R.layout.fragment_native) : PpmNativeFragment() {
-    companion object {
-        const val ARG_CUSTOM_FORMAT_ID = "ARG_CUSTOM_FORMAT_ID"
-    }
-
-    private var gamAdLoader: AdLoader? = null
-    private var customFormatId: String = ""
-
-    override fun onCreate(savedInstanceState: Bundle?) {
-        super.onCreate(savedInstanceState)
-        arguments?.let {
-            customFormatId = it.getString(ARG_CUSTOM_FORMAT_ID, "")
-        }
-    }
-
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-        if (!SourcePicker.useMockServer) {
-            SourcePicker.enableQaEndpoint(true)
-        }
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        if (!SourcePicker.useMockServer) {
-            SourcePicker.enableQaEndpoint(false)
-        }
-    }
-
-    override fun loadAd() {
-        val builder = AdManagerAdRequest.Builder()
-        val publisherAdRequest = builder.build()
-
-        nativeAdUnit?.fetchDemand { result ->
-            val fetchDemandResult = result.fetchDemandResult
-
-            if (fetchDemandResult != FetchDemandResult.SUCCESS) {
-                btnFetchDemandResultFailure.isEnabled = true
-                loadGam(publisherAdRequest)
-                return@fetchDemand
-            }
-
-            btnFetchDemandResultSuccess?.isEnabled = true
-            GamUtils.prepare(publisherAdRequest, result)
-            loadGam(publisherAdRequest)
-        }
-    }
-
-    override fun getEventButtonViewId(): Int = R.layout.lyt_native_gam_events
-
-    override fun configuratorMode(): AdConfiguratorDialogFragment.AdConfiguratorMode? = null
-
-    private fun loadGam(publisherAdRequest: AdManagerAdRequest) {
-        gamAdLoader = if (isCustomFormatExample()) createCustomFormatAdLoader() else createNativeAdLoader()
-
-        gamAdLoader?.loadAd(publisherAdRequest)
-    }
-
-    private fun createNativeAdLoader(): AdLoader = AdLoader.Builder(requireContext(), adUnitId)
-            .forNativeAd { unifiedAd ->
-                btnUnifiedRequestSuccess?.isEnabled = true
-                handleNativeAd(unifiedAd)
-            }
-            .withAdListener(object : AdListener() {
-                override fun onAdFailedToLoad(p0: LoadAdError) {
-                    btnPrimaryAdRequestFailure?.isEnabled = true
-                }
-
-                override fun onAdClicked() {
-                    btnAdClicked?.isEnabled = true
-                }
-            })
-            .build()
-
-    private fun createCustomFormatAdLoader() = AdLoader.Builder(requireContext(), adUnitId)
-            .forCustomFormatAd(customFormatId, { formatAd ->
-                btnCustomAdRequestSuccess?.isEnabled = true
-                handleCustomFormatAd(formatAd)
-            }, null)
-            .withAdListener(object : AdListener() {
-                override fun onAdFailedToLoad(p0: LoadAdError) {
-                    btnPrimaryAdRequestFailure?.isEnabled = true
-                }
-            })
-            .build()
-
-    private fun handleNativeAd(nativeAd: NativeAd?) {
-        nativeAd ?: return
-
-        if (GamUtils.didPrebidWin(nativeAd)) {
-            GamUtils.findNativeAd(nativeAd) {
-                btnNativeAdLoaded?.isEnabled = true
-                inflateViewContent(it)
-            }
-        }
-        else {
-            btnPrimaryAdWinUnified?.isEnabled = true
-            inflateNativeAd(nativeAd)
-        }
-    }
-
-    private fun handleCustomFormatAd(customFormatAd: NativeCustomFormatAd?) {
-        customFormatAd ?: return
-
-        if (GamUtils.didPrebidWin(customFormatAd)) {
-            GamUtils.findNativeAd(customFormatAd) {
-                btnNativeAdLoaded?.isEnabled = true
-                inflateViewContent(it)
-            }
-        }
-        else {
-            btnPrimaryAdWinCustom?.isEnabled = true
-            inflateGamCustomFormat(customFormatAd)
-        }
-    }
-
-
-    private fun inflateGamCustomFormat(customFormatAd: NativeCustomFormatAd) {
-
-        val title = customFormatAd.getText("title")
-        val text = customFormatAd.getText("text")
-        val cta = customFormatAd.getText("cta")
-        val sponsoredBy = customFormatAd.getText("sponsoredBy")
-        val iconUrl = customFormatAd.getText("iconUrl")?.toString() ?: ""
-        val imageUrl = customFormatAd.getText("imgUrl")?.toString() ?: ""
-
-        tvNativeTitle?.text = title
-        tvNativeBody?.text = text
-        tvNativeBrand?.text = sponsoredBy
-        btnNativeAction?.text = cta
-
-        loadImage(ivNativeMain, imageUrl)
-        loadImage(ivNativeIcon, iconUrl)
-
-        btnNativeAction?.setOnClickListener {
-            customFormatAd.performClick("cta")
-            btnAdClicked?.isEnabled = true
-        }
-    }
-
-    private fun inflateNativeAd(nativeAd: NativeAd?) {
-        nativeAd ?: return
-
-        val adView = LayoutInflater.from(requireContext()).inflate(R.layout.lyt_unified_native_ad, null) as NativeAdView
-
-        adView.mediaView = adView.findViewById(R.id.ad_media)
-
-        // Set other ad assets.
-        adView.headlineView = adView.findViewById(R.id.ad_headline)
-        adView.bodyView = adView.findViewById(R.id.ad_body)
-        adView.callToActionView = adView.findViewById(R.id.ad_call_to_action)
-        adView.iconView = adView.findViewById(R.id.ad_app_icon)
-        adView.priceView = adView.findViewById(R.id.ad_price)
-        adView.starRatingView = adView.findViewById(R.id.ad_stars)
-        adView.storeView = adView.findViewById(R.id.ad_store)
-        adView.advertiserView = adView.findViewById(R.id.ad_advertiser)
-
-        // The headline and media content are guaranteed to be in every UnifiedNativeAd.
-        (adView.headlineView as TextView).text = nativeAd.headline
-
-        nativeAd.mediaContent?.let { mediaContent ->
-            adView.mediaView?.setMediaContent(mediaContent)
-        }
-
-        // These assets aren't guaranteed to be in every UnifiedNativeAd, so it's important to
-        // check before trying to display them.
-        if (nativeAd.body == null) {
-            adView.bodyView?.visibility = View.INVISIBLE
-        }
-        else {
-            adView.bodyView?.visibility = View.VISIBLE
-            (adView.bodyView as TextView).text = nativeAd.body
-        }
-
-        if (nativeAd.callToAction == null) {
-            adView.callToActionView?.visibility = View.INVISIBLE
-        }
-        else {
-            adView.callToActionView?.visibility = View.VISIBLE
-            (adView.callToActionView as Button).text = nativeAd.callToAction
-        }
-
-        if (nativeAd.icon == null) {
-            adView.iconView?.visibility = View.GONE
-        }
-        else {
-            (adView.iconView as ImageView).setImageDrawable(nativeAd.icon?.drawable)
-            adView.iconView?.visibility = View.VISIBLE
-        }
-
-        if (nativeAd.advertiser == null) {
-            adView.advertiserView?.visibility = View.INVISIBLE
-        }
-        else {
-            (adView.advertiserView as TextView).text = nativeAd.advertiser
-            adView.advertiserView?.visibility = View.VISIBLE
-        }
-
-        // This method tells the Google Mobile Ads SDK that you have finished populating your
-        // native ad view with this native ad.
-        adView.setNativeAd(nativeAd)
-
-        adContainer?.removeAllViews()
-        adContainer?.addView(adView)
-    }
-
-    private fun isCustomFormatExample() = !TextUtils.isEmpty(customFormatId)
-}
+// TODO: Uncomment when native module will be merged
+//import android.os.Bundle
+//import android.text.TextUtils
+//import android.view.LayoutInflater
+//import android.view.View
+//import android.widget.Button
+//import android.widget.ImageView
+//import android.widget.TextView
+//import com.google.android.gms.ads.AdListener
+//import com.google.android.gms.ads.AdLoader
+//import com.google.android.gms.ads.LoadAdError
+//import com.google.android.gms.ads.admanager.AdManagerAdRequest
+//import com.google.android.gms.ads.nativead.NativeAd
+//import com.google.android.gms.ads.nativead.NativeAdView
+//import com.google.android.gms.ads.nativead.NativeCustomFormatAd
+//import kotlinx.android.synthetic.main.lyt_native_ad.*
+//import kotlinx.android.synthetic.main.lyt_native_gam_events.*
+//import org.prebid.mobile.eventhandlers.utils.GamUtils
+//import org.prebid.mobile.rendering.bidding.data.FetchDemandResult
+//import org.prebid.mobile.renderingtestapp.R
+//import org.prebid.mobile.renderingtestapp.plugplay.bidding.ppm.PpmNativeFragment
+//import org.prebid.mobile.renderingtestapp.plugplay.config.AdConfiguratorDialogFragment
+//import org.prebid.mobile.renderingtestapp.utils.SourcePicker
+//import org.prebid.mobile.renderingtestapp.utils.loadImage
+//
+//class GamNativeFragment(override val layoutRes: Int = R.layout.fragment_native) : PpmNativeFragment() {
+//    companion object {
+//        const val ARG_CUSTOM_FORMAT_ID = "ARG_CUSTOM_FORMAT_ID"
+//    }
+//
+//    private var gamAdLoader: AdLoader? = null
+//    private var customFormatId: String = ""
+//
+//    override fun onCreate(savedInstanceState: Bundle?) {
+//        super.onCreate(savedInstanceState)
+//        arguments?.let {
+//            customFormatId = it.getString(ARG_CUSTOM_FORMAT_ID, "")
+//        }
+//    }
+//
+//    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+//        super.onViewCreated(view, savedInstanceState)
+//        if (!SourcePicker.useMockServer) {
+//            SourcePicker.enableQaEndpoint(true)
+//        }
+//    }
+//
+//    override fun onDestroyView() {
+//        super.onDestroyView()
+//        if (!SourcePicker.useMockServer) {
+//            SourcePicker.enableQaEndpoint(false)
+//        }
+//    }
+//
+//    override fun loadAd() {
+//        val builder = AdManagerAdRequest.Builder()
+//        val publisherAdRequest = builder.build()
+//
+//        nativeAdUnit?.fetchDemand { result ->
+//            val fetchDemandResult = result.fetchDemandResult
+//
+//            if (fetchDemandResult != FetchDemandResult.SUCCESS) {
+//                btnFetchDemandResultFailure.isEnabled = true
+//                loadGam(publisherAdRequest)
+//                return@fetchDemand
+//            }
+//
+//            btnFetchDemandResultSuccess?.isEnabled = true
+//            GamUtils.prepare(publisherAdRequest, result)
+//            loadGam(publisherAdRequest)
+//        }
+//    }
+//
+//    override fun getEventButtonViewId(): Int = R.layout.lyt_native_gam_events
+//
+//    override fun configuratorMode(): AdConfiguratorDialogFragment.AdConfiguratorMode? = null
+//
+//    private fun loadGam(publisherAdRequest: AdManagerAdRequest) {
+//        gamAdLoader = if (isCustomFormatExample()) createCustomFormatAdLoader() else createNativeAdLoader()
+//
+//        gamAdLoader?.loadAd(publisherAdRequest)
+//    }
+//
+//    private fun createNativeAdLoader(): AdLoader = AdLoader.Builder(requireContext(), adUnitId)
+//            .forNativeAd { unifiedAd ->
+//                btnUnifiedRequestSuccess?.isEnabled = true
+//                handleNativeAd(unifiedAd)
+//            }
+//            .withAdListener(object : AdListener() {
+//                override fun onAdFailedToLoad(p0: LoadAdError) {
+//                    btnPrimaryAdRequestFailure?.isEnabled = true
+//                }
+//
+//                override fun onAdClicked() {
+//                    btnAdClicked?.isEnabled = true
+//                }
+//            })
+//            .build()
+//
+//    private fun createCustomFormatAdLoader() = AdLoader.Builder(requireContext(), adUnitId)
+//            .forCustomFormatAd(customFormatId, { formatAd ->
+//                btnCustomAdRequestSuccess?.isEnabled = true
+//                handleCustomFormatAd(formatAd)
+//            }, null)
+//            .withAdListener(object : AdListener() {
+//                override fun onAdFailedToLoad(p0: LoadAdError) {
+//                    btnPrimaryAdRequestFailure?.isEnabled = true
+//                }
+//            })
+//            .build()
+//
+//    private fun handleNativeAd(nativeAd: NativeAd?) {
+//        nativeAd ?: return
+//
+//        if (GamUtils.didPrebidWin(nativeAd)) {
+//            GamUtils.findNativeAd(nativeAd) {
+//                btnNativeAdLoaded?.isEnabled = true
+//                inflateViewContent(it)
+//            }
+//        }
+//        else {
+//            btnPrimaryAdWinUnified?.isEnabled = true
+//            inflateNativeAd(nativeAd)
+//        }
+//    }
+//
+//    private fun handleCustomFormatAd(customFormatAd: NativeCustomFormatAd?) {
+//        customFormatAd ?: return
+//
+//        if (GamUtils.didPrebidWin(customFormatAd)) {
+//            GamUtils.findNativeAd(customFormatAd) {
+//                btnNativeAdLoaded?.isEnabled = true
+//                inflateViewContent(it)
+//            }
+//        }
+//        else {
+//            btnPrimaryAdWinCustom?.isEnabled = true
+//            inflateGamCustomFormat(customFormatAd)
+//        }
+//    }
+//
+//
+//    private fun inflateGamCustomFormat(customFormatAd: NativeCustomFormatAd) {
+//
+//        val title = customFormatAd.getText("title")
+//        val text = customFormatAd.getText("text")
+//        val cta = customFormatAd.getText("cta")
+//        val sponsoredBy = customFormatAd.getText("sponsoredBy")
+//        val iconUrl = customFormatAd.getText("iconUrl")?.toString() ?: ""
+//        val imageUrl = customFormatAd.getText("imgUrl")?.toString() ?: ""
+//
+//        tvNativeTitle?.text = title
+//        tvNativeBody?.text = text
+//        tvNativeBrand?.text = sponsoredBy
+//        btnNativeAction?.text = cta
+//
+//        loadImage(ivNativeMain, imageUrl)
+//        loadImage(ivNativeIcon, iconUrl)
+//
+//        btnNativeAction?.setOnClickListener {
+//            customFormatAd.performClick("cta")
+//            btnAdClicked?.isEnabled = true
+//        }
+//    }
+//
+//    private fun inflateNativeAd(nativeAd: NativeAd?) {
+//        nativeAd ?: return
+//
+//        val adView = LayoutInflater.from(requireContext()).inflate(R.layout.lyt_unified_native_ad, null) as NativeAdView
+//
+//        adView.mediaView = adView.findViewById(R.id.ad_media)
+//
+//        // Set other ad assets.
+//        adView.headlineView = adView.findViewById(R.id.ad_headline)
+//        adView.bodyView = adView.findViewById(R.id.ad_body)
+//        adView.callToActionView = adView.findViewById(R.id.ad_call_to_action)
+//        adView.iconView = adView.findViewById(R.id.ad_app_icon)
+//        adView.priceView = adView.findViewById(R.id.ad_price)
+//        adView.starRatingView = adView.findViewById(R.id.ad_stars)
+//        adView.storeView = adView.findViewById(R.id.ad_store)
+//        adView.advertiserView = adView.findViewById(R.id.ad_advertiser)
+//
+//        // The headline and media content are guaranteed to be in every UnifiedNativeAd.
+//        (adView.headlineView as TextView).text = nativeAd.headline
+//
+//        nativeAd.mediaContent?.let { mediaContent ->
+//            adView.mediaView?.setMediaContent(mediaContent)
+//        }
+//
+//        // These assets aren't guaranteed to be in every UnifiedNativeAd, so it's important to
+//        // check before trying to display them.
+//        if (nativeAd.body == null) {
+//            adView.bodyView?.visibility = View.INVISIBLE
+//        }
+//        else {
+//            adView.bodyView?.visibility = View.VISIBLE
+//            (adView.bodyView as TextView).text = nativeAd.body
+//        }
+//
+//        if (nativeAd.callToAction == null) {
+//            adView.callToActionView?.visibility = View.INVISIBLE
+//        }
+//        else {
+//            adView.callToActionView?.visibility = View.VISIBLE
+//            (adView.callToActionView as Button).text = nativeAd.callToAction
+//        }
+//
+//        if (nativeAd.icon == null) {
+//            adView.iconView?.visibility = View.GONE
+//        }
+//        else {
+//            (adView.iconView as ImageView).setImageDrawable(nativeAd.icon?.drawable)
+//            adView.iconView?.visibility = View.VISIBLE
+//        }
+//
+//        if (nativeAd.advertiser == null) {
+//            adView.advertiserView?.visibility = View.INVISIBLE
+//        }
+//        else {
+//            (adView.advertiserView as TextView).text = nativeAd.advertiser
+//            adView.advertiserView?.visibility = View.VISIBLE
+//        }
+//
+//        // This method tells the Google Mobile Ads SDK that you have finished populating your
+//        // native ad view with this native ad.
+//        adView.setNativeAd(nativeAd)
+//
+//        adContainer?.removeAllViews()
+//        adContainer?.addView(adView)
+//    }
+//
+//    private fun isCustomFormatExample() = !TextUtils.isEmpty(customFormatId)
+//}

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/ppm/PpmNativeFeedFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/ppm/PpmNativeFeedFragment.kt
@@ -16,16 +16,17 @@
 
 package org.prebid.mobile.renderingtestapp.plugplay.bidding.ppm
 
-import org.prebid.mobile.rendering.bidding.display.NativeAdUnit
-import org.prebid.mobile.renderingtestapp.plugplay.bidding.base.BaseFeedFragment
-import org.prebid.mobile.renderingtestapp.utils.adapters.BaseFeedAdapter
-import org.prebid.mobile.renderingtestapp.utils.adapters.NativeFeedAdapter
-
-class PpmNativeFeedFragment : BaseFeedFragment() {
-
-    override fun initFeedAdapter(): BaseFeedAdapter {
-        val nativeAdUnit = NativeAdUnit(context, configId, getNativeAdConfig()!!)
-        return NativeFeedAdapter(requireContext(), nativeAdUnit)
-    }
-
-}
+// TODO: Uncomment when native module will be merged
+//import org.prebid.mobile.rendering.bidding.display.NativeAdUnit
+//import org.prebid.mobile.renderingtestapp.plugplay.bidding.base.BaseFeedFragment
+//import org.prebid.mobile.renderingtestapp.utils.adapters.BaseFeedAdapter
+//import org.prebid.mobile.renderingtestapp.utils.adapters.NativeFeedAdapter
+//
+//class PpmNativeFeedFragment : BaseFeedFragment() {
+//
+//    override fun initFeedAdapter(): BaseFeedAdapter {
+//        val nativeAdUnit = NativeAdUnit(context, configId, getNativeAdConfig()!!)
+//        return NativeFeedAdapter(requireContext(), nativeAdUnit)
+//    }
+//
+//}

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/ppm/PpmNativeFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/ppm/PpmNativeFragment.kt
@@ -16,118 +16,119 @@
 
 package org.prebid.mobile.renderingtestapp.plugplay.bidding.ppm
 
-import android.os.Bundle
-import android.util.Log
-import android.view.View
-import kotlinx.android.synthetic.main.fragment_native.*
-import kotlinx.android.synthetic.main.fragment_native.view.*
-import kotlinx.android.synthetic.main.lyt_native_ad.*
-import kotlinx.android.synthetic.main.lyt_native_ad_events.*
-import kotlinx.android.synthetic.main.lyt_native_in_app_events.*
-import org.prebid.mobile.rendering.bidding.data.FetchDemandResult
-import org.prebid.mobile.rendering.bidding.data.ntv.NativeAd
-import org.prebid.mobile.rendering.bidding.display.NativeAdUnit
-import org.prebid.mobile.rendering.bidding.listeners.NativeAdListener
-import org.prebid.mobile.rendering.models.ntv.NativeEventTracker
-import org.prebid.mobile.rendering.models.openrtb.bidRequests.assets.NativeAssetData
-import org.prebid.mobile.rendering.utils.ntv.NativeUtils
-import org.prebid.mobile.renderingtestapp.AdFragment
-import org.prebid.mobile.renderingtestapp.R
-import org.prebid.mobile.renderingtestapp.plugplay.config.AdConfiguratorDialogFragment
-import org.prebid.mobile.renderingtestapp.utils.SourcePicker
-import org.prebid.mobile.renderingtestapp.utils.loadImage
-
-open class PpmNativeFragment : AdFragment(), NativeAdListener {
-    private val TAG = PpmNativeFragment::class.java.simpleName
-
-    override val layoutRes: Int = R.layout.fragment_native
-    protected var nativeAdUnit: NativeAdUnit? = null
-    protected var nativeAd: NativeAd? = null
-
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-        if (!SourcePicker.useMockServer) {
-            SourcePicker.enableQaEndpoint(true)
-        }
-
-        if (layoutRes == R.layout.fragment_native) {
-            layoutInflater.inflate(getEventButtonViewId(), contentFragmentNative, true)
-        }
-    }
-
-    override fun initAd(): Any? {
-        nativeAdUnit = NativeAdUnit(context, configId, getNativeAdConfig()!!)
-        return nativeAdUnit
-    }
-
-    override fun loadAd() {
-        nativeAdUnit?.fetchDemand {
-
-            if (it.fetchDemandResult != FetchDemandResult.SUCCESS) {
-                btnFetchDemandResultFailure?.isEnabled = true
-                return@fetchDemand
-            }
-
-            btnFetchDemandResultSuccess?.isEnabled = true
-
-            NativeUtils.findNativeAd(it) { nativeAd ->
-                if (nativeAd == null) {
-                    btnGetNativeAdResultFailure?.isEnabled = true
-                    return@findNativeAd
-                }
-                btnGetNativeAdResultSuccess?.isEnabled = true
-
-                inflateViewContent(nativeAd)
-            }
-        }
-    }
-
-    override fun configuratorMode(): AdConfiguratorDialogFragment.AdConfiguratorMode? = null
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        nativeAdUnit?.destroy()
-        nativeAd?.destroy()
-        if (!SourcePicker.useMockServer) {
-            SourcePicker.enableQaEndpoint(false)
-        }
-    }
-
-    override fun onAdClicked(nativeAd: NativeAd?) {
-        Log.d(TAG, "onAdClicked() called with: nativeAd = $nativeAd")
-        btnAdClicked?.isEnabled = true
-    }
-
-    override fun onAdEvent(nativeAd: NativeAd?, eventType: NativeEventTracker.EventType?) {
-        Log.d(TAG, "onAdEvent() called with: nativeAd = $nativeAd, eventType = $eventType")
-        eventType ?: return
-
-        when (eventType) {
-            NativeEventTracker.EventType.IMPRESSION -> btnAdEventImpression?.isEnabled = true
-            NativeEventTracker.EventType.VIEWABLE_MRC50 -> btnAdEventMrc50?.isEnabled = true
-            NativeEventTracker.EventType.VIEWABLE_MRC100 -> btnAdEventMrc100?.isEnabled = true
-            NativeEventTracker.EventType.VIEWABLE_VIDEO50 -> btnAdEventVideo50?.isEnabled = true
-            else -> Log.d(TAG, "onAdEvent: event ignored $eventType")
-        }
-    }
-
-    protected open fun getEventButtonViewId(): Int = R.layout.lyt_native_in_app_events
-
-    protected open fun inflateViewContent(nativeAd: NativeAd?) {
-        nativeAd ?: return
-
-        this.nativeAd = nativeAd
-
-        nativeAd.setNativeAdListener(this)
-
-        nativeAd.registerView(adContainer, btnNativeAction)
-
-        tvNativeTitle?.text = nativeAd.title
-        tvNativeBody?.text = nativeAd.text
-        tvNativeBrand?.text = nativeAd.getNativeAdDataList(NativeAssetData.DataType.SPONSORED).firstOrNull()?.value
-        btnNativeAction?.text = nativeAd.callToAction
-
-        loadImage(ivNativeMain, nativeAd.imageUrl)
-        loadImage(ivNativeIcon, nativeAd.iconUrl)
-    }
-}
+// TODO: Uncomment when native module will be merged
+//import android.os.Bundle
+//import android.util.Log
+//import android.view.View
+//import kotlinx.android.synthetic.main.fragment_native.*
+//import kotlinx.android.synthetic.main.fragment_native.view.*
+//import kotlinx.android.synthetic.main.lyt_native_ad.*
+//import kotlinx.android.synthetic.main.lyt_native_ad_events.*
+//import kotlinx.android.synthetic.main.lyt_native_in_app_events.*
+//import org.prebid.mobile.rendering.bidding.data.FetchDemandResult
+//import org.prebid.mobile.rendering.bidding.data.ntv.NativeAd
+//import org.prebid.mobile.rendering.bidding.display.NativeAdUnit
+//import org.prebid.mobile.rendering.bidding.listeners.NativeAdListener
+//import org.prebid.mobile.rendering.models.ntv.NativeEventTracker
+//import org.prebid.mobile.rendering.models.openrtb.bidRequests.assets.NativeAssetData
+//import org.prebid.mobile.rendering.utils.ntv.NativeUtils
+//import org.prebid.mobile.renderingtestapp.AdFragment
+//import org.prebid.mobile.renderingtestapp.R
+//import org.prebid.mobile.renderingtestapp.plugplay.config.AdConfiguratorDialogFragment
+//import org.prebid.mobile.renderingtestapp.utils.SourcePicker
+//import org.prebid.mobile.renderingtestapp.utils.loadImage
+//
+//open class PpmNativeFragment : AdFragment(), NativeAdListener {
+//    private val TAG = PpmNativeFragment::class.java.simpleName
+//
+//    override val layoutRes: Int = R.layout.fragment_native
+//    protected var nativeAdUnit: NativeAdUnit? = null
+//    protected var nativeAd: NativeAd? = null
+//
+//    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+//        super.onViewCreated(view, savedInstanceState)
+//        if (!SourcePicker.useMockServer) {
+//            SourcePicker.enableQaEndpoint(true)
+//        }
+//
+//        if (layoutRes == R.layout.fragment_native) {
+//            layoutInflater.inflate(getEventButtonViewId(), contentFragmentNative, true)
+//        }
+//    }
+//
+//    override fun initAd(): Any? {
+//        nativeAdUnit = NativeAdUnit(context, configId, getNativeAdConfig()!!)
+//        return nativeAdUnit
+//    }
+//
+//    override fun loadAd() {
+//        nativeAdUnit?.fetchDemand {
+//
+//            if (it.fetchDemandResult != FetchDemandResult.SUCCESS) {
+//                btnFetchDemandResultFailure?.isEnabled = true
+//                return@fetchDemand
+//            }
+//
+//            btnFetchDemandResultSuccess?.isEnabled = true
+//
+//            NativeUtils.findNativeAd(it) { nativeAd ->
+//                if (nativeAd == null) {
+//                    btnGetNativeAdResultFailure?.isEnabled = true
+//                    return@findNativeAd
+//                }
+//                btnGetNativeAdResultSuccess?.isEnabled = true
+//
+//                inflateViewContent(nativeAd)
+//            }
+//        }
+//    }
+//
+//    override fun configuratorMode(): AdConfiguratorDialogFragment.AdConfiguratorMode? = null
+//
+//    override fun onDestroyView() {
+//        super.onDestroyView()
+//        nativeAdUnit?.destroy()
+//        nativeAd?.destroy()
+//        if (!SourcePicker.useMockServer) {
+//            SourcePicker.enableQaEndpoint(false)
+//        }
+//    }
+//
+//    override fun onAdClicked(nativeAd: NativeAd?) {
+//        Log.d(TAG, "onAdClicked() called with: nativeAd = $nativeAd")
+//        btnAdClicked?.isEnabled = true
+//    }
+//
+//    override fun onAdEvent(nativeAd: NativeAd?, eventType: NativeEventTracker.EventType?) {
+//        Log.d(TAG, "onAdEvent() called with: nativeAd = $nativeAd, eventType = $eventType")
+//        eventType ?: return
+//
+//        when (eventType) {
+//            NativeEventTracker.EventType.IMPRESSION -> btnAdEventImpression?.isEnabled = true
+//            NativeEventTracker.EventType.VIEWABLE_MRC50 -> btnAdEventMrc50?.isEnabled = true
+//            NativeEventTracker.EventType.VIEWABLE_MRC100 -> btnAdEventMrc100?.isEnabled = true
+//            NativeEventTracker.EventType.VIEWABLE_VIDEO50 -> btnAdEventVideo50?.isEnabled = true
+//            else -> Log.d(TAG, "onAdEvent: event ignored $eventType")
+//        }
+//    }
+//
+//    protected open fun getEventButtonViewId(): Int = R.layout.lyt_native_in_app_events
+//
+//    protected open fun inflateViewContent(nativeAd: NativeAd?) {
+//        nativeAd ?: return
+//
+//        this.nativeAd = nativeAd
+//
+//        nativeAd.setNativeAdListener(this)
+//
+//        nativeAd.registerView(adContainer, btnNativeAction)
+//
+//        tvNativeTitle?.text = nativeAd.title
+//        tvNativeBody?.text = nativeAd.text
+//        tvNativeBrand?.text = nativeAd.getNativeAdDataList(NativeAssetData.DataType.SPONSORED).firstOrNull()?.value
+//        btnNativeAction?.text = nativeAd.callToAction
+//
+//        loadImage(ivNativeMain, nativeAd.imageUrl)
+//        loadImage(ivNativeIcon, nativeAd.iconUrl)
+//    }
+//}

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/ppm/PpmNativeLinksFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/ppm/PpmNativeLinksFragment.kt
@@ -16,40 +16,41 @@
 
 package org.prebid.mobile.renderingtestapp.plugplay.bidding.ppm
 
-import android.widget.Button
-import kotlinx.android.synthetic.main.events_bids.*
-import kotlinx.android.synthetic.main.lyt_native_ad_links.*
-import org.prebid.mobile.rendering.bidding.data.ntv.NativeAd
-import org.prebid.mobile.rendering.models.openrtb.bidRequests.assets.NativeAssetData
-import org.prebid.mobile.renderingtestapp.R
-
-class PpmNativeLinksFragment : PpmNativeFragment() {
-    override val layoutRes: Int = R.layout.fragment_native_links
-
-    override fun inflateViewContent(nativeAd: NativeAd?) {
-        if (nativeAd == null) {
-            btnAdFailed?.isEnabled = true
-            return
-        }
-
-        btnAdDisplayed?.isEnabled = true
-        this.nativeAd = nativeAd
-
-        nativeAd.setNativeAdListener(this)
-
-        nativeAd.registerView(adContainer, btnNativeLinkRoot)
-
-        btnNativeLinkRoot.text = nativeAd.callToAction
-        setupButton(nativeAd, btnNativeDeeplinkFallback, NativeAssetData.DataType.SPONSORED)
-        setupButton(nativeAd, btnNativeDeeplinkOk, NativeAssetData.DataType.DESC)
-        setupButton(nativeAd, btnNativeLinkUrl, NativeAssetData.DataType.RATING)
-    }
-
-    private fun setupButton(nativeAd: NativeAd?, button: Button, dataType: NativeAssetData.DataType) {
-        val nativeData = nativeAd?.getNativeAdDataList(dataType)?.firstOrNull()
-        if (nativeData != null) {
-            button.text = nativeData.value
-            nativeAd.registerClickView(button, nativeData)
-        }
-    }
-}
+// TODO: Uncomment when native module will be merged
+//import android.widget.Button
+//import kotlinx.android.synthetic.main.events_bids.*
+//import kotlinx.android.synthetic.main.lyt_native_ad_links.*
+//import org.prebid.mobile.rendering.bidding.data.ntv.NativeAd
+//import org.prebid.mobile.rendering.models.openrtb.bidRequests.assets.NativeAssetData
+//import org.prebid.mobile.renderingtestapp.R
+//
+//class PpmNativeLinksFragment : PpmNativeFragment() {
+//    override val layoutRes: Int = R.layout.fragment_native_links
+//
+//    override fun inflateViewContent(nativeAd: NativeAd?) {
+//        if (nativeAd == null) {
+//            btnAdFailed?.isEnabled = true
+//            return
+//        }
+//
+//        btnAdDisplayed?.isEnabled = true
+//        this.nativeAd = nativeAd
+//
+//        nativeAd.setNativeAdListener(this)
+//
+//        nativeAd.registerView(adContainer, btnNativeLinkRoot)
+//
+//        btnNativeLinkRoot.text = nativeAd.callToAction
+//        setupButton(nativeAd, btnNativeDeeplinkFallback, NativeAssetData.DataType.SPONSORED)
+//        setupButton(nativeAd, btnNativeDeeplinkOk, NativeAssetData.DataType.DESC)
+//        setupButton(nativeAd, btnNativeLinkUrl, NativeAssetData.DataType.RATING)
+//    }
+//
+//    private fun setupButton(nativeAd: NativeAd?, button: Button, dataType: NativeAssetData.DataType) {
+//        val nativeData = nativeAd?.getNativeAdDataList(dataType)?.firstOrNull()
+//        if (nativeData != null) {
+//            button.text = nativeData.value
+//            nativeAd.registerClickView(button, nativeData)
+//        }
+//    }
+//}

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/ppm/PpmNativeVideoFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/ppm/PpmNativeVideoFragment.kt
@@ -16,93 +16,94 @@
 
 package org.prebid.mobile.renderingtestapp.plugplay.bidding.ppm
 
-import android.os.Bundle
-import android.util.Log
-import android.view.View
-import kotlinx.android.synthetic.main.events_native_video.*
-import kotlinx.android.synthetic.main.fragment_native_video.*
-import kotlinx.android.synthetic.main.video_controls.*
-import org.prebid.mobile.rendering.bidding.data.ntv.MediaView
-import org.prebid.mobile.rendering.bidding.data.ntv.NativeAd
-import org.prebid.mobile.rendering.errors.AdException
-import org.prebid.mobile.rendering.listeners.MediaViewListener
-import org.prebid.mobile.renderingtestapp.R
-
-
-class PpmNativeVideoFragment : PpmNativeFragment() {
-    private val TAG = PpmNativeFragment::class.java.simpleName
-
-    override val layoutRes: Int = R.layout.fragment_native_video
-
-    private val mediaViewListener = object : MediaViewListener {
-        override fun onMediaPlaybackStarted(mediaView: MediaView?) {
-            Log.d(TAG, "onMediaPlaybackStarted() called with: mediaView = $mediaView")
-            btnPlaybackStarted?.isEnabled = true
-        }
-
-        override fun onMediaPlaybackFinished(mediaView: MediaView?) {
-            Log.d(TAG, "onMediaPlaybackFinished() called with: mediaView = $mediaView")
-            btnPlaybackFinished?.isEnabled = true
-        }
-
-        override fun onMediaPlaybackPaused(mediaView: MediaView?) {
-            Log.d(TAG, "onMediaPlaybackPaused() called with: mediaView = $mediaView")
-            btnPlaybackPaused?.isEnabled = true
-        }
-
-        override fun onMediaPlaybackResumed(mediaView: MediaView?) {
-            Log.d(TAG, "onMediaPlaybackResumed() called with: mediaView = $mediaView")
-            btnPlaybackResumed?.isEnabled = true
-        }
-
-        override fun onMediaPlaybackMuted(mediaView: MediaView?) {
-            Log.d(TAG, "onMediaPlaybackMuted() called with: mediaView = $mediaView")
-            btnPlaybackMuted?.isEnabled = true
-        }
-
-        override fun onMediaPlaybackUnMuted(mediaView: MediaView?) {
-            Log.d(TAG, "onMediaPlaybackUnMuted() called with: mediaView = $mediaView")
-            btnPlaybackUnMuted?.isEnabled = true
-        }
-
-        override fun onVideoLoadingFinished(mediaView: MediaView?) {
-            Log.d(TAG, "onVideoLoadingFinished() called with: mediaView = $mediaView")
-            btnVideoLoadingFinished?.isEnabled = true
-        }
-
-        override fun onFailure(adException: AdException?) {
-            Log.d(TAG, "onFailure() called with: adException = $adException")
-            btnFailure?.isEnabled = true
-        }
-    }
-
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-        mediaView?.setMediaViewListener(mediaViewListener)
-
-        btnPlay?.setOnClickListener { mediaView?.play() }
-        btnPause?.setOnClickListener { mediaView?.pause() }
-        btnResume?.setOnClickListener { mediaView?.resume() }
-        btnMute?.setOnClickListener { mediaView?.mute() }
-        btnUnMute?.setOnClickListener { mediaView?.unMute() }
-    }
-
-    override fun onDestroyView() {
-        super.onDestroyView()
-        mediaView?.destroy()
-    }
-
-    override fun inflateViewContent(nativeAd: NativeAd?) {
-        this.nativeAd = nativeAd
-        val mediaData = nativeAd?.nativeVideoAd?.mediaData
-
-        if (mediaData == null) {
-            Log.e(TAG, "inflateViewContent: failed. Media data is null.")
-            return
-        }
-        nativeAd.setNativeAdListener(this)
-
-        nativeAd.registerView(mediaView, mediaView)
-        mediaView?.loadMedia(mediaData)
-    }
-}
+// TODO: Uncomment when native module will be merged
+//import android.os.Bundle
+//import android.util.Log
+//import android.view.View
+//import kotlinx.android.synthetic.main.events_native_video.*
+//import kotlinx.android.synthetic.main.fragment_native_video.*
+//import kotlinx.android.synthetic.main.video_controls.*
+//import org.prebid.mobile.rendering.bidding.data.ntv.MediaView
+//import org.prebid.mobile.rendering.bidding.data.ntv.NativeAd
+//import org.prebid.mobile.rendering.errors.AdException
+//import org.prebid.mobile.rendering.listeners.MediaViewListener
+//import org.prebid.mobile.renderingtestapp.R
+//
+//
+//class PpmNativeVideoFragment : PpmNativeFragment() {
+//    private val TAG = PpmNativeFragment::class.java.simpleName
+//
+//    override val layoutRes: Int = R.layout.fragment_native_video
+//
+//    private val mediaViewListener = object : MediaViewListener {
+//        override fun onMediaPlaybackStarted(mediaView: MediaView?) {
+//            Log.d(TAG, "onMediaPlaybackStarted() called with: mediaView = $mediaView")
+//            btnPlaybackStarted?.isEnabled = true
+//        }
+//
+//        override fun onMediaPlaybackFinished(mediaView: MediaView?) {
+//            Log.d(TAG, "onMediaPlaybackFinished() called with: mediaView = $mediaView")
+//            btnPlaybackFinished?.isEnabled = true
+//        }
+//
+//        override fun onMediaPlaybackPaused(mediaView: MediaView?) {
+//            Log.d(TAG, "onMediaPlaybackPaused() called with: mediaView = $mediaView")
+//            btnPlaybackPaused?.isEnabled = true
+//        }
+//
+//        override fun onMediaPlaybackResumed(mediaView: MediaView?) {
+//            Log.d(TAG, "onMediaPlaybackResumed() called with: mediaView = $mediaView")
+//            btnPlaybackResumed?.isEnabled = true
+//        }
+//
+//        override fun onMediaPlaybackMuted(mediaView: MediaView?) {
+//            Log.d(TAG, "onMediaPlaybackMuted() called with: mediaView = $mediaView")
+//            btnPlaybackMuted?.isEnabled = true
+//        }
+//
+//        override fun onMediaPlaybackUnMuted(mediaView: MediaView?) {
+//            Log.d(TAG, "onMediaPlaybackUnMuted() called with: mediaView = $mediaView")
+//            btnPlaybackUnMuted?.isEnabled = true
+//        }
+//
+//        override fun onVideoLoadingFinished(mediaView: MediaView?) {
+//            Log.d(TAG, "onVideoLoadingFinished() called with: mediaView = $mediaView")
+//            btnVideoLoadingFinished?.isEnabled = true
+//        }
+//
+//        override fun onFailure(adException: AdException?) {
+//            Log.d(TAG, "onFailure() called with: adException = $adException")
+//            btnFailure?.isEnabled = true
+//        }
+//    }
+//
+//    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+//        super.onViewCreated(view, savedInstanceState)
+//        mediaView?.setMediaViewListener(mediaViewListener)
+//
+//        btnPlay?.setOnClickListener { mediaView?.play() }
+//        btnPause?.setOnClickListener { mediaView?.pause() }
+//        btnResume?.setOnClickListener { mediaView?.resume() }
+//        btnMute?.setOnClickListener { mediaView?.mute() }
+//        btnUnMute?.setOnClickListener { mediaView?.unMute() }
+//    }
+//
+//    override fun onDestroyView() {
+//        super.onDestroyView()
+//        mediaView?.destroy()
+//    }
+//
+//    override fun inflateViewContent(nativeAd: NativeAd?) {
+//        this.nativeAd = nativeAd
+//        val mediaData = nativeAd?.nativeVideoAd?.mediaData
+//
+//        if (mediaData == null) {
+//            Log.e(TAG, "inflateViewContent: failed. Media data is null.")
+//            return
+//        }
+//        nativeAd.setNativeAdListener(this)
+//
+//        nativeAd.registerView(mediaView, mediaView)
+//        mediaView?.loadMedia(mediaData)
+//    }
+//}

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/utils/DemoItemProvider.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/utils/DemoItemProvider.kt
@@ -22,7 +22,6 @@ import com.google.android.gms.ads.AdSize
 import org.prebid.mobile.renderingtestapp.R
 import org.prebid.mobile.renderingtestapp.data.DemoItem
 import org.prebid.mobile.renderingtestapp.data.Tag
-import org.prebid.mobile.renderingtestapp.plugplay.bidding.gam.GamNativeFragment
 
 class DemoItemProvider private constructor() {
     companion object {
@@ -154,14 +153,17 @@ class DemoItemProvider private constructor() {
                     ppmNativeTagList, createBannerBundle(R.string.mock_config_id_native_styles, null, 300, 250)))
             demoList.add(DemoItem(getString(R.string.demo_bidding_in_app_native_styles_no_creative), R.id.action_header_bidding_to_in_app_native_styles,
                     ppmNativeTagList, createBannerBundle(R.string.mock_config_id_native_styles, null, 300, 250)))
-            demoList.add(DemoItem(getString(R.string.demo_bidding_in_app_native), R.id.action_header_bidding_to_in_app_native,
-                    ppmNativeTagList, createBannerBundle(R.string.mock_config_id_native_styles)))
-            demoList.add(DemoItem(getString(R.string.demo_bidding_in_app_native_feed), R.id.action_header_bidding_to_in_app_native_feed,
-                    ppmNativeTagList, createBannerBundle(R.string.mock_config_id_native_styles)))
-            demoList.add(DemoItem(getString(R.string.demo_bidding_in_app_native_links), R.id.action_header_bidding_to_in_app_native_links,
-                    ppmNativeTagList, createBannerBundle(R.string.mock_config_id_native_links)))
-            demoList.add(DemoItem(getString(R.string.demo_bidding_in_app_native_video), R.id.action_header_bidding_to_in_app_native_video,
-                    ppmNativeTagList, createBannerBundle(R.string.mock_config_id_native_video)))
+
+
+            // TODO: Uncomment when native module will be merged
+//            demoList.add(DemoItem(getString(R.string.demo_bidding_in_app_native), R.id.action_header_bidding_to_in_app_native,
+//                    ppmNativeTagList, createBannerBundle(R.string.mock_config_id_native_styles)))
+//            demoList.add(DemoItem(getString(R.string.demo_bidding_in_app_native_feed), R.id.action_header_bidding_to_in_app_native_feed,
+//                    ppmNativeTagList, createBannerBundle(R.string.mock_config_id_native_styles)))
+//            demoList.add(DemoItem(getString(R.string.demo_bidding_in_app_native_links), R.id.action_header_bidding_to_in_app_native_links,
+//                    ppmNativeTagList, createBannerBundle(R.string.mock_config_id_native_links)))
+//            demoList.add(DemoItem(getString(R.string.demo_bidding_in_app_native_video), R.id.action_header_bidding_to_in_app_native_video,
+//                    ppmNativeTagList, createBannerBundle(R.string.mock_config_id_native_video)))
 
             // GAM
             val gamBannerTagList = listOf(Tag.ALL, Tag.GAM, Tag.BANNER, Tag.MOCK)
@@ -224,32 +226,33 @@ class DemoItemProvider private constructor() {
             demoList.add(DemoItem(getString(R.string.demo_bidding_gam_native_styles_fluid), R.id.action_header_bidding_to_gam_native_styles,
                     gamNativeTagList, createBannerBundle(R.string.mock_config_id_native_styles, R.string.adunit_gam_native_fluid, AdSize.FLUID.width, AdSize.FLUID.height)))
 
-            var gamNativeBundle = createBannerBundle(R.string.mock_config_id_native_styles, R.string.adunit_gam_native_custom_template)
-            gamNativeBundle.putString(GamNativeFragment.ARG_CUSTOM_FORMAT_ID, "11934135")
-            demoList.add(DemoItem(getString(R.string.demo_bidding_gam_native_custom_templates), R.id.action_header_bidding_to_gam_native, gamNativeTagList, gamNativeBundle))
-
-            gamNativeBundle = createBannerBundle(R.string.mock_config_id_native_styles, R.string.adunit_gam_native_custom_template)
-            val staticCustomFormatId = "11982639"
-            gamNativeBundle.putString(GamNativeFragment.ARG_CUSTOM_FORMAT_ID, staticCustomFormatId)
-            demoList.add(DemoItem(getString(R.string.demo_bidding_gam_native_custom_templates_prebid_ok), R.id.action_header_bidding_to_gam_native,
-                    gamNativeTagList, gamNativeBundle))
-
-            gamNativeBundle = createBannerBundle(R.string.mock_config_id_no_bids, R.string.adunit_gam_native_custom_template)
-            gamNativeBundle.putString(GamNativeFragment.ARG_CUSTOM_FORMAT_ID, staticCustomFormatId)
-            demoList.add(DemoItem(getString(R.string.demo_bidding_gam_native_custom_templates_no_bids), R.id.action_header_bidding_to_gam_native,
-                    gamNativeTagList, gamNativeBundle))
-
-            demoList.add(DemoItem(getString(R.string.demo_bidding_gam_native_unified_ads), R.id.action_header_bidding_to_gam_native, gamNativeTagList,
-                    createBannerBundle(R.string.mock_config_id_native_styles, R.string.adunit_gam_native_unified)))
-            demoList.add(DemoItem(getString(R.string.demo_bidding_gam_native_unified_ads_prebid_ok), R.id.action_header_bidding_to_gam_native, gamNativeTagList,
-                    createBannerBundle(R.string.mock_config_id_native_styles, R.string.adunit_gam_native_unified_static)))
-            demoList.add(DemoItem(getString(R.string.demo_bidding_gam_native_unified_ads_no_bids), R.id.action_header_bidding_to_gam_native, gamNativeTagList,
-                    createBannerBundle(R.string.mock_config_id_no_bids, R.string.adunit_gam_native_unified_static)))
-
-            gamNativeBundle = createBannerBundle(R.string.mock_config_id_native_styles, R.string.adunit_gam_native_custom_template)
-            gamNativeBundle.putString(GamNativeFragment.ARG_CUSTOM_FORMAT_ID, "11934135")
-            demoList.add(DemoItem(getString(R.string.demo_bidding_gam_native_feed), R.id.action_header_bidding_to_gam_native_feed,
-                    gamNativeTagList, gamNativeBundle))
+            // TODO: Uncomment when native module will be merged
+//            var gamNativeBundle = createBannerBundle(R.string.mock_config_id_native_styles, R.string.adunit_gam_native_custom_template)
+//            gamNativeBundle.putString(GamNativeFragment.ARG_CUSTOM_FORMAT_ID, "11934135")
+//            demoList.add(DemoItem(getString(R.string.demo_bidding_gam_native_custom_templates), R.id.action_header_bidding_to_gam_native, gamNativeTagList, gamNativeBundle))
+//
+//            gamNativeBundle = createBannerBundle(R.string.mock_config_id_native_styles, R.string.adunit_gam_native_custom_template)
+//            val staticCustomFormatId = "11982639"
+//            gamNativeBundle.putString(GamNativeFragment.ARG_CUSTOM_FORMAT_ID, staticCustomFormatId)
+//            demoList.add(DemoItem(getString(R.string.demo_bidding_gam_native_custom_templates_prebid_ok), R.id.action_header_bidding_to_gam_native,
+//                    gamNativeTagList, gamNativeBundle))
+//
+//            gamNativeBundle = createBannerBundle(R.string.mock_config_id_no_bids, R.string.adunit_gam_native_custom_template)
+//            gamNativeBundle.putString(GamNativeFragment.ARG_CUSTOM_FORMAT_ID, staticCustomFormatId)
+//            demoList.add(DemoItem(getString(R.string.demo_bidding_gam_native_custom_templates_no_bids), R.id.action_header_bidding_to_gam_native,
+//                    gamNativeTagList, gamNativeBundle))
+//
+//            demoList.add(DemoItem(getString(R.string.demo_bidding_gam_native_unified_ads), R.id.action_header_bidding_to_gam_native, gamNativeTagList,
+//                    createBannerBundle(R.string.mock_config_id_native_styles, R.string.adunit_gam_native_unified)))
+//            demoList.add(DemoItem(getString(R.string.demo_bidding_gam_native_unified_ads_prebid_ok), R.id.action_header_bidding_to_gam_native, gamNativeTagList,
+//                    createBannerBundle(R.string.mock_config_id_native_styles, R.string.adunit_gam_native_unified_static)))
+//            demoList.add(DemoItem(getString(R.string.demo_bidding_gam_native_unified_ads_no_bids), R.id.action_header_bidding_to_gam_native, gamNativeTagList,
+//                    createBannerBundle(R.string.mock_config_id_no_bids, R.string.adunit_gam_native_unified_static)))
+//
+//            gamNativeBundle = createBannerBundle(R.string.mock_config_id_native_styles, R.string.adunit_gam_native_custom_template)
+//            gamNativeBundle.putString(GamNativeFragment.ARG_CUSTOM_FORMAT_ID, "11934135")
+//            demoList.add(DemoItem(getString(R.string.demo_bidding_gam_native_feed), R.id.action_header_bidding_to_gam_native_feed,
+//                    gamNativeTagList, gamNativeBundle))
 
             /// MoPub
             val mopubBannerTagList = listOf(Tag.ALL, Tag.MOPUB, Tag.BANNER, Tag.MOCK)
@@ -376,12 +379,14 @@ class DemoItemProvider private constructor() {
                     createBannerBundle(R.string.prebid_config_id_no_bids, R.string.adunit_gam_interstitial_video_320_480_no_bids, MIN_WIDTH_PERC, MIN_HEIGHT_PERC)))
             demoList.add(DemoItem(getString(R.string.demo_bidding_gam_native_styles_mrect), R.id.action_header_bidding_to_gam_native_styles,
                     gamNativeTagList, createBannerBundle(R.string.prebid_config_id_native_styles, R.string.adunit_gam_native_mrect, 300, 250)))
-            val gamNativeBundle = createBannerBundle(R.string.prebid_config_id_qa_native_styles, R.string.adunit_gam_native_custom_template, 300, 250)
-            gamNativeBundle.putString(GamNativeFragment.ARG_CUSTOM_FORMAT_ID, "11934135")
-            demoList.add(DemoItem(getString(R.string.demo_bidding_gam_native_custom_templates), R.id.action_header_bidding_to_gam_native, gamNativeTagList, gamNativeBundle))
 
-            demoList.add(DemoItem(getString(R.string.demo_bidding_gam_native_unified_ads), R.id.action_header_bidding_to_gam_native, gamNativeTagList,
-                    createBannerBundle(R.string.prebid_config_id_qa_native_styles, R.string.adunit_gam_native_unified, 300, 250)))
+            // TODO: Uncomment when native module will be merged
+//            val gamNativeBundle = createBannerBundle(R.string.prebid_config_id_qa_native_styles, R.string.adunit_gam_native_custom_template, 300, 250)
+//            gamNativeBundle.putString(GamNativeFragment.ARG_CUSTOM_FORMAT_ID, "11934135")
+//            demoList.add(DemoItem(getString(R.string.demo_bidding_gam_native_custom_templates), R.id.action_header_bidding_to_gam_native, gamNativeTagList, gamNativeBundle))
+//
+//            demoList.add(DemoItem(getString(R.string.demo_bidding_gam_native_unified_ads), R.id.action_header_bidding_to_gam_native, gamNativeTagList,
+//                    createBannerBundle(R.string.prebid_config_id_qa_native_styles, R.string.adunit_gam_native_unified, 300, 250)))
 
             // MoPub Integration
             /// MoPub
@@ -440,8 +445,8 @@ class DemoItemProvider private constructor() {
                     createBannerBundle(R.string.prebid_config_id_video_rewarded_320_480, R.string.mopub_video_interstitial_bidding_vanilla)))
 
             // Native Ad
-            demoList.add(DemoItem(getString(R.string.demo_bidding_in_app_native), R.id.action_header_bidding_to_in_app_native,
-                    ppmNativeTagList, createBannerBundle(R.string.prebid_config_id_qa_native_styles)))
+//            demoList.add(DemoItem(getString(R.string.demo_bidding_in_app_native), R.id.action_header_bidding_to_in_app_native,
+//                    ppmNativeTagList, createBannerBundle(R.string.prebid_config_id_qa_native_styles)))
         }
 
         private fun createBannerBundle(configIdRes: Int?, adUnitIdRes: Int? = null, width: Int = 0, height: Int = 0): Bundle {

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/utils/adapters/NativeFeedAdapter.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/utils/adapters/NativeFeedAdapter.kt
@@ -16,86 +16,87 @@
 
 package org.prebid.mobile.renderingtestapp.utils.adapters
 
-import android.content.Context
-import android.util.Log
-import android.view.View
-import android.view.ViewGroup
-import android.widget.FrameLayout
-import androidx.constraintlayout.widget.ConstraintLayout
-import kotlinx.android.synthetic.main.events_bids.*
-import kotlinx.android.synthetic.main.lyt_native_ad.*
-import kotlinx.android.synthetic.main.lyt_native_ad.view.*
-import org.prebid.mobile.rendering.bidding.data.FetchDemandResult
-import org.prebid.mobile.rendering.bidding.data.ntv.NativeAd
-import org.prebid.mobile.rendering.bidding.display.NativeAdUnit
-import org.prebid.mobile.rendering.bidding.listeners.NativeAdListener
-import org.prebid.mobile.rendering.bidding.listeners.OnNativeFetchCompleteListener
-import org.prebid.mobile.rendering.models.ntv.NativeEventTracker
-import org.prebid.mobile.rendering.models.openrtb.bidRequests.assets.NativeAssetData
-import org.prebid.mobile.rendering.utils.ntv.NativeUtils
-import org.prebid.mobile.renderingtestapp.R
-import org.prebid.mobile.renderingtestapp.utils.loadImage
-
-class NativeFeedAdapter(context: Context, private val nativeAdUnit: NativeAdUnit) : BaseFeedAdapter(context) {
-    private val TAG = NativeFeedAdapter::class.java.simpleName
-
-    var nativeAdLayout: ConstraintLayout? = null
-    var nativeAd: NativeAd? = null
-
-    private val fetchCompleteListener = OnNativeFetchCompleteListener {
-        if (it.fetchDemandResult != FetchDemandResult.SUCCESS) {
-            return@OnNativeFetchCompleteListener
-        }
-
-        NativeUtils.findNativeAd(it) { nativeAd ->
-            inflateViewContent(nativeAd)
-        }
-    }
-
-    private val nativeAdListener = object : NativeAdListener {
-
-        override fun onAdClicked(nativeAd: NativeAd?) {
-            Log.d(TAG, "onAdClicked() called with: nativeAd = $nativeAd")
-        }
-
-        override fun onAdEvent(nativeAd: NativeAd?, eventType: NativeEventTracker.EventType?) {
-            Log.d(TAG, "onAdEvent() called with: nativeAd = $nativeAd, eventType = $eventType")
-        }
-
-    }
-
-    override fun destroy() {
-        Log.d(TAG, "Destroying adapter")
-        nativeAd?.destroy()
-        nativeAdUnit.destroy()
-    }
-
-    override fun initAndLoadAdView(parent: ViewGroup?, container: FrameLayout): View? {
-        if (nativeAdLayout == null) {
-            nativeAdLayout = layoutInflater.inflate(R.layout.lyt_native_ad, parent, false) as ConstraintLayout
-        }
-        nativeAdUnit.fetchDemand(fetchCompleteListener)
-        return nativeAdLayout
-    }
-
-    private fun inflateViewContent(nativeAd: NativeAd?) {
-        if (nativeAd == null) {
-            return
-        }
-
-        this.nativeAd?.destroy()
-
-        this.nativeAd = nativeAd
-        nativeAd.setNativeAdListener(nativeAdListener)
-
-        nativeAd.registerView(nativeAdLayout as View, nativeAdLayout?.btnNativeAction)
-
-        nativeAdLayout?.tvNativeTitle?.text = nativeAd.title
-        nativeAdLayout?.tvNativeBody?.text = nativeAd.text
-        nativeAdLayout?.tvNativeBrand?.text = nativeAd.getNativeAdDataList(NativeAssetData.DataType.SPONSORED).firstOrNull()?.value
-        nativeAdLayout?.btnNativeAction?.text = nativeAd.callToAction
-
-        loadImage(nativeAdLayout!!.ivNativeMain, nativeAd.imageUrl)
-        loadImage(nativeAdLayout!!.ivNativeIcon, nativeAd.iconUrl)
-    }
-}
+// TODO: Uncomment when native module will be merged
+//import android.content.Context
+//import android.util.Log
+//import android.view.View
+//import android.view.ViewGroup
+//import android.widget.FrameLayout
+//import androidx.constraintlayout.widget.ConstraintLayout
+//import kotlinx.android.synthetic.main.events_bids.*
+//import kotlinx.android.synthetic.main.lyt_native_ad.*
+//import kotlinx.android.synthetic.main.lyt_native_ad.view.*
+//import org.prebid.mobile.rendering.bidding.data.FetchDemandResult
+//import org.prebid.mobile.rendering.bidding.data.ntv.NativeAd
+//import org.prebid.mobile.rendering.bidding.display.NativeAdUnit
+//import org.prebid.mobile.rendering.bidding.listeners.NativeAdListener
+//import org.prebid.mobile.rendering.bidding.listeners.OnNativeFetchCompleteListener
+//import org.prebid.mobile.rendering.models.ntv.NativeEventTracker
+//import org.prebid.mobile.rendering.models.openrtb.bidRequests.assets.NativeAssetData
+//import org.prebid.mobile.rendering.utils.ntv.NativeUtils
+//import org.prebid.mobile.renderingtestapp.R
+//import org.prebid.mobile.renderingtestapp.utils.loadImage
+//
+//class NativeFeedAdapter(context: Context, private val nativeAdUnit: NativeAdUnit) : BaseFeedAdapter(context) {
+//    private val TAG = NativeFeedAdapter::class.java.simpleName
+//
+//    var nativeAdLayout: ConstraintLayout? = null
+//    var nativeAd: NativeAd? = null
+//
+//    private val fetchCompleteListener = OnNativeFetchCompleteListener {
+//        if (it.fetchDemandResult != FetchDemandResult.SUCCESS) {
+//            return@OnNativeFetchCompleteListener
+//        }
+//
+//        NativeUtils.findNativeAd(it) { nativeAd ->
+//            inflateViewContent(nativeAd)
+//        }
+//    }
+//
+//    private val nativeAdListener = object : NativeAdListener {
+//
+//        override fun onAdClicked(nativeAd: NativeAd?) {
+//            Log.d(TAG, "onAdClicked() called with: nativeAd = $nativeAd")
+//        }
+//
+//        override fun onAdEvent(nativeAd: NativeAd?, eventType: NativeEventTracker.EventType?) {
+//            Log.d(TAG, "onAdEvent() called with: nativeAd = $nativeAd, eventType = $eventType")
+//        }
+//
+//    }
+//
+//    override fun destroy() {
+//        Log.d(TAG, "Destroying adapter")
+//        nativeAd?.destroy()
+//        nativeAdUnit.destroy()
+//    }
+//
+//    override fun initAndLoadAdView(parent: ViewGroup?, container: FrameLayout): View? {
+//        if (nativeAdLayout == null) {
+//            nativeAdLayout = layoutInflater.inflate(R.layout.lyt_native_ad, parent, false) as ConstraintLayout
+//        }
+//        nativeAdUnit.fetchDemand(fetchCompleteListener)
+//        return nativeAdLayout
+//    }
+//
+//    private fun inflateViewContent(nativeAd: NativeAd?) {
+//        if (nativeAd == null) {
+//            return
+//        }
+//
+//        this.nativeAd?.destroy()
+//
+//        this.nativeAd = nativeAd
+//        nativeAd.setNativeAdListener(nativeAdListener)
+//
+//        nativeAd.registerView(nativeAdLayout as View, nativeAdLayout?.btnNativeAction)
+//
+//        nativeAdLayout?.tvNativeTitle?.text = nativeAd.title
+//        nativeAdLayout?.tvNativeBody?.text = nativeAd.text
+//        nativeAdLayout?.tvNativeBrand?.text = nativeAd.getNativeAdDataList(NativeAssetData.DataType.SPONSORED).firstOrNull()?.value
+//        nativeAdLayout?.btnNativeAction?.text = nativeAd.callToAction
+//
+//        loadImage(nativeAdLayout!!.ivNativeMain, nativeAd.imageUrl)
+//        loadImage(nativeAdLayout!!.ivNativeIcon, nativeAd.iconUrl)
+//    }
+//}

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/utils/adapters/NativeGamFeedAdapter.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/utils/adapters/NativeGamFeedAdapter.kt
@@ -16,107 +16,108 @@
 
 package org.prebid.mobile.renderingtestapp.utils.adapters
 
-import android.content.Context
-import android.util.Log
-import android.view.View
-import android.view.ViewGroup
-import android.widget.FrameLayout
-import androidx.constraintlayout.widget.ConstraintLayout
-import com.google.android.gms.ads.AdLoader
-import com.google.android.gms.ads.admanager.AdManagerAdRequest
-import com.google.android.gms.ads.nativead.NativeCustomFormatAd
-import kotlinx.android.synthetic.main.lyt_native_ad.*
-import kotlinx.android.synthetic.main.lyt_native_ad.view.*
-import kotlinx.android.synthetic.main.lyt_native_gam_events.*
-import org.prebid.mobile.eventhandlers.utils.GamUtils
-import org.prebid.mobile.rendering.bidding.data.FetchDemandResult
-import org.prebid.mobile.rendering.bidding.data.ntv.NativeAd
-import org.prebid.mobile.rendering.bidding.display.NativeAdUnit
-import org.prebid.mobile.rendering.bidding.listeners.NativeAdListener
-import org.prebid.mobile.rendering.bidding.listeners.OnNativeFetchCompleteListener
-import org.prebid.mobile.rendering.models.ntv.NativeEventTracker
-import org.prebid.mobile.rendering.models.openrtb.bidRequests.assets.NativeAssetData
-import org.prebid.mobile.renderingtestapp.R
-import org.prebid.mobile.renderingtestapp.utils.loadImage
-
-class NativeGamFeedAdapter(context: Context,
-                           private val nativeAdUnit: NativeAdUnit,
-                           private val gamAdLoader: AdLoader) : BaseFeedAdapter(context) {
-    private val TAG = NativeFeedAdapter::class.java.simpleName
-
-    private var nativeAdLayout: ConstraintLayout? = null
-    private var nativeAd: NativeAd? = null
-
-    private val fetchCompleteListener = OnNativeFetchCompleteListener {
-        val builder = AdManagerAdRequest.Builder()
-        val publisherAdRequest = builder.build()
-
-        nativeAdUnit.fetchDemand { result ->
-            val fetchDemandResult = result.fetchDemandResult
-
-            if (fetchDemandResult != FetchDemandResult.SUCCESS) {
-                gamAdLoader.loadAd(publisherAdRequest)
-                return@fetchDemand
-            }
-
-            GamUtils.prepare(publisherAdRequest, result)
-            gamAdLoader.loadAd(publisherAdRequest)
-        }
-    }
-
-    private val nativeAdListener = object : NativeAdListener {
-        override fun onAdClicked(nativeAd: NativeAd?) {
-            Log.d(TAG, "onAdClicked() called with: nativeAd = $nativeAd")
-        }
-
-        override fun onAdEvent(nativeAd: NativeAd?, eventType: NativeEventTracker.EventType?) {
-            Log.d(TAG, "onAdEvent() called with: nativeAd = $nativeAd, eventType = $eventType")
-        }
-    }
-
-    override fun destroy() {
-        nativeAdUnit.destroy()
-    }
-
-    override fun initAndLoadAdView(parent: ViewGroup?, container: FrameLayout): View? {
-        if (nativeAdLayout == null) {
-            nativeAdLayout = layoutInflater.inflate(R.layout.lyt_native_ad, parent, false) as ConstraintLayout
-        }
-        nativeAdUnit.fetchDemand(fetchCompleteListener)
-        return nativeAdLayout
-    }
-
-    fun handleCustomFormatAd(customFormatAd: NativeCustomFormatAd?) {
-        customFormatAd ?: return
-
-        if (GamUtils.didPrebidWin(customFormatAd)) {
-            GamUtils.findNativeAd(customFormatAd) {
-                inflateViewContent(it)
-            }
-        }
-        else {
-            Log.d(TAG, "handleCustomFormatAd: prebid lost")
-        }
-    }
-
-    private fun inflateViewContent(nativeAd: NativeAd?) {
-        if (nativeAd == null) {
-            return
-        }
-
-        this.nativeAd?.destroy()
-
-        this.nativeAd = nativeAd
-        nativeAd.setNativeAdListener(nativeAdListener)
-
-        nativeAd.registerView(nativeAdLayout as View, nativeAdLayout?.btnNativeAction)
-
-        nativeAdLayout?.tvNativeTitle?.text = nativeAd.title
-        nativeAdLayout?.tvNativeBody?.text = nativeAd.text
-        nativeAdLayout?.tvNativeBrand?.text = nativeAd.getNativeAdDataList(NativeAssetData.DataType.SPONSORED).firstOrNull()?.value
-        nativeAdLayout?.btnNativeAction?.text = nativeAd.callToAction
-
-        loadImage(nativeAdLayout!!.ivNativeMain, nativeAd.imageUrl)
-        loadImage(nativeAdLayout!!.ivNativeIcon, nativeAd.iconUrl)
-    }
-}
+// TODO: Uncomment when native module will be merged
+//import android.content.Context
+//import android.util.Log
+//import android.view.View
+//import android.view.ViewGroup
+//import android.widget.FrameLayout
+//import androidx.constraintlayout.widget.ConstraintLayout
+//import com.google.android.gms.ads.AdLoader
+//import com.google.android.gms.ads.admanager.AdManagerAdRequest
+//import com.google.android.gms.ads.nativead.NativeCustomFormatAd
+//import kotlinx.android.synthetic.main.lyt_native_ad.*
+//import kotlinx.android.synthetic.main.lyt_native_ad.view.*
+//import kotlinx.android.synthetic.main.lyt_native_gam_events.*
+//import org.prebid.mobile.eventhandlers.utils.GamUtils
+//import org.prebid.mobile.rendering.bidding.data.FetchDemandResult
+//import org.prebid.mobile.rendering.bidding.data.ntv.NativeAd
+//import org.prebid.mobile.rendering.bidding.display.NativeAdUnit
+//import org.prebid.mobile.rendering.bidding.listeners.NativeAdListener
+//import org.prebid.mobile.rendering.bidding.listeners.OnNativeFetchCompleteListener
+//import org.prebid.mobile.rendering.models.ntv.NativeEventTracker
+//import org.prebid.mobile.rendering.models.openrtb.bidRequests.assets.NativeAssetData
+//import org.prebid.mobile.renderingtestapp.R
+//import org.prebid.mobile.renderingtestapp.utils.loadImage
+//
+//class NativeGamFeedAdapter(context: Context,
+//                           private val nativeAdUnit: NativeAdUnit,
+//                           private val gamAdLoader: AdLoader) : BaseFeedAdapter(context) {
+//    private val TAG = NativeFeedAdapter::class.java.simpleName
+//
+//    private var nativeAdLayout: ConstraintLayout? = null
+//    private var nativeAd: NativeAd? = null
+//
+//    private val fetchCompleteListener = OnNativeFetchCompleteListener {
+//        val builder = AdManagerAdRequest.Builder()
+//        val publisherAdRequest = builder.build()
+//
+//        nativeAdUnit.fetchDemand { result ->
+//            val fetchDemandResult = result.fetchDemandResult
+//
+//            if (fetchDemandResult != FetchDemandResult.SUCCESS) {
+//                gamAdLoader.loadAd(publisherAdRequest)
+//                return@fetchDemand
+//            }
+//
+//            GamUtils.prepare(publisherAdRequest, result)
+//            gamAdLoader.loadAd(publisherAdRequest)
+//        }
+//    }
+//
+//    private val nativeAdListener = object : NativeAdListener {
+//        override fun onAdClicked(nativeAd: NativeAd?) {
+//            Log.d(TAG, "onAdClicked() called with: nativeAd = $nativeAd")
+//        }
+//
+//        override fun onAdEvent(nativeAd: NativeAd?, eventType: NativeEventTracker.EventType?) {
+//            Log.d(TAG, "onAdEvent() called with: nativeAd = $nativeAd, eventType = $eventType")
+//        }
+//    }
+//
+//    override fun destroy() {
+//        nativeAdUnit.destroy()
+//    }
+//
+//    override fun initAndLoadAdView(parent: ViewGroup?, container: FrameLayout): View? {
+//        if (nativeAdLayout == null) {
+//            nativeAdLayout = layoutInflater.inflate(R.layout.lyt_native_ad, parent, false) as ConstraintLayout
+//        }
+//        nativeAdUnit.fetchDemand(fetchCompleteListener)
+//        return nativeAdLayout
+//    }
+//
+//    fun handleCustomFormatAd(customFormatAd: NativeCustomFormatAd?) {
+//        customFormatAd ?: return
+//
+//        if (GamUtils.didPrebidWin(customFormatAd)) {
+//            GamUtils.findNativeAd(customFormatAd) {
+//                inflateViewContent(it)
+//            }
+//        }
+//        else {
+//            Log.d(TAG, "handleCustomFormatAd: prebid lost")
+//        }
+//    }
+//
+//    private fun inflateViewContent(nativeAd: NativeAd?) {
+//        if (nativeAd == null) {
+//            return
+//        }
+//
+//        this.nativeAd?.destroy()
+//
+//        this.nativeAd = nativeAd
+//        nativeAd.setNativeAdListener(nativeAdListener)
+//
+//        nativeAd.registerView(nativeAdLayout as View, nativeAdLayout?.btnNativeAction)
+//
+//        nativeAdLayout?.tvNativeTitle?.text = nativeAd.title
+//        nativeAdLayout?.tvNativeBody?.text = nativeAd.text
+//        nativeAdLayout?.tvNativeBrand?.text = nativeAd.getNativeAdDataList(NativeAssetData.DataType.SPONSORED).firstOrNull()?.value
+//        nativeAdLayout?.btnNativeAction?.text = nativeAd.callToAction
+//
+//        loadImage(nativeAdLayout!!.ivNativeMain, nativeAd.imageUrl)
+//        loadImage(nativeAdLayout!!.ivNativeIcon, nativeAd.iconUrl)
+//    }
+//}

--- a/Example/PrebidInternalTestApp/src/main/res/navigation/bidding_navigation.xml
+++ b/Example/PrebidInternalTestApp/src/main/res/navigation/bidding_navigation.xml
@@ -134,41 +134,42 @@
             app:popExitAnim="@anim/nav_default_pop_exit_anim"
             app:popUpTo="@+id/headerBiddingFragment" />
 
-        <action
-            android:id="@+id/action_header_bidding_to_in_app_native_links"
-            app:destination="@id/navigation_in_app_native_links"
-            app:enterAnim="@anim/nav_default_enter_anim"
-            app:exitAnim="@anim/nav_default_exit_anim"
-            app:popEnterAnim="@anim/nav_default_pop_enter_anim"
-            app:popExitAnim="@anim/nav_default_pop_exit_anim"
-            app:popUpTo="@+id/headerBiddingFragment" />
+<!--        TODO: Uncomment when native module will be merged-->
+<!--        <action-->
+<!--            android:id="@+id/action_header_bidding_to_in_app_native_links"-->
+<!--            app:destination="@id/navigation_in_app_native_links"-->
+<!--            app:enterAnim="@anim/nav_default_enter_anim"-->
+<!--            app:exitAnim="@anim/nav_default_exit_anim"-->
+<!--            app:popEnterAnim="@anim/nav_default_pop_enter_anim"-->
+<!--            app:popExitAnim="@anim/nav_default_pop_exit_anim"-->
+<!--            app:popUpTo="@+id/headerBiddingFragment" />-->
 
-        <action
-            android:id="@+id/action_header_bidding_to_in_app_native_video"
-            app:destination="@id/navigation_in_app_native_video"
-            app:enterAnim="@anim/nav_default_enter_anim"
-            app:exitAnim="@anim/nav_default_exit_anim"
-            app:popEnterAnim="@anim/nav_default_pop_enter_anim"
-            app:popExitAnim="@anim/nav_default_pop_exit_anim"
-            app:popUpTo="@+id/headerBiddingFragment" />
+<!--        <action-->
+<!--            android:id="@+id/action_header_bidding_to_in_app_native_video"-->
+<!--            app:destination="@id/navigation_in_app_native_video"-->
+<!--            app:enterAnim="@anim/nav_default_enter_anim"-->
+<!--            app:exitAnim="@anim/nav_default_exit_anim"-->
+<!--            app:popEnterAnim="@anim/nav_default_pop_enter_anim"-->
+<!--            app:popExitAnim="@anim/nav_default_pop_exit_anim"-->
+<!--            app:popUpTo="@+id/headerBiddingFragment" />-->
 
-        <action
-            android:id="@+id/action_header_bidding_to_in_app_native"
-            app:destination="@id/navigation_in_app_native"
-            app:enterAnim="@anim/nav_default_enter_anim"
-            app:exitAnim="@anim/nav_default_exit_anim"
-            app:popEnterAnim="@anim/nav_default_pop_enter_anim"
-            app:popExitAnim="@anim/nav_default_pop_exit_anim"
-            app:popUpTo="@+id/headerBiddingFragment" />
+<!--        <action-->
+<!--            android:id="@+id/action_header_bidding_to_in_app_native"-->
+<!--            app:destination="@id/navigation_in_app_native"-->
+<!--            app:enterAnim="@anim/nav_default_enter_anim"-->
+<!--            app:exitAnim="@anim/nav_default_exit_anim"-->
+<!--            app:popEnterAnim="@anim/nav_default_pop_enter_anim"-->
+<!--            app:popExitAnim="@anim/nav_default_pop_exit_anim"-->
+<!--            app:popUpTo="@+id/headerBiddingFragment" />-->
 
-        <action
-            android:id="@+id/action_header_bidding_to_in_app_native_feed"
-            app:destination="@id/navigation_in_app_native_feed"
-            app:enterAnim="@anim/nav_default_enter_anim"
-            app:exitAnim="@anim/nav_default_exit_anim"
-            app:popEnterAnim="@anim/nav_default_pop_enter_anim"
-            app:popExitAnim="@anim/nav_default_pop_exit_anim"
-            app:popUpTo="@+id/headerBiddingFragment" />
+<!--        <action-->
+<!--            android:id="@+id/action_header_bidding_to_in_app_native_feed"-->
+<!--            app:destination="@id/navigation_in_app_native_feed"-->
+<!--            app:enterAnim="@anim/nav_default_enter_anim"-->
+<!--            app:exitAnim="@anim/nav_default_exit_anim"-->
+<!--            app:popEnterAnim="@anim/nav_default_pop_enter_anim"-->
+<!--            app:popExitAnim="@anim/nav_default_pop_exit_anim"-->
+<!--            app:popUpTo="@+id/headerBiddingFragment" />-->
 
         <!--GAM actions-->
         <action
@@ -261,23 +262,24 @@
             app:popExitAnim="@anim/nav_default_pop_exit_anim"
             app:popUpTo="@+id/headerBiddingFragment" />
 
-        <action
-            android:id="@+id/action_header_bidding_to_gam_native"
-            app:destination="@id/navigation_gam_native"
-            app:enterAnim="@anim/nav_default_enter_anim"
-            app:exitAnim="@anim/nav_default_exit_anim"
-            app:popEnterAnim="@anim/nav_default_pop_enter_anim"
-            app:popExitAnim="@anim/nav_default_pop_exit_anim"
-            app:popUpTo="@+id/headerBiddingFragment" />
+<!--        TODO: Uncomment when native module will be merged-->
+<!--        <action-->
+<!--            android:id="@+id/action_header_bidding_to_gam_native"-->
+<!--            app:destination="@id/navigation_gam_native"-->
+<!--            app:enterAnim="@anim/nav_default_enter_anim"-->
+<!--            app:exitAnim="@anim/nav_default_exit_anim"-->
+<!--            app:popEnterAnim="@anim/nav_default_pop_enter_anim"-->
+<!--            app:popExitAnim="@anim/nav_default_pop_exit_anim"-->
+<!--            app:popUpTo="@+id/headerBiddingFragment" />-->
 
-        <action
-            android:id="@+id/action_header_bidding_to_gam_native_feed"
-            app:destination="@id/navigation_gam_native_feed"
-            app:enterAnim="@anim/nav_default_enter_anim"
-            app:exitAnim="@anim/nav_default_exit_anim"
-            app:popEnterAnim="@anim/nav_default_pop_enter_anim"
-            app:popExitAnim="@anim/nav_default_pop_exit_anim"
-            app:popUpTo="@+id/headerBiddingFragment" />
+<!--        <action-->
+<!--            android:id="@+id/action_header_bidding_to_gam_native_feed"-->
+<!--            app:destination="@id/navigation_gam_native_feed"-->
+<!--            app:enterAnim="@anim/nav_default_enter_anim"-->
+<!--            app:exitAnim="@anim/nav_default_exit_anim"-->
+<!--            app:popEnterAnim="@anim/nav_default_pop_enter_anim"-->
+<!--            app:popExitAnim="@anim/nav_default_pop_exit_anim"-->
+<!--            app:popUpTo="@+id/headerBiddingFragment" />-->
 
         <!--MoPub actions-->
         <action
@@ -425,21 +427,23 @@
         android:id="@+id/navigation_in_app_native_styles_no_assets"
         android:name="org.prebid.mobile.renderingtestapp.plugplay.bidding.ppm.PpmNativeStylesNoAssetsFragment" />
 
-    <fragment
-        android:id="@+id/navigation_in_app_native"
-        android:name="org.prebid.mobile.renderingtestapp.plugplay.bidding.ppm.PpmNativeFragment" />
 
-    <fragment
-        android:id="@+id/navigation_in_app_native_links"
-        android:name="org.prebid.mobile.renderingtestapp.plugplay.bidding.ppm.PpmNativeLinksFragment" />
+<!--    TODO: Uncomment when native module will be merged-->
+<!--    <fragment-->
+<!--        android:id="@+id/navigation_in_app_native"-->
+<!--        android:name="org.prebid.mobile.renderingtestapp.plugplay.bidding.ppm.PpmNativeFragment" />-->
 
-    <fragment
-        android:id="@+id/navigation_in_app_native_video"
-        android:name="org.prebid.mobile.renderingtestapp.plugplay.bidding.ppm.PpmNativeVideoFragment" />
+<!--    <fragment-->
+<!--        android:id="@+id/navigation_in_app_native_links"-->
+<!--        android:name="org.prebid.mobile.renderingtestapp.plugplay.bidding.ppm.PpmNativeLinksFragment" />-->
 
-    <fragment
-        android:id="@+id/navigation_in_app_native_feed"
-        android:name="org.prebid.mobile.renderingtestapp.plugplay.bidding.ppm.PpmNativeFeedFragment" />
+<!--    <fragment-->
+<!--        android:id="@+id/navigation_in_app_native_video"-->
+<!--        android:name="org.prebid.mobile.renderingtestapp.plugplay.bidding.ppm.PpmNativeVideoFragment" />-->
+
+<!--    <fragment-->
+<!--        android:id="@+id/navigation_in_app_native_feed"-->
+<!--        android:name="org.prebid.mobile.renderingtestapp.plugplay.bidding.ppm.PpmNativeFeedFragment" />-->
 
     <!--GAM fragments-->
     <fragment
@@ -484,13 +488,14 @@
         android:id="@+id/navigation_gam_native_styles_no_assets"
         android:name="org.prebid.mobile.renderingtestapp.plugplay.bidding.gam.GamNativeStylesNoAssetsFragment" />
 
-    <fragment
-        android:id="@+id/navigation_gam_native"
-        android:name="org.prebid.mobile.renderingtestapp.plugplay.bidding.gam.GamNativeFragment" />
+<!--    TODO: Uncomment when native module will be merged-->
+<!--    <fragment-->
+<!--        android:id="@+id/navigation_gam_native"-->
+<!--        android:name="org.prebid.mobile.renderingtestapp.plugplay.bidding.gam.GamNativeFragment" />-->
 
-    <fragment
-        android:id="@+id/navigation_gam_native_feed"
-        android:name="org.prebid.mobile.renderingtestapp.plugplay.bidding.gam.GamNativeFeedFragment" />
+<!--    <fragment-->
+<!--        android:id="@+id/navigation_gam_native_feed"-->
+<!--        android:name="org.prebid.mobile.renderingtestapp.plugplay.bidding.gam.GamNativeFeedFragment" />-->
 
     <!--MoPub fragments-->
     <fragment

--- a/PrebidMobile/PrebidMobile-rendering/src/main/java/org/prebid/mobile/rendering/bidding/display/NativeAdUnit.java
+++ b/PrebidMobile/PrebidMobile-rendering/src/main/java/org/prebid/mobile/rendering/bidding/display/NativeAdUnit.java
@@ -35,7 +35,7 @@ import java.util.ArrayList;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
-public class NativeAdUnit extends BaseAdUnit {
+class NativeAdUnit extends BaseAdUnit {
     private static final String TAG = NativeAdUnit.class.getSimpleName();
 
     private OnNativeFetchCompleteListener mNativeFetchCompleteListener;

--- a/PrebidMobile/PrebidMobile-rendering/src/main/java/org/prebid/mobile/rendering/models/AdConfiguration.java
+++ b/PrebidMobile/PrebidMobile-rendering/src/main/java/org/prebid/mobile/rendering/models/AdConfiguration.java
@@ -95,10 +95,14 @@ public class AdConfiguration {
         return mAutoRefreshDelayInMillis;
     }
 
+    // TODO: Merge Native engine from original SDK and rendering codebase
+    @Deprecated
     public NativeAdConfiguration getNativeAdConfiguration() {
         return mNativeAdConfiguration;
     }
 
+    // TODO: Merge Native engine from original SDK and rendering codebase
+    @Deprecated
     public void setNativeAdConfiguration(NativeAdConfiguration nativeAdConfiguration) {
         mNativeAdConfiguration = nativeAdConfiguration;
     }


### PR DESCRIPTION
NativeAdUnit from rendering is unavailable for publishers now. Disabled native test cases in InternalTestsApp. Checked and recompiled all modules and apps in the project. #280