### PR TITLE
AdMob fixes 

### DIFF
--- a/Example/PrebidDemoKotlin/src/main/java/org/prebid/mobile/prebidkotlindemo/AdTypesRepository.kt
+++ b/Example/PrebidDemoKotlin/src/main/java/org/prebid/mobile/prebidkotlindemo/AdTypesRepository.kt
@@ -279,12 +279,23 @@ object AdTypesRepository {
                 onDestroy = { InAppAdMobBanner.destroy() }
             ),
             AdType(
-                "Interstitial",
+                "Display Interstitial",
                 onCreate = { activity, _, _ ->
                     InAppAdMobInterstitial.create(
                         activity,
                         "ca-app-pub-1875909575462531/6393291067",
                         "5a4b8dcf-f984-4b04-9448-6529908d6cb6"
+                    )
+                },
+                onDestroy = { InAppAdMobInterstitial.destroy() }
+            ),
+            AdType(
+                "Video Interstitial",
+                onCreate = { activity, _, _ ->
+                    InAppAdMobInterstitial.create(
+                        activity,
+                        "ca-app-pub-1875909575462531/6393291067",
+                        "12f58bc2-b664-4672-8d19-638bcc96fd5c"
                     )
                 },
                 onDestroy = { InAppAdMobInterstitial.destroy() }

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/admob/AdMobInterstitialFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/admob/AdMobInterstitialFragment.kt
@@ -110,7 +110,7 @@ open class AdMobInterstitialFragment : AdFragment() {
         }
     }
 
