### PR TITLE
Rendering controls settings from bid responses

### DIFF
--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/utils/DemoItemProvider.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/utils/DemoItemProvider.kt
@@ -480,6 +480,32 @@ class DemoItemProvider private constructor() {
                     )
                 )
             )
+            demoList.add(
+                DemoItem(
+                    getString(R.string.demo_bidding_in_app_interstitial_video_320_480_with_ad_configuration),
+                    ppmInterstitialAction,
+                    ppmVideoTagList,
+                    createBannerBundle(
+                        R.string.imp_prebid_id_video_interstitial_320_480,
+                        null,
+                        320, 480,
+                        R.string.response_prebid_video_interstitial_ad_configuration
+                    )
+                )
+            )
+            demoList.add(
+                DemoItem(
+                    getString(R.string.demo_bidding_in_app_interstitial_video_320_480_end_card_with_ad_configuration),
+                    ppmInterstitialAction,
+                    ppmVideoTagList,
+                    createBannerBundle(
+                        R.string.imp_prebid_id_video_interstitial_320_480_with_end_card,
+                        null,
+                        320, 480,
+                        R.string.response_prebid_video_interstitial_end_card_ad_configuration
+                    )
+                )
+            )
 
             demoList.add(
                 DemoItem(
@@ -516,16 +542,37 @@ class DemoItemProvider private constructor() {
                         R.string.imp_prebid_id_video_rewarded_end_card_320_480,
                         null,
                         MIN_WIDTH_PERC,
-                        MIN_HEIGHT_PERC,R.string.response_prebid_video_rewarded_320_480
+                        MIN_HEIGHT_PERC, R.string.response_prebid_video_rewarded_320_480
                     )
                 )
             )
             demoList.add(
                 DemoItem(
+                    getString(R.string.demo_bidding_in_app_video_rewarded_320_480_with_ad_configuration),
+                    ppmRewardedAction,
+                    ppmVideoTagList,
+                    createBannerBundle(
+                        R.string.imp_prebid_id_video_rewarded_end_card_320_480,
+                        null,
+                        MIN_WIDTH_PERC,
+                        MIN_HEIGHT_PERC, R.string.response_prebid_video_rewarded_320_480_with_ad_configuration
+                    )
+                )
+            )
+
+
+            demoList.add(
+                DemoItem(
                     getString(R.string.demo_bidding_in_app_banner_video_outstream),
                     R.id.action_header_bidding_to_in_app_banner_video,
                     ppmVideoTagList,
-                    createBannerBundle(R.string.imp_prebid_id_video_outstream, null, 300, 250,R.string.response_prebid_video_outstream)
+                    createBannerBundle(
+                        R.string.imp_prebid_id_video_outstream,
+                        null,
+                        300,
+                        250,
+                        R.string.response_prebid_video_outstream
+                    )
                 )
             )
             demoList.add(

--- a/Example/PrebidInternalTestApp/src/main/res/values/strings.xml
+++ b/Example/PrebidInternalTestApp/src/main/res/values/strings.xml
@@ -104,9 +104,12 @@
     <string name="demo_bidding_in_app_interstitial_video_320_480_end_card_skip_button">Video Interstitial 320x480 With End Card and Skip Button (In-App)</string>
     <string name="demo_bidding_in_app_interstitial_video_320_480_mraid_end_card">Video Interstitial 320x480 with MRAID End Card (In-App)</string>
     <string name="demo_bidding_in_app_interstitial_video_320_480_no_bids">Video Interstitial 320x480 (In-App) [noBids]</string>
+    <string name="demo_bidding_in_app_interstitial_video_320_480_with_ad_configuration">Video Interstitial 320x480 With Ad Configuration (In-App)</string>
+    <string name="demo_bidding_in_app_interstitial_video_320_480_end_card_with_ad_configuration">Video Interstitial 320x480 With End Card With Ad Configuration (In-App)</string>
     <string name="demo_bidding_in_app_video_rewarded_end_card_320_480">Video Rewarded 320x480 (In-App)</string>
     <string name="demo_bidding_in_app_video_rewarded_end_card_320_480_no_bids">Video Rewarded 320x480 with End Card (In-App) [noBids]</string>
     <string name="demo_bidding_in_app_video_rewarded_320_480">Video Rewarded 320x480 without End Card (In-App)</string>
+    <string name="demo_bidding_in_app_video_rewarded_320_480_with_ad_configuration">Video Rewarded 320x480 With Ad Configuration (In-App)</string>
     <string name="demo_bidding_in_app_mraid_expand">MRAID 2.0: Expand - 1 Part (In-App)</string>
     <string name="demo_bidding_in_app_mraid_expand_2">MRAID 2.0: Expand - 2 Part (In-App)</string>
     <string name="demo_bidding_in_app_mraid_resize">MRAID 2.0: Resize (In-App)</string>
@@ -362,12 +365,15 @@
     <string name="response_prebid_video_interstitial_320_480_with_end_card">response-prebid-video-interstitial-320-480-with-end-card</string>
     <string name="response_prebid_video_interstitial_deeplink">response-prebid-video-interstitial-320-480-deeplink</string>
     <string name="response_prebid_video_interstitial_skipoffset">response-prebid-video-interstitial-320-480-skip-offset</string>
+    <string name="response_prebid_video_interstitial_ad_configuration">response-prebid-video-interstitial-320-480-with-ad-configuration</string>
+    <string name="response_prebid_video_interstitial_end_card_ad_configuration">response-prebid-video-interstitial-320-480-with-end-card-with-ad-configuration</string>
     <!--  Video Outstream  -->
     <string name="response_prebid_video_outstream">response-prebid-video-outstream</string>
     <string name="response_prebid_video_outstream_end_card">response-prebid-video-outstream-with-end-card</string>
     <!--  Video Rewarded  -->
     <string name="response_prebid_video_rewarded_end_card_320_480">response-prebid-video-rewarded-320-480-without-end-card</string>
     <string name="response_prebid_video_rewarded_320_480">response-prebid-video-rewarded-320-480</string>
+    <string name="response_prebid_video_rewarded_320_480_with_ad_configuration">response-prebid-video-rewarded-320-480-with-ad-configuration</string>
 
     <!--  MRAID  -->
     <string name="response_prebid_mraid_resize">response-prebid-mraid-resize</string>

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/bidding/data/bid/Bid.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/bidding/data/bid/Bid.java
@@ -21,6 +21,7 @@ import android.util.Base64;
 import org.json.JSONArray;
 import org.json.JSONObject;
 import org.prebid.mobile.rendering.models.internal.MacrosModel;
+import org.prebid.mobile.rendering.models.openrtb.bidRequests.MobileSdkPassThrough;
 import org.prebid.mobile.rendering.utils.helpers.MacrosResolutionHelper;
 
 import java.util.HashMap;
@@ -124,6 +125,8 @@ public class Bid {
     // Advisory as to the number of seconds the bidder is willing to
     // wait between the auction and the actual impression
     private int mExp;
+
+    private MobileSdkPassThrough mobileSdkPassThrough;
 
     protected Bid() {
     }
@@ -243,6 +246,10 @@ public class Bid {
         return jsonString;
     }
 
+    public MobileSdkPassThrough getMobileSdkPassThrough() {
+        return mobileSdkPassThrough;
+    }
+
     public static Bid fromJSONObject(JSONObject jsonObject) {
         Bid bid = new Bid();
         if (jsonObject == null) {
@@ -280,6 +287,7 @@ public class Bid {
         JSONObject ext = jsonObject.optJSONObject("ext");
         if (ext != null) {
             bid.mPrebid = Prebid.fromJSONObject(ext.optJSONObject("prebid"));
+            bid.mobileSdkPassThrough = MobileSdkPassThrough.create(ext);
         }
 
         substituteMacros(bid);

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/bidding/loader/BidLoader.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/bidding/loader/BidLoader.java
@@ -17,11 +17,13 @@
 package org.prebid.mobile.rendering.bidding.loader;
 
 import android.content.Context;
+import androidx.annotation.Nullable;
 import org.prebid.mobile.LogUtil;
 import org.prebid.mobile.PrebidMobile;
 import org.prebid.mobile.rendering.bidding.data.bid.BidResponse;
 import org.prebid.mobile.rendering.bidding.listeners.BidRequesterListener;
 import org.prebid.mobile.rendering.errors.AdException;
+import org.prebid.mobile.rendering.models.openrtb.bidRequests.MobileSdkPassThrough;
 import org.prebid.mobile.rendering.networking.BaseNetworkTask;
 import org.prebid.mobile.rendering.networking.ResponseHandler;
 import org.prebid.mobile.rendering.networking.modelcontrollers.BidRequester;
@@ -60,6 +62,7 @@ public class BidLoader {
                 return;
             }
             checkTmax(response, bidResponse);
+            updateAdUnitConfiguration(bidResponse.getMobileSdkPassThrough());
             if (mRequestListener != null) {
                 setupRefreshTimer();
                 mRequestListener.onFetchCompleted(bidResponse);
@@ -200,7 +203,10 @@ public class BidLoader {
         mRequestListener.onError(new AdException(AdException.INTERNAL_ERROR, "Invalid bid response: " + msg));
     }
 
-    private void checkTmax(BaseNetworkTask.GetUrlResult response, BidResponse parsedResponse) {
+    private void checkTmax(
+            BaseNetworkTask.GetUrlResult response,
+            BidResponse parsedResponse
+    ) {
         Map<String, Object> extMap = parsedResponse.getExt().getMap();
         if (!sTimeoutHasChanged && extMap.containsKey(TMAX_REQUEST_KEY)) {
             int tmaxRequest = (int) extMap.get(TMAX_REQUEST_KEY);
@@ -211,7 +217,16 @@ public class BidLoader {
         }
     }
 
-    public interface BidRefreshListener {
-        boolean canPerformRefresh();
+    private void updateAdUnitConfiguration(@Nullable MobileSdkPassThrough mobileSdkPassThrough) {
+        if (mobileSdkPassThrough != null) {
+            mobileSdkPassThrough.modifyAdUnitConfiguration(mAdConfiguration);
+        }
     }
+
+    public interface BidRefreshListener {
+
+        boolean canPerformRefresh();
+
+    }
+
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/openrtb/bidRequests/MobileSdkPassThrough.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/openrtb/bidRequests/MobileSdkPassThrough.java
@@ -5,6 +5,7 @@ import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.prebid.mobile.LogUtil;
+import org.prebid.mobile.core.BuildConfig;
 import org.prebid.mobile.units.configuration.AdUnitConfiguration;
 import org.prebid.mobile.units.configuration.Position;
 
@@ -20,17 +21,23 @@ public class MobileSdkPassThrough {
     @Nullable
     public static MobileSdkPassThrough create(JSONObject extJson) {
         try {
-            if (extJson.has("prebid")) {
-                JSONObject prebid = extJson.getJSONObject("prebid");
-                if (prebid.has("passthrough")) {
-                    JSONArray passThroughArray = prebid.getJSONArray("passthrough");
-                    for (int i = 0; i < passThroughArray.length(); i++) {
-                        JSONObject passThrough = passThroughArray.getJSONObject(i);
-                        if (passThrough.has("type")) {
-                            String currentType = passThrough.getString("type");
-                            if (currentType.equals("prebidmobilesdk") && passThrough.has("adconfiguration")) {
-                                return new MobileSdkPassThrough(passThrough);
-                            }
+            JSONObject rootJsonObject;
+            if (!BuildConfig.DEBUG) {
+                if (extJson.has("prebid")) {
+                    rootJsonObject = extJson.getJSONObject("prebid");
+                } else return null;
+            } else {
+                rootJsonObject = extJson;
+            }
+
+            if (rootJsonObject.has("passthrough")) {
+                JSONArray passThroughArray = rootJsonObject.getJSONArray("passthrough");
+                for (int i = 0; i < passThroughArray.length(); i++) {
+                    JSONObject passThrough = passThroughArray.getJSONObject(i);
+                    if (passThrough.has("type")) {
+                        String currentType = passThrough.getString("type");
+                        if (currentType.equals("prebidmobilesdk") && passThrough.has("adconfiguration")) {
+                            return new MobileSdkPassThrough(passThrough);
                         }
                     }
                 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/openrtb/bidRequests/MobileSdkPassThrough.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/openrtb/bidRequests/MobileSdkPassThrough.java
@@ -1,0 +1,164 @@
+package org.prebid.mobile.rendering.models.openrtb.bidRequests;
+
+import androidx.annotation.Nullable;
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.prebid.mobile.LogUtil;
+import org.prebid.mobile.units.configuration.AdUnitConfiguration;
+import org.prebid.mobile.units.configuration.Position;
+
+/**
+ * A class responsible for parsing "prebidmobilesdk" pass through type from bid response.
+ * It contains interstitial control settings, like close button size or skip delay.
+ * It can be located in ext.prebid.passthrough[] or seatbid[].bid[].ext.prebid.passthrough[].
+ */
+public class MobileSdkPassThrough {
+
+    private static final String TAG = MobileSdkPassThrough.class.getSimpleName();
+
+    @Nullable
+    public static MobileSdkPassThrough create(JSONObject extJson) {
+        try {
+            if (extJson.has("prebid")) {
+                JSONObject prebid = extJson.getJSONObject("prebid");
+                if (prebid.has("passthrough")) {
+                    JSONArray passThroughArray = prebid.getJSONArray("passthrough");
+                    for (int i = 0; i < passThroughArray.length(); i++) {
+                        JSONObject passThrough = passThroughArray.getJSONObject(i);
+                        if (passThrough.has("type")) {
+                            String currentType = passThrough.getString("type");
+                            if (currentType.equals("prebidmobilesdk") && passThrough.has("adconfiguration")) {
+                                return new MobileSdkPassThrough(passThrough);
+                            }
+                        }
+                    }
+                }
+            }
+        } catch (JSONException e) {
+            LogUtil.error(TAG, "Can't parse json");
+        }
+        return null;
+    }
+
+    /**
+     * Creates unified MobileSdkPassThrough. An object from bid has higher priority.
+     *
+     * @param fromBid  - object from seatbid[].bid[].ext.prebid.passthrough[]
+     * @param fromRoot - object from ext.prebid.passthrough[]
+     */
+    @Nullable
+    public static MobileSdkPassThrough combine(
+            @Nullable MobileSdkPassThrough fromBid,
+            @Nullable MobileSdkPassThrough fromRoot
+    ) {
+        if (fromBid == null && fromRoot == null) {
+            return null;
+        } else if (fromBid == null) {
+            return fromRoot;
+        } else if (fromRoot == null) {
+            return fromBid;
+        }
+
+        if (fromBid.isMuted == null) {
+            fromBid.isMuted = fromRoot.isMuted;
+        }
+        if (fromBid.maxVideoDuration == null) {
+            fromBid.maxVideoDuration = fromRoot.maxVideoDuration;
+        }
+        if (fromBid.skipDelay == null) {
+            fromBid.skipDelay = fromRoot.skipDelay;
+        }
+        if (fromBid.closeButtonArea == null) {
+            fromBid.closeButtonArea = fromRoot.closeButtonArea;
+        }
+        if (fromBid.skipButtonArea == null) {
+            fromBid.skipButtonArea = fromRoot.skipButtonArea;
+        }
+        if (fromBid.closeButtonPosition == null) {
+            fromBid.closeButtonPosition = fromRoot.closeButtonPosition;
+        }
+        if (fromBid.skipButtonPosition == null) {
+            fromBid.skipButtonPosition = fromRoot.skipButtonPosition;
+        }
+        return fromBid;
+    }
+
+    public Boolean isMuted;
+
+    public Integer maxVideoDuration;
+    public Integer skipDelay;
+
+    public Double closeButtonArea;
+    public Double skipButtonArea;
+
+    public Position closeButtonPosition;
+    public Position skipButtonPosition;
+
+    private JSONObject configuration;
+
+    private MobileSdkPassThrough(JSONObject passThrough) {
+        try {
+            if (passThrough.has("adconfiguration")) {
+                configuration = passThrough.getJSONObject("adconfiguration");
+
+                getAndSave("ismuted", Boolean.class, it -> isMuted = it);
+                getAndSave("maxvideoduration", Integer.class, it -> maxVideoDuration = it);
+                getAndSave("skipdelay", Integer.class, it -> skipDelay = it);
+                getAndSave("closebuttonarea", Double.class, it -> closeButtonArea = it);
+                getAndSave("skipbuttonarea", Double.class, it -> skipButtonArea = it);
+                getAndSave("closebuttonposition", String.class, it -> closeButtonPosition = Position.fromString(it));
+                getAndSave("skipbuttonposition", String.class, it -> skipButtonPosition = Position.fromString(it));
+            }
+        } catch (JSONException exception) {
+            LogUtil.error(TAG, "Can't parse configuration");
+        }
+    }
+
+
+    public void modifyAdUnitConfiguration(AdUnitConfiguration adUnitConfiguration) {
+        if (isMuted != null) {
+            adUnitConfiguration.setIsMuted(isMuted);
+        }
+        if (maxVideoDuration != null) {
+            adUnitConfiguration.setMaxVideoDuration(maxVideoDuration);
+        }
+        if (skipDelay != null) {
+            adUnitConfiguration.setSkipDelay(skipDelay);
+        }
+        if (closeButtonArea != null) {
+            adUnitConfiguration.setCloseButtonArea(closeButtonArea);
+        }
+        if (skipButtonArea != null) {
+            adUnitConfiguration.setSkipButtonArea(skipButtonArea);
+        }
+        if (closeButtonPosition != null) {
+            adUnitConfiguration.setCloseButtonPosition(closeButtonPosition);
+        }
+        if (skipButtonPosition != null) {
+            adUnitConfiguration.setSkipButtonPosition(skipButtonPosition);
+        }
+    }
+
+    private <T> void getAndSave(
+            String key,
+            Class<T> classType,
+            AfterCast<T> afterCast
+    ) {
+        try {
+            if (configuration.has(key)) {
+                T result = classType.cast(configuration.get(key));
+                afterCast.save(result);
+            }
+        } catch (JSONException e) {
+            LogUtil.error(TAG, "Object " + key + " has wrong type!");
+        }
+    }
+
+    private interface AfterCast<T> {
+
+        void save(T variable);
+
+    }
+
+}

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/units/configuration/Position.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/units/configuration/Position.java
@@ -1,5 +1,7 @@
 package org.prebid.mobile.units.configuration;
 
+import androidx.annotation.Nullable;
+
 public enum Position {
     TOP_LEFT,
     TOP,
@@ -8,5 +10,29 @@ public enum Position {
     BOTTOM_RIGHT,
     BOTTOM,
     BOTTOM_LEFT,
-    LEFT
+    LEFT;
+
+    @Nullable
+    public static Position fromString(String string) {
+        switch (string.toLowerCase()) {
+            case "topleft":
+                return TOP_LEFT;
+            case "top":
+                return TOP;
+            case "topright":
+                return TOP_RIGHT;
+            case "right":
+                return RIGHT;
+            case "bottomright":
+                return BOTTOM_RIGHT;
+            case "bottom":
+                return BOTTOM;
+            case "bottomleft":
+                return BOTTOM_LEFT;
+            case "left":
+                return LEFT;
+            default:
+                return null;
+        }
+    }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/bidding/data/bid/BidResponseTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/bidding/data/bid/BidResponseTest.java
@@ -17,7 +17,9 @@
 package org.prebid.mobile.rendering.bidding.data.bid;
 
 import org.junit.Test;
+import org.prebid.mobile.rendering.models.openrtb.bidRequests.MobileSdkPassThrough;
 import org.prebid.mobile.test.utils.ResourceUtils;
+import org.prebid.mobile.units.configuration.Position;
 
 import java.io.IOException;
 
@@ -38,6 +40,7 @@ public class BidResponseTest {
         assertEquals("bidid", bidResponse.getBidId());
         assertEquals("custom", bidResponse.getCustomData());
         assertEquals(1, bidResponse.getNbr());
+        assertNull(bidResponse.getMobileSdkPassThrough());
     }
 
     @Test
@@ -66,4 +69,24 @@ public class BidResponseTest {
         assertEquals("id", bidResponse.getId());
         assertNotNull(bidResponse.getExt());
     }
+
+    @Test
+    public void testMobileSdkPassThrough_checkFieldsUnification_returnUnifiedFields() throws IOException {
+        String responseString = ResourceUtils.convertResourceToString("BidResponseTest/mobile_sdk_pass_through.json");
+
+        BidResponse subject = new BidResponse(responseString);
+        MobileSdkPassThrough mobileSdkPassThrough = subject.getMobileSdkPassThrough();
+
+        assertNotNull(mobileSdkPassThrough);
+        assertTrue(mobileSdkPassThrough.isMuted);
+        assertEquals((Double) 0.1, mobileSdkPassThrough.closeButtonArea);
+        assertEquals(Position.TOP_LEFT, mobileSdkPassThrough.closeButtonPosition);
+        assertEquals((Double) 0.2, mobileSdkPassThrough.skipButtonArea);
+        assertEquals(Position.TOP_RIGHT, mobileSdkPassThrough.skipButtonPosition);
+        assertEquals((Integer) 15, mobileSdkPassThrough.skipDelay);
+
+        /* This field presents in both MobileSdkPassThrough objects */
+        assertEquals((Integer) 11, mobileSdkPassThrough.maxVideoDuration);
+    }
+
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/models/openrtb/bidRequests/MobileSdkPassThroughTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/models/openrtb/bidRequests/MobileSdkPassThroughTest.java
@@ -1,0 +1,118 @@
+package org.prebid.mobile.rendering.models.openrtb.bidRequests;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.junit.Test;
+import org.prebid.mobile.units.configuration.AdUnitConfiguration;
+import org.prebid.mobile.units.configuration.Position;
+
+import static org.junit.Assert.*;
+
+public class MobileSdkPassThroughTest {
+
+    @Test
+    public void create_putWrongJsonObject_returnNull() throws JSONException {
+        JSONObject jsonObject = new JSONObject("{}");
+
+        MobileSdkPassThrough subject = MobileSdkPassThrough.create(jsonObject);
+
+        assertNull(subject);
+    }
+
+    @Test
+    public void create_putObjectWithWrongType_returnNull() throws JSONException {
+        JSONObject jsonObject = new JSONObject("{\"prebid\":{\"passthrough\":[{\"type\":\"any\"}]}}");
+
+        MobileSdkPassThrough subject = MobileSdkPassThrough.create(jsonObject);
+
+        assertNull(subject);
+    }
+
+    @Test
+    public void create_putObjectWithoutAdConfiguration_returnNull() throws JSONException {
+        JSONObject jsonObject = new JSONObject("{\"prebid\":{\"passthrough\":[{\"type\":\"prebidmobilesdk\"}]}}");
+
+        MobileSdkPassThrough subject = MobileSdkPassThrough.create(jsonObject);
+
+        assertNull(subject);
+    }
+
+    @Test
+    public void create_putObjectWithEmptyAdConfiguration_returnEmptyObject() throws JSONException {
+        JSONObject jsonObject = new JSONObject(
+                "{\"prebid\":{\"passthrough\":[{\"type\":\"prebidmobilesdk\", \"adconfiguration\":{}}]}}");
+
+        MobileSdkPassThrough subject = MobileSdkPassThrough.create(jsonObject);
+
+        assertNotNull(subject);
+
+        assertNull(subject.isMuted);
+        assertNull(subject.maxVideoDuration);
+        assertNull(subject.skipDelay);
+        assertNull(subject.skipButtonPosition);
+        assertNull(subject.skipButtonArea);
+        assertNull(subject.closeButtonArea);
+        assertNull(subject.closeButtonPosition);
+    }
+
+    @Test
+    public void create_putObjectWithAdConfiguration_returnFullObject() throws JSONException {
+        JSONObject jsonObject = new JSONObject(
+                "{\"prebid\":{\"passthrough\":[{\"type\":\"prebidmobilesdk\",\"adconfiguration\":{\n\"ismuted\": false,\n\"maxvideoduration\": 15,\n\"closebuttonarea\": 0.3,\n\"closebuttonposition\": \"topleft\",\n\"skipbuttonarea\": 0.3,\n\"skipbuttonposition\": \"topleft\",\n\"skipdelay\": 0}}]}}");
+
+        MobileSdkPassThrough subject = MobileSdkPassThrough.create(jsonObject);
+
+        assertNotNull(subject);
+
+        assertEquals(false, subject.isMuted);
+        assertEquals((Integer) 15, subject.maxVideoDuration);
+        assertEquals((Integer) 0, subject.skipDelay);
+        assertEquals(Position.TOP_LEFT, subject.skipButtonPosition);
+        assertEquals((Double) 0.3, subject.skipButtonArea);
+        assertEquals((Double) 0.3, subject.closeButtonArea);
+        assertEquals(Position.TOP_LEFT, subject.closeButtonPosition);
+    }
+
+    @Test
+    public void modifyAdUnitConfiguration_putObjectWithAdConfiguration_getModifiedAdUnitConfiguration() throws JSONException {
+        JSONObject jsonObject = new JSONObject(
+                "{\"prebid\":{\"passthrough\":[{\"type\":\"prebidmobilesdk\",\"adconfiguration\":{\n\"ismuted\": false,\n\"maxvideoduration\": 15,\n\"closebuttonarea\": 0.3,\n\"closebuttonposition\": \"topleft\",\n\"skipbuttonarea\": 0.3,\n\"skipbuttonposition\": \"topleft\",\n\"skipdelay\": 0}}]}}");
+
+        MobileSdkPassThrough subject = MobileSdkPassThrough.create(jsonObject);
+        AdUnitConfiguration adUnitConfiguration = new AdUnitConfiguration();
+
+        assertNotNull(subject);
+
+        subject.modifyAdUnitConfiguration(adUnitConfiguration);
+
+        assertFalse(adUnitConfiguration.isMuted());
+        assertEquals((Integer) 15, adUnitConfiguration.getMaxVideoDuration());
+        assertEquals(0, adUnitConfiguration.getSkipDelay());
+        assertEquals(Position.TOP_LEFT, adUnitConfiguration.getSkipButtonPosition());
+        assertEquals(0.3, adUnitConfiguration.getSkipButtonArea(), 0);
+        assertEquals(0.3, adUnitConfiguration.getCloseButtonArea(), 0);
+        assertEquals(Position.TOP_LEFT, adUnitConfiguration.getCloseButtonPosition());
+    }
+
+    @Test
+    public void combine_checkFromBidPriority() throws JSONException {
+        JSONObject fromBidJsonObject = new JSONObject(
+                "{\"prebid\":{\"passthrough\":[{\"type\":\"prebidmobilesdk\",\"adconfiguration\":{\n\"ismuted\": false,\n\"closebuttonarea\": 0.1}}]}}");
+        JSONObject fromRootJsonObject = new JSONObject(
+                "{\"prebid\":{\"passthrough\":[{\"type\":\"prebidmobilesdk\",\"adconfiguration\":{\n\"maxvideoduration\": 15,\n\"closebuttonarea\": 0.2}}]}}");
+        MobileSdkPassThrough fromBid = MobileSdkPassThrough.create(fromBidJsonObject);
+        MobileSdkPassThrough fromRoot = MobileSdkPassThrough.create(fromRootJsonObject);
+
+        MobileSdkPassThrough result = MobileSdkPassThrough.combine(fromBid, fromRoot);
+
+        assertNotNull(result);
+
+        /* Only in fromBid response */
+        assertFalse(result.isMuted);
+        /* Only in fromRoot response */
+        assertEquals((Integer) 15, result.maxVideoDuration);
+        /* In fromBid = 0.1, in fromRoot = 0.2, fromBid have higher priority, so must be 0.1 */
+        assertEquals((Double) 0.1, result.closeButtonArea);
+    }
+
+}

--- a/PrebidMobile/PrebidMobile-core/src/test/resources/BidResponseTest/mobile_sdk_pass_through.json
+++ b/PrebidMobile/PrebidMobile-core/src/test/resources/BidResponseTest/mobile_sdk_pass_through.json
@@ -1,0 +1,71 @@
+{
+  "id": "id",
+  "seatbid": [
+    {
+      "bid": [
+        {
+          "id": "bidId",
+          "impid": "impId",
+          "price": 0.15,
+          "adm": "adm",
+          "crid": "crid",
+          "w": 320,
+          "h": 50,
+          "ext": {
+            "prebid": {
+              "passthrough": [
+                {
+                  "type": "prebidmobilesdk",
+                  "adconfiguration": {
+                    "maxvideoduration": 11,
+                    "ismuted": true,
+                    "closebuttonarea": 0.1,
+                    "closebuttonposition": "topleft"
+                  }
+                }
+              ],
+              "cache": {
+                "key": "cacheKey",
+                "url": "cacheUrl",
+                "bids": {
+                  "url": "bidsUrl",
+                  "cacheId": "bidsCacheId"
+                }
+              },
+              "targeting": {
+                "hb_pb": "value1",
+                "hb_bidder": "value2",
+                "hb_cache_id": "value3"
+              },
+              "type": "type"
+            }
+          }
+        }
+      ],
+      "seat": "prebid"
+    }
+  ],
+  "cur": "USD",
+  "bidid": "bidid",
+  "customdata": "custom",
+  "nbr": 1,
+  "ext": {
+    "prebid": {
+      "passthrough": [
+        {
+          "type": "prebidmobilesdk",
+          "adconfiguration": {
+            "maxvideoduration": 10,
+            "skipbuttonarea": 0.2,
+            "skipbuttonposition": "topright",
+            "skipdelay": 15
+          }
+        }
+      ]
+    },
+    "responsetimemillis": {
+      "prebid": 63
+    },
+    "tmaxrequest": 3000
+  }
+}

--- a/scripts/testPrebidMobile.sh
+++ b/scripts/testPrebidMobile.sh
@@ -18,7 +18,7 @@ echoX "clean previous build"
 ./gradlew clean
 
 echoX "start unit tests"
-./gradlew -q PrebidMobile-core:testDebugUnitTest
-./gradlew -q PrebidMobile-gamEventHandlers:testDebugUnitTest
-./gradlew -q PrebidMobile-admobAdapters:testDebugUnitTest
-./gradlew -q PrebidMobile-maxAdapters:testDebugUnitTest
+./gradlew -q PrebidMobile-core:testReleaseUnitTest
+./gradlew -q PrebidMobile-gamEventHandlers:testReleaseUnitTest
+./gradlew -q PrebidMobile-admobAdapters:testReleaseUnitTest
+./gradlew -q PrebidMobile-maxAdapters:testReleaseUnitTest


### PR DESCRIPTION
Add parser for the "prebidmobilesdk" pass through. Automatically replace user ad unit configuration with ones from the bid. Values from the winning bid must have higher priority. Closes #422. 