### PR TITLE
AdMob corrections

### DIFF
--- a/Example/PrebidDemoKotlin/src/main/java/org/prebid/mobile/prebidkotlindemo/AdTypesRepository.kt
+++ b/Example/PrebidDemoKotlin/src/main/java/org/prebid/mobile/prebidkotlindemo/AdTypesRepository.kt
@@ -15,6 +15,7 @@ import org.prebid.mobile.prebidkotlindemo.ads.inappmopub.InAppMoPubBanner
 import org.prebid.mobile.prebidkotlindemo.ads.inappmopub.InAppMoPubInterstitial
 import org.prebid.mobile.prebidkotlindemo.ads.inappmopub.InAppMoPubRewardedInterstitial
 import org.prebid.mobile.prebidkotlindemo.ads.inappmopub.InAppMoPubVideoInterstitial
+import org.prebid.mobile.rendering.bidding.enums.AdUnitFormat
 
 object AdTypesRepository {
 
@@ -247,7 +248,8 @@ object AdTypesRepository {
                     InAppMoPubVideoInterstitial.create(
                         activity,
                         "062a5be1c0764e84b45244ecd58b237f",
-                        "28259226-68de-49f8-88d6-f0f2fab846e3"
+                        "28259226-68de-49f8-88d6-f0f2fab846e3",
+                        30, 30
                     )
                 },
                 onDestroy = { InAppMoPubVideoInterstitial.destroy() }
@@ -285,7 +287,8 @@ object AdTypesRepository {
                     InAppAdMobInterstitial.create(
                         activity,
                         "ca-app-pub-1875909575462531/6393291067",
-                        "5a4b8dcf-f984-4b04-9448-6529908d6cb6"
+                        "5a4b8dcf-f984-4b04-9448-6529908d6cb6",
+                        AdUnitFormat.DISPLAY
                     )
                 },
                 onDestroy = { InAppAdMobInterstitial.destroy() }
@@ -296,7 +299,8 @@ object AdTypesRepository {
                     InAppAdMobInterstitial.create(
                         activity,
                         "ca-app-pub-1875909575462531/6393291067",
-                        "12f58bc2-b664-4672-8d19-638bcc96fd5c"
+                        "12f58bc2-b664-4672-8d19-638bcc96fd5c",
+                        AdUnitFormat.VIDEO
                     )
                 },
                 onDestroy = { InAppAdMobInterstitial.destroy() }

--- a/Example/PrebidDemoKotlin/src/main/java/org/prebid/mobile/prebidkotlindemo/ads/inappadmob/InAppAdMobInterstitial.kt
+++ b/Example/PrebidDemoKotlin/src/main/java/org/prebid/mobile/prebidkotlindemo/ads/inappadmob/InAppAdMobInterstitial.kt
@@ -20,7 +20,8 @@ object InAppAdMobInterstitial {
     fun create(
         activity: Activity,
         adUnitId: String,
-        configId: String
+        configId: String,
+        adUnitFormat: AdUnitFormat
     ) {
         val extras = Bundle()
         val request = AdRequest
@@ -32,7 +33,7 @@ object InAppAdMobInterstitial {
         adUnit = MediationInterstitialAdUnit(
             activity,
             configId,
-            AdUnitFormat.DISPLAY,
+            adUnitFormat,
             mediationUtils
         )
         adUnit?.fetchDemand { result ->

--- a/Example/PrebidDemoKotlin/src/main/java/org/prebid/mobile/prebidkotlindemo/ads/inappmopub/InAppMoPubInterstitial.kt
+++ b/Example/PrebidDemoKotlin/src/main/java/org/prebid/mobile/prebidkotlindemo/ads/inappmopub/InAppMoPubInterstitial.kt
@@ -7,8 +7,8 @@ import com.mopub.common.SdkConfiguration
 import com.mopub.mediation.MoPubInterstitialMediationUtils
 import com.mopub.mobileads.MoPubErrorCode
 import com.mopub.mobileads.MoPubInterstitial
-import org.prebid.mobile.rendering.bidding.data.AdSize
 import org.prebid.mobile.rendering.bidding.display.MediationInterstitialAdUnit
+import org.prebid.mobile.rendering.bidding.enums.AdUnitFormat
 
 object InAppMoPubInterstitial {
 
@@ -38,9 +38,10 @@ object InAppMoPubInterstitial {
         adUnit = MediationInterstitialAdUnit(
             activity,
             configId,
-            AdSize(minPercentageWidth, minPercentageHeight),
+            AdUnitFormat.DISPLAY,
             mediationUtils
         )
+        adUnit?.setMinSizePercentage(minPercentageWidth, minPercentageHeight)
 
         MoPub.initializeSdk(activity, SdkConfiguration.Builder(adUnitId).build()) {
             adUnit?.fetchDemand {

--- a/Example/PrebidDemoKotlin/src/main/java/org/prebid/mobile/prebidkotlindemo/ads/inappmopub/InAppMoPubVideoInterstitial.kt
+++ b/Example/PrebidDemoKotlin/src/main/java/org/prebid/mobile/prebidkotlindemo/ads/inappmopub/InAppMoPubVideoInterstitial.kt
@@ -16,7 +16,13 @@ object InAppMoPubVideoInterstitial {
     private var moPubInterstitial: MoPubInterstitial? = null
     private var adUnit: MediationInterstitialAdUnit? = null
 
-    fun create(activity: Activity, adUnitId: String, configId: String) {
+    fun create(
+        activity: Activity,
+        adUnitId: String,
+        configId: String,
+        minPercentageWidth: Int,
+        minPercentageHeight: Int
+    ) {
         moPubInterstitial = MoPubInterstitial(activity, adUnitId)
         moPubInterstitial?.interstitialAdListener = object : MoPubInterstitial.InterstitialAdListener {
             override fun onInterstitialLoaded(p0: MoPubInterstitial?) {
@@ -35,6 +41,7 @@ object InAppMoPubVideoInterstitial {
             AdUnitFormat.VIDEO,
             mediationUtils
         )
+        adUnit?.setMinSizePercentage(minPercentageWidth, minPercentageHeight)
 
         MoPub.initializeSdk(activity, SdkConfiguration.Builder(adUnitId).build()) {
             adUnit?.fetchDemand {

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/InternalTestApplication.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/InternalTestApplication.kt
@@ -23,6 +23,7 @@ import android.preference.PreferenceManager
 import android.webkit.WebView
 import androidx.multidex.MultiDex
 import androidx.multidex.MultiDexApplication
+import org.prebid.mobile.PrebidMobile
 import org.prebid.mobile.rendering.sdk.PrebidRenderingSettings
 import org.prebid.mobile.renderingtestapp.utils.DemoItemProvider
 import org.prebid.mobile.renderingtestapp.utils.MockServerUtils
@@ -41,6 +42,7 @@ class InternalTestApplication : MultiDexApplication() {
         super.onCreate()
         instance = this
 
+        PrebidMobile.setApplicationContext(this)
         PrebidRenderingSettings.setAccountId(getString(R.string.prebid_account_id_prod))
         PrebidRenderingSettings.logLevel = PrebidRenderingSettings.LogLevel.DEBUG
 

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/admob/AdMobNativeFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/admob/AdMobNativeFragment.kt
@@ -61,9 +61,11 @@ class AdMobNativeFragment : AdFragment() {
         adLoader = AdLoader
             .Builder(requireContext(), adUnitId)
             .forNativeAd { ad: NativeAd ->
-                btnAdLoaded.isEnabled = true
+                btnAdLoaded?.isEnabled = true
                 nativeAd = ad
-                createCustomView(viewContainer, nativeAd!!)
+                viewContainer?.let {
+                    createCustomView(it, nativeAd!!)
+                }
             }
             .withAdListener(object : AdListener() {
                 override fun onAdFailedToLoad(adError: LoadAdError) {
@@ -102,8 +104,8 @@ class AdMobNativeFragment : AdFragment() {
     }
 
     private fun resetAdEvents() {
-        btnAdLoaded.isEnabled = false
-        btnAdFailed.isEnabled = false
+        btnAdLoaded?.isEnabled = false
+        btnAdFailed?.isEnabled = false
     }
 
     private fun createCustomView(wrapper: ViewGroup, nativeAd: NativeAd) {

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/mopub/MopubBannersWithInterstitialFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/mopub/MopubBannersWithInterstitialFragment.kt
@@ -31,6 +31,7 @@ import kotlinx.android.synthetic.main.fragment_interstitial_html_with_banners.*
 import org.prebid.mobile.rendering.bidding.data.AdSize
 import org.prebid.mobile.rendering.bidding.display.MediationBannerAdUnit
 import org.prebid.mobile.rendering.bidding.display.MediationInterstitialAdUnit
+import org.prebid.mobile.rendering.bidding.enums.AdUnitFormat
 import org.prebid.mobile.renderingtestapp.R
 import org.prebid.mobile.renderingtestapp.plugplay.bidding.base.BaseBannersWithInterstitialFragment
 import org.prebid.mobile.renderingtestapp.utils.getAdDescription
@@ -63,9 +64,10 @@ class MopubBannersWithInterstitialFragment : BaseBannersWithInterstitialFragment
             MediationInterstitialAdUnit(
                 requireContext(),
                 interstitialConfigId,
-                AdSize(30, 30),
+                AdUnitFormat.DISPLAY,
                 mediationUtils
             )
+        mediationInterstitialAdUnit?.setMinSizePercentage(30, 30)
 
         fetchInterstitial()
     }

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/mopub/MopubInterstitialFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/mopub/MopubInterstitialFragment.kt
@@ -25,7 +25,6 @@ import com.mopub.mobileads.MoPubErrorCode
 import com.mopub.mobileads.MoPubInterstitial
 import kotlinx.android.synthetic.main.events_mopub_interstitial.*
 import kotlinx.android.synthetic.main.fragment_mopub_interstitial.*
-import org.prebid.mobile.rendering.bidding.data.AdSize
 import org.prebid.mobile.rendering.bidding.display.MediationInterstitialAdUnit
 import org.prebid.mobile.rendering.bidding.enums.AdUnitFormat
 import org.prebid.mobile.renderingtestapp.AdFragment
@@ -114,10 +113,11 @@ class MopubInterstitialFragment : AdFragment() {
             MediationInterstitialAdUnit(
                 requireContext(),
                 configId,
-                AdSize(minWidthPerc, minHeightPerc),
+                AdUnitFormat.DISPLAY,
                 mediationUtils
             )
         }
+        mopubInterstitialAdUnit.setMinSizePercentage(30, 30)
     }
 
     private fun handleLoadButtonClick() {

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/mopub/MopubNativeFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/mopub/MopubNativeFragment.kt
@@ -184,7 +184,7 @@ open class MopubNativeFragment : AdFragment() {
 
             val image = NativeImageAsset()
             image.imageType = NativeImageAsset.IMAGE_TYPE.MAIN
-            image.hMin = 20
+            image.hMin = 200
             image.wMin = 200
             image.isRequired = true
             addAsset(image)

--- a/Example/PrebidInternalTestApp/src/main/res/values/strings.xml
+++ b/Example/PrebidInternalTestApp/src/main/res/values/strings.xml
@@ -157,13 +157,13 @@
     <string name="demo_bidding_gam_native_styles_mrect">Banner Native Styles (GAM) [MRect]</string>
     <string name="demo_bidding_gam_native_styles_fluid">Banner Native Styles (GAM) [Fluid]</string>
     <string name="demo_bidding_gam_native_styles_no_assets">Banner Native Styles No Assets (GAM) [MRect]</string>
-    <string name="demo_bidding_gam_native_custom_templates">Native Ad Custom Templates (GAM) [OK, OXANativeAd]</string>
+    <string name="demo_bidding_gam_native_custom_templates">Native Ad Custom Templates (GAM) [OK, NativeAd]</string>
     <string name="demo_bidding_gam_native_custom_templates_no_bids">Native Ad (GAM) [noBids, GADNativeCustomTemplateAd]</string>
-    <string name="demo_bidding_gam_native_unified_ads">Native Ad Unified Ad (GAM) [OK, OXANativeAd]</string>
+    <string name="demo_bidding_gam_native_unified_ads">Native Ad Unified Ad (GAM) [OK, NativeAd]</string>
     <string name="demo_bidding_gam_native_unified_ads_no_bids">Native Ad (GAM) [noBids, GADUnifiedNativeAd]</string>
     <string name="demo_bidding_gam_native_custom_templates_prebid_ok">Native Ad (GAM) [OK, GADNativeCustomTemplateAd]</string>
     <string name="demo_bidding_gam_native_unified_ads_prebid_ok">Native Ad (GAM) [OK, GADUnifiedNativeAd]</string>
-    <string name="demo_bidding_gam_native_feed">Native Ad Feed (GAM) [OK, OXANativeAd]</string>
+    <string name="demo_bidding_gam_native_feed">Native Ad Feed (GAM) [OK, NativeAd]</string>
 
 
     <!--MoPub Titles-->
@@ -194,8 +194,8 @@
     <string name="demo_bidding_mopub_native_styles_no_assets">Banner Native Styles No Assets (MoPub)</string>
     <string name="demo_bidding_mopub_native_no_bids">Native Ad (MoPub) [noBids, MPNativeAd] </string>
     <string name="demo_bidding_mopub_native_feed_no_bids">Native Ad Feed (MoPub) [noBids, MPNativeAd] </string>
-    <string name="demo_bidding_mopub_native_adapter">Native Ad (MoPub) [OK, OXANativeAdAdapter]</string>
-    <string name="demo_bidding_mopub_native_adapter_video">Native Ad Video (MoPub) [OK, OXANativeAdAdapter]</string>
+    <string name="demo_bidding_mopub_native_adapter">Native Ad (MoPub) [OK, NativeAdAdapter]</string>
+    <string name="demo_bidding_mopub_native_adapter_video">Native Ad Video (MoPub) [OK, NativeAdAdapter]</string>
 
     <!--AdMob Titles-->
     <string name="demo_bidding_admob_banner_320_50_adapter">Banner 320x50 (AdMob) [OK, OXB Adapter]</string>


### PR DESCRIPTION
Use appropriate ad unit format for interstitial. Fix native ad crash. Correction in native ad requests. Closes #354, #356, #357. 