-    private fun createFullScreenContentCallback(): FullScreenContentCallback {
+    protected fun createFullScreenContentCallback(): FullScreenContentCallback {
         return object : FullScreenContentCallback() {
             override fun onAdClicked() {
                 btnAdClicked?.isEnabled = true

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/admob/AdMobInterstitialFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/admob/AdMobInterstitialFragment.kt
@@ -3,7 +3,9 @@ package org.prebid.mobile.renderingtestapp.plugplay.bidding.admob
 import android.os.Bundle
 import android.util.Log
 import android.view.View
+import com.google.android.gms.ads.AdError
 import com.google.android.gms.ads.AdRequest
+import com.google.android.gms.ads.FullScreenContentCallback
 import com.google.android.gms.ads.LoadAdError
 import com.google.android.gms.ads.interstitial.InterstitialAd
 import com.google.android.gms.ads.interstitial.InterstitialAdLoadCallback
@@ -45,7 +47,7 @@ open class AdMobInterstitialFragment : AdFragment() {
         return adUnit
     }
 
-    open override fun loadAd() {
+    override fun loadAd() {
         val request = AdRequest
             .Builder()
             .addCustomEventExtrasBundle(PrebidInterstitialAdapter::class.java, extras!!)
@@ -61,6 +63,7 @@ open class AdMobInterstitialFragment : AdFragment() {
                     btnLoad?.text = getString(R.string.text_show)
 
                     interstitialAd = ad
+                    interstitialAd?.fullScreenContentCallback = createFullScreenContentCallback()
                 }
 
                 override fun onAdFailedToLoad(adError: LoadAdError) {
@@ -86,7 +89,12 @@ open class AdMobInterstitialFragment : AdFragment() {
 
     private fun resetAdEvents() {
         btnAdLoaded?.isEnabled = false
+        btnAdShowed?.isEnabled = false
+        btnAdImpression?.isEnabled = false
+        btnAdDismissed?.isEnabled = false
+        btnAdFailedFullScreen?.isEnabled = false
         btnAdFailed?.isEnabled = false
+        btnAdClicked?.isEnabled = false
     }
 
     private fun handleLoadButtonClick() {
@@ -99,6 +107,30 @@ open class AdMobInterstitialFragment : AdFragment() {
             btnLoad?.isEnabled = false
             btnLoad?.text = "Loading..."
             loadAd()
+        }
+    }
+
+    private fun createFullScreenContentCallback(): FullScreenContentCallback {
+        return object : FullScreenContentCallback() {
+            override fun onAdClicked() {
+                btnAdClicked?.isEnabled = true
+            }
+
+            override fun onAdImpression() {
+                btnAdImpression?.isEnabled = true
+            }
+
+            override fun onAdShowedFullScreenContent() {
+                btnAdShowed?.isEnabled = true
+            }
+
+            override fun onAdDismissedFullScreenContent() {
+                btnAdDismissed?.isEnabled = true
+            }
+
+            override fun onAdFailedToShowFullScreenContent(p0: AdError) {
+                btnAdFailedFullScreen?.isEnabled = true
+            }
         }
     }
 

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/admob/AdMobInterstitialRandomFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/admob/AdMobInterstitialRandomFragment.kt
@@ -38,6 +38,7 @@ class AdMobInterstitialRandomFragment : AdMobInterstitialFragment() {
                     btnLoad?.text = getString(R.string.text_show)
 
                     interstitialAd = ad
+                    interstitialAd?.fullScreenContentCallback = createFullScreenContentCallback()
                 }
 
                 override fun onAdFailedToLoad(adError: LoadAdError) {

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/admob/AdMobRewardedFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/admob/AdMobRewardedFragment.kt
@@ -3,7 +3,9 @@ package org.prebid.mobile.renderingtestapp.plugplay.bidding.admob
 import android.os.Bundle
 import android.util.Log
 import android.view.View
+import com.google.android.gms.ads.AdError
 import com.google.android.gms.ads.AdRequest
+import com.google.android.gms.ads.FullScreenContentCallback
 import com.google.android.gms.ads.LoadAdError
 import com.google.android.gms.ads.rewarded.RewardedAd
 import com.google.android.gms.ads.rewarded.RewardedAdLoadCallback
@@ -44,7 +46,7 @@ open class AdMobRewardedFragment : AdFragment() {
         return adUnit
     }
 
-    open override fun loadAd() {
+    override fun loadAd() {
         val request = AdRequest
             .Builder()
             .addNetworkExtrasBundle(PrebidRewardedAdapter::class.java, extras!!)
@@ -60,6 +62,7 @@ open class AdMobRewardedFragment : AdFragment() {
                     btnLoad?.text = getString(R.string.text_show)
 
                     rewardedAd = ad
+                    rewardedAd?.fullScreenContentCallback = createFullScreenContentCallback()
                 }
 
                 override fun onAdFailedToLoad(adError: LoadAdError) {
@@ -85,7 +88,12 @@ open class AdMobRewardedFragment : AdFragment() {
 
     private fun resetAdEvents() {
         btnAdLoaded?.isEnabled = false
+        btnAdShowed?.isEnabled = false
+        btnAdImpression?.isEnabled = false
+        btnAdDismissed?.isEnabled = false
+        btnAdFailedFullScreen?.isEnabled = false
         btnAdFailed?.isEnabled = false
+        btnAdClicked?.isEnabled = false
     }
 
     private fun handleLoadButtonClick() {
@@ -102,6 +110,30 @@ open class AdMobRewardedFragment : AdFragment() {
             btnLoad?.isEnabled = false
             btnLoad?.text = "Loading..."
             loadAd()
+        }
+    }
+
+    protected fun createFullScreenContentCallback(): FullScreenContentCallback {
+        return object : FullScreenContentCallback() {
+            override fun onAdClicked() {
+                btnAdClicked?.isEnabled = true
+            }
+
+            override fun onAdImpression() {
+                btnAdImpression?.isEnabled = true
+            }
+
+            override fun onAdShowedFullScreenContent() {
+                btnAdShowed?.isEnabled = true
+            }
+
+            override fun onAdDismissedFullScreenContent() {
+                btnAdDismissed?.isEnabled = true
+            }
+
+            override fun onAdFailedToShowFullScreenContent(p0: AdError) {
+                btnAdFailedFullScreen?.isEnabled = true
+            }
         }
     }
 

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/admob/AdMobRewardedRandomFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/admob/AdMobRewardedRandomFragment.kt
@@ -38,6 +38,7 @@ class AdMobRewardedRandomFragment : AdMobRewardedFragment() {
                     btnLoad?.text = getString(R.string.text_show)
 
                     rewardedAd = ad
+                    rewardedAd?.fullScreenContentCallback = createFullScreenContentCallback()
                 }
 
                 override fun onAdFailedToLoad(adError: LoadAdError) {

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/admob/FlexibleAdMobBannerFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/admob/FlexibleAdMobBannerFragment.kt
@@ -44,6 +44,7 @@ class FlexibleAdMobBannerFragment : AdMobBannerFragment() {
             AdSize(width, height),
             mediationUtils
         )
+        adUnit?.addAdditionalSizes(AdSize(728, 90))
         adUnit?.setRefreshInterval(refreshDelay)
         return adUnit
     }

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/utilities/version/VersionInfoFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/utilities/version/VersionInfoFragment.kt
@@ -33,5 +33,6 @@ class VersionInfoFragment : BaseFragment() {
         tvPrebidRenderingVersion.text = PrebidRenderingSettings.SDK_VERSION
         tvMopubVersion.text = MoPub.SDK_VERSION
         tvGamVersion.text = MobileAds.getVersionString()
+        tvOmsdkVersion.text = PrebidRenderingSettings.OMSDK_VERSION
     }
 }

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/utils/DemoItemProvider.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/utils/DemoItemProvider.kt
@@ -1684,7 +1684,7 @@ class DemoItemProvider private constructor() {
                     adMobInterstitialAction,
                     adMobInterstitialTagList,
                     createBannerBundle(
-                        R.string.prebid_config_id_interstitial_320_480,
+                        R.string.prebid_config_id_video_rewarded_320_480,
                         R.string.admob_interstitial_bidding_ad_unit_id_adapter,
                         320, 50
                     )

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/utils/DemoItemProvider.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/utils/DemoItemProvider.kt
@@ -1151,6 +1151,43 @@ class DemoItemProvider private constructor() {
                     )
                 )
             )
+
+            demoList.add(
+                DemoItem(
+                    getString(R.string.demo_bidding_admob_interstitial_display_adapter),
+                    adMobInterstitialAction,
+                    adMobInterstitialTagList,
+                    createBannerBundle(
+                        R.string.mock_config_id_interstitial_320_480,
+                        R.string.admob_interstitial_bidding_ad_unit_id_adapter,
+                        320, 480
+                    )
+                )
+            )
+            demoList.add(
+                DemoItem(
+                    getString(R.string.demo_bidding_admob_interstitial_display_admob),
+                    adMobInterstitialAction,
+                    adMobInterstitialTagList,
+                    createBannerBundle(
+                        R.string.prebid_config_id_no_bids,
+                        R.string.admob_interstitial_bidding_ad_unit_id_adapter,
+                        320, 480
+                    )
+                )
+            )
+            demoList.add(
+                DemoItem(
+                    getString(R.string.demo_bidding_admob_interstitial_display_random),
+                    adMobInterstitialRandomAction,
+                    adMobInterstitialTagList,
+                    createBannerBundle(
+                        R.string.mock_config_id_interstitial_320_480,
+                        R.string.admob_interstitial_bidding_ad_unit_id_adapter,
+                        320, 480
+                    )
+                )
+            )
         }
 
         private fun formProdDemoList() {
@@ -1686,6 +1723,43 @@ class DemoItemProvider private constructor() {
                     createBannerBundle(
                         R.string.prebid_config_id_no_bids,
                         R.string.admob_rewarded_bidding_ad_unit_id_adapter,
+                        320, 480
+                    )
+                )
+            )
+
+            demoList.add(
+                DemoItem(
+                    getString(R.string.demo_bidding_admob_interstitial_display_adapter),
+                    adMobInterstitialAction,
+                    adMobInterstitialTagList,
+                    createBannerBundle(
+                        R.string.prebid_config_id_interstitial_320_480,
+                        R.string.admob_interstitial_bidding_ad_unit_id_adapter,
+                        320, 480
+                    )
+                )
+            )
+            demoList.add(
+                DemoItem(
+                    getString(R.string.demo_bidding_admob_interstitial_display_admob),
+                    adMobInterstitialAction,
+                    adMobInterstitialTagList,
+                    createBannerBundle(
+                        R.string.prebid_config_id_no_bids,
+                        R.string.admob_interstitial_bidding_ad_unit_id_adapter,
+                        320, 480
+                    )
+                )
+            )
+            demoList.add(
+                DemoItem(
+                    getString(R.string.demo_bidding_admob_interstitial_display_random),
+                    adMobInterstitialRandomAction,
+                    adMobInterstitialTagList,
+                    createBannerBundle(
+                        R.string.prebid_config_id_interstitial_320_480,
+                        R.string.admob_interstitial_bidding_ad_unit_id_adapter,
                         320, 480
                     )
                 )

--- a/Example/PrebidInternalTestApp/src/main/res/layout/events_admob_rewarded.xml
+++ b/Example/PrebidInternalTestApp/src/main/res/layout/events_admob_rewarded.xml
@@ -28,6 +28,41 @@
             android:text="@string/event_admob_loaded"/>
 
     <org.prebid.mobile.renderingtestapp.widgets.EventCounterView
+            android:id="@+id/btnAdClicked"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/event_top_margin"
+            android:text="@string/event_admob_clicked"/>
+
+    <org.prebid.mobile.renderingtestapp.widgets.EventCounterView
+            android:id="@+id/btnAdShowed"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/event_top_margin"
+            android:text="@string/event_admob_impression"/>
+
+    <org.prebid.mobile.renderingtestapp.widgets.EventCounterView
+            android:id="@+id/btnAdImpression"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/event_top_margin"
+            android:text="@string/event_admob_interstitial_showed_full_screen"/>
+
+    <org.prebid.mobile.renderingtestapp.widgets.EventCounterView
+            android:id="@+id/btnAdDismissed"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/event_top_margin"
+            android:text="@string/event_admob_interstitial_dismissed_full_screen"/>
+
+    <org.prebid.mobile.renderingtestapp.widgets.EventCounterView
+            android:id="@+id/btnAdFailedFullScreen"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"
+            android:layout_marginTop="@dimen/event_top_margin"
+            android:text="@string/event_admob_interstitial_failed_full_screen"/>
+
+    <org.prebid.mobile.renderingtestapp.widgets.EventCounterView
             android:id="@+id/btnAdFailed"
             android:layout_width="wrap_content"
             android:layout_height="wrap_content"

--- a/Example/PrebidInternalTestApp/src/main/res/layout/fragments_version_info.xml
+++ b/Example/PrebidInternalTestApp/src/main/res/layout/fragments_version_info.xml
@@ -80,7 +80,8 @@
 
         <TableRow
             android:layout_width="match_parent"
-            android:layout_height="match_parent">
+            android:layout_height="match_parent"
+            android:layout_marginBottom="8dp">
 
             <TextView
                 android:id="@+id/labelGam"
@@ -97,6 +98,27 @@
                 android:textColor="@android:color/black"
                 android:textSize="18sp"
                 tools:text="1.0.0" />
+        </TableRow>
+
+        <TableRow
+                android:layout_width="match_parent"
+                android:layout_height="match_parent">
+
+            <TextView
+                    android:id="@+id/labelOmsdk"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:text="@string/version_tag_omsdk"
+                    android:textColor="@android:color/black"
+                    android:textSize="18sp"/>
+
+            <TextView
+                    android:id="@+id/tvOmsdkVersion"
+                    android:layout_width="wrap_content"
+                    android:layout_height="wrap_content"
+                    android:textColor="@android:color/black"
+                    android:textSize="18sp"
+                    tools:text="1.0.0"/>
         </TableRow>
 
     </TableLayout>

--- a/Example/PrebidInternalTestApp/src/main/res/values/strings.xml
+++ b/Example/PrebidInternalTestApp/src/main/res/values/strings.xml
@@ -54,6 +54,9 @@
     <string name="event_admob_impression">onAdImpression</string>
     <string name="event_admob_closed">onAdClosed</string>
     <string name="event_admob_failed">onAdFailed</string>
+    <string name="event_admob_interstitial_showed_full_screen">onAdShowedFullScreenContent</string>
+    <string name="event_admob_interstitial_failed_full_screen">onAdFailedToShowFullScreenContent</string>
+    <string name="event_admob_interstitial_dismissed_full_screen">onAdDismissedFullScreenContent</string>
 
     <!-- TCF V1 -->
     <string name="key_subject_to_gdpr">IABConsent_SubjectToGDPR</string>

--- a/Example/PrebidInternalTestApp/src/main/res/values/strings.xml
+++ b/Example/PrebidInternalTestApp/src/main/res/values/strings.xml
@@ -206,6 +206,9 @@
     <string name="demo_bidding_admob_interstitial_adapter">Interstitial (AdMob) [OK, Adapter]</string>
     <string name="demo_bidding_admob_interstitial_admob">Interstitial (AdMob) [noBids, AdMob ad]</string>
     <string name="demo_bidding_admob_interstitial_random">Interstitial (AdMob) [OK, Random]</string>
+    <string name="demo_bidding_admob_interstitial_display_adapter">Display Interstitial 320x480 (AdMob) [OK, Adapter]</string>
+    <string name="demo_bidding_admob_interstitial_display_admob">Display Interstitial 320x480 (AdMob) [noBids, AdMob Ad]</string>
+    <string name="demo_bidding_admob_interstitial_display_random">Display Interstitial 320x480 (AdMob) [OK, Random]</string>
 
     <string name="demo_bidding_admob_rewarded_adapter">Rewarded (AdMob) [OK, Adapter]</string>
     <string name="demo_bidding_admob_rewarded_adapter_no_end_card">Rewarded no EndCard (AdMob) [OK, Adapter]</string>

--- a/Example/PrebidInternalTestApp/src/main/res/values/strings.xml
+++ b/Example/PrebidInternalTestApp/src/main/res/values/strings.xml
@@ -344,6 +344,7 @@
     <string name="version_tag_prebid_rendering">Prebid Rendering:</string>
     <string name="version_tag_mopub">MoPub:</string>
     <string name="version_tag_gam">GAM:</string>
+    <string name="version_tag_omsdk">OMSDK:</string>
 
     <string name="event_counter">%1$d ( %2$s )</string>
     <string name="event_counter_default">0 ( 0 )</string>

--- a/PrebidMobile/PrebidMobile-rendering/build.gradle
+++ b/PrebidMobile/PrebidMobile-rendering/build.gradle
@@ -30,6 +30,7 @@ android {
     defaultConfig {
         buildConfigField "String", "GitHash", "\"${getGitHash()}\""
         buildConfigField "String", "VERSION", "\"${versionName}\""
+        buildConfigField "String", "OMSDK_VERSION", "\"${omSdkVersion}\""
     }
 
     dexOptions {

--- a/PrebidMobile/PrebidMobile-rendering/src/main/java/org/prebid/mobile/rendering/sdk/PrebidRenderingSettings.java
+++ b/PrebidMobile/PrebidMobile-rendering/src/main/java/org/prebid/mobile/rendering/sdk/PrebidRenderingSettings.java
@@ -77,6 +77,11 @@ public class PrebidRenderingSettings {
      */
     public static final int AUTO_REFRESH_DELAY_MIN = 15000;
 
+    /**
+     * Open measurement SDK version
+     */
+    public static final String OMSDK_VERSION = BuildConfig.OMSDK_VERSION;
+
     private static final AtomicInteger INIT_SDK_TASK_COUNT = new AtomicInteger();
     private static final int MANDATORY_TASK_COUNT = 3;
 


### PR DESCRIPTION
Add display insterstitial examples and listeners. Closes #343.

Indicate the status of interstitial ads. Closes #344.

Fix listeners and confg ids for rewarded and interstitial. Closes #345.

Add open measurement version to code. Closes #346.

Add additional size to AdMob flexible banner. Closes #349.