### PR TITLE
Remove m prefixes in class fields

### DIFF
--- a/Example/PrebidDemoJava/build.gradle
+++ b/Example/PrebidDemoJava/build.gradle
@@ -47,10 +47,10 @@ android {
 
 dependencies {
 //    Source code
-    implementation project(':PrebidMobile')
+//    implementation project(':PrebidMobile')
 
     // For testing staging releases
-//    implementation 'org.prebid:prebid-mobile-sdk:2.0.0'
+    implementation 'org.prebid:prebid-mobile-sdk:2.0.0'
 
     implementation 'androidx.appcompat:appcompat:1.2.0'
     implementation 'com.google.android.gms:play-services-ads:20.4.0'

--- a/Example/PrebidDemoKotlin/build.gradle
+++ b/Example/PrebidDemoKotlin/build.gradle
@@ -30,16 +30,16 @@ android {
 }
 
 dependencies {
-    implementation project(':PrebidMobile')
-    implementation project(':PrebidMobile-gamEventHandlers')
-    implementation project(':PrebidMobile-admobAdapters')
-    implementation project(':PrebidMobile-maxAdapters')
+//    implementation project(':PrebidMobile')
+//    implementation project(':PrebidMobile-gamEventHandlers')
+//    implementation project(':PrebidMobile-admobAdapters')
+//    implementation project(':PrebidMobile-maxAdapters')
 
     // For testing staging releases
-//    implementation 'org.prebid:prebid-mobile-sdk:2.0.0'
-//    implementation 'org.prebid:prebid-mobile-sdk-gam-event-handlers:2.0.0'
-//    implementation 'org.prebid:prebid-mobile-sdk-admob-adapters:2.0.0'
-//    implementation 'org.prebid:prebid-mobile-sdk-max-adapters:2.0.0'
+    implementation 'org.prebid:prebid-mobile-sdk:2.0.0'
+    implementation 'org.prebid:prebid-mobile-sdk-gam-event-handlers:2.0.0'
+    implementation 'org.prebid:prebid-mobile-sdk-admob-adapters:2.0.0'
+    implementation 'org.prebid:prebid-mobile-sdk-max-adapters:2.0.0'
 
     // Standard libraries
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"

--- a/Example/PrebidDemoKotlin/src/main/java/org/prebid/mobile/prebidkotlindemo/MainActivity.kt
+++ b/Example/PrebidDemoKotlin/src/main/java/org/prebid/mobile/prebidkotlindemo/MainActivity.kt
@@ -27,8 +27,8 @@ import org.prebid.mobile.prebidkotlindemo.databinding.ActivityMainBinding
 class MainActivity : AppCompatActivity() {
 
     companion object {
-        private const val FIRST_AD_SERVER = ""
-        private const val FIRST_AD_TYPE = ""
+        private const val FIRST_AD_SERVER = "In-App"
+        private const val FIRST_AD_TYPE = "Video Banner"
     }
 
     private var adType = ""

--- a/Example/PrebidInternalTestApp/build.gradle
+++ b/Example/PrebidInternalTestApp/build.gradle
@@ -84,16 +84,16 @@ dependencies {
     def nav_version = "2.3.1"
     def lifecycle_version = "2.2.0"
 
-    implementation project(':PrebidMobile')
-    implementation project(':PrebidMobile-gamEventHandlers')
-    implementation project(':PrebidMobile-admobAdapters')
-    implementation project(':PrebidMobile-maxAdapters')
+//    implementation project(':PrebidMobile')
+//    implementation project(':PrebidMobile-gamEventHandlers')
+//    implementation project(':PrebidMobile-admobAdapters')
+//    implementation project(':PrebidMobile-maxAdapters')
 
     // For testing staging releases
-//    implementation 'org.prebid:prebid-mobile-sdk:2.0.0'
-//    implementation 'org.prebid:prebid-mobile-sdk-gam-event-handlers:2.0.0'
-//    implementation 'org.prebid:prebid-mobile-sdk-admob-adapters:2.0.0'
-//    implementation 'org.prebid:prebid-mobile-sdk-max-adapters:2.0.0'
+    implementation 'org.prebid:prebid-mobile-sdk:2.0.0'
+    implementation 'org.prebid:prebid-mobile-sdk-gam-event-handlers:2.0.0'
+    implementation 'org.prebid:prebid-mobile-sdk-admob-adapters:2.0.0'
+    implementation 'org.prebid:prebid-mobile-sdk-max-adapters:2.0.0'
 
     // Base dependencies
     implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$kotlin_version"

--- a/Example/PrebidInternalTestApp/src/androidTest/java/org/prebid/mobile/renderingtestapp/uiAutomator/utils/RetryRule.java
+++ b/Example/PrebidInternalTestApp/src/androidTest/java/org/prebid/mobile/renderingtestapp/uiAutomator/utils/RetryRule.java
@@ -21,10 +21,10 @@ import org.junit.runner.Description;
 import org.junit.runners.model.Statement;
 
 public class RetryRule implements TestRule {
-    private int mMaxTries;
+    private int maxTries;
 
     public RetryRule(int maxTries) {
-        mMaxTries = maxTries;
+        this.maxTries = maxTries;
     }
 
     public Statement apply(Statement base, Description description) {
@@ -38,17 +38,16 @@ public class RetryRule implements TestRule {
                 Throwable caughtThrowable = null;
 
                 // implement retry logic here
-                for (int i = 0; i < mMaxTries; i++) {
+                for (int i = 0; i < maxTries; i++) {
                     try {
                         base.evaluate();
                         return;
-                    }
-                    catch (Throwable t) {
+                    } catch (Throwable t) {
                         caughtThrowable = t;
                         System.err.println(description.getDisplayName() + ": run " + (i + 1) + " failed");
                     }
                 }
-                System.err.println(description.getDisplayName() + ": giving up after " + mMaxTries + " failures");
+                System.err.println(description.getDisplayName() + ": giving up after " + maxTries + " failures");
                 throw caughtThrowable;
             }
         };

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/MainActivity.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/MainActivity.kt
@@ -60,7 +60,7 @@ class MainActivity : AppCompatActivity(), SdkInitListener {
 
     private val TAG = MainActivity::class.java.simpleName
 
-    private lateinit var mProgress: ProgressDialog
+    private lateinit var progress: ProgressDialog
     private lateinit var bottomAppBar: BottomNavigationView
     private lateinit var titleText: TextView
 
@@ -98,7 +98,7 @@ class MainActivity : AppCompatActivity(), SdkInitListener {
 
     override fun onSDKInit() {
         Log.i(TAG, "Prebid rendering SDK initialized successfully")
-        mProgress.dismiss()
+        progress.dismiss()
     }
 
     fun getIdlingResource(): IdlingResource? {
@@ -114,11 +114,11 @@ class MainActivity : AppCompatActivity(), SdkInitListener {
     }
 
     private fun initProgressDialog() {
-        mProgress = ProgressDialog(this)
-        mProgress.setTitle("Please wait")
-        mProgress.setMessage("Caching video ads")
-        mProgress.setCancelable(false)
-        mProgress.setProgressStyle(ProgressDialog.STYLE_SPINNER)
+        progress = ProgressDialog(this)
+        progress.setTitle("Please wait")
+        progress.setMessage("Caching video ads")
+        progress.setCancelable(false)
+        progress.setProgressStyle(ProgressDialog.STYLE_SPINNER)
     }
 
     private fun initBarNavigation() {

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/BidLog.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/BidLog.java
@@ -1,15 +1,15 @@
 package org.prebid.mobile;
 
 public class BidLog {
-    private BidLogEntry mLastEntry;
+    private BidLogEntry lastEntry;
 
-    private static BidLog sInstance;
+    private static BidLog instance;
 
     public static BidLog getInstance() {
-        if (sInstance == null) {
-            sInstance = new BidLog();
+        if (instance == null) {
+            instance = new BidLog();
         }
-        return sInstance;
+        return instance;
     }
 
     private BidLog() {
@@ -17,15 +17,15 @@ public class BidLog {
     }
 
     public BidLogEntry getLastBid() {
-        return mLastEntry;
+        return lastEntry;
     }
 
     public void setLastEntry(BidLogEntry entry) {
-        this.mLastEntry = entry;
+        this.lastEntry = entry;
     }
 
     public void cleanLog() {
-        this.mLastEntry = null;
+        this.lastEntry = null;
     }
 
     public static class BidLogEntry {

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/data/BannerAdPosition.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/data/BannerAdPosition.java
@@ -25,14 +25,14 @@ public enum BannerAdPosition {
     FOOTER(5),
     SIDEBAR(6);
 
-    private final int mValue;
+    private final int value;
 
     BannerAdPosition(int value) {
-        mValue = value;
+        this.value = value;
     }
 
     public int getValue() {
-        return mValue;
+        return value;
     }
 
     public static BannerAdPosition mapToDisplayAdPosition(int adPosition) {

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/data/VideoPlacementType.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/data/VideoPlacementType.java
@@ -24,14 +24,14 @@ public enum VideoPlacementType {
     IN_ARTICLE(3),
     IN_FEED(4);
 
-    private final int mValue;
+    private final int value;
 
     VideoPlacementType(int value) {
-        mValue = value;
+        this.value = value;
     }
 
     public int getValue() {
-        return mValue;
+        return value;
     }
 
     @Nullable

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/exceptions/AdException.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/exceptions/AdException.java
@@ -27,10 +27,10 @@ public class AdException extends Exception {
     public static final String SERVER_ERROR = "Server error";
     public static final String THIRD_PARTY = "Third Party SDK";
 
-    private String mMessage;
+    private String message;
 
     public void setMessage(String msg) {
-        mMessage = msg;
+        message = msg;
     }
 
     /**
@@ -40,7 +40,7 @@ public class AdException extends Exception {
      */
     @Override
     public String getMessage() {
-        return mMessage;
+        return message;
     }
 
     public AdException(String type, String message) {

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/mediation/MediationBannerAdUnit.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/mediation/MediationBannerAdUnit.java
@@ -31,9 +31,9 @@ public class MediationBannerAdUnit extends MediationBaseAdUnit {
 
     private static final String TAG = MediationBannerAdUnit.class.getSimpleName();
 
-    private final ScreenStateReceiver mScreenStateReceiver = new ScreenStateReceiver();
+    private final ScreenStateReceiver screenStateReceiver = new ScreenStateReceiver();
 
-    private boolean mAdFailed;
+    private boolean adFailed;
 
     public MediationBannerAdUnit(
         Context context,
@@ -42,7 +42,7 @@ public class MediationBannerAdUnit extends MediationBaseAdUnit {
         PrebidMediationDelegate mediationDelegate
     ) {
         super(context, configId, size, mediationDelegate);
-        mScreenStateReceiver.register(context);
+        screenStateReceiver.register(context);
     }
 
     @Override
@@ -50,30 +50,30 @@ public class MediationBannerAdUnit extends MediationBaseAdUnit {
         String configId,
         AdSize adSize
     ) {
-        mAdUnitConfig.addSize(adSize);
-        mAdUnitConfig.setConfigId(configId);
-        mAdUnitConfig.setAdFormat(AdFormat.BANNER);
+        adUnitConfig.addSize(adSize);
+        adUnitConfig.setConfigId(configId);
+        adUnitConfig.setAdFormat(AdFormat.BANNER);
     }
 
     @Override
     public void destroy() {
         super.destroy();
-        mScreenStateReceiver.unregister();
+        screenStateReceiver.unregister();
     }
 
     @Override
     protected void initBidLoader() {
         super.initBidLoader();
 
-        mBidLoader.setBidRefreshListener(() -> {
-            if (mAdFailed) {
-                mAdFailed = false;
+        bidLoader.setBidRefreshListener(() -> {
+            if (adFailed) {
+                adFailed = false;
                 LogUtil.debug(TAG, "Ad failed, can perform refresh.");
                 return true;
             }
 
-            boolean isViewVisible = mMediationDelegate.canPerformRefresh();
-            boolean canRefresh = mScreenStateReceiver.isScreenOn() && isViewVisible;
+            boolean isViewVisible = mediationDelegate.canPerformRefresh();
+            boolean canRefresh = screenStateReceiver.isScreenOn() && isViewVisible;
             LogUtil.debug(TAG, "Can perform refresh: " + canRefresh);
             return canRefresh;
         });
@@ -88,30 +88,30 @@ public class MediationBannerAdUnit extends MediationBaseAdUnit {
     }
 
     public final void addAdditionalSizes(AdSize... sizes) {
-        mAdUnitConfig.addSizes(sizes);
+        adUnitConfig.addSizes(sizes);
     }
 
     public final void setRefreshInterval(int seconds) {
-        mAdUnitConfig.setAutoRefreshDelay(seconds);
+        adUnitConfig.setAutoRefreshDelay(seconds);
     }
 
     public void setAdPosition(BannerAdPosition bannerAdPosition) {
         final AdPosition adPosition = BannerAdPosition.mapToAdPosition(bannerAdPosition);
-        mAdUnitConfig.setAdPosition(adPosition);
+        adUnitConfig.setAdPosition(adPosition);
     }
 
     public BannerAdPosition getAdPosition() {
-        return BannerAdPosition.mapToDisplayAdPosition(mAdUnitConfig.getAdPositionValue());
+        return BannerAdPosition.mapToDisplayAdPosition(adUnitConfig.getAdPositionValue());
     }
 
     public void stopRefresh() {
-        if (mBidLoader != null) {
-            mBidLoader.cancelRefresh();
+        if (bidLoader != null) {
+            bidLoader.cancelRefresh();
         }
     }
 
     public void onAdFailed() {
-        mAdFailed = true;
+        adFailed = true;
     }
 
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/mediation/MediationBaseAdUnit.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/mediation/MediationBaseAdUnit.java
@@ -40,13 +40,13 @@ public abstract class MediationBaseAdUnit {
 
     private static final String TAG = MediationBaseAdUnit.class.getSimpleName();
 
-    protected OnFetchCompleteListener mOnFetchCompleteListener;
-    protected WeakReference<Context> mContextWeakReference;
-    protected AdUnitConfiguration mAdUnitConfig = new AdUnitConfiguration();
-    protected PrebidMediationDelegate mMediationDelegate;
-    protected BidLoader mBidLoader;
+    protected OnFetchCompleteListener onFetchCompleteListener;
+    protected WeakReference<Context> contextWeakReference;
+    protected AdUnitConfiguration adUnitConfig = new AdUnitConfiguration();
+    protected PrebidMediationDelegate mediationDelegate;
+    protected BidLoader bidLoader;
 
-    private final BidRequesterListener mBidRequesterListener = new BidRequesterListener() {
+    private final BidRequesterListener bidRequesterListener = new BidRequesterListener() {
         @Override
         public void onFetchCompleted(BidResponse response) {
             onResponseReceived(response);
@@ -64,16 +64,16 @@ public abstract class MediationBaseAdUnit {
         AdSize adSize,
         PrebidMediationDelegate mediationDelegate
     ) {
-        mContextWeakReference = new WeakReference<>(context);
-        mMediationDelegate = mediationDelegate;
-        mAdUnitConfig.setAutoRefreshDelay(PrebidMobile.AUTO_REFRESH_DELAY_MIN / 1000);
+        contextWeakReference = new WeakReference<>(context);
+        this.mediationDelegate = mediationDelegate;
+        adUnitConfig.setAutoRefreshDelay(PrebidMobile.AUTO_REFRESH_DELAY_MIN / 1000);
         initSdk(context);
         initAdConfig(configId, adSize);
         initBidLoader();
     }
 
     protected void fetchDemand(@NonNull OnFetchCompleteListener listener) {
-        if (mMediationDelegate == null) {
+        if (mediationDelegate == null) {
             LogUtil.error(TAG, "Demand fetch failed. Mediation delegate object must be not null");
             listener.onComplete(FetchDemandResult.INVALID_AD_OBJECT);
             return;
@@ -83,7 +83,7 @@ public abstract class MediationBaseAdUnit {
             listener.onComplete(FetchDemandResult.INVALID_ACCOUNT_ID);
             return;
         }
-        if (TextUtils.isEmpty(mAdUnitConfig.getConfigId())) {
+        if (TextUtils.isEmpty(adUnitConfig.getConfigId())) {
             LogUtil.error(TAG, "Empty config id");
             listener.onComplete(FetchDemandResult.INVALID_CONFIG_ID);
             return;
@@ -96,89 +96,89 @@ public abstract class MediationBaseAdUnit {
             return;
         }
 
-        mOnFetchCompleteListener = listener;
-        mBidLoader.load();
+        onFetchCompleteListener = listener;
+        bidLoader.load();
     }
 
     public void addContextData(
         String key,
         String value
     ) {
-        mAdUnitConfig.addContextData(key, value);
+        adUnitConfig.addContextData(key, value);
     }
 
     public void updateContextData(
         String key,
         Set<String> value
     ) {
-        mAdUnitConfig.addContextData(key, value);
+        adUnitConfig.addContextData(key, value);
     }
 
     public void removeContextData(String key) {
-        mAdUnitConfig.removeContextData(key);
+        adUnitConfig.removeContextData(key);
     }
 
     public void clearContextData() {
-        mAdUnitConfig.clearContextData();
+        adUnitConfig.clearContextData();
     }
 
     public Map<String, Set<String>> getContextDataDictionary() {
-        return mAdUnitConfig.getContextDataDictionary();
+        return adUnitConfig.getContextDataDictionary();
     }
 
     public void addContextKeyword(String keyword) {
-        mAdUnitConfig.addContextKeyword(keyword);
+        adUnitConfig.addContextKeyword(keyword);
     }
 
     public void addContextKeywords(Set<String> keywords) {
-        mAdUnitConfig.addContextKeywords(keywords);
+        adUnitConfig.addContextKeywords(keywords);
     }
 
     public void removeContextKeyword(String keyword) {
-        mAdUnitConfig.removeContextKeyword(keyword);
+        adUnitConfig.removeContextKeyword(keyword);
     }
 
     public Set<String> getContextKeywordsSet() {
-        return mAdUnitConfig.getContextKeywordsSet();
+        return adUnitConfig.getContextKeywordsSet();
     }
 
     public void clearContextKeywords() {
-        mAdUnitConfig.clearContextKeywords();
+        adUnitConfig.clearContextKeywords();
     }
 
     public void setPbAdSlot(String adSlot) {
-        mAdUnitConfig.setPbAdSlot(adSlot);
+        adUnitConfig.setPbAdSlot(adSlot);
     }
 
     @Nullable
     public String getPbAdSlot() {
-        return mAdUnitConfig.getPbAdSlot();
+        return adUnitConfig.getPbAdSlot();
     }
 
     public void setAppContent(ContentObject content) {
-        mAdUnitConfig.setAppContent(content);
+        adUnitConfig.setAppContent(content);
     }
 
     public ContentObject getAppContent() {
-        return mAdUnitConfig.getAppContent();
+        return adUnitConfig.getAppContent();
     }
 
     public void addUserData(DataObject dataObject) {
-        mAdUnitConfig.addUserData(dataObject);
+        adUnitConfig.addUserData(dataObject);
     }
 
     public void clearUserData() {
-        mAdUnitConfig.clearUserData();
+        adUnitConfig.clearUserData();
     }
 
     public ArrayList<DataObject> getUserData() {
-        return mAdUnitConfig.getUserData();
+        return adUnitConfig.getUserData();
     }
 
     public void destroy() {
-        mOnFetchCompleteListener = null;
-        mBidLoader.destroy();
-        mBidLoader = null;
+        onFetchCompleteListener = null;
+        bidLoader.destroy();
+        bidLoader = null;
     }
 
     protected abstract void initAdConfig(
@@ -188,27 +188,27 @@ public abstract class MediationBaseAdUnit {
 
     protected void onResponseReceived(BidResponse response) {
         LogUtil.debug(TAG, "On response received");
-        if (mOnFetchCompleteListener == null) {
+        if (onFetchCompleteListener == null) {
             cancelRefresh();
             return;
         }
         BidResponseCache.getInstance().putBidResponse(response);
-        mMediationDelegate.handleKeywordsUpdate(response.getTargeting());
-        mMediationDelegate.setResponseToLocalExtras(response);
-        mOnFetchCompleteListener.onComplete(FetchDemandResult.SUCCESS);
+        mediationDelegate.handleKeywordsUpdate(response.getTargeting());
+        mediationDelegate.setResponseToLocalExtras(response);
+        onFetchCompleteListener.onComplete(FetchDemandResult.SUCCESS);
     }
 
     protected void onErrorReceived(AdException exception) {
         LogUtil.warning(TAG, "On error received");
-        if (mOnFetchCompleteListener == null) {
+        if (onFetchCompleteListener == null) {
             cancelRefresh();
             return;
         }
-        mOnFetchCompleteListener.onComplete(FetchDemandResult.parseErrorMessage(exception.getMessage()));
+        onFetchCompleteListener.onComplete(FetchDemandResult.parseErrorMessage(exception.getMessage()));
     }
 
     protected void initBidLoader() {
-        mBidLoader = new BidLoader(mContextWeakReference.get(), mAdUnitConfig, mBidRequesterListener);
+        bidLoader = new BidLoader(contextWeakReference.get(), adUnitConfig, bidRequesterListener);
     }
 
     private void initSdk(Context context) {
@@ -217,9 +217,9 @@ public abstract class MediationBaseAdUnit {
     }
 
     private void cancelRefresh() {
-        mBidLoader.cancelRefresh();
+        bidLoader.cancelRefresh();
         LogUtil.error(TAG, "Failed to pass callback");
-        if (mOnFetchCompleteListener == null) {
+        if (onFetchCompleteListener == null) {
             LogUtil.error(TAG, "OnFetchCompleteListener is null");
         }
     }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/mediation/MediationBaseFullScreenAdUnit.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/mediation/MediationBaseFullScreenAdUnit.java
@@ -24,14 +24,14 @@ public abstract class MediationBaseFullScreenAdUnit extends MediationBaseAdUnit 
      * Sets max video duration. If the ad from server is bigger, it will be rejected.
      */
     public void setMaxVideoDuration(int seconds) {
-        mAdUnitConfig.setMaxVideoDuration(seconds);
+        adUnitConfig.setMaxVideoDuration(seconds);
     }
 
     /**
      * Sets delay in seconds to show skip or close button.
      */
     public void setSkipDelay(int secondsDelay) {
-        mAdUnitConfig.setSkipDelay(secondsDelay);
+        adUnitConfig.setSkipDelay(secondsDelay);
     }
 
     /**
@@ -39,7 +39,7 @@ public abstract class MediationBaseFullScreenAdUnit extends MediationBaseAdUnit 
      * If value less than 0.05, size will be default.
      */
     public void setSkipButtonArea(@FloatRange(from = 0, to = 1.0) double buttonArea) {
-        mAdUnitConfig.setSkipButtonArea(buttonArea);
+        adUnitConfig.setSkipButtonArea(buttonArea);
     }
 
     /**
@@ -47,7 +47,7 @@ public abstract class MediationBaseFullScreenAdUnit extends MediationBaseAdUnit 
      * Default value TOP_RIGHT.
      */
     public void setSkipButtonPosition(Position skipButtonPosition) {
-        mAdUnitConfig.setSkipButtonPosition(skipButtonPosition);
+        adUnitConfig.setSkipButtonPosition(skipButtonPosition);
     }
 
     /**
@@ -55,7 +55,7 @@ public abstract class MediationBaseFullScreenAdUnit extends MediationBaseAdUnit 
      * If value less than 0.05, size will be default.
      */
     public void setCloseButtonArea(@FloatRange(from = 0, to = 1.0) double closeButtonArea) {
-        mAdUnitConfig.setCloseButtonArea(closeButtonArea);
+        adUnitConfig.setCloseButtonArea(closeButtonArea);
     }
 
     /**
@@ -63,21 +63,21 @@ public abstract class MediationBaseFullScreenAdUnit extends MediationBaseAdUnit 
      * Default value TOP_RIGHT.
      */
     public void setCloseButtonPosition(@Nullable Position closeButtonPosition) {
-        mAdUnitConfig.setCloseButtonPosition(closeButtonPosition);
+        adUnitConfig.setCloseButtonPosition(closeButtonPosition);
     }
 
     /**
      * Sets desired is muted property.
      */
     public void setIsMuted(boolean isMuted) {
-        mAdUnitConfig.setIsMuted(isMuted);
+        adUnitConfig.setIsMuted(isMuted);
     }
 
     /**
      * Makes sound button visible.
      */
     public void setIsSoundButtonVisible(boolean isSoundButtonVisible) {
-        mAdUnitConfig.setIsSoundButtonVisible(isSoundButtonVisible);
+        adUnitConfig.setIsSoundButtonVisible(isSoundButtonVisible);
     }
 
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/mediation/MediationInterstitialAdUnit.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/mediation/MediationInterstitialAdUnit.java
@@ -42,7 +42,7 @@ public class MediationInterstitialAdUnit extends MediationBaseFullScreenAdUnit {
         PrebidMediationDelegate mediationDelegate
     ) {
         super(context, configId, minSizePercentage, mediationDelegate);
-        mAdUnitConfig.setAdFormat(AdFormat.INTERSTITIAL);
+        adUnitConfig.setAdFormat(AdFormat.INTERSTITIAL);
     }
 
     /**
@@ -55,7 +55,7 @@ public class MediationInterstitialAdUnit extends MediationBaseFullScreenAdUnit {
         PrebidMediationDelegate mediationDelegate
     ) {
         super(context, configId, null, mediationDelegate);
-        mAdUnitConfig.setAdFormats(adUnitFormats);
+        adUnitConfig.setAdFormats(adUnitFormats);
     }
 
     @Override
@@ -68,9 +68,9 @@ public class MediationInterstitialAdUnit extends MediationBaseFullScreenAdUnit {
         String configId,
         AdSize minSizePercentage
     ) {
-        mAdUnitConfig.setMinSizePercentage(minSizePercentage);
-        mAdUnitConfig.setConfigId(configId);
-        mAdUnitConfig.setAdPosition(AdPosition.FULLSCREEN);
+        adUnitConfig.setMinSizePercentage(minSizePercentage);
+        adUnitConfig.setConfigId(configId);
+        adUnitConfig.setAdPosition(AdPosition.FULLSCREEN);
     }
 
     /**
@@ -80,7 +80,7 @@ public class MediationInterstitialAdUnit extends MediationBaseFullScreenAdUnit {
         @IntRange(from = 0, to = 100) int width,
         @IntRange(from = 0, to = 100) int height
     ) {
-        mAdUnitConfig.setMinSizePercentage(new AdSize(width, height));
+        adUnitConfig.setMinSizePercentage(new AdSize(width, height));
     }
 
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/mediation/MediationRewardedVideoAdUnit.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/mediation/MediationRewardedVideoAdUnit.java
@@ -49,20 +49,20 @@ public class MediationRewardedVideoAdUnit extends MediationBaseFullScreenAdUnit 
         String configId,
         AdSize adSize
     ) {
-        mAdUnitConfig.setConfigId(configId);
-        mAdUnitConfig.setAdFormat(AdFormat.VAST);
-        mAdUnitConfig.setRewarded(true);
-        mAdUnitConfig.setAdPosition(AdPosition.FULLSCREEN);
+        adUnitConfig.setConfigId(configId);
+        adUnitConfig.setAdFormat(AdFormat.VAST);
+        adUnitConfig.setRewarded(true);
+        adUnitConfig.setAdPosition(AdPosition.FULLSCREEN);
     }
 
     @Override
     protected final void onResponseReceived(BidResponse response) {
-        if (mOnFetchCompleteListener != null) {
+        if (onFetchCompleteListener != null) {
             LogUtil.debug(TAG, "On response received");
             BidResponseCache.getInstance().putBidResponse(response.getId(), response);
-            mMediationDelegate.setResponseToLocalExtras(response);
-            mMediationDelegate.handleKeywordsUpdate(response.getTargeting());
-            mOnFetchCompleteListener.onComplete(FetchDemandResult.SUCCESS);
+            mediationDelegate.setResponseToLocalExtras(response);
+            mediationDelegate.handleKeywordsUpdate(response.getTargeting());
+            onFetchCompleteListener.onComplete(FetchDemandResult.SUCCESS);
         }
     }
 

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/BaseInterstitialAdUnit.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/BaseInterstitialAdUnit.java
@@ -112,7 +112,7 @@ public abstract class BaseInterstitialAdUnit {
             default:
                 notifyErrorListener(new AdException(
                     AdException.INTERNAL_ERROR,
-                    "show(): Encountered an invalid mInterstitialAdUnitState - " + interstitialAdUnitState
+                    "show(): Encountered an invalid interstitialAdUnitState - " + interstitialAdUnitState
                 ));
         }
     }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/DisplayView.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/DisplayView.java
@@ -40,19 +40,19 @@ public class DisplayView extends FrameLayout {
     private final static String TAG = DisplayView.class.getSimpleName();
     private static final String CONTENT_DESCRIPTION_AD_VIEW = "adView";
 
-    private AdUnitConfiguration mAdUnitConfiguration;
-    private DisplayViewListener mDisplayViewListener;
-    private InterstitialManager mInterstitialManager;
-    private AdViewManager mAdViewManager;
-    private VideoView mVideoView;
+    private AdUnitConfiguration adUnitConfiguration;
+    private DisplayViewListener displayViewListener;
+    private InterstitialManager interstitialManager;
+    private AdViewManager adViewManager;
+    private VideoView videoView;
 
-    private EventForwardingLocalBroadcastReceiver mEventForwardingReceiver;
-    private final EventForwardingLocalBroadcastReceiver.EventForwardingBroadcastListener mBroadcastListener = this::handleBroadcastAction;
+    private EventForwardingLocalBroadcastReceiver eventForwardingReceiver;
+    private final EventForwardingLocalBroadcastReceiver.EventForwardingBroadcastListener broadcastListener = this::handleBroadcastAction;
 
-    private final AdViewManagerListener mAdViewManagerListener = new AdViewManagerListener() {
+    private final AdViewManagerListener adViewManagerListener = new AdViewManagerListener() {
         @Override
         public void adLoaded(AdDetails adDetails) {
-            // for banner mAdViewManager.show() will be called automatically
+            // for banner adViewManager.show() will be called automatically
             notifyListenerLoaded();
         }
 
@@ -85,7 +85,7 @@ public class DisplayView extends FrameLayout {
         }
     };
 
-    private final VideoViewListener mVideoViewListener = new VideoViewListener() {
+    private final VideoViewListener videoViewListener = new VideoViewListener() {
         @Override
         public void onLoaded(
             @NonNull
@@ -140,9 +140,9 @@ public class DisplayView extends FrameLayout {
             BidResponse response
     ) {
         super(context);
-        mInterstitialManager = new InterstitialManager();
-        mAdUnitConfiguration = adUnitConfiguration;
-        mDisplayViewListener = listener;
+        interstitialManager = new InterstitialManager();
+        this.adUnitConfiguration = adUnitConfiguration;
+        displayViewListener = listener;
 
         WinNotifier winNotifier = new WinNotifier();
         winNotifier.notifyWin(response, () -> {
@@ -171,74 +171,74 @@ public class DisplayView extends FrameLayout {
     }
 
     public void destroy() {
-        mAdUnitConfiguration = null;
-        mDisplayViewListener = null;
-        mInterstitialManager = null;
-        if (mVideoView != null) {
-            mVideoView.destroy();
+        adUnitConfiguration = null;
+        displayViewListener = null;
+        interstitialManager = null;
+        if (videoView != null) {
+            videoView.destroy();
         }
-        if (mAdViewManager != null) {
-            mAdViewManager.destroy();
-            mAdViewManager = null;
+        if (adViewManager != null) {
+            adViewManager.destroy();
+            adViewManager = null;
         }
 
-        if (mEventForwardingReceiver != null) {
-            mEventForwardingReceiver.unregister(mEventForwardingReceiver);
-            mEventForwardingReceiver = null;
+        if (eventForwardingReceiver != null) {
+            eventForwardingReceiver.unregister(eventForwardingReceiver);
+            eventForwardingReceiver = null;
         }
     }
 
     private void displayHtmlAd(BidResponse response) throws AdException {
-        mAdViewManager = new AdViewManager(getContext(), mAdViewManagerListener, this, mInterstitialManager);
-        mAdViewManager.loadBidTransaction(mAdUnitConfiguration, response);
+        adViewManager = new AdViewManager(getContext(), adViewManagerListener, this, interstitialManager);
+        adViewManager.loadBidTransaction(adUnitConfiguration, response);
 
-        mEventForwardingReceiver = new EventForwardingLocalBroadcastReceiver(
-            mAdUnitConfiguration.getBroadcastId(),
-            mBroadcastListener
+        eventForwardingReceiver = new EventForwardingLocalBroadcastReceiver(
+            adUnitConfiguration.getBroadcastId(),
+            broadcastListener
         );
-        mEventForwardingReceiver.register(getContext(), mEventForwardingReceiver);
+        eventForwardingReceiver.register(getContext(), eventForwardingReceiver);
     }
 
     private void displayVideoAd(BidResponse response) throws AdException {
-        mVideoView = new VideoView(getContext(), mAdUnitConfiguration);
-        mVideoView.setVideoViewListener(mVideoViewListener);
-        mVideoView.setVideoPlayerClick(true);
-        mVideoView.loadAd(mAdUnitConfiguration, response);
-        addView(mVideoView);
+        videoView = new VideoView(getContext(), adUnitConfiguration);
+        videoView.setVideoViewListener(videoViewListener);
+        videoView.setVideoPlayerClick(true);
+        videoView.loadAd(adUnitConfiguration, response);
+        addView(videoView);
     }
 
     private void notifyListenerError(AdException e) {
         LogUtil.debug(TAG, "onAdFailed");
-        if (mDisplayViewListener != null) {
-            mDisplayViewListener.onAdFailed(e);
+        if (displayViewListener != null) {
+            displayViewListener.onAdFailed(e);
         }
     }
 
     private void notifyListenerClicked() {
         LogUtil.debug(TAG, "onAdClicked");
-        if (mDisplayViewListener != null) {
-            mDisplayViewListener.onAdClicked();
+        if (displayViewListener != null) {
+            displayViewListener.onAdClicked();
         }
     }
 
     private void notifyListenerClose() {
         LogUtil.debug(TAG, "onAdClosed");
-        if (mDisplayViewListener != null) {
-            mDisplayViewListener.onAdClosed();
+        if (displayViewListener != null) {
+            displayViewListener.onAdClosed();
         }
     }
 
     private void notifyListenerDisplayed() {
         LogUtil.debug(TAG, "onAdDisplayed");
-        if (mDisplayViewListener != null) {
-            mDisplayViewListener.onAdDisplayed();
+        if (displayViewListener != null) {
+            displayViewListener.onAdDisplayed();
         }
     }
 
     private void notifyListenerLoaded() {
         LogUtil.debug(TAG, "onAdLoaded");
-        if (mDisplayViewListener != null) {
-            mDisplayViewListener.onAdLoaded();
+        if (displayViewListener != null) {
+            displayViewListener.onAdLoaded();
         }
     }
 

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/InterstitialView.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/InterstitialView.java
@@ -38,21 +38,21 @@ public class InterstitialView extends BaseAdView {
 
     private static final String TAG = InterstitialView.class.getSimpleName();
 
-    private InterstitialViewListener mListener;
-    protected InterstitialVideo mInterstitialVideo;
+    private InterstitialViewListener listener;
+    protected InterstitialVideo interstitialVideo;
 
     //region ========== Listener Area
-    private final AdViewManagerListener mOnAdViewManagerListener = new AdViewManagerListener() {
+    private final AdViewManagerListener onAdViewManagerListener = new AdViewManagerListener() {
         @Override
         public void adLoaded(final AdDetails adDetails) {
-            mListener.onAdLoaded(InterstitialView.this, adDetails);
+            listener.onAdLoaded(InterstitialView.this, adDetails);
         }
 
         @Override
         public void viewReadyForImmediateDisplay(View view) {
-            if (mAdViewManager.isNotShowingEndCard()) {
+            if (adViewManager.isNotShowingEndCard()) {
 
-                mListener.onAdDisplayed(InterstitialView.this);
+                listener.onAdDisplayed(InterstitialView.this);
             }
 
             removeAllViews();
@@ -67,16 +67,16 @@ public class InterstitialView extends BaseAdView {
 
         @Override
         public void adCompleted() {
-            mListener.onAdCompleted(InterstitialView.this);
+            listener.onAdCompleted(InterstitialView.this);
 
-            if (mInterstitialVideo != null && mInterstitialVideo.shouldShowCloseButtonOnComplete()) {
-                mInterstitialVideo.changeCloseViewVisibility(View.VISIBLE);
+            if (interstitialVideo != null && interstitialVideo.shouldShowCloseButtonOnComplete()) {
+                interstitialVideo.changeCloseViewVisibility(View.VISIBLE);
             }
         }
 
         @Override
         public void creativeClicked(String url) {
-            mListener.onAdClicked(InterstitialView.this);
+            listener.onAdClicked(InterstitialView.this);
         }
 
         @Override
@@ -93,28 +93,28 @@ public class InterstitialView extends BaseAdView {
     }
 
     public void setPubBackGroundOpacity(float opacity) {
-        mInterstitialManager.getInterstitialDisplayProperties().setPubBackGroundOpacity(opacity);
+        interstitialManager.getInterstitialDisplayProperties().setPubBackGroundOpacity(opacity);
     }
 
     public void loadAd(
         AdUnitConfiguration adUnitConfiguration,
         BidResponse bidResponse
     ) {
-        mAdViewManager.loadBidTransaction(adUnitConfiguration, bidResponse);
+        adViewManager.loadBidTransaction(adUnitConfiguration, bidResponse);
     }
 
     public void setInterstitialViewListener(InterstitialViewListener listener) {
-        mListener = listener;
+        this.listener = listener;
     }
 
     @Override
     public void onWindowFocusChanged(boolean hasWindowFocus) {
         super.onWindowFocusChanged(hasWindowFocus);
-        if (mInterstitialVideo != null) {
+        if (interstitialVideo != null) {
             if (!hasWindowFocus) {
-                mInterstitialVideo.pauseVideo();
+                interstitialVideo.pauseVideo();
             } else {
-                mInterstitialVideo.resumeVideo();
+                interstitialVideo.resumeVideo();
             }
         }
     }
@@ -125,17 +125,17 @@ public class InterstitialView extends BaseAdView {
         // so, activity's destroy() calling adview's destry should not crash
         super.destroy();
 
-        if (mInterstitialVideo != null) {
-            mInterstitialVideo.hide();
-            mInterstitialVideo.cancel();
-            mInterstitialVideo.removeViews();
+        if (interstitialVideo != null) {
+            interstitialVideo.hide();
+            interstitialVideo.cancel();
+            interstitialVideo.removeViews();
         }
     }
 
     public void showAsInterstitialFromRoot() {
         try {
-            mInterstitialManager.configureInterstitialProperties(mAdViewManager.getAdConfiguration());
-            mInterstitialManager.displayAdViewInInterstitial(getContext(), InterstitialView.this);
+            interstitialManager.configureInterstitialProperties(adViewManager.getAdConfiguration());
+            interstitialManager.displayAdViewInInterstitial(getContext(), InterstitialView.this);
         } catch (final Exception e) {
             LogUtil.error(TAG, "Interstitial failed to show:" + Log.getStackTraceString(e));
             notifyErrorListeners(new AdException(AdException.INTERNAL_ERROR, e.getMessage()));
@@ -144,17 +144,17 @@ public class InterstitialView extends BaseAdView {
 
     public void showVideoAsInterstitial() {
         try {
-            final AdUnitConfiguration adConfiguration = mAdViewManager.getAdConfiguration();
-            mInterstitialManager.configureInterstitialProperties(adConfiguration);
-            mInterstitialVideo = new InterstitialVideo(
+            final AdUnitConfiguration adConfiguration = adViewManager.getAdConfiguration();
+            interstitialManager.configureInterstitialProperties(adConfiguration);
+            interstitialVideo = new InterstitialVideo(
                 getContext(),
                 InterstitialView.this,
-                mInterstitialManager,
+                interstitialManager,
                 adConfiguration
             );
-            mInterstitialVideo.setHasEndCard(mAdViewManager.hasNextCreative());
-            mInterstitialVideo.setDialogListener(this::handleDialogEvent);
-            mInterstitialVideo.show();
+            interstitialVideo.setHasEndCard(adViewManager.hasNextCreative());
+            interstitialVideo.setDialogListener(this::handleDialogEvent);
+            interstitialVideo.show();
         } catch (final Exception e) {
             LogUtil.error(TAG, "Video interstitial failed to show:" + Log.getStackTraceString(e));
 
@@ -163,11 +163,11 @@ public class InterstitialView extends BaseAdView {
     }
 
     public void closeInterstitialVideo() {
-        if (mInterstitialVideo != null) {
-            if (mInterstitialVideo.isShowing()) {
-                mInterstitialVideo.close();
+        if (interstitialVideo != null) {
+            if (interstitialVideo.isShowing()) {
+                interstitialVideo.close();
             }
-            mInterstitialVideo = null;
+            interstitialVideo = null;
         }
     }
 
@@ -184,21 +184,21 @@ public class InterstitialView extends BaseAdView {
 
     @Override
     protected void notifyErrorListeners(final AdException adException) {
-        if (mListener != null) {
-            mListener.onAdFailed(InterstitialView.this, adException);
+        if (listener != null) {
+            listener.onAdFailed(InterstitialView.this, adException);
         }
     }
 
     @Override
     protected void handleBroadcastAction(String action) {
         if (IntentActions.ACTION_BROWSER_CLOSE.equals(action)) {
-            mListener.onAdClickThroughClosed(InterstitialView.this);
+            listener.onAdClickThroughClosed(InterstitialView.this);
         }
     }
 
     protected void setAdViewManagerValues() throws AdException {
-        mAdViewManager = new AdViewManager(getContext(), mOnAdViewManagerListener, this, mInterstitialManager);
-        AdUnitConfiguration adConfiguration = mAdViewManager.getAdConfiguration();
+        adViewManager = new AdViewManager(getContext(), onAdViewManagerListener, this, interstitialManager);
+        AdUnitConfiguration adConfiguration = adViewManager.getAdConfiguration();
         adConfiguration.setAutoRefreshDelay(0);
     }
 
@@ -218,25 +218,25 @@ public class InterstitialView extends BaseAdView {
 
     private void handleDialogEvent(DialogEventListener.EventType eventType) {
         if (eventType == DialogEventListener.EventType.SHOWN) {
-            mAdViewManager.addObstructions((formInterstitialObstructionsArray()));
+            adViewManager.addObstructions((formInterstitialObstructionsArray()));
         } else if (eventType == DialogEventListener.EventType.CLOSED) {
             handleActionClose();
         } else if (eventType == DialogEventListener.EventType.MUTE) {
-            mAdViewManager.mute();
+            adViewManager.mute();
         } else if (eventType == DialogEventListener.EventType.UNMUTE) {
-            mAdViewManager.unmute();
+            adViewManager.unmute();
         }
     }
 
     private void handleActionClose() {
-        if (mAdViewManager.isInterstitialClosed()) {
-            mAdViewManager.trackCloseEvent();
+        if (adViewManager.isInterstitialClosed()) {
+            adViewManager.trackCloseEvent();
             return;
         }
 
-        mAdViewManager.resetTransactionState();
+        adViewManager.resetTransactionState();
 
-        mListener.onAdClosed(InterstitialView.this);
+        listener.onAdClosed(InterstitialView.this);
     }
 
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/VideoView.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/VideoView.java
@@ -44,35 +44,35 @@ public class VideoView extends BaseAdView {
 
     private final static String TAG = VideoView.class.getSimpleName();
 
-    private VideoViewListener mListener;
+    private VideoViewListener listener;
 
-    private CreativeVisibilityTracker mVisibilityTracker;
-    private final CreativeVisibilityTracker.VisibilityTrackerListener mVisibilityTrackerListener = this::handleVisibilityChange;
+    private CreativeVisibilityTracker visibilityTracker;
+    private final CreativeVisibilityTracker.VisibilityTrackerListener visibilityTrackerListener = this::handleVisibilityChange;
 
-    private State mVideoViewState = State.UNDEFINED;
+    private State videoViewState = State.UNDEFINED;
 
-    private boolean mEnableVideoPlayerClick;
-    private boolean mEnableAutoPlay = true;
+    private boolean enableVideoPlayerClick;
+    private boolean enableAutoPlay = true;
 
     //region ========== Listener Area
 
-    private final AdViewManagerListener mOnAdViewManagerListener = new AdViewManagerListener() {
+    private final AdViewManagerListener onAdViewManagerListener = new AdViewManagerListener() {
         @Override
         public void adLoaded(final AdDetails adDetails) {
-            mListener.onLoaded(VideoView.this, adDetails);
+            listener.onLoaded(VideoView.this, adDetails);
             changeState(State.PLAYBACK_NOT_STARTED);
-            if (mEnableAutoPlay) {
+            if (enableAutoPlay) {
                 startVisibilityTracking();
             }
         }
 
         @Override
         public void viewReadyForImmediateDisplay(View view) {
-            if (mAdViewManager.isNotShowingEndCard()) {
-                mListener.onDisplayed(VideoView.this);
+            if (adViewManager.isNotShowingEndCard()) {
+                listener.onDisplayed(VideoView.this);
             }
             removeAllViews();
-            if (mAdViewManager.hasEndCard()) {
+            if (adViewManager.hasEndCard()) {
                 showEndCardCreative(view);
             } else {
                 showVideoCreative(view);
@@ -88,36 +88,36 @@ public class VideoView extends BaseAdView {
         public void videoCreativePlaybackFinished() {
             stopVisibilityTracking();
             changeState(State.PLAYBACK_FINISHED);
-            mListener.onPlayBackCompleted(VideoView.this);
+            listener.onPlayBackCompleted(VideoView.this);
 
-            if (mAdViewManager.isNotShowingEndCard()) {
+            if (adViewManager.isNotShowingEndCard()) {
                 showWatchAgain();
             }
         }
 
         @Override
         public void creativeClicked(String url) {
-            mListener.onClickThroughOpened(VideoView.this);
+            listener.onClickThroughOpened(VideoView.this);
         }
 
         @Override
         public void creativeMuted() {
-            mListener.onVideoMuted();
+            listener.onVideoMuted();
         }
 
         @Override
         public void creativeUnMuted() {
-            mListener.onVideoUnMuted();
+            listener.onVideoUnMuted();
         }
 
         @Override
         public void creativePaused() {
-            mListener.onPlaybackPaused();
+            listener.onPlaybackPaused();
         }
 
         @Override
         public void creativeResumed() {
-            mListener.onPlaybackResumed();
+            listener.onPlaybackResumed();
         }
     };
     //endregion ========== Listener Area
@@ -140,7 +140,7 @@ public class VideoView extends BaseAdView {
         AdUnitConfiguration adUnitConfiguration,
         BidResponse bidResponse
     ) {
-        mAdViewManager.loadBidTransaction(adUnitConfiguration, bidResponse);
+        adViewManager.loadBidTransaction(adUnitConfiguration, bidResponse);
     }
 
     public void loadAd(
@@ -150,7 +150,7 @@ public class VideoView extends BaseAdView {
         stopVisibilityTracking();
         changeState(State.UNDEFINED);
 
-        mAdViewManager.loadVideoTransaction(adConfiguration, vastXml);
+        adViewManager.loadVideoTransaction(adConfiguration, vastXml);
     }
 
     @Override
@@ -158,31 +158,31 @@ public class VideoView extends BaseAdView {
         super.destroy();
         stopVisibilityTracking();
 
-        // if (mVideoDialog != null) {
-        //     mVideoDialog.hide();
-        //     mVideoDialog.cancel();
-        //     mVideoDialog = null;
+        // if (videoDialog != null) {
+        //     videoDialog.hide();
+        //     videoDialog.cancel();
+        //     videoDialog = null;
         // }
     }
 
     public void mute(boolean enabled) {
         if (enabled) {
-            mAdViewManager.mute();
+            adViewManager.mute();
         } else {
-            mAdViewManager.unmute();
+            adViewManager.unmute();
         }
     }
 
     public void setVideoViewListener(VideoViewListener listener) {
-        mListener = listener;
+        this.listener = listener;
     }
 
     public void setVideoPlayerClick(boolean enable) {
-        mEnableVideoPlayerClick = enable;
+        enableVideoPlayerClick = enable;
     }
 
     public void setAutoPlay(boolean enable) {
-        mEnableAutoPlay = enable;
+        enableAutoPlay = enable;
 
         if (!enable) {
             stopVisibilityTracking();
@@ -191,32 +191,32 @@ public class VideoView extends BaseAdView {
 
     public void pause() {
         if (!canPause()) {
-            LogUtil.debug(TAG, "pause() can't pause " + mVideoViewState);
+            LogUtil.debug(TAG, "pause() can't pause " + videoViewState);
             return;
         }
 
         changeState(State.PAUSED_BY_USER);
-        mAdViewManager.pause();
+        adViewManager.pause();
     }
 
     public void resume() {
         if (!canResume()) {
-            LogUtil.debug(TAG, "resume() can't resume " + mVideoViewState);
+            LogUtil.debug(TAG, "resume() can't resume " + videoViewState);
             return;
         }
 
         changeState(State.PLAYING);
-        mAdViewManager.resume();
+        adViewManager.resume();
     }
 
     public void play() {
         if (!canPlay()) {
-            LogUtil.debug(TAG, "play() can't play " + mVideoViewState);
+            LogUtil.debug(TAG, "play() can't play " + videoViewState);
             return;
         }
 
         changeState(State.PLAYING);
-        mAdViewManager.show();
+        adViewManager.show();
     }
 
     @Override
@@ -235,20 +235,20 @@ public class VideoView extends BaseAdView {
     protected void handleBroadcastAction(String action) {
         switch (action) {
             case IntentActions.ACTION_BROWSER_CLOSE:
-                mListener.onClickThroughClosed(VideoView.this);
+                listener.onClickThroughClosed(VideoView.this);
                 break;
         }
     }
 
     protected void setAdViewManagerValues() throws AdException {
-        mAdViewManager = new AdViewManager(getContext(), mOnAdViewManagerListener, this, mInterstitialManager);
+        adViewManager = new AdViewManager(getContext(), onAdViewManagerListener, this, interstitialManager);
     }
 
     @Override
     protected void handleWindowFocusChange(boolean hasWindowFocus) {
         LogUtil.debug(TAG, "handleWindowFocusChange() called with: hasWindowFocus = [" + hasWindowFocus + "]");
         // visibility checker will handle resume
-        if (mEnableAutoPlay) {
+        if (enableAutoPlay) {
             return;
         }
 
@@ -257,7 +257,7 @@ public class VideoView extends BaseAdView {
 
     @Override
     public void notifyErrorListeners(final AdException adException) {
-        mListener.onLoadFailed(VideoView.this, adException);
+        listener.onLoadFailed(VideoView.this, adException);
     }
 
     private void prepareAdConfiguration(AdUnitConfiguration adUnitConfiguration) {
@@ -269,7 +269,7 @@ public class VideoView extends BaseAdView {
     private void showVideoCreative(View view) {
         VideoCreativeView videoCreativeView = (VideoCreativeView) view;
 
-        if (mEnableVideoPlayerClick) {
+        if (enableVideoPlayerClick) {
             videoCreativeView.enableVideoPlayerClick();
         }
         videoCreativeView.showVolumeControls();
@@ -280,7 +280,7 @@ public class VideoView extends BaseAdView {
 
     private void showEndCardCreative(View creativeView) {
         // if (isFullScreen()) {
-        //     mVideoDialog.showBannerCreative(creativeView);
+        //     videoDialog.showBannerCreative(creativeView);
         // }
         // else {
         Views.removeFromParent(creativeView);
@@ -308,7 +308,7 @@ public class VideoView extends BaseAdView {
             startVisibilityTracking();
         });
         // if (isFullScreen()) {
-        //     mVideoDialog.dismiss();
+        //     videoDialog.dismiss();
         // }
         addView(watchAgainButton);
     }
@@ -326,25 +326,25 @@ public class VideoView extends BaseAdView {
             InternalFriendlyObstruction.Purpose.VIDEO_CONTROLS,
             description
         );
-        mAdViewManager.addObstructions(obstruction);
+        adViewManager.addObstructions(obstruction);
     }
 
     private void startVisibilityTracking() {
         stopVisibilityTracking();
 
         final VisibilityTrackerOption visibilityTrackerOption = new VisibilityTrackerOption(NativeEventTracker.EventType.IMPRESSION);
-        mVisibilityTracker = new CreativeVisibilityTracker(
+        visibilityTracker = new CreativeVisibilityTracker(
             this,
             visibilityTrackerOption,
             true
         );
-        mVisibilityTracker.setVisibilityTrackerListener(mVisibilityTrackerListener);
-        mVisibilityTracker.startVisibilityCheck(getContext());
+        visibilityTracker.setVisibilityTrackerListener(visibilityTrackerListener);
+        visibilityTracker.startVisibilityCheck(getContext());
     }
 
     private void stopVisibilityTracking() {
-        if (mVisibilityTracker != null) {
-            mVisibilityTracker.stopVisibilityCheck();
+        if (visibilityTracker != null) {
+            visibilityTracker.stopVisibilityCheck();
         }
     }
 
@@ -353,7 +353,7 @@ public class VideoView extends BaseAdView {
 
         if (isVisible && canPlay()) {
             play();
-            LogUtil.debug(TAG, "handleVisibilityChange: auto show " + mVideoViewState);
+            LogUtil.debug(TAG, "handleVisibilityChange: auto show " + videoViewState);
             return;
         }
 
@@ -362,18 +362,18 @@ public class VideoView extends BaseAdView {
 
     private void handlePlaybackBasedOnVisibility(boolean isVisible) {
         if (!isVisible && canPause()) {
-            mAdViewManager.pause();
+            adViewManager.pause();
             changeState(State.PAUSED_AUTO);
-            LogUtil.debug(TAG, "handleVisibilityChange: auto pause " + mVideoViewState);
+            LogUtil.debug(TAG, "handleVisibilityChange: auto pause " + videoViewState);
         } else if (isVisible && isInState(State.PAUSED_AUTO)) {
-            mAdViewManager.resume();
+            adViewManager.resume();
             changeState(State.PLAYING);
-            LogUtil.debug(TAG, "handleVisibilityChange: auto resume " + mVideoViewState);
+            LogUtil.debug(TAG, "handleVisibilityChange: auto resume " + videoViewState);
         }
     }
 
     private void changeState(State undefined) {
-        mVideoViewState = undefined;
+        videoViewState = undefined;
     }
 
     private boolean canPlay() {
@@ -389,7 +389,7 @@ public class VideoView extends BaseAdView {
     }
 
     private boolean isInState(State state) {
-        return mVideoViewState == state;
+        return videoViewState == state;
     }
 
     enum State {
@@ -401,59 +401,59 @@ public class VideoView extends BaseAdView {
         PLAYBACK_FINISHED
     }
 
-    // private VideoDialog mVideoDialog;
-    // private ViewParent mViewParentBeforeExpand;
-    // private ViewGroup.LayoutParams mLayoutParamsBeforeExpand;
+    // private VideoDialog videoDialog;
+    // private ViewParent viewParentBeforeExpand;
+    // private ViewGroup.LayoutParams layoutParamsBeforeExpand;
 
-    // private final VideoDialogListener mVideoDialogListener = new VideoDialogListener() {
+    // private final VideoDialogListener videoDialogListener = new VideoDialogListener() {
     //     @Override
     //     public void onVideoDialogClosed() {
-    //         if (mAdViewManager.isInterstitialClosed()) {
-    //             mAdViewManager.trackCloseEvent();
+    //         if (adViewManager.isInterstitialClosed()) {
+    //             adViewManager.trackCloseEvent();
     //             return;
     //         }
-    //         mAdViewManager.resetTransactionState(); //?
+    //         adViewManager.resetTransactionState(); //?
     //
-    //         mListener.adInterstitialDidClose(VideoView.this);
+    //         listener.adInterstitialDidClose(VideoView.this);
     //     }
     // };
 
     // private void resetViewToInitialState() {
-    // mVideoDialog = null;
+    // videoDialog = null;
     // VideoView videoAdView = VideoView.this;
     //
-    // mAdViewManager.returnFromVideo(videoAdView);
+    // adViewManager.returnFromVideo(videoAdView);
     //
     // removeView(findViewById(R.id.iv_close_interstitial));
     //
     // Views.removeFromParent(videoAdView);
     //
-    // if (mLayoutParamsBeforeExpand != null) {
-    //     setLayoutParams(mLayoutParamsBeforeExpand);
+    // if (layoutParamsBeforeExpand != null) {
+    //     setLayoutParams(layoutParamsBeforeExpand);
     // }
     //
-    // if (mViewParentBeforeExpand instanceof ViewGroup) {
-    //     ((ViewGroup) mViewParentBeforeExpand).addView(videoAdView);
+    // if (viewParentBeforeExpand instanceof ViewGroup) {
+    //     ((ViewGroup) viewParentBeforeExpand).addView(videoAdView);
     // }
     // }
 
     //
     // @VisibleForTesting
     // protected void createDialog(Context context, final VideoCreativeView view) {
-    //     mViewParentBeforeExpand = getParent();
-    //     mLayoutParamsBeforeExpand = getLayoutParams();
+    //     viewParentBeforeExpand = getParent();
+    //     layoutParamsBeforeExpand = getLayoutParams();
     //
     //     Views.removeFromParent(this);
     //
-    //     mVideoDialog = new VideoDialog(context, view, mAdViewManager, mInterstitialManager, this);
-    //     mVideoDialog.setOnDismissListener(new VideoView.VideoDialogDismissListener(this));
-    //     mVideoDialog.setVideoDialogListener(mVideoDialogListener);
-    //     mVideoDialog.show();
+    //     videoDialog = new VideoDialog(context, view, adViewManager, interstitialManager, this);
+    //     videoDialog.setOnDismissListener(new VideoView.VideoDialogDismissListener(this));
+    //     videoDialog.setVideoDialogListener(videoDialogListener);
+    //     videoDialog.show();
     // }
 
     // private void showFullScreen() {
     //     View currentView = getChildAt(0);
-    //     if (mAdViewManager.canShowFullScreen() && mVideoDialog == null && currentView instanceof VideoCreativeView) {
+    //     if (adViewManager.canShowFullScreen() && videoDialog == null && currentView instanceof VideoCreativeView) {
     //         createDialog(getContext(), (VideoCreativeView) currentView);
     //     }
     // }
@@ -463,19 +463,19 @@ public class VideoView extends BaseAdView {
     // }
     //
     // private boolean isFullScreen() {
-    //     return mVideoDialog != null && mVideoDialog.isShowing();
+    //     return videoDialog != null && videoDialog.isShowing();
     // }
 
     // protected static class VideoDialogDismissListener implements DialogInterface.OnDismissListener {
-    //     private final WeakReference<VideoView> mWeakVideoAdView;
+    //     private final WeakReference<VideoView> weakVideoAdView;
     //
     //     public VideoDialogDismissListener(VideoView videoDialog) {
-    //         mWeakVideoAdView = new WeakReference<>(videoDialog);
+    //         weakVideoAdView = new WeakReference<>(videoDialog);
     //     }
     //
     //     @Override
     //     public void onDismiss(DialogInterface dialog) {
-    //         VideoView videoAdView = mWeakVideoAdView.get();
+    //         VideoView videoAdView = weakVideoAdView.get();
     //         if (videoAdView == null) {
     //             Log.debug(TAG, "VideoDialog.onDismiss(): Unable to perform dismiss action. VideoAdView is null");
     //             return;

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/bidding/data/bid/Bid.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/bidding/data/bid/Bid.java
@@ -30,101 +30,101 @@ import java.util.Map;
 public class Bid {
 
     // Bidder generated bid ID to assist with logging/tracking.
-    private String mId;
+    private String id;
 
     //  ID of the Imp object in the related bid request.
-    private String mImpId;
+    private String impId;
 
     // Bid price expressed as CPM although the actual transaction is
     // for a unit impression only.
-    private double mPrice;
+    private double price;
 
     // Optional means of conveying ad markup in case the bid wins;
     // supersedes the win notice if markup is included in both.
     // Substitution macros (Section 4.4) may be included.
-    private String mAdm;
+    private String adm;
 
     // Creative ID to assist with ad quality checking.
-    private String mCrid;
+    private String crid;
 
     // Width of the creative in device independent pixels (DIPS)
-    private int mWidth;
+    private int width;
 
     // Height of the creative in device independent pixels (DIPS).
-    private int mHeight;
+    private int height;
 
     // "prebid" object from "ext"
-    private Prebid mPrebid;
+    private Prebid prebid;
 
     // Win notice URL called by the exchange if the bid wins (not  necessarily indicative of a delivered, viewed, or billable ad);
     // optional means of serving ad markup
-    private String mNurl;
+    private String nurl;
 
     // Billing notice URL called by the exchange when a winning bid
     // becomes billable based on exchange-specific business policy
-    private String mBurl;
+    private String burl;
 
     // Loss notice URL called by the exchange when a bid is known to
     // have been lost
-    private String mLurl;
+    private String lurl;
 
     // ID of a preloaded ad to be served if the bid wins
-    private String mAdid;
+    private String adid;
 
     // Advertiser domain for block list checking
-    private String[] mAdomain;
+    private String[] adomain;
 
     // A platform-specific application identifier intended to be unique to the app and independent of the exchange.
-    private String mBundle;
+    private String bundle;
 
     // URL without cache-busting to an image that is representative
     // of the content of the campaign for ad quality/safety checking
-    private String mIurl;
+    private String iurl;
 
     // Campaign ID to assist with ad quality checking; the collection
     // of creatives for which iurl should be representative
-    private String mCid;
+    private String cid;
 
     // Bid json string. Used only for CacheManager.
     private String jsonString;
 
     // Tactic ID to enable buyers to label bids for reporting to the
     // exchange the tactic through which their bid was submitted
-    private String mTactic;
+    private String tactic;
 
     // IAB content categories of the creative
-    private String[] mCat;
+    private String[] cat;
 
     // Set of attributes describing the creative
-    private int[] mAttr;
+    private int[] attr;
 
     // API required by the markup if applicable
-    private int mApi;
+    private int api;
 
     // Video response protocol of the markup if applicable.
-    private int mProtocol;
+    private int protocol;
 
     // Creative media rating per IQG guidelines
-    private int mQagmediarating;
+    private int qagmediarating;
 
     // Language of the creative using ISO-639-1-alpha-2
-    private String mLanguage;
+    private String language;
 
     // Reference to the deal.id from the bid request if this bid
     // pertains to a private marketplace direct deal
-    private String mDealId;
+    private String dealId;
 
     // Relative width of the creative when expressing size as a ratio.
     // Required for Flex Ads
-    private int mWRatio;
+    private int WRatio;
 
     // Relative height of the creative when expressing size as a ratio.
     // Required for Flex Ads
-    private int mHRatio;
+    private int HRatio;
 
     // Advisory as to the number of seconds the bidder is willing to
     // wait between the auction and the actual impression
-    private int mExp;
+    private int exp;
 
     private MobileSdkPassThrough mobileSdkPassThrough;
 
@@ -132,114 +132,114 @@ public class Bid {
     }
 
     public String getId() {
-        return mId;
+        return id;
     }
 
     public String getImpId() {
-        return mImpId;
+        return impId;
     }
 
     public double getPrice() {
-        return mPrice;
+        return price;
     }
 
     public String getAdm() {
-        return mAdm;
+        return adm;
     }
 
     public String getCrid() {
-        return mCrid;
+        return crid;
     }
 
     public int getWidth() {
-        return mWidth;
+        return width;
     }
 
     public int getHeight() {
-        return mHeight;
+        return height;
     }
 
     public Prebid getPrebid() {
-        if (mPrebid == null) {
-            mPrebid = new Prebid();
+        if (prebid == null) {
+            prebid = new Prebid();
         }
-        return mPrebid;
+        return prebid;
     }
 
     public String getNurl() {
-        return mNurl;
+        return nurl;
     }
 
     public String getBurl() {
-        return mBurl;
+        return burl;
     }
 
     public String getLurl() {
-        return mLurl;
+        return lurl;
     }
 
     public String getAdid() {
-        return mAdid;
+        return adid;
     }
 
     public String[] getAdomain() {
-        return mAdomain;
+        return adomain;
     }
 
     public String getBundle() {
-        return mBundle;
+        return bundle;
     }
 
     public String getIurl() {
-        return mIurl;
+        return iurl;
     }
 
     public String getCid() {
-        return mCid;
+        return cid;
     }
 
     public String getTactic() {
-        return mTactic;
+        return tactic;
     }
 
     public String[] getCat() {
-        return mCat;
+        return cat;
     }
 
     public int[] getAttr() {
-        return mAttr;
+        return attr;
     }
 
     public int getApi() {
-        return mApi;
+        return api;
     }
 
     public int getProtocol() {
-        return mProtocol;
+        return protocol;
     }
 
     public int getQagmediarating() {
-        return mQagmediarating;
+        return qagmediarating;
     }
 
     public String getLanguage() {
-        return mLanguage;
+        return language;
     }
 
     public String getDealId() {
-        return mDealId;
+        return dealId;
     }
 
     public int getWRatio() {
-        return mWRatio;
+        return WRatio;
     }
 
     public int getHRatio() {
-        return mHRatio;
+        return HRatio;
     }
 
     public int getExp() {
-        return mExp;
+        return exp;
     }
 
     public String getJsonString() {
@@ -256,37 +256,37 @@ public class Bid {
             return bid;
         }
         bid.jsonString = jsonObject.toString();
-        bid.mId = jsonObject.optString("id", null);
-        bid.mImpId = jsonObject.optString("impid", null);
-        bid.mPrice = jsonObject.optDouble("price", 0);
-        bid.mAdm = jsonObject.optString("adm", null);
-        bid.mCrid = jsonObject.optString("crid", null);
-        bid.mWidth = jsonObject.optInt("w");
-        bid.mHeight = jsonObject.optInt("h");
+        bid.id = jsonObject.optString("id", null);
+        bid.impId = jsonObject.optString("impid", null);
+        bid.price = jsonObject.optDouble("price", 0);
+        bid.adm = jsonObject.optString("adm", null);
+        bid.crid = jsonObject.optString("crid", null);
+        bid.width = jsonObject.optInt("w");
+        bid.height = jsonObject.optInt("h");
 
-        bid.mNurl = jsonObject.optString("nurl", null);
-        bid.mBurl = jsonObject.optString("burl", null);
-        bid.mLurl = jsonObject.optString("lurl", null);
-        bid.mAdid = jsonObject.optString("adid", null);
-        bid.mAdomain = getStringArrayFromJson(jsonObject, "adomain");
-        bid.mBundle = jsonObject.optString("bundle", null);
-        bid.mIurl = jsonObject.optString("iurl", null);
-        bid.mCid = jsonObject.optString("cid", null);
-        bid.mTactic = jsonObject.optString("tactic", null);
-        bid.mCat = getStringArrayFromJson(jsonObject, "cat");
-        bid.mAttr = getIntArrayFromJson(jsonObject, "attr");
-        bid.mApi = jsonObject.optInt("api", -1);
-        bid.mProtocol = jsonObject.optInt("protocol", -1);
-        bid.mQagmediarating = jsonObject.optInt("qagmediarating", -1);
-        bid.mLanguage = jsonObject.optString("language", null);
-        bid.mDealId = jsonObject.optString("dealid", null);
-        bid.mWRatio = jsonObject.optInt("wratio");
-        bid.mHRatio = jsonObject.optInt("hratio");
-        bid.mExp = jsonObject.optInt("exp", -1);
+        bid.nurl = jsonObject.optString("nurl", null);
+        bid.burl = jsonObject.optString("burl", null);
+        bid.lurl = jsonObject.optString("lurl", null);
+        bid.adid = jsonObject.optString("adid", null);
+        bid.adomain = getStringArrayFromJson(jsonObject, "adomain");
+        bid.bundle = jsonObject.optString("bundle", null);
+        bid.iurl = jsonObject.optString("iurl", null);
+        bid.cid = jsonObject.optString("cid", null);
+        bid.tactic = jsonObject.optString("tactic", null);
+        bid.cat = getStringArrayFromJson(jsonObject, "cat");
+        bid.attr = getIntArrayFromJson(jsonObject, "attr");
+        bid.api = jsonObject.optInt("api", -1);
+        bid.protocol = jsonObject.optInt("protocol", -1);
+        bid.qagmediarating = jsonObject.optInt("qagmediarating", -1);
+        bid.language = jsonObject.optString("language", null);
+        bid.dealId = jsonObject.optString("dealid", null);
+        bid.WRatio = jsonObject.optInt("wratio");
+        bid.HRatio = jsonObject.optInt("hratio");
+        bid.exp = jsonObject.optInt("exp", -1);
 
         JSONObject ext = jsonObject.optJSONObject("ext");
         if (ext != null) {
-            bid.mPrebid = Prebid.fromJSONObject(ext.optJSONObject("prebid"));
+            bid.prebid = Prebid.fromJSONObject(ext.optJSONObject("prebid"));
             bid.mobileSdkPassThrough = MobileSdkPassThrough.create(ext);
         }
 
@@ -296,7 +296,7 @@ public class Bid {
     }
 
     public void setAdm(String adm) {
-        mAdm = adm;
+        this.adm = adm;
     }
 
     private static String[] getStringArrayFromJson(JSONObject jsonObject, String key) {
@@ -338,7 +338,7 @@ public class Bid {
         macrosModelMap.put(MacrosModel.MACROS_AUCTION_PRICE, new MacrosModel(priceText));
         macrosModelMap.put(MacrosModel.MACROS_AUCTION_PRICE_BASE_64, new MacrosModel(base64PriceText));
 
-        bid.mAdm = MacrosResolutionHelper.resolveAuctionMacros(bid.mAdm, macrosModelMap);
-        bid.mNurl = MacrosResolutionHelper.resolveAuctionMacros(bid.mNurl, macrosModelMap);
+        bid.adm = MacrosResolutionHelper.resolveAuctionMacros(bid.adm, macrosModelMap);
+        bid.nurl = MacrosResolutionHelper.resolveAuctionMacros(bid.nurl, macrosModelMap);
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/bidding/data/bid/BidResponse.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/bidding/data/bid/BidResponse.java
@@ -38,74 +38,74 @@ public class BidResponse {
     public static final String KEY_CACHE_ID = "hb_cache_id_local";
 
     // ID of the bid request to which this is a response
-    private String mId;
+    private String id;
 
     // Bid currency using ISO-4217 alpha codes.
-    private String mCur;
+    private String cur;
 
     //Bidder generated response ID to assist with logging/tracking.
-    private String mBidId;
+    private String bidId;
 
     //Optional feature to allow a bidder to set data in the exchange’s cookie
-    private String mCustomData;
+    private String customData;
 
     // Reason for not bidding
-    private int mNbr;
+    private int nbr;
 
     // Array of seatbid objects; 1+ required if a bid is to be made.
-    private List<Seatbid> mSeatbids;
-    private Ext mExt;
+    private List<Seatbid> seatbids;
+    private Ext ext;
 
-    private boolean mHasParseError = false;
-    private String mParseError;
+    private boolean hasParseError = false;
+    private String parseError;
     private String winningBidJson;
 
-    private long mCreationTime;
+    private long creationTime;
 
     private MobileSdkPassThrough mobileSdkPassThrough;
 
     public BidResponse(String json) {
-        mSeatbids = new ArrayList<>();
+        seatbids = new ArrayList<>();
         parseJson(json);
     }
 
     public String getId() {
-        return mId;
+        return id;
     }
 
     public List<Seatbid> getSeatbids() {
-        return mSeatbids;
+        return seatbids;
     }
 
     public String getCur() {
-        return mCur;
+        return cur;
     }
 
     public Ext getExt() {
-        if (mExt == null) {
-            mExt = new Ext();
+        if (ext == null) {
+            ext = new Ext();
         }
-        return mExt;
+        return ext;
     }
 
     public boolean hasParseError() {
-        return mHasParseError;
+        return hasParseError;
     }
 
     public String getParseError() {
-        return mParseError;
+        return parseError;
     }
 
     public String getBidId() {
-        return mBidId;
+        return bidId;
     }
 
     public String getCustomData() {
-        return mCustomData;
+        return customData;
     }
 
     public int getNbr() {
-        return mNbr;
+        return nbr;
     }
 
     public String getWinningBidJson() {
@@ -117,17 +117,17 @@ public class BidResponse {
 
         try {
             JSONObject responseJson = new JSONObject(json);
-            mId = responseJson.optString("id");
-            mCur = responseJson.optString("cur");
-            mBidId = responseJson.optString("bidid");
-            mCustomData = responseJson.optString("customdata");
-            mNbr = responseJson.optInt("nbr", -1);
+            id = responseJson.optString("id");
+            cur = responseJson.optString("cur");
+            bidId = responseJson.optString("bidid");
+            customData = responseJson.optString("customdata");
+            nbr = responseJson.optInt("nbr", -1);
 
             MobileSdkPassThrough rootMobilePassThrough = null;
             if (responseJson.has("ext")) {
-                mExt = new Ext();
+                ext = new Ext();
                 JSONObject extJsonObject = responseJson.optJSONObject("ext");
-                mExt.put(extJsonObject);
+                ext.put(extJsonObject);
                 if (extJsonObject != null) {
                     rootMobilePassThrough = MobileSdkPassThrough.create(extJsonObject);
                 }
@@ -137,41 +137,41 @@ public class BidResponse {
             if (jsonSeatbids != null) {
                 for (int i = 0; i < jsonSeatbids.length(); i++) {
                     Seatbid seatbid = Seatbid.fromJSONObject(jsonSeatbids.optJSONObject(i));
-                    mSeatbids.add(seatbid);
+                    seatbids.add(seatbid);
                 }
             }
 
             MobileSdkPassThrough bidMobilePassThrough = null;
             Bid winningBid = getWinningBid();
             if (winningBid == null) {
-                mHasParseError = true;
-                mParseError = "Failed to parse bids. No winning bids were found.";
-                LogUtil.info(TAG, mParseError);
+                hasParseError = true;
+                parseError = "Failed to parse bids. No winning bids were found.";
+                LogUtil.info(TAG, parseError);
             } else {
                 bidMobilePassThrough = winningBid.getMobileSdkPassThrough();
             }
 
             mobileSdkPassThrough = MobileSdkPassThrough.combine(bidMobilePassThrough, rootMobilePassThrough);
-            mCreationTime = System.currentTimeMillis();
+            creationTime = System.currentTimeMillis();
         }
         catch (JSONException e) {
-            mHasParseError = true;
-            mParseError = "Failed to parse JSON String: " + e.getMessage();
-            LogUtil.error(TAG, mParseError);
+            hasParseError = true;
+            parseError = "Failed to parse JSON String: " + e.getMessage();
+            LogUtil.error(TAG, parseError);
         }
     }
 
     public long getCreationTime() {
-        return mCreationTime;
+        return creationTime;
     }
 
     @Nullable
     public Bid getWinningBid() {
-        if (mSeatbids == null) {
+        if (seatbids == null) {
             return null;
         }
 
-        for (Seatbid seatbid : mSeatbids) {
+        for (Seatbid seatbid : seatbids) {
             for (Bid bid : seatbid.getBids()) {
                 if (hasWinningKeywords(bid.getPrebid())) {
                     winningBidJson = bid.getJsonString();
@@ -186,7 +186,7 @@ public class BidResponse {
     @NonNull
     public HashMap<String, String> getTargeting() {
         HashMap<String, String> keywords = new HashMap<>();
-        for (Seatbid seatbid : mSeatbids) {
+        for (Seatbid seatbid : seatbids) {
             for (Bid bid : seatbid.getBids()) {
                 if (bid.getPrebid() != null) {
                     keywords.putAll(bid.getPrebid().getTargeting());
@@ -201,7 +201,7 @@ public class BidResponse {
     public HashMap<String, String> getTargetingWithCacheId() {
         // required for future BidResponseCache access
         final HashMap<String, String> targeting = getTargeting();
-        targeting.put(KEY_CACHE_ID, mId);
+        targeting.put(KEY_CACHE_ID, id);
         return targeting;
     }
 

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/bidding/data/bid/Bids.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/bidding/data/bid/Bids.java
@@ -19,18 +19,19 @@ package org.prebid.mobile.rendering.bidding.data.bid;
 import org.json.JSONObject;
 
 public class Bids {
-    private String mUrl;
-    private String mCacheId;
+
+    private String url;
+    private String cacheId;
 
     protected Bids() {
     }
 
     public String getUrl() {
-        return mUrl;
+        return url;
     }
 
     public String getCacheId() {
-        return mCacheId;
+        return cacheId;
     }
 
     public static Bids fromJSONObject(JSONObject jsonObject) {
@@ -38,8 +39,8 @@ public class Bids {
         if (jsonObject == null) {
             return bids;
         }
-        bids.mUrl = jsonObject.optString("url");
-        bids.mCacheId = jsonObject.optString("cacheId");
+        bids.url = jsonObject.optString("url");
+        bids.cacheId = jsonObject.optString("cacheId");
         return bids;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/bidding/data/bid/Cache.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/bidding/data/bid/Cache.java
@@ -19,26 +19,27 @@ package org.prebid.mobile.rendering.bidding.data.bid;
 import org.json.JSONObject;
 
 public class Cache {
-    private String mKey;
-    private String mUrl;
-    private Bids mBids;
+
+    private String key;
+    private String url;
+    private Bids bids;
 
     protected Cache() {
     }
 
     public String getKey() {
-        return mKey;
+        return key;
     }
 
     public String getUrl() {
-        return mUrl;
+        return url;
     }
 
     public Bids getBids() {
-        if (mBids == null) {
-            mBids = new Bids();
+        if (bids == null) {
+            bids = new Bids();
         }
-        return mBids;
+        return bids;
     }
 
     public static Cache fromJSONObject(JSONObject jsonObject) {
@@ -46,9 +47,9 @@ public class Cache {
         if (jsonObject == null) {
             return cache;
         }
-        cache.mKey = jsonObject.optString("key");
-        cache.mUrl = jsonObject.optString("url");
-        cache.mBids = Bids.fromJSONObject(jsonObject.optJSONObject("bids"));
+        cache.key = jsonObject.optString("key");
+        cache.url = jsonObject.optString("url");
+        cache.bids = Bids.fromJSONObject(jsonObject.optJSONObject("bids"));
 
         return cache;
     }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/bidding/data/bid/Prebid.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/bidding/data/bid/Prebid.java
@@ -33,26 +33,26 @@ import static org.prebid.mobile.rendering.utils.helpers.Utils.addValue;
 
 public class Prebid {
 
-    private Cache mCache;
-    private HashMap<String, String> mTargeting = new HashMap<>();
-    private String mType;
+    private Cache cache;
+    private HashMap<String, String> targeting = new HashMap<>();
+    private String type;
 
     protected Prebid() {
     }
 
     public Cache getCache() {
-        if (mCache == null) {
-            mCache = new Cache();
+        if (cache == null) {
+            cache = new Cache();
         }
-        return mCache;
+        return cache;
     }
 
     public HashMap<String, String> getTargeting() {
-        return mTargeting;
+        return targeting;
     }
 
     public String getType() {
-        return mType;
+        return type;
     }
 
     public static Prebid fromJSONObject(JSONObject jsonObject) {
@@ -60,9 +60,9 @@ public class Prebid {
         if (jsonObject == null) {
             return prebid;
         }
-        prebid.mCache = Cache.fromJSONObject(jsonObject.optJSONObject("cache"));
-        prebid.mType = jsonObject.optString("type");
-        toHashMap(prebid.mTargeting, jsonObject.optJSONObject("targeting"));
+        prebid.cache = Cache.fromJSONObject(jsonObject.optJSONObject("cache"));
+        prebid.type = jsonObject.optString("type");
+        toHashMap(prebid.targeting, jsonObject.optJSONObject("targeting"));
         return prebid;
     }
 

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/bidding/data/bid/Seatbid.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/bidding/data/bid/Seatbid.java
@@ -26,39 +26,39 @@ import java.util.List;
 public class Seatbid {
 
     // Array of 1+ Bid objects each related to an impression.
-    private List<Bid> mBids = new ArrayList<>();
+    private List<Bid> bids = new ArrayList<>();
 
     // ID of the buyer seat (e.g., advertiser, agency) on whose behalf
     // this bid is made
-    private String mSeat;
+    private String seat;
 
     // 0 = impressions can be won individually; 1 = impressions must
     // be won or lost as a group.
-    private int mGroup;
+    private int group;
 
     // Placeholder for bidder-specific extensions to OpenRTB.
-    private Ext mExt;
+    private Ext ext;
 
     protected Seatbid() {
     }
 
     public List<Bid> getBids() {
-        return mBids;
+        return bids;
     }
 
     public String getSeat() {
-        return mSeat;
+        return seat;
     }
 
     public int getGroup() {
-        return mGroup;
+        return group;
     }
 
     public Ext getExt() {
-        if (mExt == null) {
-            mExt = new Ext();
+        if (ext == null) {
+            ext = new Ext();
         }
-        return mExt;
+        return ext;
     }
 
     public static Seatbid fromJSONObject(JSONObject jsonObject) {
@@ -72,15 +72,15 @@ public class Seatbid {
             for (int i = 0; i < jsonArray.length(); i++) {
                 Bid bid = Bid.fromJSONObject(jsonArray.optJSONObject(i));
                 if (bid != null) {
-                    seatbid.mBids.add(bid);
+                    seatbid.bids.add(bid);
                 }
             }
         }
-        seatbid.mSeat = jsonObject.optString("seat");
-        seatbid.mGroup = jsonObject.optInt("group", -1);
-        seatbid.mExt = new Ext();
+        seatbid.seat = jsonObject.optString("seat");
+        seatbid.group = jsonObject.optInt("group", -1);
+        seatbid.ext = new Ext();
         if (jsonObject.has("ext")) {
-            seatbid.mExt.put(jsonObject.optJSONObject("ext"));
+            seatbid.ext.put(jsonObject.optJSONObject("ext"));
         }
 
         return seatbid;

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/bidding/data/bid/StoredRequest.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/bidding/data/bid/StoredRequest.java
@@ -20,16 +20,16 @@ import org.json.JSONException;
 import org.json.JSONObject;
 
 public class StoredRequest {
-    private String mId;
+    private String id;
 
     public StoredRequest(String id) {
-        mId = id;
+        this.id = id;
     }
 
     public JSONObject toJSONObject() {
         JSONObject jsonObject = new JSONObject();
         try {
-            jsonObject.put("id", mId);
+            jsonObject.put("id", id);
         }
         catch (JSONException e) {
             e.printStackTrace();

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/bidding/interfaces/StandaloneBannerEventHandler.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/bidding/interfaces/StandaloneBannerEventHandler.java
@@ -21,7 +21,7 @@ import org.prebid.mobile.rendering.bidding.data.bid.Bid;
 import org.prebid.mobile.rendering.bidding.listeners.BannerEventListener;
 
 public class StandaloneBannerEventHandler implements BannerEventHandler {
-    private BannerEventListener mBannerViewListener;
+    private BannerEventListener bannerViewListener;
 
     @Override
     public AdSize[] getAdSizeArray() {
@@ -30,12 +30,12 @@ public class StandaloneBannerEventHandler implements BannerEventHandler {
 
     @Override
     public void setBannerEventListener(BannerEventListener bannerViewListener) {
-        mBannerViewListener = bannerViewListener;
+        this.bannerViewListener = bannerViewListener;
     }
 
     @Override
     public void requestAdWithBid(Bid bid) {
-        mBannerViewListener.onPrebidSdkWin();
+        bannerViewListener.onPrebidSdkWin();
     }
 
     @Override

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/bidding/interfaces/StandaloneInterstitialEventHandler.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/bidding/interfaces/StandaloneInterstitialEventHandler.java
@@ -22,18 +22,18 @@ import org.prebid.mobile.rendering.bidding.listeners.InterstitialEventListener;
 
 public class StandaloneInterstitialEventHandler implements InterstitialEventHandler {
 
-    private InterstitialEventListener mInterstitialEventListener;
+    private InterstitialEventListener interstitialEventListener;
 
     @Override
     public void setInterstitialEventListener(InterstitialEventListener interstitialEventListener) {
-        mInterstitialEventListener = interstitialEventListener;
+        this.interstitialEventListener = interstitialEventListener;
     }
 
     @Override
     public void requestAdWithBid(
             @Nullable Bid bid
     ) {
-        mInterstitialEventListener.onPrebidSdkWin();
+        interstitialEventListener.onPrebidSdkWin();
     }
 
     @Override

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/bidding/interfaces/StandaloneRewardedVideoEventHandler.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/bidding/interfaces/StandaloneRewardedVideoEventHandler.java
@@ -22,20 +22,20 @@ import org.prebid.mobile.rendering.bidding.data.bid.Bid;
 import org.prebid.mobile.rendering.bidding.listeners.RewardedVideoEventListener;
 
 public class StandaloneRewardedVideoEventHandler implements RewardedEventHandler {
-    private RewardedVideoEventListener mListener;
+    private RewardedVideoEventListener listener;
 
     @Override
     public void setRewardedEventListener(
         @NonNull
             RewardedVideoEventListener listener) {
-        mListener = listener;
+        this.listener = listener;
     }
 
     @Override
     public void requestAdWithBid(
         @Nullable
             Bid bid) {
-        mListener.onPrebidSdkWin();
+        listener.onPrebidSdkWin();
     }
 
     @Override

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/bidding/loader/BidLoader.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/bidding/loader/BidLoader.java
@@ -39,23 +39,24 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import static java.lang.Math.max;
 
 public class BidLoader {
+
     private final static String TAG = BidLoader.class.getSimpleName();
 
     private final static String TMAX_REQUEST_KEY = "tmaxrequest";
     private static boolean sTimeoutHasChanged = false;
 
-    private WeakReference<Context> mContextReference;
-    private AdUnitConfiguration mAdConfiguration;
-    private BidRequester mBidRequester;
-    private AtomicBoolean mCurrentlyLoading;
+    private WeakReference<Context> contextReference;
+    private AdUnitConfiguration adConfiguration;
+    private BidRequester bidRequester;
+    private AtomicBoolean currentlyLoading;
 
-    private BidRequesterListener mRequestListener;
-    private BidRefreshListener mBidRefreshListener;
+    private BidRequesterListener requestListener;
+    private BidRefreshListener bidRefreshListener;
 
-    private final ResponseHandler mResponseHandler = new ResponseHandler() {
+    private final ResponseHandler responseHandler = new ResponseHandler() {
         @Override
         public void onResponse(BaseNetworkTask.GetUrlResult response) {
-            mCurrentlyLoading.set(false);
+            currentlyLoading.set(false);
             BidResponse bidResponse = new BidResponse(response.responseString);
             if (bidResponse.hasParseError()) {
                 failedToLoadBid(bidResponse.getParseError());
@@ -63,38 +64,43 @@ public class BidLoader {
             }
             checkTmax(response, bidResponse);
             updateAdUnitConfiguration(bidResponse);
-            if (mRequestListener != null) {
+            if (requestListener != null) {
                 setupRefreshTimer();
-                mRequestListener.onFetchCompleted(bidResponse);
-            }
-            else {
+                requestListener.onFetchCompleted(bidResponse);
+            } else {
                 cancelRefresh();
             }
         }
 
         @Override
-        public void onError(String msg, long responseTime) {
+        public void onError(
+                String msg,
+                long responseTime
+        ) {
             failedToLoadBid(msg);
         }
 
         @Override
-        public void onErrorWithException(Exception e, long responseTime) {
+        public void onErrorWithException(
+                Exception e,
+                long responseTime
+        ) {
             failedToLoadBid(e.getMessage());
         }
     };
 
-    private final RefreshTimerTask mRefreshTimerTask = new RefreshTimerTask(() -> {
-        if (mAdConfiguration == null) {
+    private final RefreshTimerTask refreshTimerTask = new RefreshTimerTask(() -> {
+        if (adConfiguration == null) {
             LogUtil.error(TAG, "handleRefresh(): Failure. AdConfiguration is null");
             return;
         }
 
-        if (mBidRefreshListener == null) {
+        if (bidRefreshListener == null) {
             LogUtil.error(TAG, "RefreshListener is null. No refresh or load will be performed.");
             return;
         }
 
-        if (!mBidRefreshListener.canPerformRefresh()) {
+        if (!bidRefreshListener.canPerformRefresh()) {
             LogUtil.debug(TAG, "handleRefresh(): Loading skipped, rescheduling timer. View is not visible.");
             setupRefreshTimer();
             return;
@@ -105,51 +111,50 @@ public class BidLoader {
     });
 
     public BidLoader(Context context, AdUnitConfiguration adConfiguration, BidRequesterListener requestListener) {
-        mContextReference = new WeakReference<>(context);
-        mAdConfiguration = adConfiguration;
-        mRequestListener = requestListener;
-        mCurrentlyLoading = new AtomicBoolean();
+        contextReference = new WeakReference<>(context);
+        this.adConfiguration = adConfiguration;
+        this.requestListener = requestListener;
+        currentlyLoading = new AtomicBoolean();
     }
 
     public void setBidRefreshListener(BidRefreshListener bidRefreshListener) {
-        mBidRefreshListener = bidRefreshListener;
+        this.bidRefreshListener = bidRefreshListener;
     }
 
     public void load() {
-        if (mRequestListener == null) {
+        if (requestListener == null) {
             LogUtil.warning(TAG, "Listener is null");
             return;
         }
-        if (mAdConfiguration == null) {
+        if (adConfiguration == null) {
             LogUtil.warning(TAG, "No ad request configuration to load");
             return;
         }
-        if (mContextReference.get() == null) {
+        if (contextReference.get() == null) {
             LogUtil.warning(TAG, "Context is null");
             return;
         }
 
-        // If mCurrentlyLoading == false, set it to true and return true; else return false
-        // If compareAndSet returns false, it means mCurrentlyLoading was already true and therefore we should skip loading
-        if (!mCurrentlyLoading.compareAndSet(false, true)) {
+        // If currentlyLoading == false, set it to true and return true; else return false
+        // If compareAndSet returns false, it means currentlyLoading was already true and therefore we should skip loading
+        if (!currentlyLoading.compareAndSet(false, true)) {
             LogUtil.warning(TAG, "Previous load is in progress. Load() ignored.");
             return;
         }
 
-        sendBidRequest(mContextReference.get(), mAdConfiguration);
+        sendBidRequest(contextReference.get(), adConfiguration);
     }
 
     public void setupRefreshTimer() {
         LogUtil.debug(TAG, "Schedule refresh timer");
 
-        boolean isRefreshAvailable = mAdConfiguration != null
-                && mAdConfiguration.isAdType(AdFormat.BANNER);
+        boolean isRefreshAvailable = adConfiguration != null && adConfiguration.isAdType(AdFormat.BANNER);
         if (!isRefreshAvailable) {
             LogUtil.debug(TAG, "setupRefreshTimer: Canceled. AdConfiguration is null or AdType is not Banner");
             return;
         }
 
-        int refreshTimeMillis = mAdConfiguration.getAutoRefreshDelay();
+        int refreshTimeMillis = adConfiguration.getAutoRefreshDelay();
         //for user or server values <= 0, no refreshtask should be created.
         //for such invalid values, refreshTimeMillis has been set to Integer.MAX_VALUE already.
         //So, check it against it to stop it from creating a refreshtask
@@ -162,45 +167,45 @@ public class BidLoader {
 
         int reloadTime = max(refreshTimeMillis, 1000);
 
-        mRefreshTimerTask.scheduleRefreshTask(reloadTime);
+        refreshTimerTask.scheduleRefreshTask(reloadTime);
     }
 
     public void cancelRefresh() {
         LogUtil.debug(TAG, "Cancel refresh timer");
-        mRefreshTimerTask.cancelRefreshTimer();
+        refreshTimerTask.cancelRefreshTimer();
     }
 
     public void destroy() {
         cancelRefresh();
-        mRefreshTimerTask.destroy();
+        refreshTimerTask.destroy();
 
-        if (mBidRequester != null) {
-            mBidRequester.destroy();
+        if (bidRequester != null) {
+            bidRequester.destroy();
         }
-        mRequestListener = null;
-        mBidRefreshListener = null;
+        requestListener = null;
+        bidRefreshListener = null;
     }
 
     private void sendBidRequest(Context context, AdUnitConfiguration config) {
-        mCurrentlyLoading.set(true);
-        if (mBidRequester == null) {
-            mBidRequester = new BidRequester(context, config, new AdRequestInput(), mResponseHandler);
+        currentlyLoading.set(true);
+        if (bidRequester == null) {
+            bidRequester = new BidRequester(context, config, new AdRequestInput(), responseHandler);
         }
-        mBidRequester.startAdRequest();
+        bidRequester.startAdRequest();
     }
 
     private void failedToLoadBid(String msg) {
         LogUtil.error(TAG, "Invalid bid response: " + msg);
-        mCurrentlyLoading.set(false);
+        currentlyLoading.set(false);
 
-        if (mRequestListener == null) {
+        if (requestListener == null) {
             LogUtil.warning(TAG, "onFailedToLoad: Listener is null.");
             cancelRefresh();
             return;
         }
 
         setupRefreshTimer();
-        mRequestListener.onError(new AdException(AdException.INTERNAL_ERROR, "Invalid bid response: " + msg));
+        requestListener.onError(new AdException(AdException.INTERNAL_ERROR, "Invalid bid response: " + msg));
     }
 
     private void checkTmax(
@@ -224,8 +229,8 @@ public class BidLoader {
      */
     private void updateAdUnitConfiguration(@NonNull BidResponse bidResponse) {
         MobileSdkPassThrough serverParameters = bidResponse.getMobileSdkPassThrough();
-        MobileSdkPassThrough combinedParameters = MobileSdkPassThrough.combine(serverParameters, mAdConfiguration);
-        combinedParameters.modifyAdUnitConfiguration(mAdConfiguration);
+        MobileSdkPassThrough combinedParameters = MobileSdkPassThrough.combine(serverParameters, adConfiguration);
+        combinedParameters.modifyAdUnitConfiguration(adConfiguration);
         bidResponse.setMobileSdkPassThrough(combinedParameters);
     }
 

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/interstitial/AdExpandedDialog.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/interstitial/AdExpandedDialog.java
@@ -40,30 +40,29 @@ public class AdExpandedDialog extends AdBaseDialog {
 
         preInit();
 
-        if (mWebViewBase != null && mWebViewBase.isMRAID()) {
-            mWebViewBase.getMRAIDInterface().onStateChange(JSInterface.STATE_EXPANDED);
+        if (webViewBase != null && webViewBase.isMRAID()) {
+            webViewBase.getMRAIDInterface().onStateChange(JSInterface.STATE_EXPANDED);
         }
         setOnCancelListener(dialog -> {
             try {
-                if (mWebViewBase != null) {
+                if (webViewBase != null) {
                     //detach from closecontainer
-                    mWebViewBase.detachFromParent();
+                    webViewBase.detachFromParent();
                     //add it back to WebView.
-                    PrebidWebViewBase defaultContainer = (PrebidWebViewBase) mWebViewBase.getPreloadedListener();
+                    PrebidWebViewBase defaultContainer = (PrebidWebViewBase) webViewBase.getPreloadedListener();
 
-                    //use getPreloadedListener() to get defaultContainer, as mDefaultContainer is not initiated for non-mraid cases(such as interstitials)
-                    defaultContainer.addView(mWebViewBase);
+                    //use getPreloadedListener() to get defaultContainer, as defaultContainer is not initiated for non-mraid cases(such as interstitials)
+                    defaultContainer.addView(webViewBase);
                     ////IMP - get the default state
                     defaultContainer.setVisibility(View.VISIBLE);
                     //do not ever call prebidWebView.visible. It makes the default adview on click of expand to be blank.
                     if (context instanceof Activity) {
-                        ((Activity) context).setRequestedOrientation(mInitialOrientation);
-                    }
-                    else {
+                        ((Activity) context).setRequestedOrientation(initialOrientation);
+                    } else {
                         LogUtil.error(TAG, "Context is not Activity, can not set orientation");
                     }
 
-                    mWebViewBase.getMRAIDInterface().onStateChange(JSInterface.STATE_DEFAULT);
+                    webViewBase.getMRAIDInterface().onStateChange(JSInterface.STATE_DEFAULT);
                 }
             }
             catch (Exception e) {
@@ -71,20 +70,21 @@ public class AdExpandedDialog extends AdBaseDialog {
             }
         });
 
-        mWebViewBase.setDialog(this);
+        webViewBase.setDialog(this);
     }
 
     @Override
     protected void handleCloseClick() {
-        mInterstitialManager.interstitialClosed(mWebViewBase);
+        interstitialManager.interstitialClosed(webViewBase);
     }
 
     @Override
     protected void handleDialogShow() {
-        Views.removeFromParent(mAdViewContainer);
-        addContentView(mAdViewContainer,
-                                   new RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT,
-                                                                   RelativeLayout.LayoutParams.MATCH_PARENT)
+        Views.removeFromParent(adViewContainer);
+        addContentView(adViewContainer,
+                new RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT,
+                        RelativeLayout.LayoutParams.MATCH_PARENT
+                )
         );
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/interstitial/AdInterstitialDialog.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/interstitial/AdInterstitialDialog.java
@@ -40,24 +40,25 @@ public class AdInterstitialDialog extends AdBaseDialog {
                                 FrameLayout adViewContainer,
                                 InterstitialManager interstitialManager) {
         super(context, webViewBaseLocal, interstitialManager);
-        mAdViewContainer = adViewContainer;
+        this.adViewContainer = adViewContainer;
 
 
         preInit();
-        if (mInterstitialManager.getInterstitialDisplayProperties() != null) {
-            mAdViewContainer.setBackgroundColor(mInterstitialManager.getInterstitialDisplayProperties().getPubBackGroundOpacity());
+        if (this.interstitialManager.getInterstitialDisplayProperties() != null) {
+            this.adViewContainer.setBackgroundColor(this.interstitialManager.getInterstitialDisplayProperties()
+                                                                            .getPubBackGroundOpacity());
         }
 
         setListeners();
-        mWebViewBase.setDialog(this);
+        webViewBase.setDialog(this);
     }
 
     private void setListeners() {
         setOnCancelListener(dialog -> {
             try {
-                if (mWebViewBase.isMRAID() && mJsExecutor != null) {
-                    mWebViewBase.getMRAIDInterface().onStateChange(JSInterface.STATE_DEFAULT);
-                    mWebViewBase.detachFromParent();
+                if (webViewBase.isMRAID() && jsExecutor != null) {
+                    webViewBase.getMRAIDInterface().onStateChange(JSInterface.STATE_DEFAULT);
+                    webViewBase.detachFromParent();
                 }
             }
             catch (Exception e) {
@@ -68,15 +69,16 @@ public class AdInterstitialDialog extends AdBaseDialog {
 
     @Override
     protected void handleCloseClick() {
-        mInterstitialManager.interstitialClosed(mWebViewBase);
+        interstitialManager.interstitialClosed(webViewBase);
     }
 
     @Override
     protected void handleDialogShow() {
-        Views.removeFromParent(mAdViewContainer);
-        addContentView(mAdViewContainer,
-                       new RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT,
-                                                       RelativeLayout.LayoutParams.MATCH_PARENT)
+        Views.removeFromParent(adViewContainer);
+        addContentView(adViewContainer,
+                new RelativeLayout.LayoutParams(RelativeLayout.LayoutParams.MATCH_PARENT,
+                        RelativeLayout.LayoutParams.MATCH_PARENT
+                )
         );
     }
 

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/interstitial/InterstitialSizes.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/interstitial/InterstitialSizes.java
@@ -60,14 +60,14 @@ public class InterstitialSizes {
         ASPECT_RATIO_1920x1080("1920x1080"),
         ASPECT_RATIO_1920x1440("1920x1440");
 
-        private String mSize;
+        private String size;
 
         InterstitialSize(String size) {
-            mSize = size;
+            this.size = size;
         }
 
         public String getSize() {
-            return mSize;
+            return size;
         }
     }
 

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/loading/FileDownloadTask.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/loading/FileDownloadTask.java
@@ -32,16 +32,20 @@ import java.net.URLConnection;
  * More of a general task for downloading files w/o feedback on progress
  */
 public class FileDownloadTask extends BaseNetworkTask {
+
     private static final String TAG = "LibraryDownloadTask";
-    protected FileDownloadListener mListener;
-    protected File mFile;
+    protected FileDownloadListener listener;
+    protected File file;
 
     /**
      * Creates a network object
      *
      * @param handler instance of a class handling ad server responses (like , InterstitialSwitchActivity)
      */
-    public FileDownloadTask(FileDownloadListener handler, File file) {
+    public FileDownloadTask(
+            FileDownloadListener handler,
+            File file
+    ) {
         super(handler);
         if (file == null) {
             String nullFileMessage = "File is null";
@@ -50,18 +54,17 @@ public class FileDownloadTask extends BaseNetworkTask {
             }
             throw new NullPointerException(nullFileMessage);
         }
-        mFile = file;
-        if (!mFile.exists()) {
+        this.file = file;
+        if (!this.file.exists()) {
             try {
-                mFile.createNewFile();
-            }
-            catch (IOException e) {
+                this.file.createNewFile();
+            } catch (IOException e) {
                 String errorCreatingFile = "Error creating file";
                 handler.onFileDownloadError(errorCreatingFile);
                 throw new IllegalStateException(errorCreatingFile);
             }
         }
-        mListener = handler;
+        listener = handler;
     }
 
     protected long getMaxFileSize() {
@@ -104,7 +107,7 @@ public class FileDownloadTask extends BaseNetworkTask {
         FileOutputStream outputStream = null;
         InputStream inputStream = null;
         try {
-            outputStream = new FileOutputStream(mFile);
+            outputStream = new FileOutputStream(file);
             inputStream = connection.getInputStream();
             byte[] data = new byte[16384];
             int count;
@@ -129,15 +132,15 @@ public class FileDownloadTask extends BaseNetworkTask {
     protected void onPostExecute(GetUrlResult urlResult) {
         if (urlResult.getException() != null) {
             LogUtil.debug(TAG, "download of media failed" + urlResult.getException());
-            if (mListener != null) {
-                mListener.onFileDownloadError((urlResult.getException().getMessage()));
+            if (listener != null) {
+                listener.onFileDownloadError((urlResult.getException().getMessage()));
             }
             return;
         }
-        if (mListener != null) {
-            String path = mFile.getPath();
+        if (listener != null) {
+            String path = file.getPath();
             int beginIndex = path.lastIndexOf("/");
-            mListener.onFileDownloaded(beginIndex != -1 ? path.substring(beginIndex) : path);
+            listener.onFileDownloaded(beginIndex != -1 ? path.substring(beginIndex) : path);
         }
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/AbstractCreative.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/AbstractCreative.java
@@ -34,23 +34,29 @@ import org.prebid.mobile.rendering.views.interstitial.InterstitialManager;
 import java.lang.ref.WeakReference;
 
 public abstract class AbstractCreative {
+
     private static final String TAG = AbstractCreative.class.getSimpleName();
 
-    protected WeakReference<Context> mContextReference;
+    protected WeakReference<Context> contextReference;
 
-    private CreativeModel mModel;
-    private CreativeViewListener mCreativeViewListener;
-    private CreativeResolutionListener mResolutionListener;
+    private CreativeModel model;
+    private CreativeViewListener creativeViewListener;
+    private CreativeResolutionListener resolutionListener;
 
-    protected WeakReference<OmAdSessionManager> mWeakOmAdSessionManager;
+    protected WeakReference<OmAdSessionManager> weakOmAdSessionManager;
 
-    protected InterstitialManager mInterstitialManager;
+    protected InterstitialManager interstitialManager;
 
-    private View mCreativeView;
+    private View creativeView;
 
-    protected CreativeVisibilityTracker mCreativeVisibilityTracker;
+    protected CreativeVisibilityTracker creativeVisibilityTracker;
 
-    public AbstractCreative(Context context, CreativeModel model, OmAdSessionManager omAdSessionManager, InterstitialManager interstitialManager)
+    public AbstractCreative(
+            Context context,
+            CreativeModel model,
+            OmAdSessionManager omAdSessionManager,
+            InterstitialManager interstitialManager
+    )
     throws AdException {
         if (context == null) {
             throw new AdException(AdException.INTERNAL_ERROR, "Context is null");
@@ -60,14 +66,14 @@ public abstract class AbstractCreative {
             throw new AdException(AdException.INTERNAL_ERROR, "CreativeModel is null");
         }
 
-        mContextReference = new WeakReference<>(context);
+        contextReference = new WeakReference<>(context);
 
-        mModel = model;
+        this.model = model;
 
-        mWeakOmAdSessionManager = new WeakReference<>(omAdSessionManager);
-        mInterstitialManager = interstitialManager;
+        weakOmAdSessionManager = new WeakReference<>(omAdSessionManager);
+        this.interstitialManager = interstitialManager;
 
-        mModel.registerActiveOmAdSession(omAdSessionManager);
+        this.model.registerActiveOmAdSession(omAdSessionManager);
     }
 
     public abstract boolean isDisplay();
@@ -162,7 +168,7 @@ public abstract class AbstractCreative {
      * @return if the current ad config suggests that this is a video
      */
     public boolean isBuiltInVideo() {
-        return mModel.getAdConfiguration().isBuiltInVideo();
+        return model.getAdConfiguration().isBuiltInVideo();
     }
 
     /**
@@ -191,9 +197,9 @@ public abstract class AbstractCreative {
      * Specific creative cleanup. Creative must cleanup it's internal state.
      */
     public void destroy() {
-        if (mCreativeVisibilityTracker != null) {
-            mCreativeVisibilityTracker.stopVisibilityCheck();
-            mCreativeVisibilityTracker = null;
+        if (creativeVisibilityTracker != null) {
+            creativeVisibilityTracker.stopVisibilityCheck();
+            creativeVisibilityTracker = null;
         }
     }
 
@@ -210,37 +216,37 @@ public abstract class AbstractCreative {
     public abstract void handleAdWindowNoFocus();
 
     /**
-     * Changes the {@link #mCreativeVisibilityTracker} state based on ad webView window focus.
-     * If ad webView has no window focus - {@link #mCreativeVisibilityTracker} execution will be stopped.
-     * If ad webView has window focus - {@link #mCreativeVisibilityTracker} execution will be restarted.
+     * Changes the {@link #creativeVisibilityTracker} state based on ad webView window focus.
+     * If ad webView has no window focus - {@link #creativeVisibilityTracker} execution will be stopped.
+     * If ad webView has window focus - {@link #creativeVisibilityTracker} execution will be restarted.
      *
      * @param adWebViewWindowFocus adWebView focus state
      */
     public void changeVisibilityTrackerState(boolean adWebViewWindowFocus) {
-        if (mCreativeVisibilityTracker == null) {
+        if (creativeVisibilityTracker == null) {
             LogUtil.debug(TAG, "handleAdWebViewWindowFocusChange(): Failed. CreativeVisibilityTracker is null.");
             return;
         }
 
         if (!adWebViewWindowFocus) {
-            mCreativeVisibilityTracker.stopVisibilityCheck();
+            creativeVisibilityTracker.stopVisibilityCheck();
         }
         else {
-            mCreativeVisibilityTracker.stopVisibilityCheck();
-            mCreativeVisibilityTracker.startVisibilityCheck(mContextReference.get());
+            creativeVisibilityTracker.stopVisibilityCheck();
+            creativeVisibilityTracker.startVisibilityCheck(contextReference.get());
         }
     }
 
     public void setResolutionListener(CreativeResolutionListener resolutionListener) {
-        mResolutionListener = resolutionListener;
+        this.resolutionListener = resolutionListener;
     }
 
     public CreativeResolutionListener getResolutionListener() {
-        return mResolutionListener;
+        return resolutionListener;
     }
 
     public void setCreativeViewListener(CreativeViewListener creativeViewListener) {
-        mCreativeViewListener = creativeViewListener;
+        this.creativeViewListener = creativeViewListener;
     }
 
     /**
@@ -249,14 +255,14 @@ public abstract class AbstractCreative {
      * @param creativeView individual creative view. E.g. webView for HTMLCreative.
      */
     public void setCreativeView(View creativeView) {
-        mCreativeView = creativeView;
+        this.creativeView = creativeView;
     }
 
     /**
      * @return individual creative view. E.g. webView for HTMLCreative.
      */
     public View getCreativeView() {
-        return mCreativeView;
+        return creativeView;
     }
 
     /**
@@ -264,11 +270,11 @@ public abstract class AbstractCreative {
      */
     @NonNull
     public CreativeModel getCreativeModel() {
-        return mModel;
+        return model;
     }
 
     public void updateAdView(View view) {
-        OmAdSessionManager omAdSessionManager = mWeakOmAdSessionManager.get();
+        OmAdSessionManager omAdSessionManager = weakOmAdSessionManager.get();
         if (omAdSessionManager == null) {
             LogUtil.error(TAG, "Unable to updateAdView. OmAdSessionManager is null");
             return;
@@ -277,7 +283,7 @@ public abstract class AbstractCreative {
     }
 
     public CreativeViewListener getCreativeViewListener() {
-        return mCreativeViewListener;
+        return creativeViewListener;
     }
 
     public void addOmFriendlyObstruction(InternalFriendlyObstruction friendlyObstruction) {
@@ -286,7 +292,7 @@ public abstract class AbstractCreative {
             return;
         }
 
-        OmAdSessionManager omAdSessionManager = mWeakOmAdSessionManager.get();
+        OmAdSessionManager omAdSessionManager = weakOmAdSessionManager.get();
         if (omAdSessionManager == null) {
             LogUtil.error(TAG, "Unable to addOmFriendlyObstruction. OmAdSessionManager is null");
             return;

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/AdDetails.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/AdDetails.java
@@ -21,13 +21,13 @@ package org.prebid.mobile.rendering.models;
  */
 public class AdDetails {
 
-    private String mTransactionId;
+    private String transactionId;
 
     public String getTransactionId() {
-        return mTransactionId;
+        return transactionId;
     }
 
     public void setTransactionId(String transactionId) {
-        mTransactionId = transactionId;
+        this.transactionId = transactionId;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/AdPosition.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/AdPosition.java
@@ -24,13 +24,13 @@ public enum AdPosition {
     SIDEBAR(6),
     FULLSCREEN(7);
 
-    private final int mValue;
+    private final int value;
 
     AdPosition(int value) {
-        mValue = value;
+        this.value = value;
     }
 
     public int getValue() {
-        return mValue;
+        return value;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/CreativeModel.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/CreativeModel.java
@@ -42,56 +42,59 @@ public class CreativeModel {
     private static String TAG = CreativeModel.class.getSimpleName();
 
     //internal data
-    private AdUnitConfiguration mAdConfiguration;
+    private AdUnitConfiguration adConfiguration;
     //helper to get the right creative class
-    private String mName;
-    private int mDisplayDurationInSeconds = 0;
+    private String name;
+    private int displayDurationInSeconds = 0;
     //all - creative width
-    private int mWidth = 0;
+    private int width = 0;
 
     //all - creative height
-    private int mHeight = 0;
+    private int height = 0;
 
     //all - creative html
-    private String mHtml;
+    private String html;
 
-    @Nullable
-    private Integer mRefreshMax;
+    @Nullable private Integer refreshMax;
 
-    HashMap<TrackingEvent.Events, ArrayList<String>> mTrackingURLs = new HashMap<>();
+    HashMap<TrackingEvent.Events, ArrayList<String>> trackingURLs = new HashMap<>();
 
-    protected TrackingManager mTrackingManager;
-    protected OmEventTracker mOmEventTracker;
+    protected TrackingManager trackingManager;
+    protected OmEventTracker omEventTracker;
 
     //all - a unique transaction state of the ad
-    private String mTransactionState;
+    private String transactionState;
 
     //all - resolved ri url of an ad
-    private String mImpressionUrl;
+    private String impressionUrl;
 
     // Determines whether an impression is needed
     // For end cards, an impression is not necessary
-    private boolean mRequireImpressionUrl = true;
+    private boolean requireImpressionUrl = true;
 
     //all - resolved rc url of an ad
-    private String mClickUrl;
+    private String clickUrl;
 
-    private String mTracking;
-    private String mTargetUrl;
+    private String tracking;
+    private String targetUrl;
 
     // Flags that the creative is part of a transaction with an end card
     // This is important for the display layer to perform end card functions
-    private boolean mHasEndCard = false;
+    private boolean hasEndCard = false;
 
-    public CreativeModel(TrackingManager trackingManager, OmEventTracker omEventTracker, AdUnitConfiguration adConfiguration) {
-        mTrackingManager = trackingManager;
-        mAdConfiguration = adConfiguration;
-        mOmEventTracker = omEventTracker;
+    public CreativeModel(
+            TrackingManager trackingManager,
+            OmEventTracker omEventTracker,
+            AdUnitConfiguration adConfiguration
+    ) {
+        this.trackingManager = trackingManager;
+        this.adConfiguration = adConfiguration;
+        this.omEventTracker = omEventTracker;
     }
 
     //tracking firing here from Model always
     public void registerTrackingEvent(TrackingEvent.Events event, ArrayList<String> urls) {
-        mTrackingURLs.put(event, urls);
+        trackingURLs.put(event, urls);
     }
 
     //Tracking an event
@@ -101,7 +104,7 @@ public class CreativeModel {
     }
 
     public void trackEventNamed(TrackingEvent.Events event) {
-        ArrayList<String> trackingUrls = mTrackingURLs.get(event);
+        ArrayList<String> trackingUrls = trackingURLs.get(event);
 
         if (trackingUrls == null || trackingUrls.isEmpty()) {
             LogUtil.debug(TAG, "Event" + event + ": url not found for tracking");
@@ -110,144 +113,143 @@ public class CreativeModel {
 
         //Impression tracker changes
         if (event.equals(TrackingEvent.Events.IMPRESSION)) {
-            mTrackingManager.fireEventTrackingImpressionURLs(trackingUrls);
+            trackingManager.fireEventTrackingImpressionURLs(trackingUrls);
         }
         else {
             //for everything else, use standard logic with no redirection check
             //clicks(rc), would go through GetOriginalUrlTask path, for any redirection related task
             //TODO: Check if we can merge redirection check into our standard BaseNetwork class,
             //for all requests(adrequest & recordEvents)
-            mTrackingManager.fireEventTrackingURLs(trackingUrls);
+            trackingManager.fireEventTrackingURLs(trackingUrls);
         }
     }
 
     public void registerActiveOmAdSession(OmAdSessionManager omAdSessionManager) {
-        mOmEventTracker.registerActiveAdSession(omAdSessionManager);
+        omEventTracker.registerActiveAdSession(omAdSessionManager);
     }
 
     private void handleOmTracking(TrackingEvent.Events event) {
         //checking if this click is made on the end card so that we could track it in the scope
         //of OM video session
-        if (mHasEndCard && event == TrackingEvent.Events.CLICK) {
-            mOmEventTracker.trackOmVideoAdEvent(VideoAdEvent.Event.AD_CLICK);
-        }
-        else {
-            mOmEventTracker.trackOmHtmlAdEvent(event);
+        if (hasEndCard && event == TrackingEvent.Events.CLICK) {
+            omEventTracker.trackOmVideoAdEvent(VideoAdEvent.Event.AD_CLICK);
+        } else {
+            omEventTracker.trackOmHtmlAdEvent(event);
         }
     }
 
     public AdUnitConfiguration getAdConfiguration() {
-        return mAdConfiguration;
+        return adConfiguration;
     }
 
     public void setAdConfiguration(AdUnitConfiguration adConfiguration) {
-        mAdConfiguration = adConfiguration;
+        this.adConfiguration = adConfiguration;
     }
 
     public String getName() {
-        return mName;
+        return name;
     }
 
     public void setName(String name) {
-        mName = name;
+        this.name = name;
     }
 
     public int getDisplayDurationInSeconds() {
-        return mDisplayDurationInSeconds;
+        return displayDurationInSeconds;
     }
 
     public void setDisplayDurationInSeconds(int displayDurationInSeconds) {
-        mDisplayDurationInSeconds = displayDurationInSeconds;
+        this.displayDurationInSeconds = displayDurationInSeconds;
     }
 
     public int getWidth() {
-        return mWidth;
+        return width;
     }
 
     public void setWidth(int width) {
-        mWidth = width;
+        this.width = width;
     }
 
     public int getHeight() {
-        return mHeight;
+        return height;
     }
 
     public void setHeight(int height) {
-        mHeight = height;
+        this.height = height;
     }
 
     public String getHtml() {
-        return mHtml;
+        return html;
     }
 
     public void setHtml(String html) {
-        mHtml = html;
+        this.html = html;
     }
 
     @Nullable
     public Integer getRefreshMax() {
-        return mRefreshMax;
+        return refreshMax;
     }
 
     public void setRefreshMax(
         @Nullable
             Integer refreshMax) {
-        mRefreshMax = refreshMax;
+        this.refreshMax = refreshMax;
     }
 
     public String getTransactionState() {
-        return mTransactionState;
+        return transactionState;
     }
 
     public void setTransactionState(String transactionState) {
-        mTransactionState = transactionState;
+        this.transactionState = transactionState;
     }
 
     public String getImpressionUrl() {
-        return mImpressionUrl;
+        return impressionUrl;
     }
 
     public void setImpressionUrl(String impressionUrl) {
-        mImpressionUrl = impressionUrl;
+        this.impressionUrl = impressionUrl;
     }
 
     public boolean isRequireImpressionUrl() {
-        return mRequireImpressionUrl;
+        return requireImpressionUrl;
     }
 
     public void setRequireImpressionUrl(boolean requireImpressionUrl) {
-        mRequireImpressionUrl = requireImpressionUrl;
+        this.requireImpressionUrl = requireImpressionUrl;
     }
 
     public String getClickUrl() {
-        return mClickUrl;
+        return clickUrl;
     }
 
     public void setClickUrl(String clickUrl) {
-        mClickUrl = clickUrl;
+        this.clickUrl = clickUrl;
     }
 
     public String getTracking() {
-        return mTracking;
+        return tracking;
     }
 
     public void setTracking(String tracking) {
-        mTracking = tracking;
+        this.tracking = tracking;
     }
 
     public boolean hasEndCard() {
-        return mHasEndCard;
+        return hasEndCard;
     }
 
     public void setHasEndCard(boolean hasEndCard) {
-        mHasEndCard = hasEndCard;
+        this.hasEndCard = hasEndCard;
     }
 
     public void setTargetUrl(String targetUrl) {
-        mTargetUrl = targetUrl;
+        this.targetUrl = targetUrl;
     }
 
     public String getTargetUrl() {
-        return mTargetUrl;
+        return targetUrl;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/CreativeModelMakerBids.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/CreativeModelMakerBids.java
@@ -33,21 +33,24 @@ import org.prebid.mobile.rendering.video.OmEventTracker;
 import java.util.ArrayList;
 
 public class CreativeModelMakerBids {
+
     private static final String TAG = CreativeModelMakerBids.class.getSimpleName();
 
-    @NonNull
-    private final AdLoadListener mListener;
-    private final VastParserExtractor mParserExtractor = new VastParserExtractor(this::handleExtractorResult);
+    @NonNull private final AdLoadListener listener;
+    private final VastParserExtractor parserExtractor = new VastParserExtractor(this::handleExtractorResult);
 
-    private AdUnitConfiguration mAdConfiguration;
+    private AdUnitConfiguration adConfiguration;
 
     public CreativeModelMakerBids(
-            @NonNull
-                    AdLoadListener listener) {
-        mListener = listener;
+            @NonNull AdLoadListener listener
+    ) {
+        this.listener = listener;
     }
 
-    public void makeModels(AdUnitConfiguration adConfiguration, BidResponse bidResponse) {
+    public void makeModels(
+            AdUnitConfiguration adConfiguration,
+            BidResponse bidResponse
+    ) {
         if (adConfiguration == null) {
             notifyErrorListener("Successful ad response but has a null config to continue");
             return;
@@ -72,19 +75,19 @@ public class CreativeModelMakerBids {
     }
 
     public void makeVideoModels(AdUnitConfiguration adConfiguration, String vast) {
-        mAdConfiguration = adConfiguration;
-        mAdConfiguration.setAdFormat(AdFormat.VAST);
-        mParserExtractor.extract(vast);
+        this.adConfiguration = adConfiguration;
+        this.adConfiguration.setAdFormat(AdFormat.VAST);
+        parserExtractor.extract(vast);
     }
 
     public void cancel() {
-        if (mParserExtractor != null) {
-            mParserExtractor.cancel();
+        if (parserExtractor != null) {
+            parserExtractor.cancel();
         }
     }
 
     private void notifyErrorListener(String msg) {
-        mListener.onFailedToLoadAd(new AdException(AdException.INTERNAL_ERROR, msg), null);
+        listener.onFailedToLoadAd(new AdException(AdException.INTERNAL_ERROR, msg), null);
     }
 
     private void parseAcj(AdUnitConfiguration adConfiguration, BidResponse bidResponse) {
@@ -105,7 +108,7 @@ public class CreativeModelMakerBids {
         result.creativeModels.add(model);
         result.transactionState = "bid";
 
-        mListener.onCreativeModelReady(result);
+        listener.onCreativeModelReady(result);
     }
 
     private String getAdHtml(AdUnitConfiguration adConfiguration, Bid bid) {
@@ -125,11 +128,11 @@ public class CreativeModelMakerBids {
         final String loadIdentifier = result.getLoadIdentifier();
 
         if (result.hasException()) {
-            mListener.onFailedToLoadAd(result.getAdException(), loadIdentifier);
+            listener.onFailedToLoadAd(result.getAdException(), loadIdentifier);
             return;
         }
 
-        CreativeModelsMaker modelsMaker = new CreativeModelsMakerVast(loadIdentifier, mListener);
-        modelsMaker.makeModels(mAdConfiguration, result.getVastResponseParserArray());
+        CreativeModelsMaker modelsMaker = new CreativeModelsMakerVast(loadIdentifier, listener);
+        modelsMaker.makeModels(adConfiguration, result.getVastResponseParserArray());
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/CreativeModelsMakerVast.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/CreativeModelsMakerVast.java
@@ -44,21 +44,21 @@ public class CreativeModelsMakerVast extends CreativeModelsMaker {
 
     static final String VIDEO_CREATIVE_TAG = "Video";
 
-    @NonNull
-    private final AdLoadListener mListener;
+    @NonNull private final AdLoadListener listener;
 
-    private AdUnitConfiguration mAdConfiguration;
+    private AdUnitConfiguration adConfiguration;
 
-    private AdResponseParserVast mRootVastParser;
-    private AdResponseParserVast mLatestVastWrapperParser;
+    private AdResponseParserVast rootVastParser;
+    private AdResponseParserVast latestVastWrapperParser;
 
-    private String mAdLoaderIdentifier;
+    private String adLoaderIdentifier;
 
-    public CreativeModelsMakerVast(String adLoaderIdentifier,
-                                   @NonNull
-                                       AdLoadListener listener) {
-        mListener = listener;
-        mAdLoaderIdentifier = adLoaderIdentifier;
+    public CreativeModelsMakerVast(
+            String adLoaderIdentifier,
+            @NonNull AdLoadListener listener
+    ) {
+        this.listener = listener;
+        this.adLoaderIdentifier = adLoaderIdentifier;
     }
 
     @Override
@@ -68,7 +68,7 @@ public class CreativeModelsMakerVast extends CreativeModelsMaker {
             return;
         }
 
-        mAdConfiguration = adConfiguration;
+        this.adConfiguration = adConfiguration;
 
         if (parsers == null) {
             notifyErrorListener("Parsers results are null.");
@@ -80,10 +80,10 @@ public class CreativeModelsMakerVast extends CreativeModelsMaker {
             return;
         }
 
-        mRootVastParser = (AdResponseParserVast) parsers[0];
-        mLatestVastWrapperParser = (AdResponseParserVast) parsers[1];
+        rootVastParser = (AdResponseParserVast) parsers[0];
+        latestVastWrapperParser = (AdResponseParserVast) parsers[1];
 
-        if (mRootVastParser == null || mLatestVastWrapperParser == null) {
+        if (rootVastParser == null || latestVastWrapperParser == null) {
             notifyErrorListener("One of parsers is null.");
             return;
         }
@@ -101,49 +101,49 @@ public class CreativeModelsMakerVast extends CreativeModelsMaker {
              * We pre parse the impressions and trackings for faster reading at
              * video time. DO NOT REMOVE THESE LINES
              */
-            mRootVastParser.getAllTrackings(mRootVastParser, 0);
-            mRootVastParser.getImpressions(mRootVastParser, 0);
-            mRootVastParser.getClickTrackings(mRootVastParser, 0);
-            final String videoErrorUrl = mRootVastParser.getError(mRootVastParser, 0);
-            final String vastClickThroughUrl = mRootVastParser.getClickThroughUrl(mRootVastParser, 0);
-            final String videoDuration = mLatestVastWrapperParser.getVideoDuration(mLatestVastWrapperParser, 0);
-            final String skipOffset = mLatestVastWrapperParser.getSkipOffset(mLatestVastWrapperParser, 0);
-            final AdVerifications adVerifications = mRootVastParser.getAdVerification(mLatestVastWrapperParser, 0);
+            rootVastParser.getAllTrackings(rootVastParser, 0);
+            rootVastParser.getImpressions(rootVastParser, 0);
+            rootVastParser.getClickTrackings(rootVastParser, 0);
+            final String videoErrorUrl = rootVastParser.getError(rootVastParser, 0);
+            final String vastClickThroughUrl = rootVastParser.getClickThroughUrl(rootVastParser, 0);
+            final String videoDuration = latestVastWrapperParser.getVideoDuration(latestVastWrapperParser, 0);
+            final String skipOffset = latestVastWrapperParser.getSkipOffset(latestVastWrapperParser, 0);
+            final AdVerifications adVerifications = rootVastParser.getAdVerification(latestVastWrapperParser, 0);
 
             checkVideoDuration(Utils.getMsFrom(videoDuration));
 
             Result result = new Result();
-            result.loaderIdentifier = mAdLoaderIdentifier;
+            result.loaderIdentifier = adLoaderIdentifier;
 
             TrackingManager trackingManager = TrackingManager.getInstance();
             OmEventTracker omEventTracker = new OmEventTracker();
 
-            VideoCreativeModel videoModel = new VideoCreativeModel(trackingManager, omEventTracker, mAdConfiguration);
+            VideoCreativeModel videoModel = new VideoCreativeModel(trackingManager, omEventTracker, adConfiguration);
 
             videoModel.setName(VIDEO_CREATIVE_TAG);
 
-            videoModel.setMediaUrl(mLatestVastWrapperParser.getMediaFileUrl(mLatestVastWrapperParser, 0));
+            videoModel.setMediaUrl(latestVastWrapperParser.getMediaFileUrl(latestVastWrapperParser, 0));
             videoModel.setMediaDuration(Utils.getMsFrom(videoDuration));
             videoModel.setSkipOffset(Utils.getMsFrom(skipOffset));
             videoModel.setAdVerifications(adVerifications);
-            videoModel.setAuid(mRootVastParser.getVast().getAds().get(0).getId());
-            videoModel.setWidth(mLatestVastWrapperParser.getWidth());
-            videoModel.setHeight(mLatestVastWrapperParser.getHeight());
+            videoModel.setAuid(rootVastParser.getVast().getAds().get(0).getId());
+            videoModel.setWidth(latestVastWrapperParser.getWidth());
+            videoModel.setHeight(latestVastWrapperParser.getHeight());
             //put tracking urls into element.
             for (VideoAdEvent.Event videoEvent : VideoAdEvent.Event.values()) {
-                videoModel.getVideoEventUrls().put(videoEvent, mRootVastParser.getTrackingByType(videoEvent));
+                videoModel.getVideoEventUrls().put(videoEvent, rootVastParser.getTrackingByType(videoEvent));
             }
 
             //put impression urls into element
             ArrayList<String> impUrls = new ArrayList<>();
-            for (Impression impression : mRootVastParser.getImpressions()) {
+            for (Impression impression : rootVastParser.getImpressions()) {
                 impUrls.add(impression.getValue());
             }
             videoModel.getVideoEventUrls().put(VideoAdEvent.Event.AD_IMPRESSION, impUrls);
 
             //put click urls into element
             ArrayList<String> clickTrackingUrls = new ArrayList<>();
-            for (ClickTracking clickTracking : mRootVastParser.getClickTrackings()) {
+            for (ClickTracking clickTracking : rootVastParser.getClickTrackings()) {
                 clickTrackingUrls.add(clickTracking.getValue());
             }
             videoModel.getVideoEventUrls().put(VideoAdEvent.Event.AD_CLICK, clickTrackingUrls);
@@ -159,12 +159,15 @@ public class CreativeModelsMakerVast extends CreativeModelsMaker {
             result.creativeModels = new ArrayList<>();
             result.creativeModels.add(videoModel);
 
-            CreativeModel endCardModel = new CreativeModel(trackingManager, omEventTracker, mAdConfiguration);
+            CreativeModel endCardModel = new CreativeModel(trackingManager, omEventTracker, adConfiguration);
             endCardModel.setName(HTML_CREATIVE_TAG);
             endCardModel.setHasEndCard(true);
 
             // Create CompanionAd object
-            Companion companionAd = AdResponseParserVast.getCompanionAd(mLatestVastWrapperParser.getVast().getAds().get(0).getInline());
+            Companion companionAd = AdResponseParserVast.getCompanionAd(latestVastWrapperParser.getVast()
+                                                                                               .getAds()
+                                                                                               .get(0)
+                                                                                               .getInline());
             if (companionAd != null) {
                 switch (AdResponseParserVast.getCompanionResourceFormat(companionAd)) {
                     case RESOURCE_FORMAT_HTML:
@@ -210,8 +213,8 @@ public class CreativeModelsMakerVast extends CreativeModelsMaker {
                 // Flag that video creative has a corresponding end card
                 videoModel.setHasEndCard(true);
             }
-            mAdConfiguration.setInterstitialSize(videoModel.getWidth() + "x" + videoModel.getHeight());
-            mListener.onCreativeModelReady(result);
+            adConfiguration.setInterstitialSize(videoModel.getWidth() + "x" + videoModel.getHeight());
+            listener.onCreativeModelReady(result);
         } catch (Exception e) {
             LogUtil.error(TAG, "Video failed with: " + e.getMessage());
             notifyErrorListener("Video failed: " + e.getMessage());
@@ -219,12 +222,12 @@ public class CreativeModelsMakerVast extends CreativeModelsMaker {
     }
 
     private void notifyErrorListener(String msg) {
-        mListener.onFailedToLoadAd(new AdException(AdException.INTERNAL_ERROR, msg), mAdLoaderIdentifier);
+        listener.onFailedToLoadAd(new AdException(AdException.INTERNAL_ERROR, msg), adLoaderIdentifier);
     }
 
     private void checkVideoDuration(long currentDuration) throws VastParseError {
-        if (mAdConfiguration != null && mAdConfiguration.getMaxVideoDuration() != null) {
-            long maxDuration = mAdConfiguration.getMaxVideoDuration() * 1000;
+        if (adConfiguration != null && adConfiguration.getMaxVideoDuration() != null) {
+            long maxDuration = adConfiguration.getMaxVideoDuration() * 1000;
             if (currentDuration > maxDuration) {
                 throw new VastParseError("Video duration can't be more then ad unit max video duration: " + maxDuration + " (current duration: " + currentDuration + ")");
             }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/HTMLCreative.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/HTMLCreative.java
@@ -44,23 +44,26 @@ import org.prebid.mobile.rendering.views.webview.WebViewBase;
 
 import java.util.EnumSet;
 
-public class HTMLCreative extends AbstractCreative
-    implements WebViewDelegate, InterstitialManagerDisplayDelegate, Comparable {
+public class HTMLCreative extends AbstractCreative implements WebViewDelegate, InterstitialManagerDisplayDelegate, Comparable {
 
     private static final String TAG = HTMLCreative.class.getSimpleName();
 
-    private MraidController mMraidController;
+    private MraidController mraidController;
 
-    private PrebidWebViewBase mTwoPartNewWebViewBase;
+    private PrebidWebViewBase twoPartNewWebViewBase;
 
-    private boolean mIsEndCard = false;
-    private boolean mResolved;
+    private boolean isEndCard = false;
+    private boolean resolved;
 
-    public HTMLCreative(Context context, CreativeModel model, OmAdSessionManager omAdSessionManager, InterstitialManager interstitialManager)
-    throws AdException {
+    public HTMLCreative(
+            Context context,
+            CreativeModel model,
+            OmAdSessionManager omAdSessionManager,
+            InterstitialManager interstitialManager
+    ) throws AdException {
         super(context, model, omAdSessionManager, interstitialManager);
-        mInterstitialManager.setInterstitialDisplayDelegate(this);
-        mMraidController = new MraidController(mInterstitialManager);
+        this.interstitialManager.setInterstitialDisplayDelegate(this);
+        mraidController = new MraidController(this.interstitialManager);
     }
 
     @Override
@@ -75,7 +78,7 @@ public class HTMLCreative extends AbstractCreative
 
     @Override
     public void load() throws AdException {
-        if (mContextReference == null || mContextReference.get() == null) {
+        if (contextReference == null || contextReference.get() == null) {
             throw new AdException(AdException.INTERNAL_ERROR, "Context is null. Could not load adHtml");
         }
         CreativeModel model = getCreativeModel();
@@ -95,11 +98,19 @@ public class HTMLCreative extends AbstractCreative
         if (adType == AdFormat.BANNER) {
             //do all banner
             prebidWebView = (PrebidWebViewBanner) ViewPool.getInstance()
-                    .getUnoccupiedView(mContextReference.get(), null, adType, mInterstitialManager);
+                                                          .getUnoccupiedView(contextReference.get(),
+                                                                  null,
+                                                                  adType,
+                                                                  interstitialManager
+                                                          );
         } else if (adType == AdFormat.INTERSTITIAL) {
             //do all interstitials
             prebidWebView = (PrebidWebViewInterstitial) ViewPool.getInstance()
-                    .getUnoccupiedView(mContextReference.get(), null, adType, mInterstitialManager);
+                                                                .getUnoccupiedView(contextReference.get(),
+                                                                        null,
+                                                                        adType,
+                                                                        interstitialManager
+                                                                );
         }
 
         if (prebidWebView == null) {
@@ -123,14 +134,14 @@ public class HTMLCreative extends AbstractCreative
             setCreativeView(prebidWebView);
         }
 
-        mIsEndCard = model.hasEndCard();
+        isEndCard = model.hasEndCard();
     }
 
     @Override
     public void display() {
 
         if (!(getCreativeView() instanceof PrebidWebViewBase)) {
-            LogUtil.error(TAG, "Could not cast mCreativeView to a PrebidWebViewBase");
+            LogUtil.error(TAG, "Could not cast creativeView to a PrebidWebViewBase");
             return;
         }
         PrebidWebViewBase creativeWebView = (PrebidWebViewBase) getCreativeView();
@@ -146,7 +157,7 @@ public class HTMLCreative extends AbstractCreative
             return;
         }
 
-        OmAdSessionManager omAdSessionManager = mWeakOmAdSessionManager.get();
+        OmAdSessionManager omAdSessionManager = weakOmAdSessionManager.get();
         if (omAdSessionManager == null) {
             LogUtil.error(TAG, "Error creating adSession. OmAdSessionManager is null");
             return;
@@ -171,13 +182,12 @@ public class HTMLCreative extends AbstractCreative
     @Override
     public void startViewabilityTracker() {
         VisibilityTrackerOption visibilityTrackerOption = new VisibilityTrackerOption(NativeEventTracker.EventType.IMPRESSION);
-        mCreativeVisibilityTracker = new CreativeVisibilityTracker(
-            getCreativeView().getWebView(),
-            visibilityTrackerOption,
-            ((PrebidWebViewBase) getCreativeView()).getWebView().isMRAID()
+        creativeVisibilityTracker = new CreativeVisibilityTracker(getCreativeView().getWebView(),
+                visibilityTrackerOption,
+                ((PrebidWebViewBase) getCreativeView()).getWebView().isMRAID()
         );
-        mCreativeVisibilityTracker.setVisibilityTrackerListener(this::onVisibilityEvent);
-        mCreativeVisibilityTracker.startVisibilityCheck(mContextReference.get());
+        creativeVisibilityTracker.setVisibilityTrackerListener(this::onVisibilityEvent);
+        creativeVisibilityTracker.startVisibilityCheck(contextReference.get());
     }
 
     @Override
@@ -190,21 +200,21 @@ public class HTMLCreative extends AbstractCreative
 
     @Override
     public void webViewReadyToDisplay() {
-        if (mResolved) {
+        if (resolved) {
             return;
         }
 
-        mResolved = true;
+        resolved = true;
         getResolutionListener().creativeReady(this);
     }
 
     @Override
     public void webViewFailedToLoad(AdException error) {
-        if (mResolved) {
+        if (resolved) {
             return;
         }
 
-        mResolved = true;
+        resolved = true;
         getResolutionListener().creativeFailed(error);
     }
 
@@ -285,7 +295,7 @@ public class HTMLCreative extends AbstractCreative
      * @return true if WebView is resolved (loaded or failed to load callback triggered), false otherwise.
      */
     public boolean isResolved() {
-        return mResolved;
+        return resolved;
     }
 
     /**
@@ -293,7 +303,7 @@ public class HTMLCreative extends AbstractCreative
      */
     @Override
     public boolean isEndCard() {
-        return mIsEndCard;
+        return isEndCard;
     }
 
     public void destroy() {
@@ -303,8 +313,8 @@ public class HTMLCreative extends AbstractCreative
             getCreativeView().destroy();
         }
 
-        if (mMraidController != null) {
-            mMraidController.destroy();
+        if (mraidController != null) {
+            mraidController.destroy();
         }
 
         ViewPool.getInstance().clear();
@@ -318,10 +328,10 @@ public class HTMLCreative extends AbstractCreative
     }
 
     public void handleMRAIDEventsInCreative(final MraidEvent mraidEvent, final WebViewBase oldWebViewBase) {
-        if (mMraidController == null) {
-            mMraidController = new MraidController(mInterstitialManager);
+        if (mraidController == null) {
+            mraidController = new MraidController(interstitialManager);
         }
-        mMraidController.handleMraidEvent(mraidEvent, this, oldWebViewBase, mTwoPartNewWebViewBase);
+        mraidController.handleMraidEvent(mraidEvent, this, oldWebViewBase, twoPartNewWebViewBase);
     }
 
     /**
@@ -332,7 +342,7 @@ public class HTMLCreative extends AbstractCreative
      */
     private String injectingScriptContent(String html) {
         try {
-            OmAdSessionManager omAdSessionManager = mWeakOmAdSessionManager.get();
+            OmAdSessionManager omAdSessionManager = weakOmAdSessionManager.get();
             if (omAdSessionManager == null) {
                 LogUtil.debug(TAG, "Unable to injectScriptContent. AdSessionManager is null.");
                 return html;
@@ -346,6 +356,6 @@ public class HTMLCreative extends AbstractCreative
     }
 
     public void setTwoPartNewWebViewBase(PrebidWebViewBase twoPartNewWebViewBase) {
-        mTwoPartNewWebViewBase = twoPartNewWebViewBase;
+        this.twoPartNewWebViewBase = twoPartNewWebViewBase;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/InterstitialLayout.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/InterstitialLayout.java
@@ -24,13 +24,13 @@ public enum InterstitialLayout {
     ROTATABLE(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT),
     UNDEFINED(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
 
-    private int mOrientation;
+    private int orientation;
 
     InterstitialLayout(int orientation) {
-        mOrientation = orientation;
+        this.orientation = orientation;
     }
 
     public int getOrientation() {
-        return mOrientation;
+        return orientation;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/PlacementType.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/PlacementType.java
@@ -23,13 +23,13 @@ public enum PlacementType {
     IN_FEED(4),
     INTERSTITIAL(5);
 
-    private final int mValue;
+    private final int value;
 
     PlacementType(int value) {
-        mValue = value;
+        this.value = value;
     }
 
     public int getValue() {
-        return mValue;
+        return value;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/ViewPool.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/ViewPool.java
@@ -31,10 +31,10 @@ import org.prebid.mobile.rendering.views.webview.mraid.Views;
 import java.util.ArrayList;
 
 public class ViewPool {
-    @SuppressLint("StaticFieldLeak")
-    private static ViewPool sInstance = null;
-    private ArrayList<View> mOccupiedViews = new ArrayList<>();
-    private ArrayList<View> mUnoccupiedViews = new ArrayList<>();
+
+    @SuppressLint("StaticFieldLeak") private static ViewPool sInstance = null;
+    private ArrayList<View> occupiedViews = new ArrayList<>();
+    private ArrayList<View> unoccupiedViews = new ArrayList<>();
 
     private ViewPool() {
 
@@ -48,49 +48,49 @@ public class ViewPool {
     }
 
     protected int sizeOfOccupied() {
-        return mOccupiedViews.size();
+        return occupiedViews.size();
     }
 
     protected int sizeOfUnoccupied() {
-        return mUnoccupiedViews.size();
+        return unoccupiedViews.size();
     }
 
     //This will add views into occupied bucket
     public void addToOccupied(View view) {
-        if (!mOccupiedViews.contains(view) && !mUnoccupiedViews.contains(view)) {
-            mOccupiedViews.add(view);
+        if (!occupiedViews.contains(view) && !unoccupiedViews.contains(view)) {
+            occupiedViews.add(view);
         }
     }
 
     public void addToUnoccupied(View view) {
-        if (!mUnoccupiedViews.contains(view) && !mOccupiedViews.contains(view)) {
-            mUnoccupiedViews.add(view);
+        if (!unoccupiedViews.contains(view) && !occupiedViews.contains(view)) {
+            unoccupiedViews.add(view);
         }
     }
 
     //This will swap from occupied to unoccupied(after windowclose) and removes it from occupied bucket
     public void swapToUnoccupied(View view) {
-        if (!mUnoccupiedViews.contains(view)) {
-            mUnoccupiedViews.add(view);
+        if (!unoccupiedViews.contains(view)) {
+            unoccupiedViews.add(view);
 
             Views.removeFromParent(view);
         }
-        mOccupiedViews.remove(view);
+        occupiedViews.remove(view);
     }
 
     //This will swap from unoccupied to occupied(after showing/displaying) and removes it from unoccupied bucket
     private void swapToOccupied(View view) {
-        if (!mOccupiedViews.contains(view)) {
-            mOccupiedViews.add(view);
+        if (!occupiedViews.contains(view)) {
+            occupiedViews.add(view);
         }
 
-        mUnoccupiedViews.remove(view);
+        unoccupiedViews.remove(view);
     }
 
     //This only clears the bucketlist. It does not actually remove the lists. Means (size becomes 0 but list still exists)
     public void clear() {
-        mOccupiedViews.clear();
-        mUnoccupiedViews.clear();
+        occupiedViews.clear();
+        unoccupiedViews.clear();
         plugPlayView = null;
     }
 
@@ -104,15 +104,15 @@ public class ViewPool {
         if (context == null) {
             throw new AdException(AdException.INTERNAL_ERROR, "Context is null");
         }
-        if (mUnoccupiedViews != null && mUnoccupiedViews.size() > 0) {
+        if (unoccupiedViews != null && unoccupiedViews.size() > 0) {
 
-            View view = mUnoccupiedViews.get(0);
+            View view = unoccupiedViews.get(0);
 
             Views.removeFromParent(view);
 
             //get item from unoccupied & add it to occupied
             swapToOccupied(view);
-            return mOccupiedViews.get(mOccupiedViews.size() - 1);
+            return occupiedViews.get(occupiedViews.size() - 1);
         }
         //create a new one
 

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/internal/InternalFriendlyObstruction.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/internal/InternalFriendlyObstruction.java
@@ -21,26 +21,31 @@ import android.view.View;
 import java.lang.ref.WeakReference;
 
 public class InternalFriendlyObstruction {
-    private WeakReference<View> mViewWeakReference;
-    private InternalFriendlyObstruction.Purpose mFriendlyObstructionPurpose;
-    private String mDetailedDescription;
 
-    public InternalFriendlyObstruction(View view, InternalFriendlyObstruction.Purpose friendlyObstructionPurpose, String detailedDescription) {
-        mViewWeakReference = new WeakReference<>(view);
-        mFriendlyObstructionPurpose = friendlyObstructionPurpose;
-        mDetailedDescription = detailedDescription;
+    private WeakReference<View> viewWeakReference;
+    private InternalFriendlyObstruction.Purpose friendlyObstructionPurpose;
+    private String detailedDescription;
+
+    public InternalFriendlyObstruction(
+            View view,
+            InternalFriendlyObstruction.Purpose friendlyObstructionPurpose,
+            String detailedDescription
+    ) {
+        viewWeakReference = new WeakReference<>(view);
+        this.friendlyObstructionPurpose = friendlyObstructionPurpose;
+        this.detailedDescription = detailedDescription;
     }
 
     public View getView() {
-        return mViewWeakReference.get();
+        return viewWeakReference.get();
     }
 
     public InternalFriendlyObstruction.Purpose getPurpose() {
-        return mFriendlyObstructionPurpose;
+        return friendlyObstructionPurpose;
     }
 
     public String getDetailedDescription() {
-        return mDetailedDescription;
+        return detailedDescription;
     }
 
     public enum Purpose {

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/internal/MacrosModel.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/internal/MacrosModel.java
@@ -24,15 +24,15 @@ public class MacrosModel {
 
     private static final String MACROS_DEFAULT_VALUE = "\\\\\"\\\\\""; //String representation of "\"\""
 
-    private final String mReplaceValue;
+    private final String replaceValue;
 
     public MacrosModel(String replaceValue) {
-        mReplaceValue = replaceValue;
+        this.replaceValue = replaceValue;
     }
 
     @NonNull
     public String getReplaceValue() {
-        return mReplaceValue == null ? MACROS_DEFAULT_VALUE : mReplaceValue;
+        return replaceValue == null ? MACROS_DEFAULT_VALUE : replaceValue;
     }
 
     @Override
@@ -46,13 +46,11 @@ public class MacrosModel {
 
         MacrosModel that = (MacrosModel) o;
 
-        return mReplaceValue != null
-               ? mReplaceValue.equals(that.mReplaceValue)
-               : that.mReplaceValue == null;
+        return replaceValue != null ? replaceValue.equals(that.replaceValue) : that.replaceValue == null;
     }
 
     @Override
     public int hashCode() {
-        return mReplaceValue != null ? mReplaceValue.hashCode() : 0;
+        return replaceValue != null ? replaceValue.hashCode() : 0;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/internal/MraidVariableContainer.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/internal/MraidVariableContainer.java
@@ -33,40 +33,40 @@ public class MraidVariableContainer {
 
     private static String sDisabledFlags = null;
 
-    private String mUrlForLaunching;
-    private String mExpandProperties;
-    private String mOrientationProperties;
+    private String urlForLaunching;
+    private String expandProperties;
+    private String orientationProperties;
 
-    private String mCurrentState;
-    private String mCurrentExposure;
-    private Boolean mCurrentViewable = null;
+    private String currentState;
+    private String currentExposure;
+    private Boolean currentViewable = null;
 
     public String getUrlForLaunching() {
-        return mUrlForLaunching == null ? "" : mUrlForLaunching;
+        return urlForLaunching == null ? "" : urlForLaunching;
     }
 
     public void setUrlForLaunching(String urlForLaunching) {
-        mUrlForLaunching = urlForLaunching;
+        this.urlForLaunching = urlForLaunching;
     }
 
     public String getExpandProperties() {
-        return mExpandProperties;
+        return expandProperties;
     }
 
     public void setExpandProperties(String expandProperties) {
-        mExpandProperties = expandProperties;
+        this.expandProperties = expandProperties;
     }
 
     public String getOrientationProperties() {
-        return mOrientationProperties;
+        return orientationProperties;
     }
 
     public void setOrientationProperties(String orientationProperties) {
-        mOrientationProperties = orientationProperties;
+        this.orientationProperties = orientationProperties;
     }
 
     public boolean isLaunchedWithUrl() {
-        return !TextUtils.isEmpty(mUrlForLaunching);
+        return !TextUtils.isEmpty(urlForLaunching);
     }
 
     public static void setDisabledFlags(String disabledFlags) {
@@ -78,27 +78,27 @@ public class MraidVariableContainer {
     }
 
     public String getCurrentState() {
-        return mCurrentState;
+        return currentState;
     }
 
     public void setCurrentState(String currentState) {
-        mCurrentState = currentState;
+        this.currentState = currentState;
     }
 
     public String getCurrentExposure() {
-        return mCurrentExposure;
+        return currentExposure;
     }
 
     public void setCurrentExposure(String currentExposure) {
-        mCurrentExposure = currentExposure;
+        this.currentExposure = currentExposure;
     }
 
     public Boolean getCurrentViewable() {
-        return mCurrentViewable;
+        return currentViewable;
     }
 
     public void setCurrentViewable(Boolean currentViewable) {
-        mCurrentViewable = currentViewable;
+        this.currentViewable = currentViewable;
     }
 
     /**

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/internal/VastExtractorResult.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/internal/VastExtractorResult.java
@@ -23,32 +23,33 @@ import org.prebid.mobile.rendering.utils.helpers.Utils;
 import java.util.Arrays;
 
 public class VastExtractorResult {
-    private final String mLoadIdentifier = String.valueOf(Utils.generateRandomInt());
-    private AdException mAdException;
-    private AdResponseParserBase[] mVastResponseParserArray;
+
+    private final String loadIdentifier = String.valueOf(Utils.generateRandomInt());
+    private AdException adException;
+    private AdResponseParserBase[] vastResponseParserArray;
 
     public VastExtractorResult(AdResponseParserBase[] vastResponseParserArray) {
-        mVastResponseParserArray = vastResponseParserArray;
+        this.vastResponseParserArray = vastResponseParserArray;
     }
 
     public VastExtractorResult(AdException adException) {
-        mAdException = adException;
+        this.adException = adException;
     }
 
     public AdException getAdException() {
-        return mAdException;
+        return adException;
     }
 
     public String getLoadIdentifier() {
-        return mLoadIdentifier;
+        return loadIdentifier;
     }
 
     public AdResponseParserBase[] getVastResponseParserArray() {
-        return mVastResponseParserArray;
+        return vastResponseParserArray;
     }
 
     public boolean hasException() {
-        return mAdException != null;
+        return adException != null;
     }
 
     @Override
@@ -62,16 +63,14 @@ public class VastExtractorResult {
 
         VastExtractorResult that = (VastExtractorResult) o;
 
-        return mLoadIdentifier != null
-               ? mLoadIdentifier.equals(that.mLoadIdentifier)
-               : that.mLoadIdentifier == null;
+        return loadIdentifier != null ? loadIdentifier.equals(that.loadIdentifier) : that.loadIdentifier == null;
     }
 
     @Override
     public int hashCode() {
-        int result = mLoadIdentifier != null ? mLoadIdentifier.hashCode() : 0;
-        result = 31 * result + (mAdException != null ? mAdException.hashCode() : 0);
-        result = 31 * result + Arrays.hashCode(mVastResponseParserArray);
+        int result = loadIdentifier != null ? loadIdentifier.hashCode() : 0;
+        result = 31 * result + (adException != null ? adException.hashCode() : 0);
+        result = 31 * result + Arrays.hashCode(vastResponseParserArray);
         return result;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/internal/VisibilityTrackerOption.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/internal/VisibilityTrackerOption.java
@@ -19,22 +19,27 @@ package org.prebid.mobile.rendering.models.internal;
 import org.prebid.mobile.rendering.models.ntv.NativeEventTracker;
 
 public class VisibilityTrackerOption {
-    private NativeEventTracker.EventType mEventType;
-    private int mMinimumVisibleMillis;
-    private int mMinVisibilityPercentage;
-    private boolean mIsImpressionTracked;
-    private long mStartTimeMillis = Long.MIN_VALUE;
 
-    public VisibilityTrackerOption(NativeEventTracker.EventType eventType, int minimumVisibleMillis, int minVisibilityPercentage) {
-        mEventType = eventType;
-        mMinimumVisibleMillis = minimumVisibleMillis;
-        mMinVisibilityPercentage = minVisibilityPercentage;
+    private NativeEventTracker.EventType eventType;
+    private int minimumVisibleMillis;
+    private int minVisibilityPercentage;
+    private boolean isImpressionTracked;
+    private long startTimeMillis = Long.MIN_VALUE;
+
+    public VisibilityTrackerOption(
+            NativeEventTracker.EventType eventType,
+            int minimumVisibleMillis,
+            int minVisibilityPercentage
+    ) {
+        this.eventType = eventType;
+        this.minimumVisibleMillis = minimumVisibleMillis;
+        this.minVisibilityPercentage = minVisibilityPercentage;
     }
 
     public VisibilityTrackerOption(NativeEventTracker.EventType eventType) {
-        mEventType = eventType;
-        mMinimumVisibleMillis = getMinimumVisibleMillis(eventType);
-        mMinVisibilityPercentage = getMinimumVisiblePercents(eventType);
+        this.eventType = eventType;
+        minimumVisibleMillis = getMinimumVisibleMillis(eventType);
+        minVisibilityPercentage = getMinimumVisiblePercents(eventType);
     }
 
     public static int getMinimumVisibleMillis(NativeEventTracker.EventType eventType) {
@@ -66,47 +71,47 @@ public class VisibilityTrackerOption {
     }
 
     public boolean isType(NativeEventTracker.EventType eventType) {
-        return mEventType.equals(eventType);
+        return this.eventType.equals(eventType);
     }
 
     public void setStartTimeMillis(long startTimeMillis) {
-        mStartTimeMillis = startTimeMillis;
+        this.startTimeMillis = startTimeMillis;
     }
 
     public long getStartTimeMillis() {
-        return mStartTimeMillis;
+        return startTimeMillis;
     }
 
     public int getMinimumVisibleMillis() {
-        return mMinimumVisibleMillis;
+        return minimumVisibleMillis;
     }
 
     public void setMinimumVisibleMillis(int minimumVisibleMillis) {
-        mMinimumVisibleMillis = minimumVisibleMillis;
+        this.minimumVisibleMillis = minimumVisibleMillis;
     }
 
     public int getMinVisibilityPercentage() {
-        return mMinVisibilityPercentage;
+        return minVisibilityPercentage;
     }
 
     public void setMinVisibilityPercentage(int minVisibilityPercentage) {
-        mMinVisibilityPercentage = minVisibilityPercentage;
+        this.minVisibilityPercentage = minVisibilityPercentage;
     }
 
     public boolean isImpressionTracked() {
-        return mIsImpressionTracked;
+        return isImpressionTracked;
     }
 
     public void setImpressionTracked(boolean impressionTracked) {
-        mIsImpressionTracked = impressionTracked;
+        isImpressionTracked = impressionTracked;
     }
 
     public NativeEventTracker.EventType getEventType() {
-        return mEventType;
+        return eventType;
     }
 
     public void setEventType(NativeEventTracker.EventType eventType) {
-        mEventType = eventType;
+        this.eventType = eventType;
     }
 
     @Override
@@ -120,28 +125,28 @@ public class VisibilityTrackerOption {
 
         VisibilityTrackerOption that = (VisibilityTrackerOption) o;
 
-        if (mMinimumVisibleMillis != that.mMinimumVisibleMillis) {
+        if (minimumVisibleMillis != that.minimumVisibleMillis) {
             return false;
         }
-        if (mMinVisibilityPercentage != that.mMinVisibilityPercentage) {
+        if (minVisibilityPercentage != that.minVisibilityPercentage) {
             return false;
         }
-        if (mIsImpressionTracked != that.mIsImpressionTracked) {
+        if (isImpressionTracked != that.isImpressionTracked) {
             return false;
         }
-        if (mStartTimeMillis != that.mStartTimeMillis) {
+        if (startTimeMillis != that.startTimeMillis) {
             return false;
         }
-        return mEventType == that.mEventType;
+        return eventType == that.eventType;
     }
 
     @Override
     public int hashCode() {
-        int result = mEventType != null ? mEventType.hashCode() : 0;
-        result = 31 * result + mMinimumVisibleMillis;
-        result = 31 * result + mMinVisibilityPercentage;
-        result = 31 * result + (mIsImpressionTracked ? 1 : 0);
-        result = 31 * result + (int) (mStartTimeMillis ^ (mStartTimeMillis >>> 32));
+        int result = eventType != null ? eventType.hashCode() : 0;
+        result = 31 * result + minimumVisibleMillis;
+        result = 31 * result + minVisibilityPercentage;
+        result = 31 * result + (isImpressionTracked ? 1 : 0);
+        result = 31 * result + (int) (startTimeMillis ^ (startTimeMillis >>> 32));
         return result;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/internal/VisibilityTrackerResult.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/internal/VisibilityTrackerResult.java
@@ -20,35 +20,38 @@ import org.prebid.mobile.rendering.models.ntv.NativeEventTracker;
 import org.prebid.mobile.rendering.utils.exposure.ViewExposure;
 
 public class VisibilityTrackerResult {
-    private final NativeEventTracker.EventType mEventType;
-    private final ViewExposure mViewExposure;
-    private final boolean mIsVisible;
-    private final boolean mShouldFireImpression;
 
-    public VisibilityTrackerResult(NativeEventTracker.EventType eventType,
-                                   ViewExposure viewExposure,
-                                   boolean isVisible,
-                                   boolean shouldFireImpression) {
-        mEventType = eventType;
-        mViewExposure = viewExposure;
-        mIsVisible = isVisible;
-        mShouldFireImpression = shouldFireImpression;
+    private final NativeEventTracker.EventType eventType;
+    private final ViewExposure viewExposure;
+    private final boolean isVisible;
+    private final boolean shouldFireImpression;
+
+    public VisibilityTrackerResult(
+            NativeEventTracker.EventType eventType,
+            ViewExposure viewExposure,
+            boolean isVisible,
+            boolean shouldFireImpression
+    ) {
+        this.eventType = eventType;
+        this.viewExposure = viewExposure;
+        this.isVisible = isVisible;
+        this.shouldFireImpression = shouldFireImpression;
     }
 
     public NativeEventTracker.EventType getEventType() {
-        return mEventType;
+        return eventType;
     }
 
     public ViewExposure getViewExposure() {
-        return mViewExposure;
+        return viewExposure;
     }
 
     public boolean isVisible() {
-        return mIsVisible;
+        return isVisible;
     }
 
     public boolean shouldFireImpression() {
-        return mShouldFireImpression;
+        return shouldFireImpression;
     }
 
     @Override
@@ -62,26 +65,24 @@ public class VisibilityTrackerResult {
 
         VisibilityTrackerResult result = (VisibilityTrackerResult) o;
 
-        if (mIsVisible != result.mIsVisible) {
+        if (isVisible != result.isVisible) {
             return false;
         }
-        if (mShouldFireImpression != result.mShouldFireImpression) {
+        if (shouldFireImpression != result.shouldFireImpression) {
             return false;
         }
-        if (mEventType != result.mEventType) {
+        if (eventType != result.eventType) {
             return false;
         }
-        return mViewExposure != null
-               ? mViewExposure.equals(result.mViewExposure)
-               : result.mViewExposure == null;
+        return viewExposure != null ? viewExposure.equals(result.viewExposure) : result.viewExposure == null;
     }
 
     @Override
     public int hashCode() {
-        int result = mEventType != null ? mEventType.hashCode() : 0;
-        result = 31 * result + (mViewExposure != null ? mViewExposure.hashCode() : 0);
-        result = 31 * result + (mIsVisible ? 1 : 0);
-        result = 31 * result + (mShouldFireImpression ? 1 : 0);
+        int result = eventType != null ? eventType.hashCode() : 0;
+        result = 31 * result + (viewExposure != null ? viewExposure.hashCode() : 0);
+        result = 31 * result + (isVisible ? 1 : 0);
+        result = 31 * result + (shouldFireImpression ? 1 : 0);
         return result;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/ntv/NativeEventTracker.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/ntv/NativeEventTracker.java
@@ -26,29 +26,32 @@ import java.util.ArrayList;
  */
 public class NativeEventTracker {
 
-    private final EventType mEventType;
-    private final ArrayList<EventTrackingMethod> mEventTrackingMethods;
-    private Ext mExt;
+    private final EventType eventType;
+    private final ArrayList<EventTrackingMethod> eventTrackingMethods;
+    private Ext ext;
 
-    public NativeEventTracker(EventType eventType, ArrayList<EventTrackingMethod> eventTrackingMethods) {
-        mEventType = eventType;
-        mEventTrackingMethods = eventTrackingMethods;
+    public NativeEventTracker(
+            EventType eventType,
+            ArrayList<EventTrackingMethod> eventTrackingMethods
+    ) {
+        this.eventType = eventType;
+        this.eventTrackingMethods = eventTrackingMethods;
     }
 
     public EventType getEventType() {
-        return mEventType;
+        return eventType;
     }
 
     public ArrayList<EventTrackingMethod> getEventTrackingMethods() {
-        return mEventTrackingMethods;
+        return eventTrackingMethods;
     }
 
     public Ext getExt() {
-        return mExt;
+        return ext;
     }
 
     public void setExt(Ext ext) {
-        mExt = ext;
+        this.ext = ext;
     }
 
     public enum EventType {
@@ -59,10 +62,10 @@ public class NativeEventTracker {
         CUSTOM(500),
         OMID(555);
 
-        private int mId;
+        private int id;
 
         EventType(final int id) {
-            mId = id;
+            this.id = id;
         }
 
         @Nullable
@@ -84,12 +87,12 @@ public class NativeEventTracker {
         }
 
         public int getId() {
-            return mId;
+            return id;
         }
 
         public void setId(int id) {
             if (equals(CUSTOM) && !inExistingValue(id)) {
-                mId = id;
+                this.id = id;
             }
         }
 
@@ -109,10 +112,10 @@ public class NativeEventTracker {
         JS(2),
         CUSTOM(500);
 
-        private int mId;
+        private int id;
 
         EventTrackingMethod(final int id) {
-            mId = id;
+            this.id = id;
         }
 
         @Nullable
@@ -134,12 +137,12 @@ public class NativeEventTracker {
         }
 
         public int getId() {
-            return mId;
+            return id;
         }
 
         public void setId(int id) {
             if (equals(CUSTOM) && !inExistingValue(id)) {
-                mId = id;
+                this.id = id;
             }
         }
 

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/openrtb/BidRequest.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/openrtb/BidRequest.java
@@ -28,37 +28,38 @@ import org.prebid.mobile.rendering.models.openrtb.bidRequests.source.Source;
 import java.util.ArrayList;
 
 public class BidRequest extends BaseBid {
-    private String mId;
-    private App mApp = null;
-    private Device mDevice = null;
-    private ArrayList<Imp> mImps = new ArrayList<>();
-    private Regs mRegs = null;
-    private User mUser = null;
-    private Source mSource = null;
 
-    private Ext mExt = null;
+    private String id;
+    private App app = null;
+    private Device device = null;
+    private ArrayList<Imp> imps = new ArrayList<>();
+    private Regs regs = null;
+    private User user = null;
+    private Source source = null;
+
+    private Ext ext = null;
 
     public JSONObject getJsonObject() throws JSONException {
         JSONObject jsonObject = new JSONObject();
 
-        if (mImps != null && mImps.size() > 0) {
+        if (imps != null && imps.size() > 0) {
 
             JSONArray jsonArray = new JSONArray();
 
-            for (Imp i : mImps) {
+            for (Imp i : imps) {
                 jsonArray.put(i.getJsonObject());
             }
 
             toJSON(jsonObject, "imp", jsonArray);
         }
 
-        toJSON(jsonObject, "id", !TextUtils.isEmpty(mId) ? mId : null);
-        toJSON(jsonObject, "app", (mApp != null) ? mApp.getJsonObject() : null);
-        toJSON(jsonObject, "device", (mDevice != null) ? mDevice.getJsonObject() : null);
-        toJSON(jsonObject, "regs", (mRegs != null) ? mRegs.getJsonObject() : null);
-        toJSON(jsonObject, "user", (mUser != null) ? mUser.getJsonObject() : null);
-        toJSON(jsonObject, "source", mSource != null ? mSource.getJsonObject() : null);
-        toJSON(jsonObject, "ext", mExt != null ? mExt.getJsonObject() : null);
+        toJSON(jsonObject, "id", !TextUtils.isEmpty(id) ? id : null);
+        toJSON(jsonObject, "app", (app != null) ? app.getJsonObject() : null);
+        toJSON(jsonObject, "device", (device != null) ? device.getJsonObject() : null);
+        toJSON(jsonObject, "regs", (regs != null) ? regs.getJsonObject() : null);
+        toJSON(jsonObject, "user", (user != null) ? user.getJsonObject() : null);
+        toJSON(jsonObject, "source", source != null ? source.getJsonObject() : null);
+        toJSON(jsonObject, "ext", ext != null ? ext.getJsonObject() : null);
         toJSON(jsonObject, "test", PrebidMobile.getPbsDebug() ? 1 : null);
 
         return jsonObject;
@@ -68,90 +69,90 @@ public class BidRequest extends BaseBid {
 
     // App
     public App getApp() {
-        if (mApp == null) {
-            mApp = new App();
+        if (app == null) {
+            app = new App();
         }
 
-        return mApp;
+        return app;
     }
 
     public void setApp(App app) {
-        mApp = app;
+        this.app = app;
     }
 
     // Device
     public Device getDevice() {
-        if (mDevice == null) {
-            mDevice = new Device();
+        if (device == null) {
+            device = new Device();
         }
 
-        return mDevice;
+        return device;
     }
 
     public void setDevice(Device device) {
-        mDevice = device;
+        this.device = device;
     }
 
     // Imp
     public ArrayList<Imp> getImp() {
-        return mImps;
+        return imps;
     }
 
     public void setImp(ArrayList<Imp> imp) {
-        mImps = imp;
+        imps = imp;
     }
 
     // Regs
     public Regs getRegs() {
-        if (mRegs == null) {
-            mRegs = new Regs();
+        if (regs == null) {
+            regs = new Regs();
         }
 
-        return mRegs;
+        return regs;
     }
 
     public void setRegs(Regs regs) {
-        mRegs = regs;
+        this.regs = regs;
     }
 
     // User
     public User getUser() {
-        if (mUser == null) {
-            mUser = new User();
+        if (user == null) {
+            user = new User();
         }
 
-        return mUser;
+        return user;
     }
 
     public void setUser(User user) {
-        mUser = user;
+        this.user = user;
     }
 
     public void setSource(Source source) {
-        mSource = source;
+        this.source = source;
     }
 
     public Source getSource() {
-        if (mSource == null) {
-            mSource = new Source();
+        if (source == null) {
+            source = new Source();
         }
 
-        return mSource;
+        return source;
     }
 
     public void setId(String id) {
-        mId = id;
+        this.id = id;
     }
 
     @VisibleForTesting
     public String getId() {
-        return mId;
+        return id;
     }
 
     public Ext getExt() {
-        if (mExt == null) {
-            mExt = new Ext();
+        if (ext == null) {
+            ext = new Ext();
         }
-        return mExt;
+        return ext;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/openrtb/bidRequests/App.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/openrtb/bidRequests/App.java
@@ -38,8 +38,8 @@ public class App extends BaseBid {
     public Integer paid = null;
     public String keywords = null;
     public ContentObject contentObject = null;
-    private Publisher mPublisher = null;
-    private Ext mExt = null;
+    private Publisher publisher = null;
+    private Ext ext = null;
 
     public JSONObject getJsonObject() throws JSONException {
         JSONObject jsonObject = new JSONObject();
@@ -91,27 +91,23 @@ public class App extends BaseBid {
         toJSON(jsonObject, "privacypolicy", privacypolicy);
         toJSON(jsonObject, "paid", paid);
         toJSON(jsonObject, "keywords", keywords);
-        toJSON(jsonObject, "publisher", (mPublisher != null)
-                ? this.mPublisher.getJsonObject()
-                : null);
-        toJSON(jsonObject, "ext", (mExt != null)
-                                  ? mExt.getJsonObject()
-                                  : null);
+        toJSON(jsonObject, "publisher", (publisher != null) ? this.publisher.getJsonObject() : null);
+        toJSON(jsonObject, "ext", (ext != null) ? ext.getJsonObject() : null);
 
         return jsonObject;
     }
 
-    public Publisher getPublisher(){
-        if(mPublisher == null){
-            mPublisher = new Publisher();
+    public Publisher getPublisher() {
+        if (publisher == null) {
+            publisher = new Publisher();
         }
-        return mPublisher;
+        return publisher;
     }
 
-    public Ext getExt(){
-        if(mExt == null){
-            mExt = new Ext();
+    public Ext getExt() {
+        if (ext == null) {
+            ext = new Ext();
         }
-        return mExt;
+        return ext;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/openrtb/bidRequests/Device.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/openrtb/bidRequests/Device.java
@@ -68,7 +68,7 @@ public class Device extends BaseBid {
 
     public Geo geo = null;
 
-    private Ext mExt;
+    private Ext ext;
 
     public JSONObject getJsonObject() throws JSONException {
         JSONObject jsonObject = new JSONObject();
@@ -99,7 +99,7 @@ public class Device extends BaseBid {
         toJSON(jsonObject, "js", js);
         toJSON(jsonObject, "connectiontype", connectiontype);
         toJSON(jsonObject, "pxratio", pxratio);
-        toJSON(jsonObject, "ext", (mExt != null) ? mExt.getJsonObject() : null);
+        toJSON(jsonObject, "ext", (ext != null) ? ext.getJsonObject() : null);
 
         toJSON(jsonObject, "geo", (geo != null) ? geo.getJsonObject() : null);
 
@@ -122,9 +122,9 @@ public class Device extends BaseBid {
     }
 
     public Ext getExt() {
-        if (mExt == null) {
-            mExt = new Ext();
+        if (ext == null) {
+            ext = new Ext();
         }
-        return mExt;
+        return ext;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/openrtb/bidRequests/Ext.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/openrtb/bidRequests/Ext.java
@@ -26,26 +26,26 @@ import java.util.Map;
 
 public class Ext implements Serializable {
 
-    private Map<String, Object> mExtValuesHashMap = new HashMap<>();
+    private Map<String, Object> extValuesHashMap = new HashMap<>();
 
     public JSONObject getJsonObject() {
-        return new JSONObject(mExtValuesHashMap);
+        return new JSONObject(extValuesHashMap);
     }
 
     public void put(String key, String value) {
-        mExtValuesHashMap.put(key, value);
+        extValuesHashMap.put(key, value);
     }
 
     public void put(String key, Integer value) {
-        mExtValuesHashMap.put(key, value);
+        extValuesHashMap.put(key, value);
     }
 
     public void put(String key, JSONObject value) {
-        mExtValuesHashMap.put(key, value);
+        extValuesHashMap.put(key, value);
     }
 
     public void put(String key, JSONArray value) {
-        mExtValuesHashMap.put(key, value);
+        extValuesHashMap.put(key, value);
     }
 
     public void put(JSONObject jsonObject) {
@@ -55,16 +55,16 @@ public class Ext implements Serializable {
         Iterator<String> jsonIterator = jsonObject.keys();
         while (jsonIterator.hasNext()) {
             String key = jsonIterator.next();
-            mExtValuesHashMap.put(key, jsonObject.opt(key));
+            extValuesHashMap.put(key, jsonObject.opt(key));
         }
     }
 
     public void remove(String key) {
-        mExtValuesHashMap.remove(key);
+        extValuesHashMap.remove(key);
     }
 
     public Map<String, Object> getMap() {
-        return mExtValuesHashMap;
+        return extValuesHashMap;
     }
 
     @Override
@@ -78,13 +78,11 @@ public class Ext implements Serializable {
 
         Ext ext = (Ext) o;
 
-        return mExtValuesHashMap != null
-               ? mExtValuesHashMap.equals(ext.mExtValuesHashMap)
-               : ext.mExtValuesHashMap == null;
+        return extValuesHashMap != null ? extValuesHashMap.equals(ext.extValuesHashMap) : ext.extValuesHashMap == null;
     }
 
     @Override
     public int hashCode() {
-        return mExtValuesHashMap != null ? mExtValuesHashMap.hashCode() : 0;
+        return extValuesHashMap != null ? extValuesHashMap.hashCode() : 0;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/openrtb/bidRequests/Imp.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/openrtb/bidRequests/Imp.java
@@ -33,7 +33,7 @@ public class Imp extends BaseBid {
     public Video video = null;
     public Pmp pmp = null;
     public Native nativeObj;
-    private Ext mExt = null;
+    private Ext ext = null;
 
     public Integer clickBrowser = null;
 
@@ -54,17 +54,17 @@ public class Imp extends BaseBid {
         toJSON(jsonObject, "video", (video != null) ? video.getJsonObject() : null);
         toJSON(jsonObject, "native", (nativeObj != null) ? nativeObj.getJsonObject() : null);
         toJSON(jsonObject, "pmp", (pmp != null) ? pmp.getJsonObject() : null);
-        toJSON(jsonObject, "ext", (mExt != null) ? mExt.getJsonObject() : null);
+        toJSON(jsonObject, "ext", (ext != null) ? ext.getJsonObject() : null);
 
         return jsonObject;
     }
 
     public Ext getExt() {
-        if (mExt == null) {
-            mExt = new Ext();
+        if (ext == null) {
+            ext = new Ext();
         }
 
-        return mExt;
+        return ext;
     }
 
     public Banner getBanner() {

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/openrtb/bidRequests/Native.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/openrtb/bidRequests/Native.java
@@ -12,57 +12,56 @@ import java.util.ArrayList;
 import java.util.List;
 
 public class Native extends BaseBid {
-    private JSONObject mRequest;
-    private Ext mExt;
+
+    private JSONObject request;
+    private Ext ext;
 
     // Won't be implemented in 1.1
-    private int[] mApi;
-    private int[] mBattr;
+    private int[] api;
+    private int[] battr;
 
     public JSONObject getJsonObject() throws JSONException {
         JSONObject jsonObject = new JSONObject();
-        jsonObject.put("request", mRequest.toString());
+        jsonObject.put("request", request.toString());
         jsonObject.put("ver", PrebidMobile.NATIVE_VERSION);
-        jsonObject.putOpt("ext", mExt != null ? mExt.getJsonObject() : null);
+        jsonObject.putOpt("ext", ext != null ? ext.getJsonObject() : null);
         return jsonObject;
     }
 
     public void setRequestFrom(NativeAdUnitConfiguration config) {
-        mRequest = new JSONObject();
+        request = new JSONObject();
         try {
-            mRequest.put("ver", PrebidMobile.NATIVE_VERSION);
+            request.put("ver", PrebidMobile.NATIVE_VERSION);
             if (config.getContextType() != null) {
-                mRequest.put("context", config.getContextType().getID());
+                request.put("context", config.getContextType().getID());
             }
             if (config.getContextSubtype() != null) {
-                mRequest.put("contextsubtype", config.getContextSubtype().getID());
+                request.put("contextsubtype", config.getContextSubtype().getID());
             }
             if (config.getPlacementType() != null) {
-                mRequest.put("plcmttype", config.getPlacementType().getID());
+                request.put("plcmttype", config.getPlacementType().getID());
             }
             if (config.getSeq() >= 0) {
-                mRequest.put("seq", config.getSeq());
+                request.put("seq", config.getSeq());
             }
-            mRequest.put("assets", getAssetsJsonArray(config.getAssets()));
+            request.put("assets", getAssetsJsonArray(config.getAssets()));
             if (!config.getEventTrackers().isEmpty()) {
-                mRequest.put("eventtrackers", getTrackersJsonArray(config.getEventTrackers()));
+                request.put("eventtrackers", getTrackersJsonArray(config.getEventTrackers()));
             }
             if (config.getPrivacy()) {
-                mRequest.put("privacy", 1);
+                request.put("privacy", 1);
             }
-            mRequest.putOpt("ext", config.getExt() != null
-                    ? config.getExt()
-                    : null);
+            request.putOpt("ext", config.getExt() != null ? config.getExt() : null);
         } catch (JSONException e) {
             e.printStackTrace();
         }
     }
 
     public Ext getExt() {
-        if (mExt == null) {
-            mExt = new Ext();
+        if (ext == null) {
+            ext = new Ext();
         }
-        return mExt;
+        return ext;
     }
 
     private JSONArray getAssetsJsonArray(List<NativeAsset> assetList) throws JSONException {

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/openrtb/bidRequests/Regs.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/openrtb/bidRequests/Regs.java
@@ -22,20 +22,20 @@ import org.json.JSONObject;
 public class Regs extends BaseBid {
 
     public Integer coppa = null;
-    private Ext mExt = null;
+    private Ext ext = null;
 
     public JSONObject getJsonObject() throws JSONException {
         JSONObject jsonObject = new JSONObject();
 
         toJSON(jsonObject, "coppa", this.coppa);
-        toJSON(jsonObject, "ext", (mExt != null) ? mExt.getJsonObject() : null);
+        toJSON(jsonObject, "ext", (ext != null) ? ext.getJsonObject() : null);
         return jsonObject;
     }
 
     public Ext getExt() {
-        if (mExt == null) {
-            mExt = new Ext();
+        if (ext == null) {
+            ext = new Ext();
         }
-        return mExt;
+        return ext;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/openrtb/bidRequests/imps/Banner.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/openrtb/bidRequests/imps/Banner.java
@@ -30,7 +30,7 @@ public class Banner extends BaseBid {
     public Integer pos = null;
     public int[] api;
 
-    private HashSet<Format> mFormats = new HashSet<>();
+    private HashSet<Format> formats = new HashSet<>();
 
     public JSONObject getJsonObject() throws JSONException {
         JSONObject jsonObject = new JSONObject();
@@ -45,9 +45,9 @@ public class Banner extends BaseBid {
             toJSON(jsonObject, "api", jsonArray);
         }
 
-        if (mFormats.size() > 0) {
+        if (formats.size() > 0) {
             JSONArray formatsArray = new JSONArray();
-            for (Format format : mFormats) {
+            for (Format format : formats) {
                 formatsArray.put(format.getJsonObject());
             }
             toJSON(jsonObject, "format", formatsArray);
@@ -57,11 +57,11 @@ public class Banner extends BaseBid {
     }
 
     public void addFormat(int w, int h) {
-        mFormats.add(new Format(w, h));
+        formats.add(new Format(w, h));
     }
 
     @VisibleForTesting
     public HashSet<Format> getFormats() {
-        return mFormats;
+        return formats;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/openrtb/bidRequests/source/Source.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/openrtb/bidRequests/source/Source.java
@@ -23,33 +23,34 @@ import org.prebid.mobile.rendering.models.openrtb.bidRequests.BaseBid;
 import org.prebid.mobile.rendering.models.openrtb.bidRequests.Ext;
 
 public class Source extends BaseBid {
-    private String mTid;
-    private Ext mExt;
+
+    private String tid;
+    private Ext ext;
 
     public void setExt(Ext ext) {
-        mExt = ext;
+        this.ext = ext;
     }
 
     public void setTid(String tid) {
-        mTid = tid;
+        this.tid = tid;
     }
 
     public Ext getExt() {
-        if (mExt == null) {
-            mExt = new Ext();
+        if (ext == null) {
+            ext = new Ext();
         }
-        return mExt;
+        return ext;
     }
 
     public String getTid() {
-        return mTid;
+        return tid;
     }
 
     public JSONObject getJsonObject() throws JSONException {
         JSONObject jsonObject = new JSONObject();
 
-        toJSON(jsonObject, "tid", !TextUtils.isEmpty(mTid) ? mTid : null);
-        toJSON(jsonObject, "ext", (mExt != null) ? mExt.getJsonObject() : null);
+        toJSON(jsonObject, "tid", !TextUtils.isEmpty(tid) ? tid : null);
+        toJSON(jsonObject, "ext", (ext != null) ? ext.getJsonObject() : null);
 
         return jsonObject;
     }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/mraid/handler/FetchPropertiesHandler.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/mraid/handler/FetchPropertiesHandler.java
@@ -23,13 +23,12 @@ import androidx.annotation.NonNull;
 import org.prebid.mobile.rendering.views.webview.mraid.JSInterface;
 
 public class FetchPropertiesHandler extends Handler {
-    @NonNull
-    private final FetchPropertyCallback mCallback;
+    @NonNull private final FetchPropertyCallback callback;
 
     public FetchPropertiesHandler(
         @NonNull
             FetchPropertyCallback callback) {
-        mCallback = callback;
+        this.callback = callback;
     }
 
     @Override
@@ -40,10 +39,10 @@ public class FetchPropertiesHandler extends Handler {
         handler.post(() -> {
             try {
                 final String expandProperties = message.getData().getString(JSInterface.JSON_VALUE);
-                mCallback.onResult(expandProperties);
+                callback.onResult(expandProperties);
             }
             catch (Exception e) {
-                mCallback.onError(e);
+                callback.onError(e);
             }
         });
     }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/mraid/methods/MraidCalendarEvent.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/mraid/methods/MraidCalendarEvent.java
@@ -24,10 +24,10 @@ import org.prebid.mobile.rendering.views.webview.mraid.JSInterface;
 
 public class MraidCalendarEvent {
 
-    private BaseJSInterface mJsi;
+    private BaseJSInterface jsi;
 
     public MraidCalendarEvent(BaseJSInterface jsInterface) {
-        this.mJsi = jsInterface;
+        this.jsi = jsInterface;
     }
 
     public void createCalendarEvent(String parameters) {
@@ -39,7 +39,7 @@ public class MraidCalendarEvent {
                 ManagersResolver.getInstance().getDeviceManager().createCalendarEvent(calendarEventWrapper);
             }
             catch (Exception e) {
-                mJsi.onError("create_calendar_event_error", JSInterface.ACTION_CREATE_CALENDAR_EVENT);
+                jsi.onError("create_calendar_event_error", JSInterface.ACTION_CREATE_CALENDAR_EVENT);
             }
         }
     }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/mraid/methods/MraidClose.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/mraid/methods/MraidClose.java
@@ -33,19 +33,24 @@ import org.prebid.mobile.rendering.views.webview.mraid.JSInterface;
 import org.prebid.mobile.rendering.views.webview.mraid.Views;
 
 public class MraidClose {
-    private static final String TAG = MraidClose.class.getSimpleName();
-    private WebViewBase mWebViewBase;
-    private BaseJSInterface mJsi;
-    private Context mContext;
 
-    public MraidClose(Context context, BaseJSInterface jsInterface, WebViewBase adBaseView) {
-        mContext = context;
-        mWebViewBase = adBaseView;
-        mJsi = jsInterface;
+    private static final String TAG = MraidClose.class.getSimpleName();
+    private WebViewBase webViewBase;
+    private BaseJSInterface jsi;
+    private Context context;
+
+    public MraidClose(
+            Context context,
+            BaseJSInterface jsInterface,
+            WebViewBase adBaseView
+    ) {
+        this.context = context;
+        webViewBase = adBaseView;
+        jsi = jsInterface;
     }
 
     public void closeThroughJS() {
-        final Context context = mContext;
+        final Context context = this.context;
         if (context == null) {
             LogUtil.error(TAG, "Context is null");
             return;
@@ -54,8 +59,8 @@ public class MraidClose {
         Handler uiHandler = new Handler(Looper.getMainLooper());
         uiHandler.post(() -> {
             try {
-                String state = mJsi.getMraidVariableContainer().getCurrentState();
-                WebViewBase webViewBase = mWebViewBase;
+                String state = jsi.getMraidVariableContainer().getCurrentState();
+                WebViewBase webViewBase = this.webViewBase;
 
                 if (isContainerStateInvalid(state)) {
                     LogUtil.debug(TAG, "closeThroughJS: Skipping. Wrong container state: " + state);
@@ -64,7 +69,8 @@ public class MraidClose {
 
                 changeState(state);
 
-                if (webViewBase instanceof WebViewBanner && webViewBase.getMRAIDInterface().getDefaultLayoutParams() != null) {
+                if (webViewBase instanceof WebViewBanner && webViewBase.getMRAIDInterface()
+                                                                       .getDefaultLayoutParams() != null) {
                     webViewBase.setLayoutParams(webViewBase.getMRAIDInterface().getDefaultLayoutParams());
                 }
             }
@@ -79,31 +85,29 @@ public class MraidClose {
             case JSInterface.STATE_EXPANDED:
             case JSInterface.STATE_RESIZED:
 
-                if (mContext instanceof AdBrowserActivity) {
-                    ((AdBrowserActivity) mContext).finish();
-                }
-                else if (mWebViewBase.getDialog() != null) {
+                if (context instanceof AdBrowserActivity) {
+                    ((AdBrowserActivity) context).finish();
+                } else if (webViewBase.getDialog() != null) {
                     //Unregister orientation change listener & cancel the dialog on close of an expanded ad.
-                    mWebViewBase.getDialog().cleanup();
-                    mWebViewBase.setDialog(null);
-                }
-                else {
-                    FrameLayout frameLayout = (FrameLayout) mWebViewBase.getParent();
+                    webViewBase.getDialog().cleanup();
+                    webViewBase.setDialog(null);
+                } else {
+                    FrameLayout frameLayout = (FrameLayout) webViewBase.getParent();
                     removeParent(frameLayout);
 
-                    addWebViewToContainer(mWebViewBase);
+                    addWebViewToContainer(webViewBase);
 
                     //Add expanded view into rootView as well  & remove this null chk once done. Shud work for both expand & resize
 
-                    if (mJsi.getRootView() != null) {
-                        mJsi.getRootView().removeView(frameLayout);
+                    if (jsi.getRootView() != null) {
+                        jsi.getRootView().removeView(frameLayout);
                     }
                 }
-                mJsi.onStateChange(JSInterface.STATE_DEFAULT);
+                jsi.onStateChange(JSInterface.STATE_DEFAULT);
                 break;
             case JSInterface.STATE_DEFAULT:
                 makeViewInvisible();
-                mJsi.onStateChange(JSInterface.STATE_HIDDEN);
+                jsi.onStateChange(JSInterface.STATE_HIDDEN);
                 break;
         }
     }
@@ -119,25 +123,25 @@ public class MraidClose {
     private void removeParent(FrameLayout frameLayout) {
 
         if (frameLayout != null) {
-            frameLayout.removeView(mWebViewBase);
+            frameLayout.removeView(webViewBase);
         }
         else {
             //This should never happen though!
             //Because, if close is called, that would mean, it's parent is always a CloseableLayout(for expanded/resized banners & interstitials )
             //Hence, the previous if block should suffice.
             //But adding it to fix any crash, if above is not the case.
-            Views.removeFromParent(mWebViewBase);
+            Views.removeFromParent(webViewBase);
         }
     }
 
     private void makeViewInvisible() {
         Handler handler = new Handler(Looper.getMainLooper());
         handler.post(() -> {
-            if (mWebViewBase == null) {
+            if (webViewBase == null) {
                 LogUtil.error(TAG, "makeViewInvisible failed: webViewBase is null");
                 return;
             }
-            mWebViewBase.setVisibility(View.INVISIBLE);
+            webViewBase.setVisibility(View.INVISIBLE);
         });
     }
 

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/mraid/methods/MraidController.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/mraid/methods/MraidController.java
@@ -38,27 +38,28 @@ import org.prebid.mobile.rendering.views.webview.mraid.JSInterface;
 import static org.prebid.mobile.rendering.views.webview.mraid.JSInterface.*;
 
 public class MraidController {
+
     private static final String TAG = MraidController.class.getSimpleName();
 
-    protected InterstitialManager mInterstitialManager;
-    private MraidUrlHandler mMraidUrlHandler;
-    private MraidResize mMraidResize;
-    private MraidStorePicture mMraidStorePicture;
-    private MraidCalendarEvent mMraidCalendarEvent;
-    private MraidExpand mMraidExpand;
+    protected InterstitialManager interstitialManager;
+    private MraidUrlHandler mraidUrlHandler;
+    private MraidResize mraidResize;
+    private MraidStorePicture mraidStorePicture;
+    private MraidCalendarEvent mraidCalendarEvent;
+    private MraidExpand mraidExpand;
 
-    private InterstitialManagerMraidDelegate mInterstitialManagerMraidDelegate = new InterstitialManagerMraidDelegate() {
+    private InterstitialManagerMraidDelegate interstitialManagerMraidDelegate = new InterstitialManagerMraidDelegate() {
         @Override
         public boolean collapseMraid() {
-            if (mMraidExpand == null) {
+            if (mraidExpand == null) {
                 return false;
             }
-            if (mMraidExpand.isMraidExpanded()) {
-                mInterstitialManager.getHtmlCreative().mraidAdCollapsed();
+            if (mraidExpand.isMraidExpanded()) {
+                interstitialManager.getHtmlCreative().mraidAdCollapsed();
             }
-            mMraidExpand.nullifyDialog();
+            mraidExpand.nullifyDialog();
             //make MraidExpand null, so a new MraidExpand is created for a new expansion
-            mMraidExpand = null;
+            mraidExpand = null;
             return true;
         }
 
@@ -79,9 +80,9 @@ public class MraidController {
 
         @Override
         public void destroyMraidExpand() {
-            if (mMraidExpand != null) {
-                mMraidExpand.destroy();
-                mMraidExpand = null;
+            if (mraidExpand != null) {
+                mraidExpand.destroy();
+                mraidExpand = null;
             }
         }
     };
@@ -89,19 +90,19 @@ public class MraidController {
     public MraidController(
         @NonNull
             InterstitialManager interstitialManager) {
-        mInterstitialManager = interstitialManager;
-        mInterstitialManager.setMraidDelegate(mInterstitialManagerMraidDelegate);
+        this.interstitialManager = interstitialManager;
+        this.interstitialManager.setMraidDelegate(interstitialManagerMraidDelegate);
     }
 
     public void close(WebViewBase oldWebViewBase) {
-        mInterstitialManager.interstitialClosed(oldWebViewBase);
+        interstitialManager.interstitialClosed(oldWebViewBase);
     }
 
     public void createCalendarEvent(BaseJSInterface jsInterface, String parameters) {
-        if (mMraidCalendarEvent == null) {
-            mMraidCalendarEvent = new MraidCalendarEvent(jsInterface);
+        if (mraidCalendarEvent == null) {
+            mraidCalendarEvent = new MraidCalendarEvent(jsInterface);
         }
-        mMraidCalendarEvent.createCalendarEvent(parameters);
+        mraidCalendarEvent.createCalendarEvent(parameters);
     }
 
     public void expand(WebViewBase oldWebViewBase, PrebidWebViewBase twoPartNewWebViewBase,
@@ -167,22 +168,20 @@ public class MraidController {
     }
 
     public void changeOrientation() {
-        if (mMraidExpand != null && mMraidExpand.getInterstitialViewController() != null) {
+        if (mraidExpand != null && mraidExpand.getInterstitialViewController() != null) {
             try {
-                mMraidExpand.getInterstitialViewController().handleSetOrientationProperties();
-            }
-            catch (AdException e) {
+                mraidExpand.getInterstitialViewController().handleSetOrientationProperties();
+            } catch (AdException e) {
                 LogUtil.error(TAG, Log.getStackTraceString(e));
             }
         }
     }
 
     public void open(WebViewBase oldWebViewBase, String uri, int broadcastId) {
-        if (mMraidUrlHandler == null) {
-            mMraidUrlHandler = new MraidUrlHandler(oldWebViewBase.getContext(),
-                                                   oldWebViewBase.getMRAIDInterface());
+        if (mraidUrlHandler == null) {
+            mraidUrlHandler = new MraidUrlHandler(oldWebViewBase.getContext(), oldWebViewBase.getMRAIDInterface());
         }
-        mMraidUrlHandler.open(uri, broadcastId);
+        mraidUrlHandler.open(uri, broadcastId);
     }
 
     public void playVideo(WebViewBase oldWebViewBase, MraidEvent event) {
@@ -190,37 +189,39 @@ public class MraidController {
     }
 
     public void resize(WebViewBase oldWebViewBase) {
-        if (mMraidResize == null) {
-            mMraidResize = new MraidResize(oldWebViewBase.getContext(),
-                                           oldWebViewBase.getMRAIDInterface(),
-                                           oldWebViewBase,
-                                           mInterstitialManager);
+        if (mraidResize == null) {
+            mraidResize = new MraidResize(oldWebViewBase.getContext(),
+                    oldWebViewBase.getMRAIDInterface(),
+                    oldWebViewBase,
+                    interstitialManager
+            );
         }
-        mMraidResize.resize();
+        mraidResize.resize();
     }
 
     public void storePicture(WebViewBase oldWebViewBase, String uri) {
-        if (mMraidStorePicture == null) {
-            mMraidStorePicture = new MraidStorePicture(oldWebViewBase.getContext(),
-                                                       oldWebViewBase.getMRAIDInterface(),
-                                                       oldWebViewBase);
+        if (mraidStorePicture == null) {
+            mraidStorePicture = new MraidStorePicture(oldWebViewBase.getContext(),
+                    oldWebViewBase.getMRAIDInterface(),
+                    oldWebViewBase
+            );
         }
-        mMraidStorePicture.storePicture(uri);
+        mraidStorePicture.storePicture(uri);
     }
 
     public void destroy() {
-        if (mMraidResize != null) {
-            mMraidResize.destroy();
-            mMraidResize = null;
+        if (mraidResize != null) {
+            mraidResize.destroy();
+            mraidResize = null;
         }
-        if (mMraidUrlHandler != null) {
-            mMraidUrlHandler.destroy();
-            mMraidUrlHandler = null;
+        if (mraidUrlHandler != null) {
+            mraidUrlHandler.destroy();
+            mraidUrlHandler = null;
         }
 
-        if (mMraidExpand != null) {
-            mMraidExpand.destroy();
-            mMraidExpand = null;
+        if (mraidExpand != null) {
+            mraidExpand.destroy();
+            mraidExpand = null;
         }
     }
 
@@ -228,18 +229,19 @@ public class MraidController {
                                             boolean addOldViewToBackStack,
                                             final MraidEvent mraidEvent,
                                             final DisplayCompletionListener displayCompletionListener) {
-        if (mMraidExpand == null) {
+        if (mraidExpand == null) {
             initMraidExpand(adBaseView, displayCompletionListener, mraidEvent);
             return;
         }
         //2 part may be?? OR click of video.close from an expanded ad
         if (addOldViewToBackStack) {
-            mInterstitialManager.addOldViewToBackStack((WebViewBase) adBaseView,
-                                                       mraidEvent.mraidActionHelper,
-                                                       mMraidExpand.getInterstitialViewController());
+            interstitialManager.addOldViewToBackStack((WebViewBase) adBaseView,
+                    mraidEvent.mraidActionHelper,
+                    mraidExpand.getInterstitialViewController()
+            );
         }
 
-        mMraidExpand.setDisplayView(adBaseView);
+        mraidExpand.setDisplayView(adBaseView);
 
         if (displayCompletionListener != null) {
             displayCompletionListener.onDisplayCompleted();
@@ -280,10 +282,10 @@ public class MraidController {
     protected void initMraidExpand(final View adBaseView,
                                    final DisplayCompletionListener displayCompletionListener,
                                    final MraidEvent mraidEvent) {
-        mMraidExpand = new MraidExpand(adBaseView.getContext(), ((WebViewBase) adBaseView), mInterstitialManager);
+        mraidExpand = new MraidExpand(adBaseView.getContext(), ((WebViewBase) adBaseView), interstitialManager);
 
         if (mraidEvent.mraidAction.equals(JSInterface.ACTION_EXPAND)) {
-            mMraidExpand.setMraidExpanded(true);
+            mraidExpand.setMraidExpanded(true);
         }
 
         Handler handler = new Handler(Looper.getMainLooper());
@@ -292,12 +294,12 @@ public class MraidController {
                 LogUtil.debug(TAG, "mraidExpand");
                 //send click event on expand
                 ((WebViewBase) adBaseView).sendClickCallBack(mraidEvent.mraidActionHelper);
-                mMraidExpand.expand(mraidEvent.mraidActionHelper, () -> {
+                mraidExpand.expand(mraidEvent.mraidActionHelper, () -> {
                     if (displayCompletionListener != null) {
                         displayCompletionListener.onDisplayCompleted();
 
                         //send expandedCallback to pubs
-                        mInterstitialManager.getHtmlCreative().mraidAdExpanded();
+                        interstitialManager.getHtmlCreative().mraidAdExpanded();
                     }
                 });
             }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/mraid/methods/MraidEventHandlerNotifierRunnable.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/mraid/methods/MraidEventHandlerNotifierRunnable.java
@@ -25,35 +25,38 @@ import org.prebid.mobile.rendering.views.webview.mraid.JsExecutor;
 import java.lang.ref.WeakReference;
 
 public class MraidEventHandlerNotifierRunnable implements Runnable {
+
     private static final String TAG = MraidEventHandlerNotifierRunnable.class.getSimpleName();
 
-    private final WeakReference<HTMLCreative> mWeakHtmlCreative;
-    private final WeakReference<WebViewBase> mWeakWebViewBase;
-    private final WeakReference<JsExecutor> mWeakJsExecutor;
+    private final WeakReference<HTMLCreative> weakHtmlCreative;
+    private final WeakReference<WebViewBase> weakWebViewBase;
+    private final WeakReference<JsExecutor> weakJsExecutor;
 
-    private MraidEvent mMraidEvent;
+    private MraidEvent mraidEvent;
 
-    public MraidEventHandlerNotifierRunnable(HTMLCreative htmlCreative,
-                                             WebViewBase webViewBase,
-                                             MraidEvent mraidEvent,
-                                             JsExecutor jsExecutor) {
-        mWeakHtmlCreative = new WeakReference<>(htmlCreative);
-        mWeakWebViewBase = new WeakReference<>(webViewBase);
-        mWeakJsExecutor = new WeakReference<>(jsExecutor);
-        mMraidEvent = mraidEvent;
+    public MraidEventHandlerNotifierRunnable(
+            HTMLCreative htmlCreative,
+            WebViewBase webViewBase,
+            MraidEvent mraidEvent,
+            JsExecutor jsExecutor
+    ) {
+        weakHtmlCreative = new WeakReference<>(htmlCreative);
+        weakWebViewBase = new WeakReference<>(webViewBase);
+        weakJsExecutor = new WeakReference<>(jsExecutor);
+        this.mraidEvent = mraidEvent;
     }
 
     @Override
     public void run() {
-        HTMLCreative htmlCreative = mWeakHtmlCreative.get();
-        WebViewBase webViewBase = mWeakWebViewBase.get();
+        HTMLCreative htmlCreative = weakHtmlCreative.get();
+        WebViewBase webViewBase = weakWebViewBase.get();
         if (htmlCreative == null || webViewBase == null) {
             LogUtil.debug(TAG, "Unable to pass event to handler. HtmlCreative or webviewBase is null");
             return;
         }
-        htmlCreative.handleMRAIDEventsInCreative(mMraidEvent, webViewBase);
+        htmlCreative.handleMRAIDEventsInCreative(mraidEvent, webViewBase);
 
-        final JsExecutor jsExecutor = mWeakJsExecutor.get();
+        final JsExecutor jsExecutor = weakJsExecutor.get();
         if (jsExecutor == null) {
             LogUtil.debug(TAG, "Unable to executeNativeCallComplete(). JsExecutor is null.");
             return;

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/mraid/methods/MraidExpand.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/mraid/methods/MraidExpand.java
@@ -37,33 +37,40 @@ import org.prebid.mobile.rendering.views.webview.mraid.JSInterface;
 import org.prebid.mobile.rendering.views.webview.mraid.Views;
 
 public class MraidExpand {
+
     public static final String TAG = MraidExpand.class.getSimpleName();
-    private WebViewBase mWebViewBanner;
+    private WebViewBase webViewBanner;
 
-    private BaseJSInterface mJsi;
-    private InterstitialManager mInterstitialManager;
-    private Context mContext;
-    private AdBaseDialog mExpandedDialog;
+    private BaseJSInterface jsi;
+    private InterstitialManager interstitialManager;
+    private Context context;
+    private AdBaseDialog expandedDialog;
 
-    private boolean mMraidExpanded;
+    private boolean mraidExpanded;
 
-    public MraidExpand(Context context, WebViewBase adBaseView, InterstitialManager interstitialManager) {
-        mContext = context;
-        mWebViewBanner = adBaseView;
-        mJsi = adBaseView.getMRAIDInterface();
-        mInterstitialManager = interstitialManager;
+    public MraidExpand(
+            Context context,
+            WebViewBase adBaseView,
+            InterstitialManager interstitialManager
+    ) {
+        this.context = context;
+        webViewBanner = adBaseView;
+        jsi = adBaseView.getMRAIDInterface();
+        this.interstitialManager = interstitialManager;
     }
 
     public void expand(final String url, final CompletedCallBack completedCallBack) {
 
-        mJsi.followToOriginalUrl(url, new RedirectUrlListener() {
+        jsi.followToOriginalUrl(url, new RedirectUrlListener() {
             @Override
-            public void onSuccess(final String url, String contentType) {
+            public void onSuccess(
+                    final String url,
+                    String contentType
+            ) {
 
                 if (Utils.isVideoContent(contentType)) {
-                    mJsi.playVideo(url);
-                }
-                else {
+                    jsi.playVideo(url);
+                } else {
                     performExpand(url, completedCallBack);
                 }
             }
@@ -77,29 +84,29 @@ public class MraidExpand {
     }
 
     public void setDisplayView(View displayView) {
-        if (mExpandedDialog != null) {
-            mExpandedDialog.setDisplayView(displayView);
+        if (expandedDialog != null) {
+            expandedDialog.setDisplayView(displayView);
         }
     }
 
     public AdBaseDialog getInterstitialViewController() {
-        return mExpandedDialog;
+        return expandedDialog;
     }
 
     public void nullifyDialog() {
-        if (mExpandedDialog != null) {
-            mExpandedDialog.cancel();
-            mExpandedDialog.cleanup();
-            mExpandedDialog = null;
+        if (expandedDialog != null) {
+            expandedDialog.cancel();
+            expandedDialog.cleanup();
+            expandedDialog = null;
         }
     }
 
     public void destroy() {
-        if (mJsi != null) {
-            Views.removeFromParent(mJsi.getDefaultAdContainer());
+        if (jsi != null) {
+            Views.removeFromParent(jsi.getDefaultAdContainer());
         }
-        if (mExpandedDialog != null) {
-            mExpandedDialog.dismiss();
+        if (expandedDialog != null) {
+            expandedDialog.dismiss();
         }
     }
 
@@ -108,7 +115,7 @@ public class MraidExpand {
      * This flag is used to enable/disable MRAID expand property.
      */
     public boolean isMraidExpanded() {
-        return mMraidExpanded;
+        return mraidExpanded;
     }
 
     /**
@@ -116,11 +123,11 @@ public class MraidExpand {
      * This flag is used to enable/disable MRAID expand property.
      */
     public void setMraidExpanded(boolean mraidExpanded) {
-        this.mMraidExpanded = mraidExpanded;
+        this.mraidExpanded = mraidExpanded;
     }
 
     private void performExpand(String url, CompletedCallBack completedCallBack) {
-        final Context context = mContext;
+        final Context context = this.context;
         if (context == null) {
             LogUtil.error(TAG, "Context is null");
             return;
@@ -129,7 +136,7 @@ public class MraidExpand {
         Handler uiHandler = new Handler(Looper.getMainLooper());
         uiHandler.post(() -> {
             try {
-                final MraidVariableContainer mraidVariableContainer = mJsi.getMraidVariableContainer();
+                final MraidVariableContainer mraidVariableContainer = jsi.getMraidVariableContainer();
 
                 String state = mraidVariableContainer.getCurrentState();
 
@@ -138,7 +145,7 @@ public class MraidExpand {
                     return;
                 }
 
-                mJsi.setDefaultLayoutParams(mWebViewBanner.getLayoutParams());
+                jsi.setDefaultLayoutParams(webViewBanner.getLayoutParams());
 
                 if (url != null) {
                     mraidVariableContainer.setUrlForLaunching(url);
@@ -166,9 +173,9 @@ public class MraidExpand {
             return;
         }
 
-        mExpandedDialog = new AdExpandedDialog(context, mWebViewBanner, mInterstitialManager);//HAS be on UI thread
+        expandedDialog = new AdExpandedDialog(context, webViewBanner, interstitialManager);//HAS be on UI thread
         //Workaround fix for a random crash on multiple clicks on 2part expand and press back key
-        mExpandedDialog.show();
+        expandedDialog.show();
         if (completedCallBack != null) {
             completedCallBack.expandDialogShown();
         }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/mraid/methods/MraidScreenMetrics.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/mraid/methods/MraidScreenMetrics.java
@@ -28,135 +28,129 @@ import org.prebid.mobile.rendering.utils.helpers.Dips;
  * extra memory that would otherwise be needed to do these conversions.
  */
 public class MraidScreenMetrics {
-    @NonNull
-    private final Context mContext;
-    @NonNull
-    private final Rect mScreenRect;
-    @NonNull
-    private final Rect mScreenRectDips;
+    @NonNull private final Context context;
+    @NonNull private final Rect screenRect;
+    @NonNull private final Rect screenRectDips;
 
-    @NonNull
-    private final Rect mRootViewRect;
-    @NonNull
-    private final Rect mRootViewRectDips;
+    @NonNull private final Rect rootViewRect;
+    @NonNull private final Rect rootViewRectDips;
 
-    @NonNull
-    private final Rect mCurrentAdRect;
-    @NonNull
-    private final Rect mCurrentAdRectDips;
+    @NonNull private final Rect currentAdRect;
+    @NonNull private final Rect currentAdRectDips;
 
-    @NonNull
-    private final Rect mDefaultAdRect;
-    @NonNull
-    private final Rect mDefaultAdRectDips;
+    @NonNull private final Rect defaultAdRect;
+    @NonNull private final Rect defaultAdRectDips;
 
-    private Rect mCurrentMaxSizeRect;
-    private Rect mDefaultPosition;
+    private Rect currentMaxSizeRect;
+    private Rect defaultPosition;
 
-    private final float mDensity;
+    private final float density;
 
-    public MraidScreenMetrics(Context context, float density) {
-        mContext = context.getApplicationContext();
-        mDensity = density;
+    public MraidScreenMetrics(
+            Context context,
+            float density
+    ) {
+        this.context = context.getApplicationContext();
+        this.density = density;
 
-        mScreenRect = new Rect();
-        mScreenRectDips = new Rect();
+        screenRect = new Rect();
+        screenRectDips = new Rect();
 
-        mRootViewRect = new Rect();
-        mRootViewRectDips = new Rect();
+        rootViewRect = new Rect();
+        rootViewRectDips = new Rect();
 
-        mCurrentAdRect = new Rect();
-        mCurrentAdRectDips = new Rect();
+        currentAdRect = new Rect();
+        currentAdRectDips = new Rect();
 
-        mDefaultAdRect = new Rect();
-        mDefaultAdRectDips = new Rect();
+        defaultAdRect = new Rect();
+        defaultAdRectDips = new Rect();
     }
 
     private void convertToDips(Rect sourceRect, Rect outRect) {
-        outRect.set(
-                Dips.pixelsToIntDips(sourceRect.left, mContext),
-                Dips.pixelsToIntDips(sourceRect.top, mContext),
-                Dips.pixelsToIntDips(sourceRect.right, mContext),
-                Dips.pixelsToIntDips(sourceRect.bottom, mContext));
+        outRect.set(Dips.pixelsToIntDips(sourceRect.left, context),
+                Dips.pixelsToIntDips(sourceRect.top, context),
+                Dips.pixelsToIntDips(sourceRect.right, context),
+                Dips.pixelsToIntDips(sourceRect.bottom, context)
+        );
     }
 
     public float getDensity() {
-        return mDensity;
+        return density;
     }
 
     public void setScreenSize(int width, int height) {
-        mScreenRect.set(0, 0, width, height);
-        convertToDips(mScreenRect, mScreenRectDips);
+        screenRect.set(0, 0, width, height);
+        convertToDips(screenRect, screenRectDips);
     }
 
     @NonNull
     public Rect getScreenRect() {
-        return mScreenRect;
+        return screenRect;
     }
 
     @NonNull
     public Rect getScreenRectDips() {
-        return mScreenRectDips;
+        return screenRectDips;
     }
 
     public void setRootViewPosition(int x, int y, int width, int height) {
-        mRootViewRect.set(x, y, x + width, y + height);
-        convertToDips(mRootViewRect, mRootViewRectDips);
+        rootViewRect.set(x, y, x + width, y + height);
+        convertToDips(rootViewRect, rootViewRectDips);
     }
 
     @NonNull
     public Rect getRootViewRect() {
-        return mRootViewRect;
+        return rootViewRect;
     }
 
     @NonNull
     public Rect getRootViewRectDips() {
-        return mRootViewRectDips;
+        return rootViewRectDips;
     }
 
     public void setCurrentAdPosition(int x, int y, int width, int height) {
-        mCurrentAdRect.set(x, y, x + width, y + height);
-        convertToDips(mCurrentAdRect, mCurrentAdRectDips);
+        currentAdRect.set(x, y, x + width, y + height);
+        convertToDips(currentAdRect, currentAdRectDips);
     }
 
     @NonNull
     public Rect getCurrentAdRect() {
-        return mCurrentAdRect;
+        return currentAdRect;
     }
 
     @NonNull
     public Rect getCurrentAdRectDips() {
-        return mCurrentAdRectDips;
+        return currentAdRectDips;
     }
 
     public void setDefaultAdPosition(int x, int y, int width, int height) {
-        mDefaultAdRect.set(x, y, x + width, y + height);
-        convertToDips(mDefaultAdRect, mDefaultAdRectDips);
+        defaultAdRect.set(x, y, x + width, y + height);
+        convertToDips(defaultAdRect, defaultAdRectDips);
     }
 
     @NonNull
     public Rect getDefaultAdRect() {
-        return mDefaultAdRect;
+        return defaultAdRect;
     }
 
     @NonNull
     public Rect getDefaultAdRectDips() {
-        return mDefaultAdRectDips;
+        return defaultAdRectDips;
     }
 
     public Rect getCurrentMaxSizeRect() {
-        return mCurrentMaxSizeRect;
+        return currentMaxSizeRect;
     }
 
     public void setCurrentMaxSizeRect(Rect currentMaxSizeRect) {
-        mCurrentMaxSizeRect = new Rect(0, 0, currentMaxSizeRect.width(), currentMaxSizeRect.height());
+        this.currentMaxSizeRect = new Rect(0, 0, currentMaxSizeRect.width(), currentMaxSizeRect.height());
     }
 
     public void setDefaultPosition(Rect defaultPosition) {
-        mDefaultPosition = defaultPosition;
+        this.defaultPosition = defaultPosition;
     }
 
     public Rect getDefaultPosition() {
-        return mDefaultPosition;
+        return defaultPosition;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/mraid/methods/MraidStorePicture.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/mraid/methods/MraidStorePicture.java
@@ -32,31 +32,36 @@ import org.prebid.mobile.rendering.views.webview.mraid.JSInterface;
 import static android.Manifest.permission.WRITE_EXTERNAL_STORAGE;
 
 public class MraidStorePicture {
+
     private static final String TAG = MraidStorePicture.class.getSimpleName();
-    private WebViewBase mAdBaseView;
-    private BaseJSInterface mJsi;
+    private WebViewBase adBaseView;
+    private BaseJSInterface jsi;
 
-    private String mUrlToStore = null;
+    private String urlToStore = null;
 
-    private Context mContext;
+    private Context context;
 
-    public MraidStorePicture(Context context, BaseJSInterface jsInterface, WebViewBase adBaseView) {
-        mContext = context;
-        mAdBaseView = adBaseView;
-        mJsi = jsInterface;
+    public MraidStorePicture(
+            Context context,
+            BaseJSInterface jsInterface,
+            WebViewBase adBaseView
+    ) {
+        this.context = context;
+        this.adBaseView = adBaseView;
+        jsi = jsInterface;
     }
 
     public void storePicture(String url) {
         if (url != null && !url.equals("")) {
-            mUrlToStore = url;
+            urlToStore = url;
 
-            if (mAdBaseView != null && mContext != null) {
+            if (adBaseView != null && context != null) {
                 Handler handler = new Handler(Looper.getMainLooper());
                 handler.post(() -> {
-                    AlertDialog.Builder builder = new AlertDialog.Builder(mContext);
+                    AlertDialog.Builder builder = new AlertDialog.Builder(context);
                     builder.setTitle("Save image?");
 
-                    builder.setMessage("Would you like to save this image? " + mUrlToStore);
+                    builder.setMessage("Would you like to save this image? " + urlToStore);
 
                     builder.setPositiveButton(android.R.string.yes, (dialogInterface, i) -> storePicture());
 
@@ -64,12 +69,14 @@ public class MraidStorePicture {
 
                     AlertDialog dialog = builder.create();
                     //android.view.WindowManager$BadTokenException: Unable to add window -- token android.os.BinderProxy@4f935b0 is not valid; is your activity running?
-                    if (mContext instanceof Activity && !((Activity) mContext).isFinishing()) {
+                    if (context instanceof Activity && !((Activity) context).isFinishing()) {
                         //show dialog
                         dialog.show();
-                    }
-                    else {
-                        LogUtil.error(TAG, "Context is not activity or activity is finishing, can not show expand dialog");
+                    } else {
+                        LogUtil.error(
+                                TAG,
+                                "Context is not activity or activity is finishing, can not show expand dialog"
+                        );
                     }
                 });
             }
@@ -81,15 +88,15 @@ public class MraidStorePicture {
             try {
                 DeviceInfoManager devicePolicyManager = ManagersResolver.getInstance().getDeviceManager();
                 if (!devicePolicyManager.isPermissionGranted(WRITE_EXTERNAL_STORAGE)) {
-                    mJsi.onError("store_picture", JSInterface.ACTION_STORE_PICTURE);
+                    jsi.onError("store_picture", JSInterface.ACTION_STORE_PICTURE);
                 }
                 else {
-                    devicePolicyManager.storePicture(mUrlToStore);
+                    devicePolicyManager.storePicture(urlToStore);
                 }
             }
             catch (Exception e) {
                 //send a mraid error back to the ad
-                mJsi.onError("Failed to store picture", JSInterface.ACTION_STORE_PICTURE);
+                jsi.onError("Failed to store picture", JSInterface.ACTION_STORE_PICTURE);
                 LogUtil.error(TAG, "Failed to store picture: " + Log.getStackTraceString(e));
             }
         }).start();

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/mraid/methods/MraidUrlHandler.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/mraid/methods/MraidUrlHandler.java
@@ -30,49 +30,50 @@ public class MraidUrlHandler {
 
     public static final String TAG = MraidUrlHandler.class.getSimpleName();
 
-    private final Context mContext;
-    private final BaseJSInterface mJsi;
+    private final Context context;
+    private final BaseJSInterface jsi;
 
-    private boolean mUrlHandleInProgress;
+    private boolean urlHandleInProgress;
 
-    public MraidUrlHandler(Context context, BaseJSInterface jsInterface) {
-        mContext = context;
-        mJsi = jsInterface;
+    public MraidUrlHandler(
+            Context context,
+            BaseJSInterface jsInterface
+    ) {
+        this.context = context;
+        jsi = jsInterface;
     }
 
-    public void open(String url, int broadcastId) {
+    public void open(
+            String url,
+            int broadcastId
+    ) {
 
-        if (!mUrlHandleInProgress) {
-            mUrlHandleInProgress = true;
-            createUrlHandler(broadcastId)
-                .handleUrl(mContext,
-                           url,
-                           null,
-                           true); // navigation is performed by user
+        if (!urlHandleInProgress) {
+            urlHandleInProgress = true;
+            createUrlHandler(broadcastId).handleUrl(context, url, null, true); // navigation is performed by user
         }
     }
 
     public void destroy() {
-        if (mJsi != null) {
-            mJsi.destroy();
+        if (jsi != null) {
+            jsi.destroy();
         }
     }
 
     @VisibleForTesting
     UrlHandler createUrlHandler(int broadcastId) {
-        return new UrlHandler.Builder()
-            .withDeepLinkPlusAction(new DeepLinkPlusAction())
-            .withDeepLinkAction(new DeepLinkAction())
-            .withMraidInternalBrowserAction(new MraidInternalBrowserAction(mJsi, broadcastId))
+        return new UrlHandler.Builder().withDeepLinkPlusAction(new DeepLinkPlusAction())
+                                       .withDeepLinkAction(new DeepLinkAction())
+                                       .withMraidInternalBrowserAction(new MraidInternalBrowserAction(jsi, broadcastId))
             .withResultListener(new UrlHandler.UrlHandlerResultListener() {
                 @Override
                 public void onSuccess(String url, UrlAction urlAction) {
-                    mUrlHandleInProgress = false;
+                    urlHandleInProgress = false;
                 }
 
                 @Override
                 public void onFailure(String url) {
-                    mUrlHandleInProgress = false;
+                    urlHandleInProgress = false;
                     LogUtil.debug(TAG, "Failed to handleUrl: " + url);
                 }
             })

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/mraid/methods/TwoPartExpandRunnable.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/mraid/methods/TwoPartExpandRunnable.java
@@ -26,40 +26,48 @@ import org.prebid.mobile.rendering.views.webview.WebViewBase;
 import java.lang.ref.WeakReference;
 
 public class TwoPartExpandRunnable implements Runnable {
+
     private static final String TAG = TwoPartExpandRunnable.class.getSimpleName();
 
-    private WeakReference<HTMLCreative> mWeakHtmlCreative;
-    private MraidEvent mMraidEvent;
-    private WebViewBase mOldWebViewBase;
-    private MraidController mMraidController;
+    private WeakReference<HTMLCreative> weakHtmlCreative;
+    private MraidEvent mraidEvent;
+    private WebViewBase oldWebViewBase;
+    private MraidController mraidController;
 
-    TwoPartExpandRunnable(HTMLCreative htmlCreative, MraidEvent mraidEvent,
-                          WebViewBase oldWebViewBase, MraidController mraidController) {
-        mWeakHtmlCreative = new WeakReference<>(htmlCreative);
-        mMraidEvent = mraidEvent;
-        mOldWebViewBase = oldWebViewBase;
-        mMraidController = mraidController;
+    TwoPartExpandRunnable(
+            HTMLCreative htmlCreative,
+            MraidEvent mraidEvent,
+            WebViewBase oldWebViewBase,
+            MraidController mraidController
+    ) {
+        weakHtmlCreative = new WeakReference<>(htmlCreative);
+        this.mraidEvent = mraidEvent;
+        this.oldWebViewBase = oldWebViewBase;
+        this.mraidController = mraidController;
     }
 
     // NOTE: handleMRAIDEventsInCreative ACTION_EXPAND is invoked from a background thread.
     // This means the webview instantiation should be performed from a UI thread.
     @Override
     public void run() {
-        HTMLCreative htmlCreative = mWeakHtmlCreative.get();
+        HTMLCreative htmlCreative = weakHtmlCreative.get();
         if (htmlCreative == null) {
             LogUtil.error(TAG, "HTMLCreative object is null");
             return;
         }
 
-        PrebidWebViewBase prebidWebViewBanner = new PrebidWebViewBanner(mOldWebViewBase.getContext(), mMraidController.mInterstitialManager);
+        PrebidWebViewBase prebidWebViewBanner = new PrebidWebViewBanner(
+                oldWebViewBase.getContext(),
+                mraidController.interstitialManager
+        );
         //inject mraid.js & load url here, for 2part expand
-        prebidWebViewBanner.setOldWebView(mOldWebViewBase);
-        prebidWebViewBanner.initTwoPartAndLoad(mMraidEvent.mraidActionHelper);
+        prebidWebViewBanner.setOldWebView(oldWebViewBase);
+        prebidWebViewBanner.initTwoPartAndLoad(mraidEvent.mraidActionHelper);
         prebidWebViewBanner.setWebViewDelegate(htmlCreative);
         prebidWebViewBanner.setCreative(htmlCreative);
         //Set a view before handling any action.
         htmlCreative.setCreativeView(prebidWebViewBanner);
         htmlCreative.setTwoPartNewWebViewBase(prebidWebViewBanner);
-        mMraidController.expand(mOldWebViewBase, prebidWebViewBanner, mMraidEvent);
+        mraidController.expand(oldWebViewBase, prebidWebViewBanner, mraidEvent);
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/mraid/methods/network/GetOriginalUrlTask.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/mraid/methods/network/GetOriginalUrlTask.java
@@ -34,11 +34,11 @@ import java.util.Arrays;
 public class GetOriginalUrlTask extends BaseNetworkTask {
 
     static final int MAX_REDIRECTS = 3;
-    private String mConnectionURL;
+    private String connectionURL;
 
     public GetOriginalUrlTask(ResponseHandler handler) {
         super(handler);
-        mResult = new GetUrlResult();
+        result = new GetUrlResult();
     }
 
     private static boolean isRedirect(int code) {
@@ -61,10 +61,9 @@ public class GetOriginalUrlTask extends BaseNetworkTask {
             if (location == null) {
                 location = urlConnection.getRequestProperty("Location");
             }
-            retVal[0] = !TextUtils.isEmpty(location) ? location : mConnectionURL;
-        }
-        else {
-            retVal[0] = mConnectionURL;
+            retVal[0] = !TextUtils.isEmpty(location) ? location : connectionURL;
+        } else {
+            retVal[0] = connectionURL;
             retVal[2] = "quit";
         }
         retVal[1] = urlConnection.getHeaderField("Content-Type");
@@ -72,21 +71,21 @@ public class GetOriginalUrlTask extends BaseNetworkTask {
             retVal[1] = urlConnection.getRequestProperty("Content-Type");
         }
 
-        mResult.JSRedirectURI = retVal;
-        return mResult;
+        result.JSRedirectURI = retVal;
+        return result;
     }
 
     private String[] getRedirectionUrlWithType(GetUrlParams param) {
-        mConnectionURL = param.url;
+        connectionURL = param.url;
 
         if (Utils.isMraidActionUrl(param.url) || TextUtils.isEmpty(param.url)) {
             // Avoid network connection creation
             return new String[]{param.url, null, null};
         }
 
-        mResult = super.doInBackground(param);
+        result = super.doInBackground(param);
 
-        return mResult.JSRedirectURI;
+        return result.JSRedirectURI;
     }
 
     @Override
@@ -97,15 +96,15 @@ public class GetOriginalUrlTask extends BaseNetworkTask {
     private GetUrlResult getUrl(GetUrlParams... params) {
 
         if (isCancelled() || !validParams(params)) {
-            return mResult;
+            return result;
         }
 
         GetUrlParams param = params[0];
-        mResult.originalUrl = param != null ? param.url : null;
+        result.originalUrl = param != null ? param.url : null;
 
         processRedirects(param);
 
-        return mResult;
+        return result;
     }
 
     /*
@@ -131,8 +130,8 @@ public class GetOriginalUrlTask extends BaseNetworkTask {
 
             if (TextUtils.isEmpty(currentUrl)) {
                 // First call
-                if (TextUtils.isEmpty(mResult.contentType)) {
-                    mResult.contentType = currentResponse[1];
+                if (TextUtils.isEmpty(result.contentType)) {
+                    result.contentType = currentResponse[1];
                 }
                 break;
             }
@@ -143,8 +142,8 @@ public class GetOriginalUrlTask extends BaseNetworkTask {
                 this an opportunity for clarity should we actually need to hold
                 on to the originally requested url...
              */
-            mResult.originalUrl = currentResponse[0];
-            mResult.contentType = currentResponse[1];
+            result.originalUrl = currentResponse[0];
+            result.contentType = currentResponse[1];
 
             //no more redirects so we break, retval[2] was explicitly set to "quit"
             if (currentResponse[2] == "quit") {

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/mraid/methods/network/UrlResolutionTask.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/mraid/methods/network/UrlResolutionTask.java
@@ -34,10 +34,10 @@ import java.net.URL;
 public class UrlResolutionTask extends AsyncTask<String, Void, String> {
     private static final String TAG = UrlResolutionTask.class.getSimpleName();
 
-    @NonNull private final UrlResolutionListener mListener;
+    @NonNull private final UrlResolutionListener listener;
 
     public UrlResolutionTask(@NonNull UrlResolutionListener listener) {
-        mListener = listener;
+        this.listener = listener;
     }
 
     @Nullable
@@ -143,7 +143,7 @@ public class UrlResolutionTask extends AsyncTask<String, Void, String> {
             onCancelled();
         }
         else {
-            mListener.onSuccess(resolvedUrl);
+            listener.onSuccess(resolvedUrl);
         }
     }
 
@@ -151,7 +151,7 @@ public class UrlResolutionTask extends AsyncTask<String, Void, String> {
     protected void onCancelled() {
         super.onCancelled();
 
-        mListener.onFailure("Task for resolving url was cancelled", null);
+        listener.onFailure("Task for resolving url was cancelled", null);
     }
 
     public interface UrlResolutionListener {

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/mraid/methods/others/OrientationManager.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/mraid/methods/others/OrientationManager.java
@@ -25,14 +25,14 @@ public class OrientationManager
 		landscape(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE),
 		none(ActivityInfo.SCREEN_ORIENTATION_UNSPECIFIED);
 
-		private final int mActivityInfoOrientation;
+		private final int activityInfoOrientation;
 
 		ForcedOrientation(final int activityInfoOrientation) {
-			mActivityInfoOrientation = activityInfoOrientation;
+			this.activityInfoOrientation = activityInfoOrientation;
 		}
 
 		public int getActivityInfoOrientation() {
-			return mActivityInfoOrientation;
+			return activityInfoOrientation;
 		}
 	}
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/networking/exception/BaseExceptionHolder.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/networking/exception/BaseExceptionHolder.java
@@ -21,22 +21,22 @@ package org.prebid.mobile.rendering.networking.exception;
  */
 public class BaseExceptionHolder extends BaseExceptionProvider {
 
-    private Exception mException;
+    private Exception exception;
 
     public BaseExceptionHolder() {
         // Create without exception
     }
 
     public BaseExceptionHolder(Exception exception) {
-        mException = exception;
+        this.exception = exception;
     }
 
     public void setException(Exception exception) {
-        mException = exception;
+        this.exception = exception;
     }
 
     @Override
     public Exception getException() {
-        return mException;
+        return exception;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/networking/modelcontrollers/AsyncVastLoader.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/networking/modelcontrollers/AsyncVastLoader.java
@@ -24,7 +24,7 @@ import org.prebid.mobile.rendering.utils.helpers.Utils;
 
 public class AsyncVastLoader {
 
-    private AsyncTask mVideoRequestAsyncTask;
+    private AsyncTask videoRequestAsyncTask;
 
     public void loadVast(String vastUrl, BaseResponseHandler responseHandler) {
         cancelTask();
@@ -38,12 +38,12 @@ public class AsyncVastLoader {
             params.name = "videorequest";
         }
 
-        mVideoRequestAsyncTask = videoRequestTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, params);
+        videoRequestAsyncTask = videoRequestTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, params);
     }
 
     public void cancelTask() {
-        if (mVideoRequestAsyncTask != null) {
-            mVideoRequestAsyncTask.cancel(true);
+        if (videoRequestAsyncTask != null) {
+            videoRequestAsyncTask.cancel(true);
         }
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/networking/modelcontrollers/BidRequester.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/networking/modelcontrollers/BidRequester.java
@@ -30,13 +30,13 @@ public class BidRequester extends Requester {
 
     public BidRequester(Context context, AdUnitConfiguration config, AdRequestInput adRequestInput, ResponseHandler responseHandler) {
         super(context, config, adRequestInput, responseHandler);
-        mRequestName = REQUEST_NAME;
+        requestName = REQUEST_NAME;
     }
 
     @Override
     public void startAdRequest() {
-        if (TextUtils.isEmpty (mAdConfiguration.getConfigId())) {
-            mAdResponseCallBack.onError("No configuration id specified.", 0);
+        if (TextUtils.isEmpty(adConfiguration.getConfigId())) {
+            adResponseCallBack.onError("No configuration id specified.", 0);
             return;
         }
 

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/networking/parameters/AdRequestInput.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/networking/parameters/AdRequestInput.java
@@ -28,10 +28,10 @@ public class AdRequestInput {
 
     private static final String TAG = AdRequestInput.class.getSimpleName();
 
-    private BidRequest mBidRequest;
+    private BidRequest bidRequest;
 
     public AdRequestInput() {
-        mBidRequest = new BidRequest();
+        bidRequest = new BidRequest();
     }
 
     public AdRequestInput getDeepCopy() {
@@ -40,10 +40,10 @@ public class AdRequestInput {
         try {
             ByteArrayOutputStream baos = new ByteArrayOutputStream();
             ObjectOutputStream oos = new ObjectOutputStream(baos);
-            oos.writeObject(mBidRequest);
+            oos.writeObject(bidRequest);
             ByteArrayInputStream bais = new ByteArrayInputStream(baos.toByteArray());
             ObjectInputStream ois = new ObjectInputStream(bais);
-            newAdRequestInput.mBidRequest = (BidRequest) ois.readObject();
+            newAdRequestInput.bidRequest = (BidRequest) ois.readObject();
         }
         catch (Exception e) {
             LogUtil.error(TAG, "Failed to make deep copy of bid request");
@@ -54,10 +54,10 @@ public class AdRequestInput {
     }
 
     public BidRequest getBidRequest() {
-        return mBidRequest;
+        return bidRequest;
     }
 
     public void setBidRequest(BidRequest bidRequest) {
-        mBidRequest = bidRequest;
+        this.bidRequest = bidRequest;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/networking/parameters/AppInfoParameterBuilder.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/networking/parameters/AppInfoParameterBuilder.java
@@ -29,10 +29,10 @@ import java.util.Set;
 
 public class AppInfoParameterBuilder extends ParameterBuilder {
 
-    private AdUnitConfiguration mAdConfiguration;
+    private AdUnitConfiguration adConfiguration;
 
     public AppInfoParameterBuilder(AdUnitConfiguration adConfiguration) {
-        mAdConfiguration = adConfiguration;
+        this.adConfiguration = adConfiguration;
     }
 
     @Override
@@ -65,7 +65,7 @@ public class AppInfoParameterBuilder extends ParameterBuilder {
             app.getPublisher().name = publisherName;
         }
 
-        app.contentObject = mAdConfiguration.getAppContent();
+        app.contentObject = adConfiguration.getAppContent();
 
         app.getExt().put("prebid", Prebid.getJsonObjectForApp(BasicParameterBuilder.DISPLAY_MANAGER_VALUE, PrebidMobile.SDK_VERSION));
         final Map<String, Set<String>> contextDataDictionary = TargetingParams.getContextDataDictionary();

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/networking/parameters/BasicParameterBuilder.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/networking/parameters/BasicParameterBuilder.java
@@ -74,14 +74,18 @@ public class BasicParameterBuilder extends ParameterBuilder {
      */
     private static final List<Integer> SUPPORTED_MRAID_VERSIONS = Arrays.asList(3, 5, 6);
 
-    private final AdUnitConfiguration mAdConfiguration;
-    private final boolean mBrowserActivityAvailable;
-    private final Resources mResources;
+    private final AdUnitConfiguration adConfiguration;
+    private final boolean browserActivityAvailable;
+    private final Resources resources;
 
-    public BasicParameterBuilder(AdUnitConfiguration adConfiguration, Resources resources, boolean browserActivityAvailable) {
-        mAdConfiguration = adConfiguration;
-        mBrowserActivityAvailable = browserActivityAvailable;
-        mResources = resources;
+    public BasicParameterBuilder(
+            AdUnitConfiguration adConfiguration,
+            Resources resources,
+            boolean browserActivityAvailable
+    ) {
+        this.adConfiguration = adConfiguration;
+        this.browserActivityAvailable = browserActivityAvailable;
+        this.resources = resources;
     }
 
     @Override
@@ -101,16 +105,16 @@ public class BasicParameterBuilder extends ParameterBuilder {
     }
 
     private void configureImpObject(Imp imp, String uuid) {
-        if (mAdConfiguration != null) {
+        if (adConfiguration != null) {
             setDisplayManager(imp);
             setCommonImpValues(imp, uuid);
-            if (mAdConfiguration.getNativeConfiguration() != null) {
+            if (adConfiguration.getNativeConfiguration() != null) {
                 setNativeImpValues(imp);
             } else {
-                if (mAdConfiguration.isAdType(AdFormat.BANNER) || mAdConfiguration.isAdType(AdFormat.INTERSTITIAL)) {
+                if (adConfiguration.isAdType(AdFormat.BANNER) || adConfiguration.isAdType(AdFormat.INTERSTITIAL)) {
                     setBannerImpValues(imp);
                 }
-                if (mAdConfiguration.isAdType(AdFormat.VAST)) {
+                if (adConfiguration.isAdType(AdFormat.VAST)) {
                     setVideoImpValues(imp);
                 }
             }
@@ -119,7 +123,7 @@ public class BasicParameterBuilder extends ParameterBuilder {
 
     private void configureBidRequest(BidRequest bidRequest, String uuid) {
         bidRequest.setId(uuid);
-        boolean isVideo = mAdConfiguration.isAdType(AdFormat.VAST);
+        boolean isVideo = adConfiguration.isAdType(AdFormat.VAST);
         bidRequest.getExt().put("prebid", Prebid.getJsonObjectForBidRequest(PrebidMobile.getPrebidServerAccountId(), isVideo));
         //if coppaEnabled - set 1, else No coppa is sent
         if (PrebidMobile.isCoppaEnabled) {
@@ -143,7 +147,7 @@ public class BasicParameterBuilder extends ParameterBuilder {
         user.buyerUid = TargetingParams.getBuyerId();
         user.ext = TargetingParams.getUserExt();
 
-        ArrayList<DataObject> userData = mAdConfiguration.getUserData();
+        ArrayList<DataObject> userData = adConfiguration.getUserData();
         if (!userData.isEmpty()) {
             user.dataObjects = userData;
         }
@@ -185,8 +189,8 @@ public class BasicParameterBuilder extends ParameterBuilder {
     private void setVideoImpValues(Imp imp) {
         Video video = new Video();
 
-        if (mAdConfiguration.isOriginalAdUnit()) {
-            VideoBaseAdUnit.Parameters videoParameters = mAdConfiguration.getVideoParameters();
+        if (adConfiguration.isOriginalAdUnit()) {
+            VideoBaseAdUnit.Parameters videoParameters = adConfiguration.getVideoParameters();
             if (videoParameters != null) {
                 video.minduration = videoParameters.getMinDuration();
                 video.maxduration = videoParameters.getMaxDuration();
@@ -251,22 +255,21 @@ public class BasicParameterBuilder extends ParameterBuilder {
             video.playbackend = VIDEO_INTERSTITIAL_PLAYBACK_END;//On Leaving Viewport or when Terminated by User
             video.delivery = new int[]{VIDEO_DELIVERY_DOWNLOAD};
 
-            if (mAdConfiguration.isAdPositionValid()) {
-                video.pos = mAdConfiguration.getAdPositionValue();
+            if (adConfiguration.isAdPositionValid()) {
+                video.pos = adConfiguration.getAdPositionValue();
             }
         }
 
-        if (!mAdConfiguration.isPlacementTypeValid()) {
+        if (!adConfiguration.isPlacementTypeValid()) {
             video.placement = PlacementType.INTERSTITIAL.getValue();
-            if (mResources != null) {
-                Configuration deviceConfiguration = mResources.getConfiguration();
+            if (resources != null) {
+                Configuration deviceConfiguration = resources.getConfiguration();
                 video.w = deviceConfiguration.screenWidthDp;
                 video.h = deviceConfiguration.screenHeightDp;
             }
-        }
-        else {
-            video.placement = mAdConfiguration.getPlacementTypeValue();
-            for (AdSize size : mAdConfiguration.getSizes()) {
+        } else {
+            video.placement = adConfiguration.getPlacementTypeValue();
+            for (AdSize size : adConfiguration.getSizes()) {
                 video.w = size.getWidth();
                 video.h = size.getHeight();
                 break;
@@ -278,8 +281,8 @@ public class BasicParameterBuilder extends ParameterBuilder {
 
     private void setBannerImpValues(Imp imp) {
         Banner banner = new Banner();
-        if (mAdConfiguration.isOriginalAdUnit()) {
-            BannerBaseAdUnit.Parameters parameters = mAdConfiguration.getBannerParameters();
+        if (adConfiguration.isOriginalAdUnit()) {
+            BannerBaseAdUnit.Parameters parameters = adConfiguration.getBannerParameters();
             if (parameters != null && parameters.getApi() != null && parameters.getApi().size() > 0) {
                 List<Signals.Api> apiObjects = parameters.getApi();
                 int[] api = new int[apiObjects.size()];
@@ -292,45 +295,44 @@ public class BasicParameterBuilder extends ParameterBuilder {
             banner.api = getApiFrameworks();
         }
 
-        if (mAdConfiguration.isAdType(AdFormat.BANNER)) {
-            for (AdSize size : mAdConfiguration.getSizes()) {
+        if (adConfiguration.isAdType(AdFormat.BANNER)) {
+            for (AdSize size : adConfiguration.getSizes()) {
                 banner.addFormat(size.getWidth(), size.getHeight());
             }
-        } else if (mAdConfiguration.isAdType(AdFormat.INTERSTITIAL) && mResources != null) {
-            Configuration deviceConfiguration = mResources.getConfiguration();
+        } else if (adConfiguration.isAdType(AdFormat.INTERSTITIAL) && resources != null) {
+            Configuration deviceConfiguration = resources.getConfiguration();
             banner.addFormat(deviceConfiguration.screenWidthDp, deviceConfiguration.screenHeightDp);
         }
 
-        if (mAdConfiguration.isAdPositionValid()) {
-            banner.pos = mAdConfiguration.getAdPositionValue();
+        if (adConfiguration.isAdPositionValid()) {
+            banner.pos = adConfiguration.getAdPositionValue();
         }
 
         imp.banner = banner;
     }
 
     private void setNativeImpValues(Imp imp) {
-        if (mAdConfiguration.getNativeConfiguration() != null) {
-            imp.getNative().setRequestFrom(mAdConfiguration.getNativeConfiguration());
+        if (adConfiguration.getNativeConfiguration() != null) {
+            imp.getNative().setRequestFrom(adConfiguration.getNativeConfiguration());
         }
     }
 
     private void setCommonImpValues(Imp imp, String uuid) {
         imp.id = uuid;
-        boolean isInterstitial = mAdConfiguration.isAdType(AdFormat.VAST) ||
-                mAdConfiguration.isAdType(AdFormat.INTERSTITIAL);
+        boolean isInterstitial = adConfiguration.isAdType(AdFormat.VAST) || adConfiguration.isAdType(AdFormat.INTERSTITIAL);
         //Send 1 for interstitial/interstitial video and 0 for banners
         imp.instl = isInterstitial ? 1 : 0;
         // 0 == embedded, 1 == native
-        imp.clickBrowser = !PrebidMobile.useExternalBrowser && mBrowserActivityAvailable ? 0 : 1;
+        imp.clickBrowser = !PrebidMobile.useExternalBrowser && browserActivityAvailable ? 0 : 1;
         //set secure=1 for https or secure=0 for http
-        if (!mAdConfiguration.isAdType(AdFormat.VAST)) {
+        if (!adConfiguration.isAdType(AdFormat.VAST)) {
             imp.secure = 1;
         }
-        imp.getExt().put("prebid", Prebid.getJsonObjectForImp(mAdConfiguration));
+        imp.getExt().put("prebid", Prebid.getJsonObjectForImp(adConfiguration));
 
-        final Map<String, Set<String>> contextDataDictionary = mAdConfiguration.getContextDataDictionary();
+        final Map<String, Set<String>> contextDataDictionary = adConfiguration.getContextDataDictionary();
         JSONObject data = Utils.toJson(contextDataDictionary);
-        Utils.addValue(data, "adslot", mAdConfiguration.getPbAdSlot());
+        Utils.addValue(data, "adslot", adConfiguration.getPbAdSlot());
         JSONObject context = new JSONObject();
 
         if (data.length() > 0) {

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/networking/parameters/DeviceInfoParameterBuilder.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/networking/parameters/DeviceInfoParameterBuilder.java
@@ -33,10 +33,10 @@ public class DeviceInfoParameterBuilder extends ParameterBuilder {
 
     static final String PLATFORM_VALUE = "Android";
 
-    private AdUnitConfiguration mAdConfiguration;
+    private AdUnitConfiguration adConfiguration;
 
     public DeviceInfoParameterBuilder(AdUnitConfiguration configuration) {
-        mAdConfiguration = configuration;
+        adConfiguration = configuration;
     }
 
     @Override
@@ -71,7 +71,7 @@ public class DeviceInfoParameterBuilder extends ParameterBuilder {
             boolean lmt = AdIdManager.isLimitAdTrackingEnabled();
             device.lmt = lmt ? 1 : 0;
 
-            final AdSize minSizePercentage = mAdConfiguration.getMinSizePercentage();
+            final AdSize minSizePercentage = adConfiguration.getMinSizePercentage();
             if (minSizePercentage != null) {
                 device.getExt().put("prebid", Prebid.getJsonObjectForDeviceMinSizePerc(minSizePercentage));
             }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/networking/parameters/UserConsentParameterBuilder.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/networking/parameters/UserConsentParameterBuilder.java
@@ -26,10 +26,10 @@ public class UserConsentParameterBuilder extends ParameterBuilder {
     private static final String US_PRIVACY = "us_privacy";
     private static final String CONSENT = "consent";
 
-    private final UserConsentManager mUserConsentManager;
+    private final UserConsentManager userConsentManager;
 
     public UserConsentParameterBuilder(UserConsentManager userConsentManager) {
-        mUserConsentManager = userConsentManager;
+        this.userConsentManager = userConsentManager;
     }
 
     @Override
@@ -41,13 +41,13 @@ public class UserConsentParameterBuilder extends ParameterBuilder {
     }
 
     private void appendGdprParameter(BidRequest bidRequest) {
-        String isSubjectToGdpr = mUserConsentManager.getSubjectToGdpr();
+        String isSubjectToGdpr = userConsentManager.getSubjectToGdpr();
 
         if (!Utils.isBlank(isSubjectToGdpr)) {
             Integer gdprValue = "1".equals(isSubjectToGdpr) ? 1 : 0;
             bidRequest.getRegs().getExt().put(GDPR, gdprValue);
 
-            String userConsentString = mUserConsentManager.getUserConsentString();
+            String userConsentString = userConsentManager.getUserConsentString();
             if (!Utils.isBlank(userConsentString)) {
                 bidRequest.getUser().getExt().put(CONSENT, userConsentString);
             }
@@ -55,7 +55,7 @@ public class UserConsentParameterBuilder extends ParameterBuilder {
     }
 
     private void appendCcpaParameter(BidRequest bidRequest) {
-        String usPrivacyString = mUserConsentManager.getUsPrivacyString();
+        String usPrivacyString = userConsentManager.getUsPrivacyString();
 
         if (!Utils.isBlank(usPrivacyString)) {
             bidRequest.getRegs().getExt().put(US_PRIVACY, usPrivacyString);

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/networking/urlBuilder/BidUrlComponents.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/networking/urlBuilder/BidUrlComponents.java
@@ -31,7 +31,7 @@ public class BidUrlComponents extends URLComponents {
     public String getQueryArgString() {
         String openrtb = "";
         try {
-            JSONObject bidRequestJson = mAdRequestInput.getBidRequest().getJsonObject();
+            JSONObject bidRequestJson = adRequestInput.getBidRequest().getJsonObject();
             if (bidRequestJson.length() > 0) {
                 openrtb = bidRequestJson.toString();
             }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/networking/urlBuilder/PathBuilderBase.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/networking/urlBuilder/PathBuilderBase.java
@@ -21,11 +21,11 @@ public class PathBuilderBase extends URLPathBuilder {
     private static final String API_VERSION = "1.0";
     private static final String PROTOCOL = "https";
 
-    protected String mRoute = "ma";
+    protected String route = "ma";
 
     @Override
     public String buildURLPath(String domain) {
-        return PROTOCOL + "://" + domain + "/" + mRoute + "/" + API_VERSION + "/";
+        return PROTOCOL + "://" + domain + "/" + route + "/" + API_VERSION + "/";
     }
 
     public PathBuilderBase() {

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/networking/urlBuilder/URLBuilder.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/networking/urlBuilder/URLBuilder.java
@@ -23,19 +23,23 @@ import java.util.ArrayList;
 
 public class URLBuilder {
 
-    private final URLPathBuilder mPathBuilder;
-    private final ArrayList<ParameterBuilder> mParamBuilders;
-    private final AdRequestInput mAdRequestInput;
+    private final URLPathBuilder pathBuilder;
+    private final ArrayList<ParameterBuilder> paramBuilders;
+    private final AdRequestInput adRequestInput;
 
-    public URLBuilder(URLPathBuilder pathBuilder, ArrayList<ParameterBuilder> parameterBuilders, AdRequestInput adRequestInput) {
-        mPathBuilder = pathBuilder;
-        mParamBuilders = parameterBuilders;
-        mAdRequestInput = adRequestInput;
+    public URLBuilder(
+            URLPathBuilder pathBuilder,
+            ArrayList<ParameterBuilder> parameterBuilders,
+            AdRequestInput adRequestInput
+    ) {
+        this.pathBuilder = pathBuilder;
+        paramBuilders = parameterBuilders;
+        this.adRequestInput = adRequestInput;
     }
 
     public BidUrlComponents buildUrl() {
-        AdRequestInput adRequestInput = buildParameters(mParamBuilders, mAdRequestInput);
-        String initialPath = mPathBuilder.buildURLPath("");
+        AdRequestInput adRequestInput = buildParameters(paramBuilders, this.adRequestInput);
+        String initialPath = pathBuilder.buildURLPath("");
         return new BidUrlComponents(initialPath, adRequestInput);
     }
 

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/networking/urlBuilder/URLComponents.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/networking/urlBuilder/URLComponents.java
@@ -27,19 +27,23 @@ import java.net.URLEncoder;
 import java.util.Hashtable;
 
 public class URLComponents {
+
     private static final String TAG = URLComponents.class.getSimpleName();
     private static final String MISC_OPENRTB = "openrtb";
 
-    private final String mBaseUrl;
-    public final AdRequestInput mAdRequestInput;
+    private final String baseUrl;
+    public final AdRequestInput adRequestInput;
 
-    public URLComponents(String baseUrl, AdRequestInput adRequestInput) {
-        mBaseUrl = baseUrl;
-        mAdRequestInput = adRequestInput;
+    public URLComponents(
+            String baseUrl,
+            AdRequestInput adRequestInput
+    ) {
+        this.baseUrl = baseUrl;
+        this.adRequestInput = adRequestInput;
     }
 
     public String getFullUrl() {
-        String fullUrl = mBaseUrl;
+        String fullUrl = baseUrl;
         String queryArgString = getQueryArgString();
         if (Utils.isNotBlank(queryArgString)) {
             fullUrl += "?" + queryArgString;
@@ -53,7 +57,7 @@ public class URLComponents {
 
         // If BidRequest object available, put into query arg hashtable
         try {
-            JSONObject bidRequestJson = mAdRequestInput.getBidRequest().getJsonObject();
+            JSONObject bidRequestJson = adRequestInput.getBidRequest().getJsonObject();
 
             if (bidRequestJson.length() > 0) {
                 tempQueryArgs.put(MISC_OPENRTB, bidRequestJson.toString());
@@ -91,10 +95,10 @@ public class URLComponents {
     }
 
     public String getBaseUrl() {
-        return mBaseUrl;
+        return baseUrl;
     }
 
     public AdRequestInput getAdRequestInput() {
-        return mAdRequestInput;
+        return adRequestInput;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/parser/AdResponseParserVast.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/parser/AdResponseParserVast.java
@@ -44,28 +44,28 @@ public class AdResponseParserVast extends AdResponseParserBase {
     public static final int RESOURCE_FORMAT_IFRAME = 2;
     public static final int RESOURCE_FORMAT_STATIC = 3;
 
-    private boolean mReady;
+    private boolean ready;
 
-    private volatile AdResponseParserVast mWrappedVASTXml;
+    private volatile AdResponseParserVast wrappedVASTXml;
 
-    private ArrayList<org.prebid.mobile.rendering.video.vast.Tracking> mTrackings;
-    private ArrayList<ClickTracking> mClickTrackings;
-    private ArrayList<Impression> mImpressions;
+    private ArrayList<org.prebid.mobile.rendering.video.vast.Tracking> trackings;
+    private ArrayList<ClickTracking> clickTrackings;
+    private ArrayList<Impression> impressions;
 
-    private VAST mVast;
+    private VAST vast;
 
     public ArrayList<org.prebid.mobile.rendering.video.vast.Tracking> getTrackings() {
-        return mTrackings;
+        return trackings;
     }
 
     public ArrayList<Impression> getImpressions() {
 
-        return mImpressions;
+        return impressions;
     }
 
     public ArrayList<ClickTracking> getClickTrackings() {
 
-        return mClickTrackings;
+        return clickTrackings;
     }
 
     public static class Tracking {
@@ -118,13 +118,13 @@ public class AdResponseParserVast extends AdResponseParserBase {
             "impression",
             "click"};
 
-        private int mEvent;
+        private int event;
 
-        private String mUrl;
+        private String url;
 
         public Tracking(String event, String url) {
-            mEvent = findEvent(event);
-            mUrl = url;
+            this.event = findEvent(event);
+            this.url = url;
         }
 
         private int findEvent(String event) {
@@ -137,31 +137,30 @@ public class AdResponseParserVast extends AdResponseParserBase {
         }
 
         public int getEvent() {
-            return mEvent;
+            return event;
         }
 
         public String getUrl() {
-            return mUrl;
+            return url;
         }
     }
 
     public AdResponseParserVast(String data) throws VastParseError {
-        mTrackings = new ArrayList<>();
-        mImpressions = new ArrayList<>();
-        mClickTrackings = new ArrayList<>();
-        mReady = false;
+        trackings = new ArrayList<>();
+        impressions = new ArrayList<>();
+        clickTrackings = new ArrayList<>();
+        ready = false;
 
         try {
             readVAST(data);
-        }
-        catch (Exception e) {
+        } catch (Exception e) {
             throw new VastParseError(e.getLocalizedMessage());
         }
-        mReady = true;
+        ready = true;
     }
 
     public VAST getVast() {
-        return mVast;
+        return vast;
     }
 
     private void readVAST(String data) throws XmlPullParserException, IOException {
@@ -174,7 +173,7 @@ public class AdResponseParserVast extends AdResponseParserBase {
         parser.setInput(new StringReader(data));
         parser.nextTag();
 
-        mVast = new VAST(parser);
+        vast = new VAST(parser);
     }
 
     @Nullable
@@ -192,8 +191,8 @@ public class AdResponseParserVast extends AdResponseParserBase {
 
     public List<String> getImpressionTrackerUrl() {
         List<String> urls = new ArrayList<>();
-        if (mWrappedVASTXml != null && mWrappedVASTXml.getImpressionTrackerUrl() != null) {
-            urls.addAll(mWrappedVASTXml.getImpressionTrackerUrl());
+        if (wrappedVASTXml != null && wrappedVASTXml.getImpressionTrackerUrl() != null) {
+            urls.addAll(wrappedVASTXml.getImpressionTrackerUrl());
         }
 
         return urls;
@@ -201,7 +200,7 @@ public class AdResponseParserVast extends AdResponseParserBase {
 
     public String getVastUrl() {
 
-        for (Ad ad : mVast.getAds()) {
+        for (Ad ad : vast.getAds()) {
 
             if (ad.getWrapper() != null && ad.getWrapper().getVastUrl() != null) {
 
@@ -221,8 +220,8 @@ public class AdResponseParserVast extends AdResponseParserBase {
          * and then we get its meduaFile URL. Note that index is hardcoded in the call
          * as 0 for the first Ad node. So we have to figure out a solution for Ad pods.
          */
-        if (mWrappedVASTXml != null) {
-            mWrappedVASTXml.getMediaFileUrl(mWrappedVASTXml, index);
+        if (wrappedVASTXml != null) {
+            wrappedVASTXml.getMediaFileUrl(wrappedVASTXml, index);
         }
         /**
          * Now that we have reached the last node, we can get its mediaFileUrl.
@@ -231,7 +230,7 @@ public class AdResponseParserVast extends AdResponseParserBase {
          */
         else {
 
-            Ad ad = parserVast.mVast.getAds().get(index);
+            Ad ad = parserVast.vast.getAds().get(index);
 
             for (Creative creative : ad.getInline().getCreatives()) {
 
@@ -289,18 +288,18 @@ public class AdResponseParserVast extends AdResponseParserBase {
     }
 
     public ArrayList<Impression> getImpressions(AdResponseParserVast parserVast, int index) {
-        if (getImpressionEvents(parserVast.mVast, index) != null) {
-            mImpressions.addAll(getImpressionEvents(parserVast.mVast, index));
+        if (getImpressionEvents(parserVast.vast, index) != null) {
+            impressions.addAll(getImpressionEvents(parserVast.vast, index));
         }
 
         /**
          * Here we use a recursion pattern to traverse the nested VAST nodes "parserVast",
          */
-        if (parserVast.mWrappedVASTXml != null) {
-            getImpressions(parserVast.mWrappedVASTXml, index);
+        if (parserVast.wrappedVASTXml != null) {
+            getImpressions(parserVast.wrappedVASTXml, index);
         }
 
-        return mImpressions;
+        return impressions;
     }
 
     public ArrayList<org.prebid.mobile.rendering.video.vast.Tracking> getTrackingEvents(VAST vast, int index) {
@@ -349,22 +348,22 @@ public class AdResponseParserVast extends AdResponseParserBase {
 
     public ArrayList<org.prebid.mobile.rendering.video.vast.Tracking> getAllTrackings(AdResponseParserVast parserVast, int index) {
 
-        if (getTrackingEvents(parserVast.mVast, index) != null) {
-            mTrackings.addAll(getTrackingEvents(parserVast.mVast, index));
+        if (getTrackingEvents(parserVast.vast, index) != null) {
+            trackings.addAll(getTrackingEvents(parserVast.vast, index));
         }
 
         /**
          * Here we use a recursion pattern to traverse the nested VAST nodes "parserVast",
          */
-        if (parserVast.mWrappedVASTXml != null) {
-            getAllTrackings(parserVast.mWrappedVASTXml, index);
+        if (parserVast.wrappedVASTXml != null) {
+            getAllTrackings(parserVast.wrappedVASTXml, index);
         }
 
-        return mTrackings;
+        return trackings;
     }
 
     public ArrayList<String> getTrackingByType(VideoAdEvent.Event event) {
-        Iterator<org.prebid.mobile.rendering.video.vast.Tracking> iterator = mTrackings.iterator();
+        Iterator<org.prebid.mobile.rendering.video.vast.Tracking> iterator = trackings.iterator();
 
         ArrayList<String> urls = new ArrayList<>();
 
@@ -383,12 +382,11 @@ public class AdResponseParserVast extends AdResponseParserBase {
 
     public String getSkipOffset(AdResponseParserVast parserVast, int index) {
 
-        if (mWrappedVASTXml != null) {
-            return mWrappedVASTXml.getSkipOffset(parserVast, index);
-        }
-        else {
+        if (wrappedVASTXml != null) {
+            return wrappedVASTXml.getSkipOffset(parserVast, index);
+        } else {
 
-            Ad ad = parserVast.mVast.getAds().get(index);
+            Ad ad = parserVast.vast.getAds().get(index);
 
             if (ad != null && ad.getInline() != null) {
 
@@ -406,13 +404,11 @@ public class AdResponseParserVast extends AdResponseParserBase {
 
     public String getVideoDuration(AdResponseParserVast parserVast, int index) {
 
-        if (mWrappedVASTXml != null) {
-            return mWrappedVASTXml.getVideoDuration(parserVast, index);
-        }
+        if (wrappedVASTXml != null) {
+            return wrappedVASTXml.getVideoDuration(parserVast, index);
+        } else {
 
-        else {
-
-            Ad ad = parserVast.mVast.getAds().get(index);
+            Ad ad = parserVast.vast.getAds().get(index);
 
             if (ad != null && ad.getInline() != null) {
 
@@ -430,7 +426,7 @@ public class AdResponseParserVast extends AdResponseParserBase {
 
     public AdVerifications getAdVerification(AdResponseParserVast parserVast, int index) {
 
-        Ad ad = parserVast.mVast.getAds().get(index);
+        Ad ad = parserVast.vast.getAds().get(index);
 
         if (ad == null || ad.getInline() == null) {
             return null;
@@ -463,7 +459,7 @@ public class AdResponseParserVast extends AdResponseParserBase {
 
     public String getError(AdResponseParserVast parserVast, int index) {
 
-        Ad ad = parserVast.mVast.getAds().get(index);
+        Ad ad = parserVast.vast.getAds().get(index);
 
         if (ad != null && ad.getInline() != null && ad.getInline().getError() != null) {
             return ad.getInline().getError().getValue();
@@ -474,17 +470,18 @@ public class AdResponseParserVast extends AdResponseParserBase {
 
     public String getClickThroughUrl(AdResponseParserVast parserVast, int index) {
 
-        if (mWrappedVASTXml != null) {
-            return mWrappedVASTXml.getClickThroughUrl(mWrappedVASTXml, index);
-        }
+        if (wrappedVASTXml != null) {
+            return wrappedVASTXml.getClickThroughUrl(wrappedVASTXml, index);
+        } else {
 
-        else {
-
-            Ad ad = parserVast.mVast.getAds().get(index);
+            Ad ad = parserVast.vast.getAds().get(index);
 
             for (Creative creative : ad.getInline().getCreatives()) {
 
-                if (creative.getLinear() != null && creative.getLinear().getVideoClicks() != null && creative.getLinear().getVideoClicks().getClickThrough() != null) {
+                if (creative.getLinear() != null && creative.getLinear()
+                                                            .getVideoClicks() != null && creative.getLinear()
+                                                                                                 .getVideoClicks()
+                                                                                                 .getClickThrough() != null) {
 
                     return creative.getLinear().getVideoClicks().getClickThrough().getValue();
                 }
@@ -522,26 +519,26 @@ public class AdResponseParserVast extends AdResponseParserBase {
     }
 
     public ArrayList<ClickTracking> getClickTrackings(AdResponseParserVast parserVast, int index) {
-        ArrayList<ClickTracking> clickTrackingsList = findClickTrackings(parserVast.mVast, index);
+        ArrayList<ClickTracking> clickTrackingsList = findClickTrackings(parserVast.vast, index);
         if (clickTrackingsList != null) {
-            mClickTrackings.addAll(clickTrackingsList);
+            clickTrackings.addAll(clickTrackingsList);
         }
 
         /**
          * Here we use a recursion pattern to traverse the nested VAST nodes "parserVast",
          */
-        if (parserVast.mWrappedVASTXml != null) {
-            getClickTrackings(parserVast.mWrappedVASTXml, index);
+        if (parserVast.wrappedVASTXml != null) {
+            getClickTrackings(parserVast.wrappedVASTXml, index);
         }
 
-        return mClickTrackings;
+        return clickTrackings;
     }
 
     public List<String> getClickTrackingUrl() {
 
         List<String> urls = new ArrayList<>();
-        if (mWrappedVASTXml != null && mWrappedVASTXml.getClickTrackingUrl() != null) {
-            urls.addAll(mWrappedVASTXml.getClickTrackingUrl());
+        if (wrappedVASTXml != null && wrappedVASTXml.getClickTrackingUrl() != null) {
+            urls.addAll(wrappedVASTXml.getClickTrackingUrl());
         }
 
         return urls;
@@ -682,24 +679,32 @@ public class AdResponseParserVast extends AdResponseParserBase {
 
     public synchronized boolean isReady() {
 
-        return mReady && (mWrappedVASTXml == null || mWrappedVASTXml.isReady());
+        return ready && (wrappedVASTXml == null || wrappedVASTXml.isReady());
     }
 
 
     public void setWrapper(AdResponseParserVast vastXml) {
-        mWrappedVASTXml = vastXml;
+        wrappedVASTXml = vastXml;
     }
 
     /**
      * @return null if no wrapped XML is present, a reference to a wrapped VASTXmlParse if it is
      */
     public AdResponseParserVast getWrappedVASTXml() {
-        return mWrappedVASTXml;
+        return wrappedVASTXml;
     }
 
     public int getWidth() {
         try {
-            return Integer.parseInt(mVast.getAds().get(0).getInline().getCreatives().get(0).getLinear().getMediaFiles().get(0).getWidth());
+            return Integer.parseInt(vast.getAds()
+                                        .get(0)
+                                        .getInline()
+                                        .getCreatives()
+                                        .get(0)
+                                        .getLinear()
+                                        .getMediaFiles()
+                                        .get(0)
+                                        .getWidth());
         }
         catch (Exception e) {
             return 0;
@@ -708,7 +713,15 @@ public class AdResponseParserVast extends AdResponseParserBase {
 
     public int getHeight() {
         try {
-            return Integer.parseInt(mVast.getAds().get(0).getInline().getCreatives().get(0).getLinear().getMediaFiles().get(0).getHeight());
+            return Integer.parseInt(vast.getAds()
+                                        .get(0)
+                                        .getInline()
+                                        .getCreatives()
+                                        .get(0)
+                                        .getLinear()
+                                        .getMediaFiles()
+                                        .get(0)
+                                        .getHeight());
         }
         catch (Exception e) {
             return 0;

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/BaseManager.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/BaseManager.java
@@ -20,20 +20,19 @@ import android.content.Context;
 
 import java.lang.ref.WeakReference;
 
-public class BaseManager implements Manager
-{
-	private WeakReference<Context> mContextReference;
-	private boolean mIsInit;
+public class BaseManager implements Manager {
+
+	private WeakReference<Context> contextReference;
+	private boolean isInit;
 
 	/**
 	 * Check initialization of manager.
-	 * 
+	 *
 	 * @return true, if manager was initialized
 	 */
 	@Override
-	public boolean isInit()
-	{
-		return mIsInit;
+	public boolean isInit() {
+		return isInit;
 	}
 
 	/**
@@ -45,10 +44,9 @@ public class BaseManager implements Manager
 	@Override
 	public void init(Context context)
 	{
-		if (context != null)
-		{
-			mContextReference = new WeakReference<>(context);
-			mIsInit = true;
+		if (context != null) {
+			contextReference = new WeakReference<>(context);
+			isInit = true;
 		}
 	}
 
@@ -58,10 +56,9 @@ public class BaseManager implements Manager
 	 * @return the context
 	 */
 	@Override
-	public Context getContext()
-	{
-		if (mContextReference != null) {
-			return mContextReference.get();
+	public Context getContext() {
+		if (contextReference != null) {
+			return contextReference.get();
 		}
 		return null;
 	}
@@ -71,9 +68,8 @@ public class BaseManager implements Manager
 	 * 
 	 */
 	@Override
-	public void dispose()
-	{
-		mIsInit = false;
-		mContextReference = null;
+	public void dispose() {
+		isInit = false;
+		contextReference = null;
 	}
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/JSLibraryManager.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/JSLibraryManager.java
@@ -26,14 +26,15 @@ import org.prebid.mobile.rendering.utils.helpers.Utils;
  * Provides JS scripts extracted from bundled resource
  */
 public class JSLibraryManager {
+
     private static JSLibraryManager sInstance;
 
-    private Context mContext;
-    private String mMRAIDscript;
-    private String mOMSDKscirpt;
+    private Context context;
+    private String MRAIDscript;
+    private String OMSDKscirpt;
 
     private JSLibraryManager(Context context) {
-        mContext = context.getApplicationContext();
+        this.context = context.getApplicationContext();
         initScriptStrings();
     }
 
@@ -49,16 +50,16 @@ public class JSLibraryManager {
     }
 
     public String getMRAIDScript() {
-        return mMRAIDscript;
+        return MRAIDscript;
     }
 
     public String getOMSDKScript() {
-        return mOMSDKscirpt;
+        return OMSDKscirpt;
     }
 
     private void initScriptStrings() {
-        Resources resources = mContext.getResources();
-        mMRAIDscript = Utils.loadStringFromFile(resources, R.raw.mraid);
-        mOMSDKscirpt = Utils.loadStringFromFile(resources, R.raw.omsdk_v1);
+        Resources resources = context.getResources();
+        MRAIDscript = Utils.loadStringFromFile(resources, R.raw.mraid);
+        OMSDKscirpt = Utils.loadStringFromFile(resources, R.raw.omsdk_v1);
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/ManagersResolver.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/ManagersResolver.java
@@ -32,17 +32,18 @@ import java.util.Map;
  * respectively.
  */
 public class ManagersResolver {
+
     private static final String TAG = ManagersResolver.class.getSimpleName();
-    private final Hashtable<ManagerType, Manager> mRegisteredManagers = new Hashtable<>();
-    private WeakReference<Context> mContextReference;
+    private final Hashtable<ManagerType, Manager> registeredManagers = new Hashtable<>();
+    private WeakReference<Context> contextReference;
 
     private void setContext(Context context) {
-        mContextReference = new WeakReference<>(context);
+        contextReference = new WeakReference<>(context);
     }
 
     public Context getContext() {
-        if (mContextReference != null) {
-            return mContextReference.get();
+        if (contextReference != null) {
+            return contextReference.get();
         }
 
         return null;
@@ -98,8 +99,8 @@ public class ManagersResolver {
      * @return Manager
      */
     public Manager getManager(ManagerType type) {
-        if (mRegisteredManagers.containsKey(type)) {
-            return mRegisteredManagers.get(type);
+        if (registeredManagers.containsKey(type)) {
+            return registeredManagers.get(type);
         }
         return null;
     }
@@ -153,19 +154,19 @@ public class ManagersResolver {
 
         manager = new DeviceInfoImpl();
         manager.init(context);
-        mRegisteredManagers.put(ManagerType.DEVICE_MANAGER, manager);
+        registeredManagers.put(ManagerType.DEVICE_MANAGER, manager);
 
         manager = new LastKnownLocationInfoManager();
         manager.init(context);
-        mRegisteredManagers.put(ManagerType.LOCATION_MANAGER, manager);
+        registeredManagers.put(ManagerType.LOCATION_MANAGER, manager);
 
         manager = new NetworkConnectionInfoManager();
         manager.init(context);
-        mRegisteredManagers.put(ManagerType.NETWORK_MANAGER, manager);
+        registeredManagers.put(ManagerType.NETWORK_MANAGER, manager);
 
         manager = new UserConsentManager();
         manager.init(context);
-        mRegisteredManagers.put(ManagerType.USER_CONSENT_MANAGER, manager);
+        registeredManagers.put(ManagerType.USER_CONSENT_MANAGER, manager);
     }
 
     /**
@@ -187,7 +188,7 @@ public class ManagersResolver {
     }
 
     public void dispose() {
-        for (Map.Entry<ManagerType, Manager> entry : mRegisteredManagers.entrySet()) {
+        for (Map.Entry<ManagerType, Manager> entry : registeredManagers.entrySet()) {
             final Manager manager = entry.getValue();
             if (manager != null) {
                 manager.dispose();

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/calendar/CalendarEventWrapper.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/calendar/CalendarEventWrapper.java
@@ -38,74 +38,71 @@ public final class CalendarEventWrapper
 		UNKNOWN
 	}
 
-	public enum Transparency
-	{
+	public enum Transparency {
 		TRANSPARENT,
 		OPAQUE,
 		UNKNOWN
 	}
 
-	private String mId;
-	private String mDescription;
-	private String mLocation;
-	private String mSummary;
-    private DateWrapper mStart;
-    private DateWrapper mEnd;
-	private Status mStatus;
-	private Transparency mTransparency;
-    private CalendarRepeatRule mRecurrence;
-    private DateWrapper mReminder;
+	private String id;
+	private String description;
+	private String location;
+	private String summary;
+	private DateWrapper start;
+	private DateWrapper end;
+	private Status status;
+	private Transparency transparency;
+	private CalendarRepeatRule recurrence;
+	private DateWrapper reminder;
 
-	public String getId()
-	{
-		return mId;
+	public String getId() {
+		return id;
 	}
 
-	public void setId(String id)
-	{
-        mId = id;
+	public void setId(String id) {
+		this.id = id;
 	}
 
 	public String getDescription()
 	{
-		return mDescription;
+		return description;
 	}
 
 	public void setDescription(String description)
 	{
-        mDescription = description;
+		this.description = description;
 	}
 
 	public String getLocation()
 	{
-		return mLocation;
+		return location;
 	}
 
 	public void setLocation(String location)
 	{
-        mLocation = location;
+		this.location = location;
 	}
 
 	public String getSummary()
 	{
-		return mSummary;
+		return summary;
 	}
 
 	public void setSummary(String summary)
 	{
-        mSummary = summary;
+		this.summary = summary;
 	}
 
     public DateWrapper getStart()
 	{
-		return mStart;
+		return start;
 	}
 
 	public void setStart(String start)
 	{
 		try
 		{
-            mStart = new DateWrapper(start);
+			this.start = new DateWrapper(start);
 		}
 		catch (ParseException e)
 		{
@@ -115,14 +112,14 @@ public final class CalendarEventWrapper
 
     public DateWrapper getEnd()
 	{
-		return mEnd;
+		return end;
 	}
 
 	public void setEnd(String end)
 	{
 		try
 		{
-            mEnd = new DateWrapper(end);
+			this.end = new DateWrapper(end);
 		}
 		catch (ParseException e)
 		{
@@ -132,44 +129,44 @@ public final class CalendarEventWrapper
 
 	public Status getStatus()
 	{
-		return mStatus;
+		return status;
 	}
 
 	public void setStatus(Status status)
 	{
-        mStatus = status;
+		this.status = status;
 	}
 
 	public Transparency getTransparency()
 	{
-		return mTransparency;
+		return transparency;
 	}
 
 	public void setTransparency(Transparency transparency)
 	{
-        mTransparency = transparency;
+		this.transparency = transparency;
 	}
 
     public CalendarRepeatRule getRecurrence()
 	{
-		return mRecurrence;
+		return recurrence;
 	}
 
     public void setRecurrence(CalendarRepeatRule recurrence)
 	{
-        mRecurrence = recurrence;
+		this.recurrence = recurrence;
 	}
 
     public DateWrapper getReminder()
 	{
-		return mReminder;
+		return reminder;
 	}
 
 	public void setReminder(String reminder)
 	{
 		try
 		{
-            mReminder = new DateWrapper(reminder);
+			this.reminder = new DateWrapper(reminder);
 		}
 		catch (ParseException e)
 		{

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/calendar/CalendarFactory.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/calendar/CalendarFactory.java
@@ -20,14 +20,14 @@ import org.prebid.mobile.rendering.utils.helpers.Utils;
 
 final public class CalendarFactory {
 
-    private ICalendar mImplementation;
+    private ICalendar implementation;
 
     private CalendarFactory() {
         if (Utils.atLeastICS()) {
-            mImplementation = new CalendarGTE14();
+            implementation = new CalendarGTE14();
         }
         else {
-            mImplementation = new CalendarLT14();
+            implementation = new CalendarLT14();
         }
     }
 
@@ -36,6 +36,6 @@ final public class CalendarFactory {
     }
 
     public static ICalendar getCalendarInstance() {
-        return CalendarImplHolder.instance.mImplementation;
+        return CalendarImplHolder.instance.implementation;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/calendar/CalendarRepeatRule.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/calendar/CalendarRepeatRule.java
@@ -26,6 +26,7 @@ import java.text.ParseException;
  * Wraps an JSON calendar repeat rule element.
  */
 public final class CalendarRepeatRule {
+
     private final static String TAG = CalendarRepeatRule.class.getSimpleName();
 
     public enum Frequency {
@@ -36,39 +37,39 @@ public final class CalendarRepeatRule {
         UNKNOWN
     }
 
-    private Frequency mFrequency;
-    private Integer mInterval = 1;
-    private DateWrapper mExpires;
-    private DateWrapper[] mExceptionDates;
-    private Short[] mDaysInWeek;
-    private Short[] mDaysInMonth;
-    private Short[] mDaysInYear;
-    private Short[] mWeeksInMonth;
-    private Short[] mMonthsInYear;
+    private Frequency frequency;
+    private Integer interval = 1;
+    private DateWrapper expires;
+    private DateWrapper[] exceptionDates;
+    private Short[] daysInWeek;
+    private Short[] daysInMonth;
+    private Short[] daysInYear;
+    private Short[] weeksInMonth;
+    private Short[] monthsInYear;
 
     public Frequency getFrequency() {
-        return mFrequency;
+        return frequency;
     }
 
     public void setFrequency(Frequency frequency) {
-        mFrequency = frequency;
+        this.frequency = frequency;
     }
 
     public Integer getInterval() {
-        return mInterval;
+        return interval;
     }
 
     public void setInterval(Integer interval) {
-        mInterval = interval;
+        this.interval = interval;
     }
 
     public DateWrapper getExpires() {
-        return mExpires;
+        return expires;
     }
 
     public void setExpires(String expires) {
         try {
-            mExpires = new DateWrapper(expires);
+            this.expires = new DateWrapper(expires);
         }
         catch (ParseException e) {
             LogUtil.error(TAG, "Failed to parse expires date:" + e.getMessage());
@@ -76,20 +77,20 @@ public final class CalendarRepeatRule {
     }
 
     public DateWrapper[] getExceptionDates() {
-        return mExceptionDates;
+        return exceptionDates;
     }
 
     public void setExceptionDates(String[] exceptionDates) {
         if (exceptionDates != null) {
-            mExceptionDates = new DateWrapper[exceptionDates.length];
+            this.exceptionDates = new DateWrapper[exceptionDates.length];
             int ind = 0;
             for (String dateTimeString : exceptionDates) {
                 try {
-                    mExceptionDates[ind] = new DateWrapper(dateTimeString);
+                    this.exceptionDates[ind] = new DateWrapper(dateTimeString);
                 }
                 catch (ParseException e) {
                     // Date can't be parsed
-                    mExceptionDates[ind] = null;
+                    this.exceptionDates[ind] = null;
 
                     LogUtil.error(TAG, "Failed to parse exception date:" + e.getMessage());
                 }
@@ -99,43 +100,43 @@ public final class CalendarRepeatRule {
     }
 
     public Short[] getDaysInWeek() {
-        return mDaysInWeek;
+        return daysInWeek;
     }
 
     public void setDaysInWeek(Short[] daysInWeek) {
-        mDaysInWeek = daysInWeek;
+        this.daysInWeek = daysInWeek;
     }
 
     public Short[] getDaysInMonth() {
-        return mDaysInMonth;
+        return daysInMonth;
     }
 
     public void setDaysInMonth(Short[] daysInMonth) {
-        mDaysInMonth = daysInMonth;
+        this.daysInMonth = daysInMonth;
     }
 
     public Short[] getDaysInYear() {
-        return mDaysInYear;
+        return daysInYear;
     }
 
     public void setDaysInYear(Short[] daysInYear) {
-        mDaysInYear = daysInYear;
+        this.daysInYear = daysInYear;
     }
 
     public Short[] getWeeksInMonth() {
-        return mWeeksInMonth;
+        return weeksInMonth;
     }
 
     public void setWeeksInMonth(Short[] weeksInMonth) {
-        mWeeksInMonth = weeksInMonth;
+        this.weeksInMonth = weeksInMonth;
     }
 
     public Short[] getMonthsInYear() {
-        return mMonthsInYear;
+        return monthsInYear;
     }
 
     public void setMonthsInYear(Short[] monthsInYear) {
-        mMonthsInYear = monthsInYear;
+        this.monthsInYear = monthsInYear;
     }
 
     public CalendarRepeatRule(JSONObject params) {

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/calendar/DateWrapper.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/calendar/DateWrapper.java
@@ -40,35 +40,35 @@ public class DateWrapper {
     private static final String TIME_PATTERN8 = "HH:mm:ssZZZ";
     private static final String TIME_PATTERN9 = "HH:mmZZZ";
 
-    private Date mDate;
-    private String mTimeZone;
-    private boolean mIsEmpty;
+    private Date date;
+    private String timeZone;
+    private boolean isEmpty;
 
     public boolean isEmpty() {
-        return mIsEmpty;
+        return isEmpty;
     }
 
     public Date getDate() {
-        return mDate;
+        return date;
     }
 
     public void setDate(Date date) {
-        mDate = date;
+        this.date = date;
     }
 
     public String getTimeZone() {
-        return mTimeZone;
+        return timeZone;
     }
 
     public void setTimeZone(String timeZone) {
         if (timeZone != null && !timeZone.startsWith("GMT")) {
             timeZone = "GMT" + timeZone;
         }
-        mTimeZone = timeZone;
+        this.timeZone = timeZone;
     }
 
     public long getTime() {
-        return mDate != null ? mDate.getTime() : 0;
+        return date != null ? date.getTime() : 0;
     }
 
     private static SimpleDateFormat tryPattern(String datetime, String pattern) {
@@ -100,7 +100,7 @@ public class DateWrapper {
             }
             else {
                 SimpleDateFormat dateTimeFormat = new SimpleDateFormat(DATE_PATTERN);
-                mDate = dateTimeFormat.parse(dateTimeString);
+                this.date = dateTimeFormat.parse(dateTimeString);
             }
 
             if (date != null && time != null && sep != null) {
@@ -108,7 +108,7 @@ public class DateWrapper {
             }
         }
         else {
-            mIsEmpty = true;
+            isEmpty = true;
         }
     }
 
@@ -156,7 +156,7 @@ public class DateWrapper {
             }
 
             SimpleDateFormat dateTimeFormat = new SimpleDateFormat(dateTimePattern);
-            mDate = dateTimeFormat.parse(dateTimeString);
+            date = dateTimeFormat.parse(dateTimeString);
         }
     }
 
@@ -171,11 +171,11 @@ public class DateWrapper {
 
         DateWrapper dateWrapper = (DateWrapper) o;
 
-        return mDate != null ? mDate.equals(dateWrapper.mDate) : dateWrapper.mDate == null;
+        return date != null ? date.equals(dateWrapper.date) : dateWrapper.date == null;
     }
 
     @Override
     public int hashCode() {
-        return mDate != null ? mDate.hashCode() : 0;
+        return date != null ? date.hashCode() : 0;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/deviceData/managers/DeviceInfoImpl.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/deviceData/managers/DeviceInfoImpl.java
@@ -49,11 +49,11 @@ import static android.content.pm.ActivityInfo.*;
 public class DeviceInfoImpl extends BaseManager implements DeviceInfoManager {
 
     private String TAG = DeviceInfoImpl.class.getSimpleName();
-    private TelephonyManager mTelephonyManager;
-    private WindowManager mWindowManager;
-    private PowerManager mPowerManager;
-    private KeyguardManager mKeyguardManager;
-    private PackageManager mPackageManager;
+    private TelephonyManager telephonyManager;
+    private WindowManager windowManager;
+    private PowerManager powerManager;
+    private KeyguardManager keyguardManager;
+    private PackageManager packageManager;
 
     /**
      * @see DeviceInfoManager
@@ -62,11 +62,11 @@ public class DeviceInfoImpl extends BaseManager implements DeviceInfoManager {
     public void init(Context context) {
         super.init(context);
         if (super.isInit() && getContext() != null) {
-            mTelephonyManager = (TelephonyManager) getContext().getSystemService(Context.TELEPHONY_SERVICE);
-            mWindowManager = (WindowManager) getContext().getSystemService(Context.WINDOW_SERVICE);
-            mPowerManager = (PowerManager) getContext().getSystemService(Context.POWER_SERVICE);
-            mKeyguardManager = (KeyguardManager) getContext().getSystemService(Context.KEYGUARD_SERVICE);
-            mPackageManager = getContext().getPackageManager();
+            telephonyManager = (TelephonyManager) getContext().getSystemService(Context.TELEPHONY_SERVICE);
+            windowManager = (WindowManager) getContext().getSystemService(Context.WINDOW_SERVICE);
+            powerManager = (PowerManager) getContext().getSystemService(Context.POWER_SERVICE);
+            keyguardManager = (KeyguardManager) getContext().getSystemService(Context.KEYGUARD_SERVICE);
+            packageManager = getContext().getPackageManager();
 
             hasTelephony();
         }
@@ -74,15 +74,15 @@ public class DeviceInfoImpl extends BaseManager implements DeviceInfoManager {
 
     @Override
     public boolean hasTelephony() {
-        if (mTelephonyManager == null) {
+        if (telephonyManager == null) {
             return false;
         }
 
-        if (mPackageManager == null) {
+        if (packageManager == null) {
             return false;
         }
 
-        return mPackageManager.hasSystemFeature(PackageManager.FEATURE_TELEPHONY);
+        return packageManager.hasSystemFeature(PackageManager.FEATURE_TELEPHONY);
     }
 
     /**
@@ -91,9 +91,9 @@ public class DeviceInfoImpl extends BaseManager implements DeviceInfoManager {
     @Override
     public String getMccMnc() {
         String operatorISO;
-        if (isInit() && mTelephonyManager != null) {
+        if (isInit() && telephonyManager != null) {
             //This API does not need permission check for PHONE_STATE.
-            operatorISO = mTelephonyManager.getNetworkOperator();
+            operatorISO = telephonyManager.getNetworkOperator();
 
             String MCC;
             String MNC;
@@ -109,9 +109,9 @@ public class DeviceInfoImpl extends BaseManager implements DeviceInfoManager {
     @Override
     public String getCarrier() {
         String networkOperatorName = null;
-        if (isInit() && mTelephonyManager != null) {
+        if (isInit() && telephonyManager != null) {
             //This API does not need permission check for PHONE_STATE.
-            networkOperatorName = mTelephonyManager.getNetworkOperatorName();
+            networkOperatorName = telephonyManager.getNetworkOperatorName();
         }
         return networkOperatorName;
     }
@@ -150,10 +150,10 @@ public class DeviceInfoImpl extends BaseManager implements DeviceInfoManager {
     public void dispose() {
         super.dispose();
 
-        mTelephonyManager = null;
-        mKeyguardManager = null;
-        mPowerManager = null;
-        mWindowManager = null;
+        telephonyManager = null;
+        keyguardManager = null;
+        powerManager = null;
+        windowManager = null;
     }
 
     /**
@@ -161,7 +161,7 @@ public class DeviceInfoImpl extends BaseManager implements DeviceInfoManager {
      */
     @Override
     public int getScreenWidth() {
-        return Utils.getScreenWidth(mWindowManager);
+        return Utils.getScreenWidth(windowManager);
     }
 
     /**
@@ -169,7 +169,7 @@ public class DeviceInfoImpl extends BaseManager implements DeviceInfoManager {
      */
     @Override
     public int getScreenHeight() {
-        return Utils.getScreenHeight(mWindowManager);
+        return Utils.getScreenHeight(windowManager);
     }
 
     /**
@@ -177,8 +177,8 @@ public class DeviceInfoImpl extends BaseManager implements DeviceInfoManager {
      */
     @Override
     public boolean isScreenOn() {
-        if (mPowerManager != null) {
-            return mPowerManager.isScreenOn();
+        if (powerManager != null) {
+            return powerManager.isScreenOn();
         }
         return false;
     }
@@ -188,8 +188,8 @@ public class DeviceInfoImpl extends BaseManager implements DeviceInfoManager {
      */
     @Override
     public boolean isScreenLocked() {
-        if (mKeyguardManager != null) {
-            return mKeyguardManager.inKeyguardRestrictedInputMode();
+        if (keyguardManager != null) {
+            return keyguardManager.inKeyguardRestrictedInputMode();
         }
         return false;
     }
@@ -284,7 +284,7 @@ public class DeviceInfoImpl extends BaseManager implements DeviceInfoManager {
 
     @Override
     public boolean hasGps() {
-        return mPackageManager.hasSystemFeature(PackageManager.FEATURE_LOCATION_GPS);
+        return packageManager.hasSystemFeature(PackageManager.FEATURE_LOCATION_GPS);
     }
 
     @VisibleForTesting

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/deviceData/managers/LastKnownLocationInfoManager.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/deviceData/managers/LastKnownLocationInfoManager.java
@@ -29,8 +29,8 @@ import static android.content.pm.PackageManager.PERMISSION_GRANTED;
 public final class LastKnownLocationInfoManager extends BaseManager implements LocationInfoManager {
 
     private static String TAG = LastKnownLocationInfoManager.class.getSimpleName();
-    private android.location.LocationManager mLocManager;
-    private Location mLocation;
+    private android.location.LocationManager locManager;
+    private Location location;
 
     private static final int TWO_MINUTES = 1000 * 60 * 2;
 
@@ -51,22 +51,21 @@ public final class LastKnownLocationInfoManager extends BaseManager implements L
         Location gpsLastKnownLocation = null;
         Location ntwLastKnownLocation = null;
         if (super.isInit() && getContext() != null) {
-            mLocManager = (android.location.LocationManager) getContext().getSystemService(Context.LOCATION_SERVICE);
+            locManager = (android.location.LocationManager) getContext().getSystemService(Context.LOCATION_SERVICE);
 
-            if (isLocationPermissionGranted() && mLocManager != null) {
-                gpsLastKnownLocation = mLocManager.getLastKnownLocation(android.location.LocationManager.GPS_PROVIDER);
-                ntwLastKnownLocation = mLocManager.getLastKnownLocation(android.location.LocationManager.NETWORK_PROVIDER);
+            if (isLocationPermissionGranted() && locManager != null) {
+                gpsLastKnownLocation = locManager.getLastKnownLocation(android.location.LocationManager.GPS_PROVIDER);
+                ntwLastKnownLocation = locManager.getLastKnownLocation(android.location.LocationManager.NETWORK_PROVIDER);
             }
 
             if (gpsLastKnownLocation != null) {
-                mLocation = gpsLastKnownLocation;
+                location = gpsLastKnownLocation;
 
-                if (ntwLastKnownLocation != null && isBetterLocation(ntwLastKnownLocation, mLocation)) {
-                    mLocation = ntwLastKnownLocation;
+                if (ntwLastKnownLocation != null && isBetterLocation(ntwLastKnownLocation, location)) {
+                    location = ntwLastKnownLocation;
                 }
-            }
-            else if (ntwLastKnownLocation != null) {
-                mLocation = ntwLastKnownLocation;
+            } else if (ntwLastKnownLocation != null) {
+                location = ntwLastKnownLocation;
             }
         }
     }
@@ -142,7 +141,7 @@ public final class LastKnownLocationInfoManager extends BaseManager implements L
      */
     @Override
     public Double getLatitude() {
-        return mLocation != null ? mLocation.getLatitude() : null;
+        return location != null ? location.getLatitude() : null;
     }
 
     /**
@@ -150,22 +149,22 @@ public final class LastKnownLocationInfoManager extends BaseManager implements L
      */
     @Override
     public Double getLongitude() {
-        return mLocation != null ? mLocation.getLongitude() : null;
+        return location != null ? location.getLongitude() : null;
     }
 
     @Override
     public Float getAccuracy() {
-        return mLocation != null ? mLocation.getAccuracy() : null;
+        return location != null ? location.getAccuracy() : null;
     }
 
     @Override
     public Long getElapsedSeconds() {
-        return mLocation != null ? (System.currentTimeMillis() - mLocation.getTime()) / 1000 : null;
+        return location != null ? (System.currentTimeMillis() - location.getTime()) / 1000 : null;
     }
 
     @Override
     public boolean isLocationAvailable() {
-        return mLocation != null;
+        return location != null;
     }
 
     /**
@@ -175,8 +174,8 @@ public final class LastKnownLocationInfoManager extends BaseManager implements L
     @Override
     public void dispose() {
         super.dispose();
-        mLocManager = null;
-        mLocation = null;
+        locManager = null;
+        location = null;
     }
 
     private boolean isLocationPermissionGranted() {

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/deviceData/managers/NetworkConnectionInfoManager.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/deviceData/managers/NetworkConnectionInfoManager.java
@@ -26,7 +26,7 @@ import org.prebid.mobile.rendering.networking.parameters.UserParameters;
 import org.prebid.mobile.rendering.sdk.BaseManager;
 
 public final class NetworkConnectionInfoManager extends BaseManager implements ConnectionInfoManager {
-    private ConnectivityManager mConnectivityManager;
+    private ConnectivityManager connectivityManager;
 
     /**
      * @see ConnectionInfoManager
@@ -35,7 +35,8 @@ public final class NetworkConnectionInfoManager extends BaseManager implements C
     public void init(Context context) {
         super.init(context);
         if (super.isInit() && getContext() != null) {
-            mConnectivityManager = (ConnectivityManager) getContext().getApplicationContext().getSystemService(Context.CONNECTIVITY_SERVICE);
+            connectivityManager = (ConnectivityManager) getContext().getApplicationContext()
+                                                                    .getSystemService(Context.CONNECTIVITY_SERVICE);
         }
     }
 
@@ -48,17 +49,16 @@ public final class NetworkConnectionInfoManager extends BaseManager implements C
         NetworkInfo info = null;
         UserParameters.ConnectionType result = UserParameters.ConnectionType.OFFLINE;
         if (isInit() && getContext() != null) {
-            if (mConnectivityManager != null) {
+            if (connectivityManager != null) {
                 if (getContext().checkCallingOrSelfPermission(Manifest.permission.ACCESS_NETWORK_STATE) == PackageManager.PERMISSION_GRANTED) {
-                    info = mConnectivityManager.getActiveNetworkInfo();
+                    info = connectivityManager.getActiveNetworkInfo();
                 }
             }
             if (info != null) {
                 int netType = info.getType();
                 if (info.isConnected()) {
                     boolean isMobile = netType == ConnectivityManager.TYPE_MOBILE || netType == ConnectivityManager.TYPE_MOBILE_DUN || netType == ConnectivityManager.TYPE_MOBILE_HIPRI || netType == ConnectivityManager.TYPE_MOBILE_MMS || netType == ConnectivityManager.TYPE_MOBILE_SUPL;
-                    result = isMobile
-                             ? UserParameters.ConnectionType.CELL
+                    result = isMobile ? UserParameters.ConnectionType.CELL
                              : UserParameters.ConnectionType.WIFI;
                 }
             }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/deviceData/managers/UserConsentManager.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/deviceData/managers/UserConsentManager.java
@@ -41,33 +41,33 @@ public class UserConsentManager extends BaseManager {
     // CCPA
     private static final String US_PRIVACY_STRING = "IABUSPrivacy_String";
 
-    private String mUsPrivacyString;
+    private String usPrivacyString;
 
-    private String mIsSubjectToGdpr = "";
-    private String mConsentString;
-    private String mPurposeConsent;
+    private String isSubjectToGdpr = "";
+    private String consentString;
+    private String purposeConsent;
 
-    private String mTcfV2ConsentString;
-    private int mTcfV2GdprApplies = NOT_ASSIGNED;
+    private String tcfV2ConsentString;
+    private int tcfV2GdprApplies = NOT_ASSIGNED;
     /**
      * The unsigned integer ID of CMP SDK. Less than 0 values should be considered invalid.
      */
-    private int mCmpSdkId = NOT_ASSIGNED;
+    private int cmpSdkId = NOT_ASSIGNED;
 
-    private SharedPreferences mSharedPreferences;
-    private SharedPreferences.OnSharedPreferenceChangeListener mOnSharedPreferenceChangeListener;
+    private SharedPreferences sharedPreferences;
+    private SharedPreferences.OnSharedPreferenceChangeListener onSharedPreferenceChangeListener;
 
     @Override
     public void init(Context context) {
         super.init(context);
 
         if (super.isInit() && context != null) {
-            mSharedPreferences = PreferenceManager.getDefaultSharedPreferences(getContext());
-            initConsentValuesAtStart(mSharedPreferences);
+            sharedPreferences = PreferenceManager.getDefaultSharedPreferences(getContext());
+            initConsentValuesAtStart(sharedPreferences);
 
-            mOnSharedPreferenceChangeListener = this::getConsentValues;
+            onSharedPreferenceChangeListener = this::getConsentValues;
 
-            mSharedPreferences.registerOnSharedPreferenceChangeListener(mOnSharedPreferenceChangeListener);
+            sharedPreferences.registerOnSharedPreferenceChangeListener(onSharedPreferenceChangeListener);
         }
     }
 
@@ -84,19 +84,19 @@ public class UserConsentManager extends BaseManager {
     private Object getConsentValues(SharedPreferences preferences, String key) {
         switch (key) {
             case SUBJECT_TO_GDPR:
-                return mIsSubjectToGdpr = preferences.getString(SUBJECT_TO_GDPR, null);
+                return isSubjectToGdpr = preferences.getString(SUBJECT_TO_GDPR, null);
             case CONSENT_STRING:
-                return mConsentString = preferences.getString(CONSENT_STRING, null);
+                return consentString = preferences.getString(CONSENT_STRING, null);
             case CMP_SDK_ID:
-                return mCmpSdkId = preferences.getInt(CMP_SDK_ID, NOT_ASSIGNED);
+                return cmpSdkId = preferences.getInt(CMP_SDK_ID, NOT_ASSIGNED);
             case GDPR_APPLIES:
-                return mTcfV2GdprApplies = preferences.getInt(GDPR_APPLIES, NOT_ASSIGNED);
+                return tcfV2GdprApplies = preferences.getInt(GDPR_APPLIES, NOT_ASSIGNED);
             case TRANSPARENCY_CONSENT_STRING:
-                return mTcfV2ConsentString = preferences.getString(TRANSPARENCY_CONSENT_STRING, null);
+                return tcfV2ConsentString = preferences.getString(TRANSPARENCY_CONSENT_STRING, null);
             case US_PRIVACY_STRING:
-                return mUsPrivacyString = preferences.getString(US_PRIVACY_STRING, null);
+                return usPrivacyString = preferences.getString(US_PRIVACY_STRING, null);
             case PURPOSE_CONSENT:
-                return mPurposeConsent = preferences.getString(PURPOSE_CONSENT, null);
+                return purposeConsent = preferences.getString(PURPOSE_CONSENT, null);
         }
 
         return null;
@@ -107,19 +107,19 @@ public class UserConsentManager extends BaseManager {
             return getTcfV2GdprApplies();
         }
 
-        return mIsSubjectToGdpr;
+        return isSubjectToGdpr;
     }
 
     public String getUserConsentString() {
         if (shouldUseTcfV2()) {
-            return mTcfV2ConsentString;
+            return tcfV2ConsentString;
         }
 
-        return mConsentString;
+        return consentString;
     }
 
     public String getUsPrivacyString() {
-        return mUsPrivacyString;
+        return usPrivacyString;
     }
 
     //fetch advertising identifier based TCF 2.0 Purpose1 value
@@ -154,24 +154,24 @@ public class UserConsentManager extends BaseManager {
 
     @Nullable
     Boolean getPurposeConsent(int consentIndex) {
-        boolean isConsentStringInvalid = TextUtils.isEmpty(mPurposeConsent) || mPurposeConsent.length() <= consentIndex;
-        return isConsentStringInvalid ? null : mPurposeConsent.charAt(consentIndex) == '1';
+        boolean isConsentStringInvalid = TextUtils.isEmpty(purposeConsent) || purposeConsent.length() <= consentIndex;
+        return isConsentStringInvalid ? null : purposeConsent.charAt(consentIndex) == '1';
     }
 
     /**
-     * @return true if {@link #mCmpSdkId} is grater or equal than 0, false otherwise.
+     * @return true if {@link #cmpSdkId} is grater or equal than 0, false otherwise.
      */
     @VisibleForTesting
     boolean shouldUseTcfV2() {
-        return mCmpSdkId >= 0;
+        return cmpSdkId >= 0;
     }
 
     @VisibleForTesting
     String getTcfV2GdprApplies() {
-        if (mTcfV2GdprApplies == NOT_ASSIGNED) {
+        if (tcfV2GdprApplies == NOT_ASSIGNED) {
             return null;
         }
 
-        return String.valueOf(mTcfV2GdprApplies);
+        return String.valueOf(tcfV2GdprApplies);
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/broadcast/MraidOrientationBroadcastReceiver.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/broadcast/MraidOrientationBroadcastReceiver.java
@@ -24,21 +24,22 @@ import org.prebid.mobile.rendering.views.webview.mraid.JSInterface;
 import java.lang.ref.WeakReference;
 
 public class MraidOrientationBroadcastReceiver extends OrientationBroadcastReceiver {
+
     private static final String TAG = MraidOrientationBroadcastReceiver.class.getSimpleName();
 
-    private final WeakReference<BaseJSInterface> mBaseJSInterfaceWeakReference;
+    private final WeakReference<BaseJSInterface> baseJSInterfaceWeakReference;
 
-    private String mMraidAction;
-    private String mState;
+    private String mraidAction;
+    private String state;
 
     public MraidOrientationBroadcastReceiver(BaseJSInterface baseJSInterface) {
-        mBaseJSInterfaceWeakReference = new WeakReference<>(baseJSInterface);
+        baseJSInterfaceWeakReference = new WeakReference<>(baseJSInterface);
     }
 
     @Override
     public void handleOrientationChange(int currentRotation) {
         super.handleOrientationChange(currentRotation);
-        BaseJSInterface baseJSInterface = mBaseJSInterfaceWeakReference.get();
+        BaseJSInterface baseJSInterface = baseJSInterfaceWeakReference.get();
         if (baseJSInterface == null) {
             LogUtil.debug(TAG, "handleOrientationChange failure. BaseJsInterface is null");
             return;
@@ -51,17 +52,15 @@ public class MraidOrientationBroadcastReceiver extends OrientationBroadcastRecei
     }
 
     public void setState(String state) {
-        mState = state;
+        this.state = state;
     }
 
     public void setMraidAction(String action) {
-        mMraidAction = action;
+        mraidAction = action;
     }
 
     private boolean shouldHandleClose() {
-        return mState != null
-               && !JSInterface.STATE_DEFAULT.equals(mState)
-               && Build.VERSION.SDK_INT == Build.VERSION_CODES.KITKAT
-               && JSInterface.ACTION_RESIZE.equals(mMraidAction);
+        return state != null && !JSInterface.STATE_DEFAULT.equals(state) && Build.VERSION.SDK_INT == Build.VERSION_CODES.KITKAT && JSInterface.ACTION_RESIZE.equals(
+                mraidAction);
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/broadcast/OrientationBroadcastReceiver.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/broadcast/OrientationBroadcastReceiver.java
@@ -27,10 +27,10 @@ public class OrientationBroadcastReceiver extends BroadcastReceiver {
 
     private static final String TAG = OrientationBroadcastReceiver.class.getSimpleName();
 
-    private Context mApplicationContext;
+    private Context applicationContext;
 
     // -1 until this gets set at least once
-    private int mLastRotation = -1;
+    private int lastRotation = -1;
     private boolean orientationChanged;
 
     @Override
@@ -38,10 +38,10 @@ public class OrientationBroadcastReceiver extends BroadcastReceiver {
         LogUtil.debug(TAG, "onReceive");
         if (Intent.ACTION_CONFIGURATION_CHANGED.equals(intent.getAction())) {
             int orientation = getDisplayRotation();
-            if (orientation != mLastRotation) {
-                mLastRotation = orientation;
+            if (orientation != lastRotation) {
+                lastRotation = orientation;
                 setOrientationChanged(true);
-                handleOrientationChange(mLastRotation);
+                handleOrientationChange(lastRotation);
             } else {
                 setOrientationChanged(false);
             }
@@ -63,26 +63,25 @@ public class OrientationBroadcastReceiver extends BroadcastReceiver {
     }
 
     private int getDisplayRotation() {
-        WindowManager wm = (WindowManager) mApplicationContext.getSystemService(Context.WINDOW_SERVICE);
+        WindowManager wm = (WindowManager) applicationContext.getSystemService(Context.WINDOW_SERVICE);
         return wm.getDefaultDisplay().getRotation();
     }
 
     public void register(final Context context) {
         if (context != null) {
             LogUtil.debug(TAG, "register");
-            mApplicationContext = context.getApplicationContext();
-            if (mApplicationContext != null) {
-                mApplicationContext.registerReceiver(this,
-                                                         new IntentFilter(Intent.ACTION_CONFIGURATION_CHANGED));
+            applicationContext = context.getApplicationContext();
+            if (applicationContext != null) {
+                applicationContext.registerReceiver(this, new IntentFilter(Intent.ACTION_CONFIGURATION_CHANGED));
             }
         }
     }
 
     public void unregister() {
-        if (mApplicationContext != null) {
+        if (applicationContext != null) {
             LogUtil.debug(TAG, "unregister");
-            mApplicationContext.unregisterReceiver(this);
-            mApplicationContext = null;
+            applicationContext.unregisterReceiver(this);
+            applicationContext = null;
         }
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/broadcast/ScreenStateReceiver.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/broadcast/ScreenStateReceiver.java
@@ -25,9 +25,9 @@ import org.prebid.mobile.LogUtil;
 public class ScreenStateReceiver extends BroadcastReceiver {
     private static final String TAG = ScreenStateReceiver.class.getSimpleName();
 
-    private Context mApplicationContext;
+    private Context applicationContext;
 
-    private boolean mIsScreenOn = true;
+    private boolean isScreenOn = true;
 
     @Override
     public void onReceive(final Context context, final Intent intent) {
@@ -38,15 +38,15 @@ public class ScreenStateReceiver extends BroadcastReceiver {
         final String action = intent.getAction();
 
         if (Intent.ACTION_USER_PRESENT.equals(action)) {
-            mIsScreenOn = true;
+            isScreenOn = true;
         }
         else if (Intent.ACTION_SCREEN_OFF.equals(action)) {
-            mIsScreenOn = false;
+            isScreenOn = false;
         }
     }
 
     public boolean isScreenOn() {
-        return mIsScreenOn;
+        return isScreenOn;
     }
 
     public void register(final Context context) {
@@ -58,17 +58,17 @@ public class ScreenStateReceiver extends BroadcastReceiver {
         final IntentFilter filter = new IntentFilter(Intent.ACTION_SCREEN_OFF);
         filter.addAction(Intent.ACTION_USER_PRESENT);
 
-        mApplicationContext = context.getApplicationContext();
-        mApplicationContext.registerReceiver(this, filter);
+        applicationContext = context.getApplicationContext();
+        applicationContext.registerReceiver(this, filter);
     }
 
     public void unregister() {
-        if (mApplicationContext == null) {
+        if (applicationContext == null) {
             LogUtil.debug(TAG, "unregister: Failed. Context is null");
             return;
         }
 
-        mApplicationContext.unregisterReceiver(this);
-        mApplicationContext = null;
+        applicationContext.unregisterReceiver(this);
+        applicationContext = null;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/broadcast/local/BaseLocalBroadcastReceiver.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/broadcast/local/BaseLocalBroadcastReceiver.java
@@ -27,12 +27,11 @@ import androidx.localbroadcastmanager.content.LocalBroadcastManager;
 public abstract class BaseLocalBroadcastReceiver extends BroadcastReceiver {
     private static final String BROADCAST_IDENTIFIER_KEY = "BROADCAST_IDENTIFIER_KEY";
 
-    private final long mBroadcastId;
-    @Nullable
-    private Context mApplicationContext;
+    private final long broadcastId;
+    @Nullable private Context applicationContext;
 
     public BaseLocalBroadcastReceiver(long broadcastId) {
-        mBroadcastId = broadcastId;
+        this.broadcastId = broadcastId;
     }
 
     public static void sendLocalBroadcast(
@@ -53,16 +52,15 @@ public abstract class BaseLocalBroadcastReceiver extends BroadcastReceiver {
         final Context context,
         @NonNull
         final BroadcastReceiver broadcastReceiver) {
-        mApplicationContext = context.getApplicationContext();
-        LocalBroadcastManager.getInstance(mApplicationContext).registerReceiver(broadcastReceiver,
-                                                                                getIntentFilter());
+        applicationContext = context.getApplicationContext();
+        LocalBroadcastManager.getInstance(applicationContext).registerReceiver(broadcastReceiver, getIntentFilter());
     }
 
     public void unregister(final @Nullable
                                BroadcastReceiver broadcastReceiver) {
-        if (mApplicationContext != null && broadcastReceiver != null) {
-            LocalBroadcastManager.getInstance(mApplicationContext).unregisterReceiver(broadcastReceiver);
-            mApplicationContext = null;
+        if (applicationContext != null && broadcastReceiver != null) {
+            LocalBroadcastManager.getInstance(applicationContext).unregisterReceiver(broadcastReceiver);
+            applicationContext = null;
         }
     }
 
@@ -76,6 +74,6 @@ public abstract class BaseLocalBroadcastReceiver extends BroadcastReceiver {
         @NonNull
         final Intent intent) {
         final long receivedIdentifier = intent.getLongExtra(BROADCAST_IDENTIFIER_KEY, -1);
-        return mBroadcastId == receivedIdentifier;
+        return broadcastId == receivedIdentifier;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/broadcast/local/EventForwardingLocalBroadcastReceiver.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/broadcast/local/EventForwardingLocalBroadcastReceiver.java
@@ -24,14 +24,13 @@ import org.prebid.mobile.rendering.utils.constants.IntentActions;
 
 public class EventForwardingLocalBroadcastReceiver extends BaseLocalBroadcastReceiver {
 
-    @NonNull
-    private final EventForwardingBroadcastListener mListener;
+    @NonNull private final EventForwardingBroadcastListener listener;
 
     public EventForwardingLocalBroadcastReceiver(long broadcastId,
                                                  @NonNull
                                                      EventForwardingBroadcastListener listener) {
         super(broadcastId);
-        mListener = listener;
+        this.listener = listener;
     }
 
     @Override
@@ -41,7 +40,7 @@ public class EventForwardingLocalBroadcastReceiver extends BaseLocalBroadcastRec
         }
 
         final String action = intent.getAction();
-        mListener.onEvent(action);
+        listener.onEvent(action);
     }
 
     @NonNull

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/device/DeviceVolumeObserver.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/device/DeviceVolumeObserver.java
@@ -28,20 +28,22 @@ import static android.provider.Settings.System.CONTENT_URI;
 
 public class DeviceVolumeObserver extends ContentObserver {
 
-    private final Context mApplicationContext;
-    private final AudioManager mAudioManager;
-    private final DeviceVolumeListener mDeviceVolumeListener;
+    private final Context applicationContext;
+    private final AudioManager audioManager;
+    private final DeviceVolumeListener deviceVolumeListener;
 
-    private Float mStoredDeviceVolume;
+    private Float storedDeviceVolume;
 
-    public DeviceVolumeObserver(final Context applicationContext,
-                                final Handler handler,
-                                final DeviceVolumeListener deviceVolumeListener) {
+    public DeviceVolumeObserver(
+            final Context applicationContext,
+            final Handler handler,
+            final DeviceVolumeListener deviceVolumeListener
+    ) {
         super(handler);
 
-        mApplicationContext = applicationContext;
-        mAudioManager = (AudioManager) applicationContext.getSystemService(AUDIO_SERVICE);
-        mDeviceVolumeListener = deviceVolumeListener;
+        this.applicationContext = applicationContext;
+        audioManager = (AudioManager) applicationContext.getSystemService(AUDIO_SERVICE);
+        this.deviceVolumeListener = deviceVolumeListener;
     }
 
     @Override
@@ -50,20 +52,20 @@ public class DeviceVolumeObserver extends ContentObserver {
 
         final Float currentDeviceVolume = getDeviceVolume();
         if (hasDeviceVolumeChanged(currentDeviceVolume)) {
-            mStoredDeviceVolume = currentDeviceVolume;
+            storedDeviceVolume = currentDeviceVolume;
             notifyDeviceVolumeListener();
         }
     }
 
     public void start() {
-        mStoredDeviceVolume = getDeviceVolume();
+        storedDeviceVolume = getDeviceVolume();
         notifyDeviceVolumeListener();
 
-        mApplicationContext.getContentResolver().registerContentObserver(CONTENT_URI, true, this);
+        applicationContext.getContentResolver().registerContentObserver(CONTENT_URI, true, this);
     }
 
     public void stop() {
-        mApplicationContext.getContentResolver().unregisterContentObserver(this);
+        applicationContext.getContentResolver().unregisterContentObserver(this);
     }
 
     @VisibleForTesting
@@ -81,17 +83,17 @@ public class DeviceVolumeObserver extends ContentObserver {
     }
 
     private Float getDeviceVolume() {
-        final int deviceVolume = mAudioManager.getStreamVolume(STREAM_MUSIC);
-        final int maxVolume = mAudioManager.getStreamMaxVolume(STREAM_MUSIC);
+        final int deviceVolume = audioManager.getStreamVolume(STREAM_MUSIC);
+        final int maxVolume = audioManager.getStreamMaxVolume(STREAM_MUSIC);
         return convertDeviceVolume(deviceVolume, maxVolume);
     }
 
     private boolean hasDeviceVolumeChanged(final Float currentDeviceVolume) {
-        return currentDeviceVolume == null || !currentDeviceVolume.equals(mStoredDeviceVolume);
+        return currentDeviceVolume == null || !currentDeviceVolume.equals(storedDeviceVolume);
     }
 
     private void notifyDeviceVolumeListener() {
-        mDeviceVolumeListener.onDeviceVolumeChanged(mStoredDeviceVolume);
+        deviceVolumeListener.onDeviceVolumeChanged(storedDeviceVolume);
     }
 
     public interface DeviceVolumeListener {

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/exposure/ViewExposure.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/exposure/ViewExposure.java
@@ -22,24 +22,28 @@ import java.util.List;
 
 public class ViewExposure {
 
-    private float mExposurePercentage;
-    private Rect mVisibleRectangle;
-    private List<Rect> mOcclusionRectangleList;
+    private float exposurePercentage;
+    private Rect visibleRectangle;
+    private List<Rect> occlusionRectangleList;
 
-    public ViewExposure(float exposurePercentage, Rect visibleRectangle, List<Rect> occlusionRectangleList) {
-        mExposurePercentage = exposurePercentage;
-        mVisibleRectangle = visibleRectangle;
-        mOcclusionRectangleList = occlusionRectangleList;
+    public ViewExposure(
+            float exposurePercentage,
+            Rect visibleRectangle,
+            List<Rect> occlusionRectangleList
+    ) {
+        this.exposurePercentage = exposurePercentage;
+        this.visibleRectangle = visibleRectangle;
+        this.occlusionRectangleList = occlusionRectangleList;
     }
 
     public ViewExposure() {
-        mExposurePercentage = 0.0f;
-        mVisibleRectangle = new Rect();
-        mOcclusionRectangleList = null;
+        exposurePercentage = 0.0f;
+        visibleRectangle = new Rect();
+        occlusionRectangleList = null;
     }
 
     public float getExposurePercentage() {
-        return mExposurePercentage;
+        return exposurePercentage;
     }
 
     @Override
@@ -53,49 +57,58 @@ public class ViewExposure {
 
         ViewExposure that = (ViewExposure) o;
 
-        if (Float.compare(that.mExposurePercentage, mExposurePercentage) != 0) {
+        if (Float.compare(that.exposurePercentage, exposurePercentage) != 0) {
             return false;
         }
-        if (mVisibleRectangle != null
-            ? !mVisibleRectangle.equals(that.mVisibleRectangle)
-            : that.mVisibleRectangle != null) {
+        if (visibleRectangle != null ? !visibleRectangle.equals(that.visibleRectangle) : that.visibleRectangle != null) {
             return false;
         }
-        return mOcclusionRectangleList != null
-               ? mOcclusionRectangleList.equals(that.mOcclusionRectangleList)
-               : that.mOcclusionRectangleList == null;
+        return occlusionRectangleList != null ? occlusionRectangleList.equals(that.occlusionRectangleList) : that.occlusionRectangleList == null;
     }
 
     @Override
     public int hashCode() {
-        int result = (mExposurePercentage != +0.0f ? Float.floatToIntBits(mExposurePercentage) : 0);
-        result = 31 * result + (mVisibleRectangle != null ? mVisibleRectangle.hashCode() : 0);
-        result = 31 * result + (mOcclusionRectangleList != null
-                                ? mOcclusionRectangleList.hashCode()
-                                : 0);
+        int result = (exposurePercentage != +0.0f ? Float.floatToIntBits(exposurePercentage) : 0);
+        result = 31 * result + (visibleRectangle != null ? visibleRectangle.hashCode() : 0);
+        result = 31 * result + (occlusionRectangleList != null ? occlusionRectangleList.hashCode() : 0);
         return result;
     }
 
     @Override
     public String toString() {
         StringBuilder builder = new StringBuilder();
-        builder.append("{")
-               .append("\"exposedPercentage\":").append(mExposurePercentage * 100).append(",");
+        builder.append("{").append("\"exposedPercentage\":").append(exposurePercentage * 100).append(",");
         builder.append("\"visibleRectangle\":{")
-               .append("\"x\":").append(mVisibleRectangle.left).append(",")
-               .append("\"y\":").append(mVisibleRectangle.top).append(",")
-               .append("\"width\":").append(mVisibleRectangle.width()).append(",")
-               .append("\"height\":").append(mVisibleRectangle.height()).append("}");
-        if (mOcclusionRectangleList != null && !mOcclusionRectangleList.isEmpty()) {
+               .append("\"x\":")
+               .append(visibleRectangle.left)
+               .append(",")
+               .append("\"y\":")
+               .append(visibleRectangle.top)
+               .append(",")
+               .append("\"width\":")
+               .append(visibleRectangle.width())
+               .append(",")
+               .append("\"height\":")
+               .append(visibleRectangle.height())
+               .append("}");
+        if (occlusionRectangleList != null && !occlusionRectangleList.isEmpty()) {
             builder.append(", \"occlusionRectangles\":[");
-            for (int i = 0; i < mOcclusionRectangleList.size(); i++) {
-                Rect currentRect = mOcclusionRectangleList.get(i);
+            for (int i = 0; i < occlusionRectangleList.size(); i++) {
+                Rect currentRect = occlusionRectangleList.get(i);
                 builder.append("{")
-                       .append("\"x\":").append(currentRect.left).append(",")
-                       .append("\"y\":").append(currentRect.top).append(",")
-                       .append("\"width\":").append(currentRect.width()).append(",")
-                       .append("\"height\":").append(currentRect.height()).append("}");
-                if (i < mOcclusionRectangleList.size() - 1) {
+                       .append("\"x\":")
+                       .append(currentRect.left)
+                       .append(",")
+                       .append("\"y\":")
+                       .append(currentRect.top)
+                       .append(",")
+                       .append("\"width\":")
+                       .append(currentRect.width())
+                       .append(",")
+                       .append("\"height\":")
+                       .append(currentRect.height())
+                       .append("}");
+                if (i < occlusionRectangleList.size() - 1) {
                     builder.append(",");
                 }
             }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/helpers/AdIdManager.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/helpers/AdIdManager.java
@@ -94,20 +94,24 @@ public class AdIdManager {
     }
 
     private static class FetchAdIdInfoTask extends AsyncTask<Void, Void, Void> {
-        private final WeakReference<Context> mContextWeakReference;
-        private final AdIdFetchListener mAdIdFetchListener;
 
-        public FetchAdIdInfoTask(Context context, AdIdFetchListener listener) {
-            mContextWeakReference = new WeakReference<>(context);
+        private final WeakReference<Context> contextWeakReference;
+        private final AdIdFetchListener adIdFetchListener;
+
+        public FetchAdIdInfoTask(
+                Context context,
+                AdIdFetchListener listener
+        ) {
+            contextWeakReference = new WeakReference<>(context);
 
             // All listeners provided are created as local method variables; If these listeners
             // are ever moved to a class member variable, this needs to be changed to a WeakReference
-            mAdIdFetchListener = listener;
+            adIdFetchListener = listener;
         }
 
         @Override
         protected Void doInBackground(Void... voids) {
-            Context context = mContextWeakReference.get();
+            Context context = contextWeakReference.get();
 
             if (isCancelled()) {
                 return null;
@@ -130,8 +134,8 @@ public class AdIdManager {
 
         @Override
         protected void onPostExecute(Void aVoid) {
-            if (mAdIdFetchListener != null) {
-                mAdIdFetchListener.adIdFetchCompletion();
+            if (adIdFetchListener != null) {
+                adIdFetchListener.adIdFetchCompletion();
             }
         }
     }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/helpers/HandlerQueueManager.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/helpers/HandlerQueueManager.java
@@ -21,7 +21,7 @@ import android.os.Handler;
 import java.util.Hashtable;
 
 public class HandlerQueueManager {
-    private Hashtable<String, Handler> mHandlersQueue = new Hashtable<>();
+    private Hashtable<String, Handler> handlersQueue = new Hashtable<>();
 
     /**
      * Calculates handler hash and puts handler in queue.
@@ -68,10 +68,10 @@ public class HandlerQueueManager {
     }
 
     public void clearQueue() {
-        mHandlersQueue.clear();
+        handlersQueue.clear();
     }
 
     private Hashtable<String, Handler> getHandlersQueue() {
-        return mHandlersQueue;
+        return handlersQueue;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/helpers/RefreshTimerTask.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/helpers/RefreshTimerTask.java
@@ -23,29 +23,29 @@ import org.prebid.mobile.LogUtil;
 
 public class RefreshTimerTask {
     private static final String TAG = RefreshTimerTask.class.getSimpleName();
-    private Handler mRefreshHandler;
+    private Handler refreshHandler;
 
     //for unit testing only
-    private boolean mRefreshExecuted;
+    private boolean refreshExecuted;
 
-    private RefreshTriggered mRefreshTriggerListener;
+    private RefreshTriggered refreshTriggerListener;
 
-    private final Runnable mRefreshRunnable = new Runnable() {
+    private final Runnable refreshRunnable = new Runnable() {
         @Override
         public void run() {
-            if (mRefreshTriggerListener == null) {
-                LogUtil.error(TAG, "Failed to notify mRefreshTriggerListener. mRefreshTriggerListener instance is null");
+            if (refreshTriggerListener == null) {
+                LogUtil.error(TAG, "Failed to notify refreshTriggerListener. refreshTriggerListener instance is null");
                 return;
             }
 
-            mRefreshTriggerListener.handleRefresh();
-            mRefreshExecuted = true;
+            refreshTriggerListener.handleRefresh();
+            refreshExecuted = true;
         }
     };
 
     public RefreshTimerTask(RefreshTriggered refreshTriggered) {
-        mRefreshHandler = new Handler(Looper.getMainLooper());
-        mRefreshTriggerListener = refreshTriggered;
+        refreshHandler = new Handler(Looper.getMainLooper());
+        refreshTriggerListener = refreshTriggered;
     }
 
     /**
@@ -62,28 +62,28 @@ public class RefreshTimerTask {
     }
 
     public void cancelRefreshTimer() {
-        if (mRefreshHandler != null) {
-            mRefreshHandler.removeCallbacksAndMessages(null);
+        if (refreshHandler != null) {
+            refreshHandler.removeCallbacksAndMessages(null);
         }
     }
 
     public void destroy() {
         cancelRefreshTimer();
-        mRefreshHandler = null;
-        mRefreshExecuted = false;
+        refreshHandler = null;
+        refreshExecuted = false;
     }
 
     /**
      * Queue new task that should be performed in UI thread.
      */
     private void queueUIThreadTask(long interval) {
-        if (mRefreshHandler != null) {
-            mRefreshHandler.postDelayed(mRefreshRunnable, interval);
+        if (refreshHandler != null) {
+            refreshHandler.postDelayed(refreshRunnable, interval);
         }
     }
 
     @VisibleForTesting
     boolean isRefreshExecuted() {
-        return mRefreshExecuted;
+        return refreshExecuted;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/helpers/Utils.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/helpers/Utils.java
@@ -66,16 +66,9 @@ public final class Utils {
 
     public static float DENSITY;
 
-    private static final String[] mRecognizedMraidActionPrefixes = new String[]{
-        "tel:",
-        "voicemail:",
-        "sms:",
-        "mailto:",
-        "geo:",
-        "google.streetview:",
-        "market:"};
+    private static final String[] recognizedMraidActionPrefixes = new String[]{"tel:", "voicemail:", "sms:", "mailto:", "geo:", "google.streetview:", "market:"};
 
-    private static final String[] mVideoContent = new String[]{"3gp", "mp4", "ts", "webm", "mkv"};
+    private static final String[] videoContent = new String[]{"3gp", "mp4", "ts", "webm", "mkv"};
 
     private static String convertParamsToString(String url, String key, String value) {
 
@@ -106,7 +99,7 @@ public final class Utils {
 
     public static boolean isMraidActionUrl(String url) {
         if (!TextUtils.isEmpty(url)) {
-            for (String prefix : mRecognizedMraidActionPrefixes) {
+            for (String prefix : recognizedMraidActionPrefixes) {
                 if (url.startsWith(prefix)) {
                     return true;
                 }
@@ -120,7 +113,7 @@ public final class Utils {
         if (!TextUtils.isEmpty(type)) {
             String ext = MimeTypeMap.getSingleton().getExtensionFromMimeType(type);
             if (!TextUtils.isEmpty(ext)) {
-                for (String content : mVideoContent) {
+                for (String content : videoContent) {
                     if (ext.equalsIgnoreCase(content)) {
                         return true;
                     }
@@ -274,25 +267,24 @@ public final class Utils {
      * @return true if available and writeable
      */
     public static boolean isExternalStorageAvailable() {
-        boolean mExternalStorageAvailable;
-        boolean mExternalStorageWriteable;
+        boolean externalStorageAvailable;
+        boolean externalStorageWriteable;
         String state = Environment.getExternalStorageState();
         if (Environment.MEDIA_MOUNTED.equals(state)) {
             // We can read and write the media
-            mExternalStorageAvailable = mExternalStorageWriteable = true;
-        }
-        else if (Environment.MEDIA_MOUNTED_READ_ONLY.equals(state)) {
+            externalStorageAvailable = externalStorageWriteable = true;
+        } else if (Environment.MEDIA_MOUNTED_READ_ONLY.equals(state)) {
             // We can only read the media
-            mExternalStorageAvailable = true;
-            mExternalStorageWriteable = false;
+            externalStorageAvailable = true;
+            externalStorageWriteable = false;
         }
         else {
             // Something else is wrong. It may be one of many other states, but
             // all we need to know is we can neither read nor write
-            mExternalStorageAvailable = mExternalStorageWriteable = false;
+            externalStorageAvailable = externalStorageWriteable = false;
         }
 
-        return mExternalStorageAvailable && mExternalStorageWriteable;
+        return externalStorageAvailable && externalStorageWriteable;
     }
 
     private static boolean osAtLeast(int requiredVersion) {

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/helpers/VisibilityChecker.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/helpers/VisibilityChecker.java
@@ -30,30 +30,33 @@ import static org.prebid.mobile.rendering.models.ntv.NativeEventTracker.EventTyp
 import static org.prebid.mobile.rendering.models.ntv.NativeEventTracker.EventType.OMID;
 
 public class VisibilityChecker {
+
     private final String TAG = VisibilityChecker.class.getSimpleName();
 
-    private final VisibilityTrackerOption mVisibilityTrackerOption;
-    private final ViewExposureChecker mViewExposureChecker;
+    private final VisibilityTrackerOption visibilityTrackerOption;
+    private final ViewExposureChecker viewExposureChecker;
 
-    private final Rect mClipRect = new Rect();
+    private final Rect clipRect = new Rect();
 
     public VisibilityChecker(final VisibilityTrackerOption visibilityTrackerOption) {
-        mVisibilityTrackerOption = visibilityTrackerOption;
-        mViewExposureChecker = new ViewExposureChecker();
+        this.visibilityTrackerOption = visibilityTrackerOption;
+        viewExposureChecker = new ViewExposureChecker();
     }
 
-    public VisibilityChecker(final VisibilityTrackerOption visibilityTrackerOption,
-                             final ViewExposureChecker viewExposureChecker) {
-        mVisibilityTrackerOption = visibilityTrackerOption;
-        mViewExposureChecker = viewExposureChecker;
+    public VisibilityChecker(
+            final VisibilityTrackerOption visibilityTrackerOption,
+            final ViewExposureChecker viewExposureChecker
+    ) {
+        this.visibilityTrackerOption = visibilityTrackerOption;
+        this.viewExposureChecker = viewExposureChecker;
     }
 
     public boolean hasBeenVisible() {
-        return mVisibilityTrackerOption.getStartTimeMillis() != Long.MIN_VALUE;
+        return visibilityTrackerOption.getStartTimeMillis() != Long.MIN_VALUE;
     }
 
     public void setStartTimeMillis() {
-        mVisibilityTrackerOption.setStartTimeMillis(SystemClock.uptimeMillis());
+        visibilityTrackerOption.setStartTimeMillis(SystemClock.uptimeMillis());
     }
 
     public boolean hasRequiredTimeElapsed() {
@@ -61,12 +64,11 @@ public class VisibilityChecker {
             return false;
         }
 
-        return SystemClock.uptimeMillis() - mVisibilityTrackerOption.getStartTimeMillis() >= mVisibilityTrackerOption.getMinimumVisibleMillis();
+        return SystemClock.uptimeMillis() - visibilityTrackerOption.getStartTimeMillis() >= visibilityTrackerOption.getMinimumVisibleMillis();
     }
 
     public boolean isVisible(View trackedView, ViewExposure viewExposure) {
-        if (mVisibilityTrackerOption.isType(IMPRESSION)
-            || mVisibilityTrackerOption.isType(OMID)) {
+        if (visibilityTrackerOption.isType(IMPRESSION) || visibilityTrackerOption.isType(OMID)) {
             return isVisible(trackedView);
         }
 
@@ -75,7 +77,7 @@ public class VisibilityChecker {
         }
 
         final float exposurePercentage = viewExposure.getExposurePercentage() * 100;
-        return exposurePercentage >= mVisibilityTrackerOption.getMinVisibilityPercentage();
+        return exposurePercentage >= visibilityTrackerOption.getMinVisibilityPercentage();
     }
 
     public boolean isVisible(
@@ -103,13 +105,11 @@ public class VisibilityChecker {
         }
 
         // Calculate area of view not clipped by any of its parents
-        final int widthInDips = Dips.pixelsToIntDips((float) mClipRect.width(),
-                                                     view.getContext());
-        final int heightInDips = Dips.pixelsToIntDips((float) mClipRect.height(),
-                                                      view.getContext());
+        final int widthInDips = Dips.pixelsToIntDips((float) clipRect.width(), view.getContext());
+        final int heightInDips = Dips.pixelsToIntDips((float) clipRect.height(), view.getContext());
         final long visibleViewAreaInDips = (long) (widthInDips * heightInDips);
 
-        return visibleViewAreaInDips >= mVisibilityTrackerOption.getMinVisibilityPercentage();
+        return visibleViewAreaInDips >= visibilityTrackerOption.getMinVisibilityPercentage();
     }
 
     public boolean isVisibleForRefresh(
@@ -121,7 +121,7 @@ public class VisibilityChecker {
         }
 
         // View completely clipped by its parents
-        return view.getGlobalVisibleRect(mClipRect);
+        return view.getGlobalVisibleRect(clipRect);
     }
 
     public ViewExposure checkViewExposure(
@@ -132,12 +132,12 @@ public class VisibilityChecker {
             return null;
         }
 
-        ViewExposure exposure = mViewExposureChecker.exposure(view);
+        ViewExposure exposure = viewExposureChecker.exposure(view);
         LogUtil.debug(TAG, exposure != null ? exposure.toString() : "null exposure");
         return exposure;
     }
 
     public VisibilityTrackerOption getVisibilityTrackerOption() {
-        return mVisibilityTrackerOption;
+        return visibilityTrackerOption;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/url/action/BrowserAction.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/url/action/BrowserAction.java
@@ -29,12 +29,16 @@ import org.prebid.mobile.rendering.utils.url.UrlHandler;
 import org.prebid.mobile.rendering.views.browser.AdBrowserActivity;
 
 public class BrowserAction implements UrlAction {
-    private final int mBroadcastId;
-    @Nullable private final OnBrowserActionResultListener mOnBrowserActionResultListener;
 
-    public BrowserAction(int broadcastId, @Nullable OnBrowserActionResultListener onBrowserActionResultListener) {
-        mBroadcastId = broadcastId;
-        mOnBrowserActionResultListener = onBrowserActionResultListener;
+    private final int broadcastId;
+    @Nullable private final OnBrowserActionResultListener onBrowserActionResultListener;
+
+    public BrowserAction(
+            int broadcastId,
+            @Nullable OnBrowserActionResultListener onBrowserActionResultListener
+    ) {
+        this.broadcastId = broadcastId;
+        this.onBrowserActionResultListener = onBrowserActionResultListener;
     }
 
     @Override
@@ -50,7 +54,7 @@ public class BrowserAction implements UrlAction {
             throw new ActionNotResolvedException("performAction(): Failed. Url is invalid or there is no activity to handle action.");
         }
 
-        ExternalViewerUtils.startBrowser(context, uri.toString(), mBroadcastId, true, mOnBrowserActionResultListener);
+        ExternalViewerUtils.startBrowser(context, uri.toString(), broadcastId, true, onBrowserActionResultListener);
     }
 
     private boolean canHandleLink(Context context, Uri uri) {

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/url/action/MraidInternalBrowserAction.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/url/action/MraidInternalBrowserAction.java
@@ -34,14 +34,18 @@ import org.prebid.mobile.rendering.views.webview.mraid.BaseJSInterface;
 import java.lang.ref.WeakReference;
 
 public class MraidInternalBrowserAction implements UrlAction {
+
     private static final String TAG = MraidInternalBrowserAction.class.getSimpleName();
 
-    private final WeakReference<BaseJSInterface> mJSInterfaceWeakReference;
-    private final int mBroadcastId;
+    private final WeakReference<BaseJSInterface> JSInterfaceWeakReference;
+    private final int broadcastId;
 
-    public MraidInternalBrowserAction(BaseJSInterface jsInterface, int broadcastId) {
-        mJSInterfaceWeakReference = new WeakReference<>(jsInterface);
-        mBroadcastId = broadcastId;
+    public MraidInternalBrowserAction(
+            BaseJSInterface jsInterface,
+            int broadcastId
+    ) {
+        JSInterfaceWeakReference = new WeakReference<>(jsInterface);
+        this.broadcastId = broadcastId;
     }
 
     @Override
@@ -53,7 +57,7 @@ public class MraidInternalBrowserAction implements UrlAction {
     @Override
     public void performAction(Context context, UrlHandler urlHandler, Uri uri)
     throws ActionNotResolvedException {
-        BaseJSInterface baseJSInterface = mJSInterfaceWeakReference.get();
+        BaseJSInterface baseJSInterface = JSInterfaceWeakReference.get();
         if (baseJSInterface == null) {
             throw new ActionNotResolvedException("Action can't be handled. BaseJSInterface is null");
         }
@@ -107,7 +111,6 @@ public class MraidInternalBrowserAction implements UrlAction {
             mraidVariableContainer.setUrlForLaunching(url);
         }
 
-        ExternalViewerUtils.startBrowser(context, mraidVariableContainer.getUrlForLaunching(),  mBroadcastId,
-                                         true, null);
+        ExternalViewerUtils.startBrowser(context, mraidVariableContainer.getUrlForLaunching(), broadcastId, true, null);
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/LruController.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/LruController.java
@@ -32,20 +32,20 @@ public class LruController {
     private final static String CACHE_POSTFIX = "_cache";
 
     private static final int MAX_VIDEO_ENTRIES = 30;
-    private final static LruCache<String, byte[]> mLruCache = new LruCache<>(MAX_VIDEO_ENTRIES);
+    private final static LruCache<String, byte[]> lruCache = new LruCache<>(MAX_VIDEO_ENTRIES);
 
     public static void putVideoCache(String videoPath, byte[] data) {
         if (getVideoCache(videoPath) == null) {
-            mLruCache.put(videoPath, data);
+            lruCache.put(videoPath, data);
         }
     }
 
     public static byte[] getVideoCache(String videoPath) {
-        return mLruCache.get(videoPath);
+        return lruCache.get(videoPath);
     }
 
     public static boolean isAlreadyCached(String videoPath) {
-        return mLruCache.get(videoPath) != null;
+        return lruCache.get(videoPath) != null;
     }
 
     public static boolean saveCacheToFile(
@@ -61,7 +61,7 @@ public class LruController {
                 OutputStream os = new FileOutputStream(file);
                 os.write(data);
                 os.close();
-                mLruCache.remove(videoPath);
+                lruCache.remove(videoPath);
                 LogUtil.debug(TAG, "Cache saved to file");
                 return true;
             }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/OmEventTracker.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/OmEventTracker.java
@@ -26,58 +26,58 @@ import java.lang.ref.WeakReference;
 public class OmEventTracker {
     private static final String TAG = OmEventTracker.class.getSimpleName();
 
-    private WeakReference<OmAdSessionManager> mWeakReferenceOmAdSessionManager;
+    private WeakReference<OmAdSessionManager> weakReferenceOmAdSessionManager;
 
     public void registerActiveAdSession(OmAdSessionManager omAdSessionManager) {
-        mWeakReferenceOmAdSessionManager = new WeakReference<>(omAdSessionManager);
+        weakReferenceOmAdSessionManager = new WeakReference<>(omAdSessionManager);
     }
 
     public void trackOmVideoAdEvent(VideoAdEvent.Event event) {
-        if (mWeakReferenceOmAdSessionManager == null || mWeakReferenceOmAdSessionManager.get() == null) {
+        if (weakReferenceOmAdSessionManager == null || weakReferenceOmAdSessionManager.get() == null) {
             LogUtil.warning(TAG, "Unable to trackOmVideoAdEvent: AdSessionManager is null");
             return;
         }
 
-        OmAdSessionManager omAdSessionManager = mWeakReferenceOmAdSessionManager.get();
+        OmAdSessionManager omAdSessionManager = weakReferenceOmAdSessionManager.get();
         omAdSessionManager.trackAdVideoEvent(event);
     }
 
     public void trackOmHtmlAdEvent(TrackingEvent.Events event) {
-        if (mWeakReferenceOmAdSessionManager == null || mWeakReferenceOmAdSessionManager.get() == null) {
+        if (weakReferenceOmAdSessionManager == null || weakReferenceOmAdSessionManager.get() == null) {
             LogUtil.warning(TAG, "Unable to trackOmHtmlAdEvent: AdSessionManager is null");
             return;
         }
-        OmAdSessionManager omAdSessionManager = mWeakReferenceOmAdSessionManager.get();
+        OmAdSessionManager omAdSessionManager = weakReferenceOmAdSessionManager.get();
         omAdSessionManager.trackDisplayAdEvent(event);
     }
 
     public void trackOmPlayerStateChange(InternalPlayerState playerState) {
-        if (mWeakReferenceOmAdSessionManager == null || mWeakReferenceOmAdSessionManager.get() == null) {
+        if (weakReferenceOmAdSessionManager == null || weakReferenceOmAdSessionManager.get() == null) {
             LogUtil.warning(TAG, "Unable to trackOmPlayerStateChange: AdSessionManager is null");
             return;
         }
 
-        OmAdSessionManager omAdSessionManager = mWeakReferenceOmAdSessionManager.get();
+        OmAdSessionManager omAdSessionManager = weakReferenceOmAdSessionManager.get();
         omAdSessionManager.trackPlayerStateChangeEvent(playerState);
     }
 
     public void trackVideoAdStarted(float duration, float volume) {
-        if (mWeakReferenceOmAdSessionManager == null || mWeakReferenceOmAdSessionManager.get() == null) {
+        if (weakReferenceOmAdSessionManager == null || weakReferenceOmAdSessionManager.get() == null) {
             LogUtil.warning(TAG, "Unable to trackVideoAdStarted: AdSessionManager is null");
             return;
         }
 
-        OmAdSessionManager omAdSessionManager = mWeakReferenceOmAdSessionManager.get();
+        OmAdSessionManager omAdSessionManager = weakReferenceOmAdSessionManager.get();
         omAdSessionManager.videoAdStarted(duration, volume);
     }
 
     public void trackNonSkippableStandaloneVideoLoaded(boolean isAutoPlay) {
-        if (mWeakReferenceOmAdSessionManager == null || mWeakReferenceOmAdSessionManager.get() == null) {
+        if (weakReferenceOmAdSessionManager == null || weakReferenceOmAdSessionManager.get() == null) {
             LogUtil.warning(TAG, "Unable to trackVideoAdStarted: AdSessionManager is null");
             return;
         }
 
-        OmAdSessionManager omAdSessionManager = mWeakReferenceOmAdSessionManager.get();
+        OmAdSessionManager omAdSessionManager = weakReferenceOmAdSessionManager.get();
         omAdSessionManager.nonSkippableStandaloneVideoAdLoaded(isAutoPlay);
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/VideoCreative.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/VideoCreative.java
@@ -48,15 +48,13 @@ public class VideoCreative extends VideoCreativeProtocol
     implements VideoCreativeViewListener, InterstitialManagerVideoDelegate {
     private static final String TAG = VideoCreative.class.getSimpleName();
 
-    @NonNull
-    private final VideoCreativeModel mModel;
+    @NonNull private final VideoCreativeModel model;
 
-    @VisibleForTesting
-    VideoCreativeView mVideoCreativeView;
+    @VisibleForTesting VideoCreativeView videoCreativeView;
 
-    private AsyncTask mVideoDownloadTask;
+    private AsyncTask videoDownloadTask;
 
-    private String mPreloadedVideoFilePath;
+    private String preloadedVideoFilePath;
 
     public VideoCreative(Context context,
                          @NonNull
@@ -64,9 +62,9 @@ public class VideoCreative extends VideoCreativeProtocol
     throws AdException {
         super(context, model, omAdSessionManager, interstitialManager);
 
-        mModel = model;
-        if (mInterstitialManager != null) {
-            mInterstitialManager.setInterstitialVideoDelegate(this);
+        this.model = model;
+        if (this.interstitialManager != null) {
+            this.interstitialManager.setInterstitialVideoDelegate(this);
         }
     }
 
@@ -75,34 +73,34 @@ public class VideoCreative extends VideoCreativeProtocol
         //Use URLConnection to download a video file.
         BaseNetworkTask.GetUrlParams params = new BaseNetworkTask.GetUrlParams();
 
-        params.url = mModel.getMediaUrl();
+        params.url = model.getMediaUrl();
         params.userAgent = AppInfoManager.getUserAgent();
         params.requestType = "GET";
         params.name = BaseNetworkTask.DOWNLOAD_TASK;
 
-        Context context = mContextReference.get();
+        Context context = contextReference.get();
         if (context != null) {
-            AdUnitConfiguration adConfiguration = mModel.getAdConfiguration();
+            AdUnitConfiguration adConfiguration = model.getAdConfiguration();
             String shortenedPath = LruController.getShortenedPath(params.url);
             File file = new File(context.getFilesDir(), shortenedPath);
             VideoDownloadTask videoDownloadTask = new VideoDownloadTask(context, file,
                                                                         new VideoCreativeVideoPreloadListener(this), adConfiguration);
-            mVideoDownloadTask = videoDownloadTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, params);
+            this.videoDownloadTask = videoDownloadTask.executeOnExecutor(AsyncTask.THREAD_POOL_EXECUTOR, params);
         }
     }
 
     @Override
     public void display() {
-        if (mVideoCreativeView != null) {
-            mVideoCreativeView.start(mModel.getAdConfiguration().getVideoInitialVolume());
+        if (videoCreativeView != null) {
+            videoCreativeView.start(model.getAdConfiguration().getVideoInitialVolume());
 
-            if (mModel.getAdConfiguration().isMuted()) {
+            if (model.getAdConfiguration().isMuted()) {
                 mute();
             } else {
                 unmute();
             }
 
-            mModel.trackPlayerStateChange(InternalPlayerState.NORMAL);
+            model.trackPlayerStateChange(InternalPlayerState.NORMAL);
             startViewabilityTracker();
         }
     }
@@ -110,7 +108,7 @@ public class VideoCreative extends VideoCreativeProtocol
     @Override
     public void skip() {
         LogUtil.debug(TAG, "Track 'skip' event");
-        mModel.trackVideoEvent(VideoAdEvent.Event.AD_SKIP);
+        model.trackVideoEvent(VideoAdEvent.Event.AD_SKIP);
         // Send it to AdView
         getCreativeViewListener().creativeDidComplete(this);
     }
@@ -128,27 +126,27 @@ public class VideoCreative extends VideoCreativeProtocol
     @Override
     public void onFailure(AdException error) {
         // ad -> inline -> error
-        mModel.trackVideoEvent(VideoAdEvent.Event.AD_ERROR);
+        model.trackVideoEvent(VideoAdEvent.Event.AD_ERROR);
         getResolutionListener().creativeFailed(error);
     }
 
     @Override
     public void onEvent(VideoAdEvent.Event trackingEvent) {
-        mModel.trackVideoEvent(trackingEvent);
+        model.trackVideoEvent(trackingEvent);
 
         notifyCreativeViewListener(trackingEvent);
     }
 
     @Override
     public void trackAdLoaded() {
-        mModel.trackNonSkippableStandaloneVideoLoaded(false);
+        model.trackNonSkippableStandaloneVideoLoaded(false);
     }
 
     @Override
     public void onVolumeChanged(float volume) {
         notifyVolumeChanged(volume);
 
-        OmAdSessionManager omAdSessionManager = mWeakOmAdSessionManager.get();
+        OmAdSessionManager omAdSessionManager = weakOmAdSessionManager.get();
         if (omAdSessionManager == null) {
             LogUtil.error(TAG, "trackVolume failed, OmAdSessionManager is null");
             return;
@@ -158,17 +156,17 @@ public class VideoCreative extends VideoCreativeProtocol
 
     @Override
     public void onPlayerStateChanged(InternalPlayerState state) {
-        mModel.trackPlayerStateChange(state);
+        model.trackPlayerStateChange(state);
     }
 
     @Override
     public boolean isInterstitialClosed() {
-        return mModel.hasEndCard();
+        return model.hasEndCard();
     }
 
     @Override
     public long getMediaDuration() {
-        return mModel.getMediaDuration();
+        return model.getMediaDuration();
     }
 
     @Override
@@ -179,14 +177,14 @@ public class VideoCreative extends VideoCreativeProtocol
 
     @Override
     public void resume() {
-        if (mVideoCreativeView != null && mVideoCreativeView.hasVideoStarted()) {
-            mVideoCreativeView.resume();
+        if (videoCreativeView != null && videoCreativeView.hasVideoStarted()) {
+            videoCreativeView.resume();
         }
     }
 
     @Override
     public boolean isPlaying() {
-        return mVideoCreativeView != null && mVideoCreativeView.isPlaying();
+        return videoCreativeView != null && videoCreativeView.isPlaying();
     }
 
     @Override
@@ -197,38 +195,38 @@ public class VideoCreative extends VideoCreativeProtocol
 
     @Override
     public void pause() {
-        if (mVideoCreativeView != null && mVideoCreativeView.isPlaying()) {
-            mVideoCreativeView.pause();
+        if (videoCreativeView != null && videoCreativeView.isPlaying()) {
+            videoCreativeView.pause();
         }
     }
 
     @Override
     public void mute() {
-        if (mVideoCreativeView != null && mVideoCreativeView.getVolume() != 0) {
-            mVideoCreativeView.mute();
+        if (videoCreativeView != null && videoCreativeView.getVolume() != 0) {
+            videoCreativeView.mute();
         }
     }
 
     @Override
     public void unmute() {
-        if (mVideoCreativeView != null && mVideoCreativeView.getVolume() == 0) {
-            mVideoCreativeView.unMute();
+        if (videoCreativeView != null && videoCreativeView.getVolume() == 0) {
+            videoCreativeView.unMute();
         }
     }
 
     @Override
     public void createOmAdSession() {
-        OmAdSessionManager omAdSessionManager = mWeakOmAdSessionManager.get();
+        OmAdSessionManager omAdSessionManager = weakOmAdSessionManager.get();
         if (omAdSessionManager == null) {
             LogUtil.error(TAG, "Error creating AdSession. OmAdSessionManager is null");
             return;
         }
 
-        AdUnitConfiguration adConfiguration = mModel.getAdConfiguration();
+        AdUnitConfiguration adConfiguration = model.getAdConfiguration();
         ContentObject contentObject = adConfiguration.getAppContent();
         String contentUrl = null;
         if (contentObject != null) contentUrl = contentObject.getUrl();
-        omAdSessionManager.initVideoAdSession(mModel.getAdVerifications(), contentUrl);
+        omAdSessionManager.initVideoAdSession(model.getAdVerifications(), contentUrl);
         startOmSession();
     }
 
@@ -236,28 +234,27 @@ public class VideoCreative extends VideoCreativeProtocol
     public void startViewabilityTracker() {
         VisibilityTrackerOption visibilityTrackerOption = new VisibilityTrackerOption(NativeEventTracker.EventType.IMPRESSION);
 
-        mCreativeVisibilityTracker = new CreativeVisibilityTracker(getCreativeView(),
-                                                                   visibilityTrackerOption);
-        mCreativeVisibilityTracker.setVisibilityTrackerListener((result) -> {
+        creativeVisibilityTracker = new CreativeVisibilityTracker(getCreativeView(), visibilityTrackerOption);
+        creativeVisibilityTracker.setVisibilityTrackerListener((result) -> {
             if (result.isVisible() && result.shouldFireImpression()) {
-                mModel.trackVideoEvent(VideoAdEvent.Event.AD_IMPRESSION);
-                mCreativeVisibilityTracker.stopVisibilityCheck();
-                mCreativeVisibilityTracker = null;
+                model.trackVideoEvent(VideoAdEvent.Event.AD_IMPRESSION);
+                creativeVisibilityTracker.stopVisibilityCheck();
+                creativeVisibilityTracker = null;
             }
         });
-        mCreativeVisibilityTracker.startVisibilityCheck(mContextReference.get());
+        creativeVisibilityTracker.startVisibilityCheck(contextReference.get());
     }
 
     @Override
     public void destroy() {
         super.destroy();
 
-        if (mVideoCreativeView != null) {
-            mVideoCreativeView.destroy();
+        if (videoCreativeView != null) {
+            videoCreativeView.destroy();
         }
 
-        if (mVideoDownloadTask != null) {
-            mVideoDownloadTask.cancel(true);
+        if (videoDownloadTask != null) {
+            videoDownloadTask.cancel(true);
         }
     }
 
@@ -272,12 +269,12 @@ public class VideoCreative extends VideoCreativeProtocol
     }
 
     /**
-     * @return true if {@link #mPreloadedVideoFilePath} is not empty and file exists in filesDir, false otherwise.
+     * @return true if {@link #preloadedVideoFilePath} is not empty and file exists in filesDir, false otherwise.
      */
     @Override
     public boolean isResolved() {
-        if (mContextReference.get() != null && !TextUtils.isEmpty(mPreloadedVideoFilePath)) {
-            File file = new File(mContextReference.get().getFilesDir(), mPreloadedVideoFilePath);
+        if (contextReference.get() != null && !TextUtils.isEmpty(preloadedVideoFilePath)) {
+            File file = new File(contextReference.get().getFilesDir(), preloadedVideoFilePath);
             return file.exists();
         }
         return false;
@@ -290,8 +287,8 @@ public class VideoCreative extends VideoCreativeProtocol
 
     @Override
     public void onVideoInterstitialClosed() {
-        if (mVideoCreativeView != null) {
-            mVideoCreativeView.destroy();
+        if (videoCreativeView != null) {
+            videoCreativeView.destroy();
         }
         if (getCreativeViewListener() != null) {
             getCreativeViewListener().creativeDidComplete(this);
@@ -299,18 +296,18 @@ public class VideoCreative extends VideoCreativeProtocol
     }
 
     public long getVideoSkipOffset() {
-        return mModel.getSkipOffset();
+        return model.getSkipOffset();
     }
 
     @Override
     public void trackVideoEvent(VideoAdEvent.Event event) {
-        mModel.trackVideoEvent(event);
+        model.trackVideoEvent(event);
     }
 
     @Override
     @NonNull
     public VideoCreativeModel getCreativeModel() {
-        return mModel;
+        return model;
     }
 
     private void loadContinued() {
@@ -321,7 +318,7 @@ public class VideoCreative extends VideoCreativeProtocol
             getResolutionListener().creativeFailed(e);
             return;
         }
-        setCreativeView(mVideoCreativeView);
+        setCreativeView(videoCreativeView);
         //VideoView has been created. Send adDidLoad() to pubs
         onReadyForDisplay();
     }
@@ -330,61 +327,61 @@ public class VideoCreative extends VideoCreativeProtocol
     private void createCreativeView() throws AdException {
         Uri videoUri = null;
 
-        final Context context = mContextReference.get();
+        final Context context = contextReference.get();
         if (context != null) {
-            final AdUnitConfiguration adConfiguration = mModel.getAdConfiguration();
-            mVideoCreativeView = new VideoCreativeView(context, this);
-            mVideoCreativeView.setBroadcastId(adConfiguration.getBroadcastId());
+            final AdUnitConfiguration adConfiguration = model.getAdConfiguration();
+            videoCreativeView = new VideoCreativeView(context, this);
+            videoCreativeView.setBroadcastId(adConfiguration.getBroadcastId());
 
             // Get the preloaded video from device file storage
-            videoUri = Uri.parse(context.getFilesDir() + (mModel.getMediaUrl()));
+            videoUri = Uri.parse(context.getFilesDir() + (model.getMediaUrl()));
         }
 
         // Show call-to-action overlay right away if click through url is available & end card is not available
         showCallToAction();
 
-        mVideoCreativeView.setCallToActionUrl(mModel.getVastClickthroughUrl());
-        mVideoCreativeView.setVastVideoDuration(getMediaDuration());
-        mVideoCreativeView.setVideoUri(videoUri);
+        videoCreativeView.setCallToActionUrl(model.getVastClickthroughUrl());
+        videoCreativeView.setVastVideoDuration(getMediaDuration());
+        videoCreativeView.setVideoUri(videoUri);
     }
 
     private void startOmSession() {
-        OmAdSessionManager omAdSessionManager = mWeakOmAdSessionManager.get();
+        OmAdSessionManager omAdSessionManager = weakOmAdSessionManager.get();
 
         if (omAdSessionManager == null) {
             LogUtil.error(TAG, "startOmSession: Failed. omAdSessionManager is null");
             return;
         }
 
-        if (mVideoCreativeView == null) {
+        if (videoCreativeView == null) {
             LogUtil.error(TAG, "startOmSession: Failed. VideoCreativeView is null");
             return;
         }
 
-        startOmSession(omAdSessionManager, (View) mVideoCreativeView.getVideoPlayerView());
-        mModel.registerActiveOmAdSession(omAdSessionManager);
+        startOmSession(omAdSessionManager, (View) videoCreativeView.getVideoPlayerView());
+        model.registerActiveOmAdSession(omAdSessionManager);
     }
 
     private void trackVideoAdStart() {
-        if (mVideoCreativeView == null || mVideoCreativeView.getVideoPlayerView() == null) {
-            LogUtil.error(TAG, "trackVideoAdStart error. mVideoCreativeView or VideoPlayerView is null.");
+        if (videoCreativeView == null || videoCreativeView.getVideoPlayerView() == null) {
+            LogUtil.error(TAG, "trackVideoAdStart error. videoCreativeView or VideoPlayerView is null.");
             return;
         }
 
-        VideoPlayerView plugPlayVideoView = mVideoCreativeView.getVideoPlayerView();
+        VideoPlayerView plugPlayVideoView = videoCreativeView.getVideoPlayerView();
         int duration = plugPlayVideoView.getDuration();
         float volume = plugPlayVideoView.getVolume();
 
-        mModel.trackVideoAdStarted(duration, volume);
+        model.trackVideoAdStarted(duration, volume);
     }
 
     protected void complete() {
         LogUtil.debug(TAG, "track 'complete' event");
 
-        mModel.trackVideoEvent(VideoAdEvent.Event.AD_COMPLETE);
+        model.trackVideoEvent(VideoAdEvent.Event.AD_COMPLETE);
 
-        if (mVideoCreativeView != null) {
-            mVideoCreativeView.hideVolumeControls();
+        if (videoCreativeView != null) {
+            videoCreativeView.hideVolumeControls();
         }
 
         // Send it to AdView
@@ -392,10 +389,9 @@ public class VideoCreative extends VideoCreativeProtocol
     }
 
     protected void showCallToAction() {
-        if (!mModel.getAdConfiguration().isBuiltInVideo()
-            && Utils.isNotBlank(mModel.getVastClickthroughUrl())
-            && !mModel.hasEndCard()) {
-            mVideoCreativeView.showCallToAction();
+        if (!model.getAdConfiguration()
+                  .isBuiltInVideo() && Utils.isNotBlank(model.getVastClickthroughUrl()) && !model.hasEndCard()) {
+            videoCreativeView.showCallToAction();
         }
     }
 
@@ -407,7 +403,7 @@ public class VideoCreative extends VideoCreativeProtocol
                 trackVideoAdStart();
                 break;
             case AD_CLICK:
-                creativeViewListener.creativeWasClicked(this, mVideoCreativeView.getCallToActionUrl());
+                creativeViewListener.creativeWasClicked(this, videoCreativeView.getCallToActionUrl());
                 break;
             case AD_RESUME:
                 creativeViewListener.creativeResumed(this);
@@ -431,28 +427,28 @@ public class VideoCreative extends VideoCreativeProtocol
 
     private static class VideoCreativeVideoPreloadListener implements FileDownloadListener {
 
-        private WeakReference<VideoCreative> mWeakVideoCreative;
+        private WeakReference<VideoCreative> weakVideoCreative;
 
         VideoCreativeVideoPreloadListener(VideoCreative videoCreative) {
-            mWeakVideoCreative = new WeakReference<>(videoCreative);
+            weakVideoCreative = new WeakReference<>(videoCreative);
         }
 
         @Override
         public void onFileDownloaded(String shortenedPath) {
-            VideoCreative videoCreative = mWeakVideoCreative.get();
+            VideoCreative videoCreative = weakVideoCreative.get();
             if (videoCreative == null) {
                 LogUtil.warning(TAG, "VideoCreative is null");
                 return;
             }
 
-            videoCreative.mPreloadedVideoFilePath = shortenedPath;
-            videoCreative.mModel.setMediaUrl(shortenedPath);
+            videoCreative.preloadedVideoFilePath = shortenedPath;
+            videoCreative.model.setMediaUrl(shortenedPath);
             videoCreative.loadContinued();
         }
 
         @Override
         public void onFileDownloadError(String error) {
-            VideoCreative videoCreative = mWeakVideoCreative.get();
+            VideoCreative videoCreative = weakVideoCreative.get();
             if (videoCreative == null) {
                 LogUtil.warning(TAG, "VideoCreative is null");
                 return;

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/VideoCreativeModel.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/VideoCreativeModel.java
@@ -30,103 +30,108 @@ public class VideoCreativeModel extends CreativeModel {
 
     private static String TAG = VideoCreativeModel.class.getSimpleName();
 
-    private HashMap<VideoAdEvent.Event, ArrayList<String>> mVideoEventUrls = new HashMap<>();
-    private String mMediaUrl;
+    private HashMap<VideoAdEvent.Event, ArrayList<String>> videoEventUrls = new HashMap<>();
+    private String mediaUrl;
 
     //interstitial video: media duration
-    private long mMediaDuration;
-    private String mAuid;
-    private long mSkipOffset;
+    private long mediaDuration;
+    private String auid;
+    private long skipOffset;
 
     // interstitial video: click-through URL
-    private String mVastClickthroughUrl;
-    private AdVerifications mAdVerifications;
+    private String vastClickthroughUrl;
+    private AdVerifications adVerifications;
 
 
-    public VideoCreativeModel(TrackingManager trackingManager,
-                              OmEventTracker omEventTracker,
-                              AdUnitConfiguration adConfiguration) {
+    public VideoCreativeModel(
+            TrackingManager trackingManager,
+            OmEventTracker omEventTracker,
+            AdUnitConfiguration adConfiguration
+    ) {
         super(trackingManager, omEventTracker, adConfiguration);
     }
 
-    public void registerVideoEvent(VideoAdEvent.Event event, ArrayList<String> urls) {
-        mVideoEventUrls.put(event, urls);
+    public void registerVideoEvent(
+            VideoAdEvent.Event event,
+            ArrayList<String> urls
+    ) {
+        videoEventUrls.put(event, urls);
     }
 
     public void trackVideoEvent(VideoAdEvent.Event videoEvent) {
-        mOmEventTracker.trackOmVideoAdEvent(videoEvent);
-        ArrayList<String> urls = mVideoEventUrls.get(videoEvent);
+        omEventTracker.trackOmVideoAdEvent(videoEvent);
+        ArrayList<String> urls = videoEventUrls.get(videoEvent);
         if (urls == null) {
             LogUtil.debug(TAG, "Event" + videoEvent + " not found");
             return;
         }
 
-        mTrackingManager.fireEventTrackingURLs(urls);
+        trackingManager.fireEventTrackingURLs(urls);
 
         LogUtil.info(TAG, "Video event '" + videoEvent.name() + "' was fired with urls: " + urls.toString());
     }
 
     public void trackPlayerStateChange(InternalPlayerState changedPlayerState) {
-        mOmEventTracker.trackOmPlayerStateChange(changedPlayerState);
+        omEventTracker.trackOmPlayerStateChange(changedPlayerState);
     }
 
     public void trackVideoAdStarted(float duration, float volume) {
-        mOmEventTracker.trackVideoAdStarted(duration, volume);
+        omEventTracker.trackVideoAdStarted(duration, volume);
     }
 
     public void trackNonSkippableStandaloneVideoLoaded(boolean isAutoPlay) {
-        mOmEventTracker.trackNonSkippableStandaloneVideoLoaded(isAutoPlay);
+        omEventTracker.trackNonSkippableStandaloneVideoLoaded(isAutoPlay);
     }
 
     public HashMap<VideoAdEvent.Event, ArrayList<String>> getVideoEventUrls() {
-        return mVideoEventUrls;
+        return videoEventUrls;
     }
 
     public String getMediaUrl() {
-        return mMediaUrl;
+        return mediaUrl;
     }
 
     public void setMediaUrl(String mediaUrl) {
-        mMediaUrl = mediaUrl;
+        this.mediaUrl = mediaUrl;
     }
 
     public long getMediaDuration() {
-        return mMediaDuration;
+        return mediaDuration;
     }
 
     public void setMediaDuration(long mediaDuration) {
-        mMediaDuration = mediaDuration;
+        this.mediaDuration = mediaDuration;
     }
 
     public long getSkipOffset() {
-        return mSkipOffset;
+        return skipOffset;
     }
 
     public void setSkipOffset(long skipOffset) {
-        mSkipOffset = skipOffset;
+        this.skipOffset = skipOffset;
     }
 
     public String getAuid() {
-        return mAuid;
+        return auid;
     }
 
     public void setAuid(String auid) {
-        mAuid = auid;
+        this.auid = auid;
     }
 
     public String getVastClickthroughUrl() {
-        return mVastClickthroughUrl;
+        return vastClickthroughUrl;
     }
 
     public void setVastClickthroughUrl(String vastClickthroughUrl) {
-        mVastClickthroughUrl = vastClickthroughUrl;
+        this.vastClickthroughUrl = vastClickthroughUrl;
     }
 
     public AdVerifications getAdVerifications() {
-        return mAdVerifications;
+        return adVerifications;
     }
 
     public void setAdVerifications(AdVerifications adVerifications) {
-        mAdVerifications = adVerifications;
+        this.adVerifications = adVerifications;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/VideoCreativeView.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/VideoCreativeView.java
@@ -39,23 +39,25 @@ import static android.widget.RelativeLayout.LayoutParams.MATCH_PARENT;
 import static android.widget.RelativeLayout.LayoutParams.WRAP_CONTENT;
 
 public class VideoCreativeView extends RelativeLayout {
+
     private static final String TAG = VideoCreativeView.class.getSimpleName();
 
-    private final VideoCreativeViewListener mVideoCreativeViewListener;
+    private final VideoCreativeViewListener videoCreativeViewListener;
 
-    @Nullable
-    private View mCallToActionView;
-    private ExoPlayerView mExoPlayerView;
-    private VolumeControlView mVolumeControlView;
+    @Nullable private View callToActionView;
+    private ExoPlayerView exoPlayerView;
+    private VolumeControlView volumeControlView;
 
-    private String mCallToActionUrl;
-    private boolean mUrlHandleInProgress;
-    private int mBroadcastId;
+    private String callToActionUrl;
+    private boolean urlHandleInProgress;
+    private int broadcastId;
 
-    public VideoCreativeView(Context context, VideoCreativeViewListener videoCreativeViewListener)
-    throws AdException {
+    public VideoCreativeView(
+            Context context,
+            VideoCreativeViewListener videoCreativeViewListener
+    ) throws AdException {
         super(context);
-        mVideoCreativeViewListener = videoCreativeViewListener;
+        this.videoCreativeViewListener = videoCreativeViewListener;
         init();
     }
 
@@ -65,49 +67,49 @@ public class VideoCreativeView extends RelativeLayout {
             return;
         }
 
-        mExoPlayerView.setVideoUri(videoUri);
+        exoPlayerView.setVideoUri(videoUri);
     }
 
     public void setVastVideoDuration(long duration) {
-        mExoPlayerView.setVastVideoDuration(duration);
+        exoPlayerView.setVastVideoDuration(duration);
     }
 
     public void setBroadcastId(int broadcastId) {
-        mBroadcastId = broadcastId;
+        this.broadcastId = broadcastId;
     }
 
     public void setCallToActionUrl(String callToActionUrl) {
-        mCallToActionUrl = callToActionUrl;
+        this.callToActionUrl = callToActionUrl;
     }
 
     public String getCallToActionUrl() {
-        return mCallToActionUrl;
+        return callToActionUrl;
     }
 
     public void start(float initialVolume) {
-        mExoPlayerView.start(initialVolume);
+        exoPlayerView.start(initialVolume);
     }
 
     public void stop() {
-        mExoPlayerView.stop();
+        exoPlayerView.stop();
     }
 
     public void pause() {
-        mExoPlayerView.pause();
+        exoPlayerView.pause();
     }
 
     public void resume() {
-        mExoPlayerView.resume();
+        exoPlayerView.resume();
     }
 
     public void mute() {
-        mExoPlayerView.mute();
+        exoPlayerView.mute();
 
         updateVolumeControlView(VolumeControlView.VolumeState.MUTED);
     }
 
     public void unMute() {
-        mExoPlayerView.unMute();
+        exoPlayerView.unMute();
 
         updateVolumeControlView(VolumeControlView.VolumeState.UN_MUTED);
     }
@@ -117,9 +119,9 @@ public class VideoCreativeView extends RelativeLayout {
     }
 
     public void hideCallToAction() {
-        if (mCallToActionView != null) {
-            removeView(mCallToActionView);
-            mCallToActionView = null;
+        if (callToActionView != null) {
+            removeView(callToActionView);
+            callToActionView = null;
         }
     }
 
@@ -128,13 +130,13 @@ public class VideoCreativeView extends RelativeLayout {
     }
 
     public VolumeControlView getVolumeControlView() {
-        return mVolumeControlView;
+        return volumeControlView;
     }
 
     public void hideVolumeControls() {
-        if (mVolumeControlView != null) {
-            removeView(mVolumeControlView);
-            mVolumeControlView = null;
+        if (volumeControlView != null) {
+            removeView(volumeControlView);
+            volumeControlView = null;
         }
     }
 
@@ -143,23 +145,23 @@ public class VideoCreativeView extends RelativeLayout {
     }
 
     public boolean isPlaying() {
-        return mExoPlayerView.isPlaying();
+        return exoPlayerView.isPlaying();
     }
 
     public boolean hasVideoStarted() {
-        return mExoPlayerView.getCurrentPosition() != -1;
+        return exoPlayerView.getCurrentPosition() != -1;
     }
 
     public VideoPlayerView getVideoPlayerView() {
-        return mExoPlayerView;
+        return exoPlayerView;
     }
 
     public float getVolume() {
-        return mExoPlayerView.getVolume();
+        return exoPlayerView.getVolume();
     }
 
     public void destroy() {
-        mExoPlayerView.destroy();
+        exoPlayerView.destroy();
         ViewPool.getInstance().clear();
     }
 
@@ -167,16 +169,19 @@ public class VideoCreativeView extends RelativeLayout {
         LayoutParams layoutParams = new LayoutParams(MATCH_PARENT, MATCH_PARENT);
         setLayoutParams(layoutParams);
 
-        mExoPlayerView = (ExoPlayerView) ViewPool
-                .getInstance()
-                .getUnoccupiedView(getContext(), mVideoCreativeViewListener, AdFormat.VAST, null);
+        exoPlayerView = (ExoPlayerView) ViewPool.getInstance()
+                                                .getUnoccupiedView(getContext(),
+                                                        videoCreativeViewListener,
+                                                        AdFormat.VAST,
+                                                        null
+                                                );
 
-        addView(mExoPlayerView);
+        addView(exoPlayerView);
     }
 
     private void addCallToActionView() {
-        mCallToActionView = inflate(getContext(), R.layout.lyt_call_to_action, null);
-        mCallToActionView.setOnClickListener(v -> handleCallToActionClick());
+        callToActionView = inflate(getContext(), R.layout.lyt_call_to_action, null);
+        callToActionView.setOnClickListener(v -> handleCallToActionClick());
 
         final int width = Dips.dipsToIntPixels(128, getContext());
         final int height = Dips.dipsToIntPixels(36, getContext());
@@ -188,17 +193,16 @@ public class VideoCreativeView extends RelativeLayout {
         layoutParams.addRule(ALIGN_PARENT_RIGHT);
         layoutParams.setMargins(margin, margin, margin, margin);
 
-        addView(mCallToActionView, layoutParams);
+        addView(callToActionView, layoutParams);
     }
 
     private void addVolumeControlView() {
         LayoutParams layoutParams = new LayoutParams(WRAP_CONTENT, WRAP_CONTENT);
-        mVolumeControlView = new VolumeControlView(getContext(), VolumeControlView.VolumeState.MUTED);
-        mVolumeControlView.setVolumeControlListener(state -> {
+        volumeControlView = new VolumeControlView(getContext(), VolumeControlView.VolumeState.MUTED);
+        volumeControlView.setVolumeControlListener(state -> {
             if (state == VolumeControlView.VolumeState.MUTED) {
                 mute();
-            }
-            else {
+            } else {
                 unMute();
             }
         });
@@ -209,41 +213,40 @@ public class VideoCreativeView extends RelativeLayout {
         layoutParams.addRule(ALIGN_PARENT_LEFT);
         layoutParams.setMargins(margin, margin, margin, margin);
 
-        addView(mVolumeControlView, layoutParams);
+        addView(volumeControlView, layoutParams);
     }
 
     private void handleCallToActionClick() {
-        if (mUrlHandleInProgress) {
+        if (urlHandleInProgress) {
             LogUtil.debug(TAG, "handleCallToActionClick: Skipping. Url handle in progress");
             return;
         }
-        mUrlHandleInProgress = true;
+        urlHandleInProgress = true;
 
-        createUrlHandler().handleUrl(getContext(), mCallToActionUrl, null, true);
+        createUrlHandler().handleUrl(getContext(), callToActionUrl, null, true);
 
-        mVideoCreativeViewListener.onEvent(VideoAdEvent.Event.AD_CLICK);
+        videoCreativeViewListener.onEvent(VideoAdEvent.Event.AD_CLICK);
     }
 
     private void updateVolumeControlView(VolumeControlView.VolumeState unMuted) {
-        if (mVolumeControlView != null) {
-            mVolumeControlView.updateIcon(unMuted);
+        if (volumeControlView != null) {
+            volumeControlView.updateIcon(unMuted);
         }
     }
 
     UrlHandler createUrlHandler() {
-        return new UrlHandler.Builder()
-            .withDeepLinkPlusAction(new DeepLinkPlusAction())
-            .withDeepLinkAction(new DeepLinkAction())
-            .withBrowserAction(new BrowserAction(mBroadcastId, null))
+        return new UrlHandler.Builder().withDeepLinkPlusAction(new DeepLinkPlusAction())
+                                       .withDeepLinkAction(new DeepLinkAction())
+                                       .withBrowserAction(new BrowserAction(broadcastId, null))
             .withResultListener(new UrlHandler.UrlHandlerResultListener() {
                 @Override
                 public void onSuccess(String url, UrlAction urlAction) {
-                    mUrlHandleInProgress = false;
+                    urlHandleInProgress = false;
                 }
 
                 @Override
                 public void onFailure(String url) {
-                    mUrlHandleInProgress = false;
+                    urlHandleInProgress = false;
                     LogUtil.debug(TAG, "Failed to handleUrl: " + url + ". Handling fallback");
                 }
             })

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/Ad.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/Ad.java
@@ -21,43 +21,39 @@ import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.IOException;
 
-public class Ad extends VASTParserBase
-{
-    private final static String VAST_AD = "Ad";
+public class Ad extends VASTParserBase {
+
+	private final static String VAST_AD = "Ad";
 	private final static String VAST_INLINE = "InLine";
 	private final static String VAST_WRAPPER = "Wrapper";
 
-    private InLine mInline;
-    private Wrapper mWrapper;
+	private InLine inline;
+	private Wrapper wrapper;
 
-    private String mId;
-    private String mSequence;
+	private String id;
+	private String sequence;
 
-	public Ad(XmlPullParser p) throws XmlPullParserException, IOException
-	{
+	public Ad(XmlPullParser p) throws XmlPullParserException, IOException {
 
 		p.require(XmlPullParser.START_TAG, null, VAST_AD);
 
-        mId = p.getAttributeValue(null, "id");
-        mSequence = p.getAttributeValue(null, "sequence");
+		id = p.getAttributeValue(null, "id");
+		sequence = p.getAttributeValue(null, "sequence");
 
-		while (p.next() != XmlPullParser.END_TAG)
-		{
-			if (p.getEventType() != XmlPullParser.START_TAG)
-			{
+		while (p.next() != XmlPullParser.END_TAG) {
+			if (p.getEventType() != XmlPullParser.START_TAG) {
 				continue;
 			}
 			String name = p.getName();
-			if (name != null && name.equals(VAST_INLINE))
-			{
+			if (name != null && name.equals(VAST_INLINE)) {
 				p.require(XmlPullParser.START_TAG, null, VAST_INLINE);
-                mInline = new InLine(p);
+				inline = new InLine(p);
 				p.require(XmlPullParser.END_TAG, null, VAST_INLINE);
 			}
 			else if (name != null && name.equals(VAST_WRAPPER))
 			{
 				p.require(XmlPullParser.START_TAG, null, VAST_WRAPPER);
-                mWrapper = new Wrapper(p);
+				wrapper = new Wrapper(p);
 				p.require(XmlPullParser.END_TAG, null, VAST_WRAPPER);
 			}
 			else
@@ -69,19 +65,19 @@ public class Ad extends VASTParserBase
 	}
 
     public InLine getInline() {
-        return mInline;
+		return inline;
     }
 
     public Wrapper getWrapper() {
-        return mWrapper;
+		return wrapper;
     }
 
     public String getId() {
-        return mId;
+		return id;
     }
 
     public String getSequence() {
-        return mSequence;
+		return sequence;
     }
 
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/AdParameters.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/AdParameters.java
@@ -21,23 +21,22 @@ import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.IOException;
 
-public class AdParameters extends VASTParserBase
-{
-    private final String mXmlEncoded;
-    private String mValue;
+public class AdParameters extends VASTParserBase {
 
-	public AdParameters(XmlPullParser p) throws XmlPullParserException, IOException
-	{
+    private final String xmlEncoded;
+    private String value;
 
-        mXmlEncoded = p.getAttributeValue(null, "xmlEncoded");
-        mValue = readText(p);
+    public AdParameters(XmlPullParser p) throws XmlPullParserException, IOException {
+
+        xmlEncoded = p.getAttributeValue(null, "xmlEncoded");
+        value = readText(p);
     }
 
     public String getXmlEncoded() {
-        return mXmlEncoded;
+        return xmlEncoded;
     }
 
     public String getValue() {
-        return mValue;
+        return value;
 	}
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/AdSystem.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/AdSystem.java
@@ -21,21 +21,21 @@ import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.IOException;
 
-public class AdSystem extends VASTParserBase
-{
-    private String mVersion;
-    private String mValue;
+public class AdSystem extends VASTParserBase {
+
+    private String version;
+    private String value;
 
     public AdSystem(XmlPullParser p) throws XmlPullParserException, IOException {
-        mVersion = p.getAttributeValue(null, "version");
-        mValue = readText(p);
+        version = p.getAttributeValue(null, "version");
+        value = readText(p);
     }
 
     public String getVersion() {
-        return mVersion;
+        return version;
     }
 
     public String getValue() {
-        return mValue;
+        return value;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/AdVerifications.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/AdVerifications.java
@@ -25,10 +25,10 @@ import java.util.ArrayList;
 public class AdVerifications extends VASTParserBase {
     private static final String VAST_VERIFICATION = "Verification";
 
-    private final ArrayList<Verification> mVerifications;
+    private final ArrayList<Verification> verifications;
 
     public AdVerifications(XmlPullParser p) throws IOException, XmlPullParserException {
-        mVerifications = new ArrayList<>();
+        verifications = new ArrayList<>();
         while (p.next() != XmlPullParser.END_TAG) {
             if (p.getEventType() != XmlPullParser.START_TAG) {
                 continue;
@@ -37,7 +37,7 @@ public class AdVerifications extends VASTParserBase {
             if (name != null && name.equals(VAST_VERIFICATION)) {
                 p.require(XmlPullParser.START_TAG, null, VAST_VERIFICATION);
                 Verification verification = new Verification(p);
-                mVerifications.add(verification);
+                verifications.add(verification);
                 p.require(XmlPullParser.END_TAG, null, VAST_VERIFICATION);
             }
             else {
@@ -47,6 +47,6 @@ public class AdVerifications extends VASTParserBase {
     }
 
     public ArrayList<Verification> getVerifications() {
-        return mVerifications;
+        return verifications;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/BaseId.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/BaseId.java
@@ -21,23 +21,22 @@ import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.IOException;
 
-public class BaseId extends VASTParserBase
-{
-    private String mId;
-    private String mValue;
+public class BaseId extends VASTParserBase {
 
-	public BaseId(XmlPullParser p) throws XmlPullParserException, IOException
-	{
+    private String id;
+    private String value;
 
-        mId = p.getAttributeValue(null, "id");
-        mValue = readText(p);
+    public BaseId(XmlPullParser p) throws XmlPullParserException, IOException {
+
+        id = p.getAttributeValue(null, "id");
+        value = readText(p);
     }
 
     public String getId() {
-        return mId;
+        return id;
     }
 
     public String getValue() {
-        return mValue;
+        return value;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/BaseValue.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/BaseValue.java
@@ -23,16 +23,16 @@ import java.io.IOException;
 
 public class BaseValue extends VASTParserBase
 {
-    private String mValue;
+    private String value;
 
 	public BaseValue(XmlPullParser p) throws XmlPullParserException, IOException
 	{
 
-        mValue = readText(p);
+        value = readText(p);
 
 	}
 
     public String getValue() {
-        return mValue;
+        return value;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/Companion.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/Companion.java
@@ -24,104 +24,101 @@ import java.util.ArrayList;
 
 public class Companion extends VASTParserBase
 {
-	private final static String VAST_COMPANION = "Companion";
-	private final static String VAST_STATICRESOURCE = "StaticResource";
-	private final static String VAST_IFRAMERESOUCE = "IFrameResource";
-	private final static String VAST_HTMLRESOURCE = "HTMLResource";
-	private final static String VAST_ADPARAMETERS = "AdParameters";
-	private final static String VAST_ALTTEXT = "AltText";
-	private final static String VAST_COMPANIONCLICKTHROUGH = "CompanionClickThrough";
-	private final static String VAST_COMPANIONCLICKTRACKING = "CompanionClickTracking";
-	private final static String VAST_TRACKINGEVENTS = "TrackingEvents";
 
-    private String mId;
-    private String mWidth;
-    private String mHeight;
-    private String mAssetWidth;
-    private String mAssetHeight;
-    private String mExpandedWidth;
-    private String mExpandedHeight;
-    private String mApiFramework;
-    private String mAdSlotID;
+    private final static String VAST_COMPANION = "Companion";
+    private final static String VAST_STATICRESOURCE = "StaticResource";
+    private final static String VAST_IFRAMERESOUCE = "IFrameResource";
+    private final static String VAST_HTMLRESOURCE = "HTMLResource";
+    private final static String VAST_ADPARAMETERS = "AdParameters";
+    private final static String VAST_ALTTEXT = "AltText";
+    private final static String VAST_COMPANIONCLICKTHROUGH = "CompanionClickThrough";
+    private final static String VAST_COMPANIONCLICKTRACKING = "CompanionClickTracking";
+    private final static String VAST_TRACKINGEVENTS = "TrackingEvents";
 
-    private StaticResource mStaticResource;
-    private IFrameResource mIFrameResource;
-    private HTMLResource mHTMLResource;
-    private AdParameters mAdParameters;
-    private AltText mAltText;
-    private CompanionClickThrough mCompanionClickThrough;
-    private CompanionClickTracking mCompanionClickTracking;
-    private ArrayList<Tracking> mTrackingEvents;
+    private String id;
+    private String width;
+    private String height;
+    private String assetWidth;
+    private String assetHeight;
+    private String expandedWidth;
+    private String expandedHeight;
+    private String apiFramework;
+    private String adSlotID;
 
-	public Companion(XmlPullParser p) throws XmlPullParserException, IOException
-	{
+    private StaticResource staticResource;
+    private IFrameResource iFrameResource;
+    private HTMLResource HTMLResource;
+    private AdParameters adParameters;
+    private AltText altText;
+    private CompanionClickThrough companionClickThrough;
+    private CompanionClickTracking companionClickTracking;
+    private ArrayList<Tracking> trackingEvents;
 
-		p.require(XmlPullParser.START_TAG, null, VAST_COMPANION);
+    public Companion(XmlPullParser p) throws XmlPullParserException, IOException {
 
-        mId = p.getAttributeValue(null, "id");
-        mWidth = p.getAttributeValue(null, "width");
-        mHeight = p.getAttributeValue(null, "height");
-        mAssetWidth = p.getAttributeValue(null, "assetWidth");
-        mAssetHeight = p.getAttributeValue(null, "assetHeight");
-        mExpandedWidth = p.getAttributeValue(null, "expandedWidth");
-        mExpandedHeight = p.getAttributeValue(null, "expandedHeight");
-        mApiFramework = p.getAttributeValue(null, "apiFramework");
-        mAdSlotID = p.getAttributeValue(null, "adSlotID");
+        p.require(XmlPullParser.START_TAG, null, VAST_COMPANION);
 
-		while (p.next() != XmlPullParser.END_TAG)
-		{
-			if (p.getEventType() != XmlPullParser.START_TAG)
-			{
-				continue;
-			}
-			String name = p.getName();
-			if (name != null && name.equals(VAST_STATICRESOURCE))
-			{
-				p.require(XmlPullParser.START_TAG, null, VAST_STATICRESOURCE);
-                mStaticResource = new StaticResource(p);
-				p.require(XmlPullParser.END_TAG, null, VAST_STATICRESOURCE);
+        id = p.getAttributeValue(null, "id");
+        width = p.getAttributeValue(null, "width");
+        height = p.getAttributeValue(null, "height");
+        assetWidth = p.getAttributeValue(null, "assetWidth");
+        assetHeight = p.getAttributeValue(null, "assetHeight");
+        expandedWidth = p.getAttributeValue(null, "expandedWidth");
+        expandedHeight = p.getAttributeValue(null, "expandedHeight");
+        apiFramework = p.getAttributeValue(null, "apiFramework");
+        adSlotID = p.getAttributeValue(null, "adSlotID");
+
+        while (p.next() != XmlPullParser.END_TAG) {
+            if (p.getEventType() != XmlPullParser.START_TAG) {
+                continue;
+            }
+            String name = p.getName();
+            if (name != null && name.equals(VAST_STATICRESOURCE)) {
+                p.require(XmlPullParser.START_TAG, null, VAST_STATICRESOURCE);
+                staticResource = new StaticResource(p);
+                p.require(XmlPullParser.END_TAG, null, VAST_STATICRESOURCE);
 			}
 			else if (name != null && name.equals(VAST_IFRAMERESOUCE))
 			{
-				p.require(XmlPullParser.START_TAG, null, VAST_IFRAMERESOUCE);
-                mIFrameResource = new IFrameResource(p);
-				p.require(XmlPullParser.END_TAG, null, VAST_IFRAMERESOUCE);
+                p.require(XmlPullParser.START_TAG, null, VAST_IFRAMERESOUCE);
+                iFrameResource = new IFrameResource(p);
+                p.require(XmlPullParser.END_TAG, null, VAST_IFRAMERESOUCE);
 			}
 			else if (name != null && name.equals(VAST_HTMLRESOURCE))
 			{
-				p.require(XmlPullParser.START_TAG, null, VAST_HTMLRESOURCE);
-                mHTMLResource = new HTMLResource(p);
-				p.require(XmlPullParser.END_TAG, null, VAST_HTMLRESOURCE);
+                p.require(XmlPullParser.START_TAG, null, VAST_HTMLRESOURCE);
+                HTMLResource = new HTMLResource(p);
+                p.require(XmlPullParser.END_TAG, null, VAST_HTMLRESOURCE);
 			}
 			else if (name != null && name.equals(VAST_ADPARAMETERS))
 			{
-				p.require(XmlPullParser.START_TAG, null, VAST_ADPARAMETERS);
-                mAdParameters = new AdParameters(p);
-				p.require(XmlPullParser.END_TAG, null, VAST_ADPARAMETERS);
+                p.require(XmlPullParser.START_TAG, null, VAST_ADPARAMETERS);
+                adParameters = new AdParameters(p);
+                p.require(XmlPullParser.END_TAG, null, VAST_ADPARAMETERS);
 			}
 			else if (name != null && name.equals(VAST_ALTTEXT))
 			{
-				p.require(XmlPullParser.START_TAG, null, VAST_ALTTEXT);
-                mAltText = new AltText(p);
-				p.require(XmlPullParser.END_TAG, null, VAST_ALTTEXT);
+                p.require(XmlPullParser.START_TAG, null, VAST_ALTTEXT);
+                altText = new AltText(p);
+                p.require(XmlPullParser.END_TAG, null, VAST_ALTTEXT);
 			}
 			else if (name != null && name.equals(VAST_COMPANIONCLICKTHROUGH))
 			{
-				p.require(XmlPullParser.START_TAG, null, VAST_COMPANIONCLICKTHROUGH);
-                mCompanionClickThrough = new CompanionClickThrough(p);
-				p.require(XmlPullParser.END_TAG, null, VAST_COMPANIONCLICKTHROUGH);
+                p.require(XmlPullParser.START_TAG, null, VAST_COMPANIONCLICKTHROUGH);
+                companionClickThrough = new CompanionClickThrough(p);
+                p.require(XmlPullParser.END_TAG, null, VAST_COMPANIONCLICKTHROUGH);
 			}
 			else if (name != null && name.equals(VAST_COMPANIONCLICKTRACKING))
 			{
-				p.require(XmlPullParser.START_TAG, null, VAST_COMPANIONCLICKTRACKING);
-                mCompanionClickTracking = new CompanionClickTracking(p);
-				p.require(XmlPullParser.END_TAG, null, VAST_COMPANIONCLICKTRACKING);
+                p.require(XmlPullParser.START_TAG, null, VAST_COMPANIONCLICKTRACKING);
+                companionClickTracking = new CompanionClickTracking(p);
+                p.require(XmlPullParser.END_TAG, null, VAST_COMPANIONCLICKTRACKING);
 			}
 			else if (name != null && name.equals(VAST_TRACKINGEVENTS))
 			{
-				p.require(XmlPullParser.START_TAG, null, VAST_TRACKINGEVENTS);
-                mTrackingEvents = (new TrackingEvents(p)).getTrackingEvents();
-				p.require(XmlPullParser.END_TAG, null, VAST_TRACKINGEVENTS);
+                p.require(XmlPullParser.START_TAG, null, VAST_TRACKINGEVENTS);
+                trackingEvents = (new TrackingEvents(p)).getTrackingEvents();
+                p.require(XmlPullParser.END_TAG, null, VAST_TRACKINGEVENTS);
 			}
 			else
 			{
@@ -132,70 +129,70 @@ public class Companion extends VASTParserBase
 	}
 
     public String getId() {
-        return mId;
+        return id;
     }
 
     public String getWidth() {
-        return mWidth;
+        return width;
     }
 
     public String getHeight() {
-        return mHeight;
+        return height;
     }
 
     public String getAssetWidth() {
-        return mAssetWidth;
+        return assetWidth;
     }
 
     public String getAssetHeight() {
-        return mAssetHeight;
+        return assetHeight;
     }
 
     public String getExpandedWidth() {
-        return mExpandedWidth;
+        return expandedWidth;
     }
 
     public String getExpandedHeight() {
-        return mExpandedHeight;
+        return expandedHeight;
     }
 
     public String getApiFramework() {
-        return mApiFramework;
+        return apiFramework;
     }
 
     public String getAdSlotID() {
-        return mAdSlotID;
+        return adSlotID;
     }
 
     public StaticResource getStaticResource() {
-        return mStaticResource;
+        return staticResource;
     }
 
     public IFrameResource getIFrameResource() {
-        return mIFrameResource;
+        return iFrameResource;
     }
 
     public HTMLResource getHtmlResource() {
-        return mHTMLResource;
+        return HTMLResource;
     }
 
     public AdParameters getAdParameters() {
-        return mAdParameters;
+        return adParameters;
     }
 
     public AltText getAltText() {
-        return mAltText;
+        return altText;
     }
 
     public CompanionClickThrough getCompanionClickThrough() {
-        return mCompanionClickThrough;
+        return companionClickThrough;
     }
 
     public CompanionClickTracking getCompanionClickTracking() {
-        return mCompanionClickTracking;
+        return companionClickTracking;
     }
 
     public ArrayList<Tracking> getTrackingEvents() {
-        return mTrackingEvents;
+        return trackingEvents;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/CompanionAds.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/CompanionAds.java
@@ -27,12 +27,12 @@ public class CompanionAds extends VASTParserBase
     private final static String VAST_COMPANIONADS = "CompanionAds";
     private final static String VAST_COMPANION = "Companion";
 
-    private ArrayList<Companion> mCompanionAds;
+    private ArrayList<Companion> companionAds;
 
 	public CompanionAds(XmlPullParser p) throws XmlPullParserException, IOException
 	{
 
-        mCompanionAds = new ArrayList<>();
+		companionAds = new ArrayList<>();
 
 		p.require(XmlPullParser.START_TAG, null, VAST_COMPANIONADS);
 
@@ -46,7 +46,7 @@ public class CompanionAds extends VASTParserBase
 			if (name != null && name.equals(VAST_COMPANION))
 			{
 				p.require(XmlPullParser.START_TAG, null, VAST_COMPANION);
-                mCompanionAds.add(new Companion(p));
+				companionAds.add(new Companion(p));
 				p.require(XmlPullParser.END_TAG, null, VAST_COMPANION);
 			}
 			else
@@ -58,6 +58,6 @@ public class CompanionAds extends VASTParserBase
 	}
 
     public ArrayList<Companion> getCompanionAds() {
-        return mCompanionAds;
+		return companionAds;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/Creative.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/Creative.java
@@ -23,30 +23,31 @@ import java.io.IOException;
 import java.util.ArrayList;
 
 public class Creative extends VASTParserBase {
+
     private final static String VAST_CREATIVE = "Creative";
     private final static String VAST_CREATIVEEXTENSTONS = "CreativeExtensions";
     private final static String VAST_LINEAR = "Linear";
     private final static String VAST_COMPANIONADS = "CompanionAds";
     private final static String VAST_NONLINEARADS = "NonLinearAds";
 
-    private String mId;
-    private String mSequence;
-    private String mAdID;
-    private String mApiFramework;
+    private String id;
+    private String sequence;
+    private String adID;
+    private String apiFramework;
 
-    private ArrayList<CreativeExtension> mCreativeExtensions;
-    private Linear mLinear;
-    private ArrayList<Companion> mCompanionAds;
-    private NonLinearAds mNonLinearAds;
+    private ArrayList<CreativeExtension> creativeExtensions;
+    private Linear linear;
+    private ArrayList<Companion> companionAds;
+    private NonLinearAds nonLinearAds;
 
     public Creative(XmlPullParser p) throws XmlPullParserException, IOException {
 
         p.require(XmlPullParser.START_TAG, null, VAST_CREATIVE);
 
-        mId = p.getAttributeValue(null, "id");
-        mSequence = p.getAttributeValue(null, "sequence");
-        mAdID = p.getAttributeValue(null, "adID");
-        mApiFramework = p.getAttributeValue(null, "apiFramework");
+        id = p.getAttributeValue(null, "id");
+        sequence = p.getAttributeValue(null, "sequence");
+        adID = p.getAttributeValue(null, "adID");
+        apiFramework = p.getAttributeValue(null, "apiFramework");
 
         while (p.next() != XmlPullParser.END_TAG) {
             if (p.getEventType() != XmlPullParser.START_TAG) {
@@ -55,22 +56,22 @@ public class Creative extends VASTParserBase {
             String name = p.getName();
             if (name != null && name.equals(VAST_CREATIVEEXTENSTONS)) {
                 p.require(XmlPullParser.START_TAG, null, VAST_CREATIVEEXTENSTONS);
-                mCreativeExtensions = (new CreativeExtensions(p)).getCreativeExtenstions();
+                creativeExtensions = (new CreativeExtensions(p)).getCreativeExtenstions();
                 p.require(XmlPullParser.END_TAG, null, VAST_CREATIVEEXTENSTONS);
             }
             else if (name != null && name.equals(VAST_LINEAR)) {
                 p.require(XmlPullParser.START_TAG, null, VAST_LINEAR);
-                mLinear = new Linear(p);
+                linear = new Linear(p);
                 p.require(XmlPullParser.END_TAG, null, VAST_LINEAR);
             }
             else if (name != null && name.equals(VAST_COMPANIONADS)) {
                 p.require(XmlPullParser.START_TAG, null, VAST_COMPANIONADS);
-                mCompanionAds = (new CompanionAds(p)).getCompanionAds();
+                companionAds = (new CompanionAds(p)).getCompanionAds();
                 p.require(XmlPullParser.END_TAG, null, VAST_COMPANIONADS);
             }
             else if (name != null && name.equals(VAST_NONLINEARADS)) {
                 p.require(XmlPullParser.START_TAG, null, VAST_NONLINEARADS);
-                mNonLinearAds = new NonLinearAds(p);
+                nonLinearAds = new NonLinearAds(p);
                 p.require(XmlPullParser.END_TAG, null, VAST_NONLINEARADS);
             }
             else {
@@ -80,38 +81,38 @@ public class Creative extends VASTParserBase {
     }
 
     public String getId() {
-        return mId;
+        return id;
     }
 
     public String getSequence() {
-        return mSequence;
+        return sequence;
     }
 
     public String getAdID() {
-        return mAdID;
+        return adID;
     }
 
     public String getApiFramework() {
-        return mApiFramework;
+        return apiFramework;
     }
 
     public ArrayList<CreativeExtension> getCreativeExtensions() {
-        return mCreativeExtensions;
+        return creativeExtensions;
     }
 
     public Linear getLinear() {
-        return mLinear;
+        return linear;
     }
 
     public ArrayList<Companion> getCompanionAds() {
-        return mCompanionAds;
+        return companionAds;
     }
 
     public void setCompanionAds(ArrayList<Companion> companionAds) {
-        mCompanionAds = companionAds;
+        this.companionAds = companionAds;
     }
 
     public NonLinearAds getNonLinearAds() {
-        return mNonLinearAds;
+        return nonLinearAds;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/CreativeExtensions.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/CreativeExtensions.java
@@ -27,12 +27,12 @@ public class CreativeExtensions extends VASTParserBase
     private final static String VAST_CREATIVEEXTENSIONS = "CreativeExtensions";
     private final static String VAST_CREATIVEEXTENSION = "CreativeExtension";
 
-    private ArrayList<CreativeExtension> mCreativeExtenstions;
+    private ArrayList<CreativeExtension> creativeExtenstions;
 
 	public CreativeExtensions(XmlPullParser p) throws XmlPullParserException, IOException
 	{
 
-        mCreativeExtenstions = new ArrayList<>();
+		creativeExtenstions = new ArrayList<>();
 
 		p.require(XmlPullParser.START_TAG, null, VAST_CREATIVEEXTENSIONS);
 		while (p.next() != XmlPullParser.END_TAG)
@@ -45,7 +45,7 @@ public class CreativeExtensions extends VASTParserBase
 			if (name != null && name.equals(VAST_CREATIVEEXTENSION))
 			{
 				p.require(XmlPullParser.START_TAG, null, VAST_CREATIVEEXTENSION);
-                mCreativeExtenstions.add(new CreativeExtension(p));
+				creativeExtenstions.add(new CreativeExtension(p));
 
 				p.require(XmlPullParser.END_TAG, null, VAST_CREATIVEEXTENSION);
 
@@ -59,6 +59,6 @@ public class CreativeExtensions extends VASTParserBase
 	}
 
     public ArrayList<CreativeExtension> getCreativeExtenstions() {
-        return mCreativeExtenstions;
+		return creativeExtenstions;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/Creatives.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/Creatives.java
@@ -27,12 +27,12 @@ public class Creatives extends VASTParserBase
     private final static String VAST_CREATIVES = "Creatives";
     private final static String VAST_CREATIVE = "Creative";
 
-    private ArrayList<Creative> mCreatives;
+    private ArrayList<Creative> creatives;
 
 	public Creatives(XmlPullParser p) throws XmlPullParserException, IOException
 	{
 
-		mCreatives = new ArrayList<>();
+		creatives = new ArrayList<>();
 
 		p.require(XmlPullParser.START_TAG, null, VAST_CREATIVES);
 		while (p.next() != XmlPullParser.END_TAG)
@@ -45,7 +45,7 @@ public class Creatives extends VASTParserBase
 			if (name != null && name.equals(VAST_CREATIVE))
 			{
 				p.require(XmlPullParser.START_TAG, null, VAST_CREATIVE);
-                mCreatives.add(new Creative(p));
+				creatives.add(new Creative(p));
 				p.require(XmlPullParser.END_TAG, null, VAST_CREATIVE);
 			}
 			else
@@ -57,6 +57,6 @@ public class Creatives extends VASTParserBase
 	}
 
     public ArrayList<Creative> getCreatives() {
-        return mCreatives;
+		return creatives;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/Extension.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/Extension.java
@@ -21,17 +21,16 @@ import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.IOException;
 
-public class Extension extends VASTParserBase
-{
-    private String mType;
-    private AdVerifications mAdVerifications;
+public class Extension extends VASTParserBase {
+
+	private String type;
+	private AdVerifications adVerifications;
 
 	private final static String VAST_AD_VERIFICATIONS = "AdVerifications";
 	private final static String VAST_EXTENSION = "Extension";
 
-	public Extension(XmlPullParser p) throws XmlPullParserException, IOException
-	{
-        mType = p.getAttributeValue(null, "type");
+	public Extension(XmlPullParser p) throws XmlPullParserException, IOException {
+		type = p.getAttributeValue(null, "type");
 
 		p.require(XmlPullParser.START_TAG, null, VAST_EXTENSION);
 		while (p.next() != XmlPullParser.END_TAG) {
@@ -43,7 +42,7 @@ public class Extension extends VASTParserBase
 			String name = p.getName();
 			if (name != null && name.equals(VAST_AD_VERIFICATIONS)) {
 				p.require(XmlPullParser.START_TAG, null, VAST_AD_VERIFICATIONS);
-                mAdVerifications = new AdVerifications(p);
+				adVerifications = new AdVerifications(p);
 				p.require(XmlPullParser.END_TAG, null, VAST_AD_VERIFICATIONS);
 			} else {
 				skip(p);
@@ -52,10 +51,10 @@ public class Extension extends VASTParserBase
 	}
 
     public String getType() {
-        return mType;
+		return type;
     }
 
     public AdVerifications getAdVerifications() {
-        return mAdVerifications;
+		return adVerifications;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/Extensions.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/Extensions.java
@@ -27,11 +27,11 @@ public class Extensions extends VASTParserBase
 	private final static String VAST_EXTENSIONS = "Extensions";
 	private final static String VAST_EXTENSION = "Extension";
 
-	private ArrayList<Extension> mExtensions;
+	private ArrayList<Extension> extensions;
 
 	public Extensions(XmlPullParser p) throws XmlPullParserException, IOException
 	{
-		mExtensions = new ArrayList<>();
+		extensions = new ArrayList<>();
 
 		p.require(XmlPullParser.START_TAG, null, VAST_EXTENSIONS);
 		while (p.next() != XmlPullParser.END_TAG)
@@ -44,7 +44,7 @@ public class Extensions extends VASTParserBase
 			if (name != null && name.equals(VAST_EXTENSION))
 			{
 				p.require(XmlPullParser.START_TAG, null, VAST_EXTENSION);
-				mExtensions.add(new Extension(p));
+				extensions.add(new Extension(p));
 				p.require(XmlPullParser.END_TAG, null, VAST_EXTENSION);
 			}
 			else
@@ -55,6 +55,6 @@ public class Extensions extends VASTParserBase
 	}
 
 	public ArrayList<Extension> getExtensions() {
-		return mExtensions;
+		return extensions;
 	}
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/Icon.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/Icon.java
@@ -21,80 +21,76 @@ import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.IOException;
 
-public class Icon extends VASTParserBase
-{
-	private final static String VAST_ICON = "Icon";
-	private final static String VAST_STATICRESOURCE = "StaticResource";
-	private final static String VAST_IFRAMERESOURCE = "IFrameResource";
-	private final static String VAST_HTMLRESOURCE = "HTMLResource";
-	private final static String VAST_ICONCLICKS = "IconClicks";
-	private final static String VAST_ICONVIEWTRACKING = "IconViewTracking";
+public class Icon extends VASTParserBase {
 
-    private String mProgram;
-    private String mWidth;
-    private String mHeight;
-    private String mXPosition;
-    private String mYPosition;
-    private String mDuration;
-    private String mOffset;
-    private String mApiFramework;
+    private final static String VAST_ICON = "Icon";
+    private final static String VAST_STATICRESOURCE = "StaticResource";
+    private final static String VAST_IFRAMERESOURCE = "IFrameResource";
+    private final static String VAST_HTMLRESOURCE = "HTMLResource";
+    private final static String VAST_ICONCLICKS = "IconClicks";
+    private final static String VAST_ICONVIEWTRACKING = "IconViewTracking";
 
-    private StaticResource mStaticResource;
-    private IFrameResource mIFrameResource;
-    private HTMLResource mHtmlResource;
-    private IconClicks mIconClicks;
-    private IconViewTracking mIconViewTracking;
+    private String program;
+    private String width;
+    private String height;
+    private String xPosition;
+    private String yPosition;
+    private String duration;
+    private String offset;
+    private String apiFramework;
 
-	public Icon(XmlPullParser p) throws XmlPullParserException, IOException
-	{
+    private StaticResource staticResource;
+    private IFrameResource iFrameResource;
+    private HTMLResource htmlResource;
+    private IconClicks iconClicks;
+    private IconViewTracking iconViewTracking;
 
-		p.require(XmlPullParser.START_TAG, null, VAST_ICON);
+    public Icon(XmlPullParser p) throws XmlPullParserException, IOException {
 
-        mProgram = p.getAttributeValue(null, "program");
-        mWidth = p.getAttributeValue(null, "width");
-        mHeight = p.getAttributeValue(null, "height");
-        mXPosition = p.getAttributeValue(null, "xPosition");
-        mYPosition = p.getAttributeValue(null, "yPosition");
-        mDuration = p.getAttributeValue(null, "duration");
-        mOffset = p.getAttributeValue(null, "offset");
-        mApiFramework = p.getAttributeValue(null, "apiFramework");
+        p.require(XmlPullParser.START_TAG, null, VAST_ICON);
 
-		while (p.next() != XmlPullParser.END_TAG)
-		{
-			if (p.getEventType() != XmlPullParser.START_TAG)
-			{
-				continue;
-			}
-			String name = p.getName();
-			if (name != null && name.equals(VAST_STATICRESOURCE))
-			{
-				p.require(XmlPullParser.START_TAG, null, VAST_STATICRESOURCE);
-                mStaticResource = new StaticResource(p);
-				p.require(XmlPullParser.END_TAG, null, VAST_STATICRESOURCE);
+        program = p.getAttributeValue(null, "program");
+        width = p.getAttributeValue(null, "width");
+        height = p.getAttributeValue(null, "height");
+        xPosition = p.getAttributeValue(null, "xPosition");
+        yPosition = p.getAttributeValue(null, "yPosition");
+        duration = p.getAttributeValue(null, "duration");
+        offset = p.getAttributeValue(null, "offset");
+        apiFramework = p.getAttributeValue(null, "apiFramework");
+
+        while (p.next() != XmlPullParser.END_TAG) {
+            if (p.getEventType() != XmlPullParser.START_TAG) {
+                continue;
+            }
+            String name = p.getName();
+            if (name != null && name.equals(VAST_STATICRESOURCE)) {
+                p.require(XmlPullParser.START_TAG, null, VAST_STATICRESOURCE);
+                staticResource = new StaticResource(p);
+                p.require(XmlPullParser.END_TAG, null, VAST_STATICRESOURCE);
 			}
 			else if (name != null && name.equals(VAST_IFRAMERESOURCE))
 			{
-				p.require(XmlPullParser.START_TAG, null, VAST_IFRAMERESOURCE);
-                mIFrameResource = new IFrameResource(p);
-				p.require(XmlPullParser.END_TAG, null, VAST_IFRAMERESOURCE);
+                p.require(XmlPullParser.START_TAG, null, VAST_IFRAMERESOURCE);
+                iFrameResource = new IFrameResource(p);
+                p.require(XmlPullParser.END_TAG, null, VAST_IFRAMERESOURCE);
 			}
 			else if (name != null && name.equals(VAST_HTMLRESOURCE))
 			{
-				p.require(XmlPullParser.START_TAG, null, VAST_HTMLRESOURCE);
-                mHtmlResource = new HTMLResource(p);
-				p.require(XmlPullParser.END_TAG, null, VAST_HTMLRESOURCE);
+                p.require(XmlPullParser.START_TAG, null, VAST_HTMLRESOURCE);
+                htmlResource = new HTMLResource(p);
+                p.require(XmlPullParser.END_TAG, null, VAST_HTMLRESOURCE);
 			}
 			else if (name != null && name.equals(VAST_ICONCLICKS))
 			{
-				p.require(XmlPullParser.START_TAG, null, VAST_ICONCLICKS);
-                mIconClicks = new IconClicks(p);
-				p.require(XmlPullParser.END_TAG, null, VAST_ICONCLICKS);
+                p.require(XmlPullParser.START_TAG, null, VAST_ICONCLICKS);
+                iconClicks = new IconClicks(p);
+                p.require(XmlPullParser.END_TAG, null, VAST_ICONCLICKS);
 			}
 			else if (name != null && name.equals(VAST_ICONVIEWTRACKING))
 			{
-				p.require(XmlPullParser.START_TAG, null, VAST_ICONVIEWTRACKING);
-                mIconViewTracking = new IconViewTracking(p);
-				p.require(XmlPullParser.END_TAG, null, VAST_ICONVIEWTRACKING);
+                p.require(XmlPullParser.START_TAG, null, VAST_ICONVIEWTRACKING);
+                iconViewTracking = new IconViewTracking(p);
+                p.require(XmlPullParser.END_TAG, null, VAST_ICONVIEWTRACKING);
 			}
 			else
 			{
@@ -105,34 +101,34 @@ public class Icon extends VASTParserBase
 	}
 
     public String getProgram() {
-        return mProgram;
+        return program;
     }
 
     public String getWidth() {
-        return mWidth;
+        return width;
     }
 
     public String getHeight() {
-        return mHeight;
+        return height;
     }
 
     public String getXPosition() {
-        return mXPosition;
+        return xPosition;
     }
 
     public String getYPosition() {
-        return mYPosition;
+        return yPosition;
     }
 
     public String getDuration() {
-        return mDuration;
+        return duration;
     }
 
     public String getOffset() {
-        return mOffset;
+        return offset;
     }
 
     public String getApiFramework() {
-        return mApiFramework;
+        return apiFramework;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/IconClicks.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/IconClicks.java
@@ -21,36 +21,33 @@ import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.IOException;
 
-public class IconClicks extends VASTParserBase
-{
+public class IconClicks extends VASTParserBase {
+
 	private final static String VAST_ICONCLICKS = "IconClicks";
 	private final static String VAST_ICONCLICKTHROUGH = "IconClickThrough";
 	private final static String VAST_ICONCLICKTRACKING = "IconClickTracking";
 
-    private IconClickThrough mIconClickThrough;
-    private IconClickTracking mIconClickTracking;
+	private IconClickThrough iconClickThrough;
+	private IconClickTracking iconClickTracking;
 
-	public IconClicks(XmlPullParser p) throws XmlPullParserException, IOException
-	{
+	public IconClicks(XmlPullParser p) throws XmlPullParserException, IOException {
 
 		p.require(XmlPullParser.START_TAG, null, VAST_ICONCLICKS);
-		while (p.next() != XmlPullParser.END_TAG)
-		{
-			if (p.getEventType() != XmlPullParser.START_TAG)
-			{
+		while (p.next() != XmlPullParser.END_TAG) {
+			if (p.getEventType() != XmlPullParser.START_TAG) {
 				continue;
 			}
 			String name = p.getName();
 			if (name != null && name.equals(VAST_ICONCLICKTHROUGH))
 			{
 				p.require(XmlPullParser.START_TAG, null, VAST_ICONCLICKTHROUGH);
-                mIconClickThrough = new IconClickThrough(p);
+				iconClickThrough = new IconClickThrough(p);
 				p.require(XmlPullParser.END_TAG, null, VAST_ICONCLICKTHROUGH);
 			}
 			else if (name != null && name.equals(VAST_ICONCLICKTRACKING))
 			{
 				p.require(XmlPullParser.START_TAG, null, VAST_ICONCLICKTRACKING);
-                mIconClickTracking = new IconClickTracking(p);
+				iconClickTracking = new IconClickTracking(p);
 				p.require(XmlPullParser.END_TAG, null, VAST_ICONCLICKTRACKING);
 			}
 			else
@@ -62,10 +59,10 @@ public class IconClicks extends VASTParserBase
 	}
 
     public IconClickThrough getIconClickThrough() {
-        return mIconClickThrough;
+		return iconClickThrough;
     }
 
     public IconClickTracking getIconClickTracking() {
-        return mIconClickTracking;
+		return iconClickTracking;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/Icons.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/Icons.java
@@ -27,12 +27,12 @@ public class Icons extends VASTParserBase
     private final static String VAST_ICONS = "Icons";
     private final static String VAST_ICON = "Icon";
 
-    private ArrayList<Icon> mIcons;
+    private ArrayList<Icon> icons;
 
 	public Icons(XmlPullParser p) throws XmlPullParserException, IOException
 	{
 
-		mIcons = new ArrayList<>();
+		icons = new ArrayList<>();
 
 		p.require(XmlPullParser.START_TAG, null, VAST_ICONS);
 		while (p.next() != XmlPullParser.END_TAG)
@@ -45,7 +45,7 @@ public class Icons extends VASTParserBase
 			if (name != null && name.equals(VAST_ICON))
 			{
 				p.require(XmlPullParser.START_TAG, null, VAST_ICON);
-                mIcons.add(new Icon(p));
+				icons.add(new Icon(p));
 				p.require(XmlPullParser.END_TAG, null, VAST_ICON);
 			}
 			else
@@ -57,6 +57,6 @@ public class Icons extends VASTParserBase
 	}
 
     public ArrayList<Icon> getIcons() {
-        return mIcons;
+		return icons;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/InLine.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/InLine.java
@@ -37,97 +37,93 @@ public class InLine extends VASTParserBase
 	private final static String VAST_EXTENSIONS = "Extensions";
 	private final static String VAST_AD_VERIFICATIONS = "AdVerifications";
 
-	private AdSystem mAdSystem;
-	private AdTitle mAdTitle;
-	private Description mDescription;
-	private Advertiser mAdvertiser;
-	private Pricing mPricing;
-	private Survey mSurvey;
-	private Error mError;
-	private ArrayList<Impression> mImpressions;
-	private ArrayList<Creative> mCreatives;
-	private Extensions mExtensions;
-	private AdVerifications mAdVerifications;
+	private AdSystem adSystem;
+	private AdTitle adTitle;
+	private Description description;
+	private Advertiser advertiser;
+	private Pricing pricing;
+	private Survey survey;
+	private Error error;
+	private ArrayList<Impression> impressions;
+	private ArrayList<Creative> creatives;
+	private Extensions extensions;
+	private AdVerifications adVerifications;
 
-	public InLine(XmlPullParser p) throws XmlPullParserException, IOException
-	{
+	public InLine(XmlPullParser p) throws XmlPullParserException, IOException {
 
 		p.require(XmlPullParser.START_TAG, null, VAST_INLINE);
 
-		while (p.next() != XmlPullParser.END_TAG)
-		{
-			if (p.getEventType() != XmlPullParser.START_TAG)
-			{
+		while (p.next() != XmlPullParser.END_TAG) {
+			if (p.getEventType() != XmlPullParser.START_TAG) {
 				continue;
 			}
 			String name = p.getName();
 			if (name != null && name.equals(VAST_ADSYSTEM))
 			{
 				p.require(XmlPullParser.START_TAG, null, VAST_ADSYSTEM);
-				mAdSystem = new AdSystem(p);
+				adSystem = new AdSystem(p);
 				p.require(XmlPullParser.END_TAG, null, VAST_ADSYSTEM);
 			}
 			else if (name != null && name.equals(VAST_ADTITLE))
 			{
 				p.require(XmlPullParser.START_TAG, null, VAST_ADTITLE);
-				mAdTitle = new AdTitle(p);
+				adTitle = new AdTitle(p);
 				p.require(XmlPullParser.END_TAG, null, VAST_ADTITLE);
 			}
 			else if (name != null && name.equals(VAST_DESCRIPTION))
 			{
 				p.require(XmlPullParser.START_TAG, null, VAST_DESCRIPTION);
-				mDescription = new Description(p);
+				description = new Description(p);
 				p.require(XmlPullParser.END_TAG, null, VAST_DESCRIPTION);
 			}
 			else if (name != null && name.equals(VAST_ADVERTISER))
 			{
 				p.require(XmlPullParser.START_TAG, null, VAST_ADVERTISER);
-				mAdvertiser = new Advertiser(p);
+				advertiser = new Advertiser(p);
 				p.require(XmlPullParser.END_TAG, null, VAST_ADVERTISER);
 			}
 			else if (name != null && name.equals(VAST_PRICING))
 			{
 				p.require(XmlPullParser.START_TAG, null, VAST_PRICING);
-				mPricing = new Pricing(p);
+				pricing = new Pricing(p);
 				p.require(XmlPullParser.END_TAG, null, VAST_PRICING);
 			}
 			else if (name != null && name.equals(VAST_SURVEY))
 			{
 				p.require(XmlPullParser.START_TAG, null, VAST_SURVEY);
-				mSurvey = new Survey(p);
+				survey = new Survey(p);
 				p.require(XmlPullParser.END_TAG, null, VAST_SURVEY);
 			}
 			else if (name != null && name.equals(VAST_ERROR))
 			{
 				p.require(XmlPullParser.START_TAG, null, VAST_ERROR);
-				mError = new Error(p);
+				error = new Error(p);
 				p.require(XmlPullParser.END_TAG, null, VAST_ERROR);
 			}
 			else if (name != null && name.equals(VAST_IMPRESSION))
 			{
-				if (mImpressions == null)
-				{
-					mImpressions = new ArrayList<>();
+				if (impressions == null) {
+					impressions = new ArrayList<>();
 				}
 				p.require(XmlPullParser.START_TAG, null, VAST_IMPRESSION);
-				mImpressions.add(new Impression(p));
+				impressions.add(new Impression(p));
 				p.require(XmlPullParser.END_TAG, null, VAST_IMPRESSION);
 			}
 			else if (name != null && name.equals(VAST_CREATIVES))
 			{
 				p.require(XmlPullParser.START_TAG, null, VAST_CREATIVES);
-				mCreatives = (new Creatives(p)).getCreatives();
+				creatives = (new Creatives(p)).getCreatives();
 				p.require(XmlPullParser.END_TAG, null, VAST_CREATIVES);
 			}
 			else if (name != null && name.equals(VAST_EXTENSIONS))
 			{
 				p.require(XmlPullParser.START_TAG, null, VAST_EXTENSIONS);
-				mExtensions = new Extensions(p);
+				extensions = new Extensions(p);
 				p.require(XmlPullParser.END_TAG, null, VAST_EXTENSIONS);
 			}
 			else if (name != null && name.equals(VAST_AD_VERIFICATIONS)) {
 				p.require(XmlPullParser.START_TAG, null, VAST_AD_VERIFICATIONS);
-				mAdVerifications = new AdVerifications(p);
+				adVerifications = new AdVerifications(p);
 				p.require(XmlPullParser.END_TAG, null, VAST_AD_VERIFICATIONS);
 			}
 			else
@@ -139,50 +135,50 @@ public class InLine extends VASTParserBase
 	}
 
 	public AdSystem getAdSystem() {
-		return mAdSystem;
+		return adSystem;
 	}
 
 	public AdTitle getAdTitle() {
-		return mAdTitle;
+		return adTitle;
 	}
 
 	public Description getDescription() {
-		return mDescription;
+		return description;
 	}
 
 	public Advertiser getAdvertiser() {
-		return mAdvertiser;
+		return advertiser;
 	}
 
 	public Pricing getPricing() {
-		return mPricing;
+		return pricing;
 	}
 
 	public Survey getSurvey() {
-		return mSurvey;
+		return survey;
 	}
 
 	public Error getError() {
-		return mError;
+		return error;
 	}
 
 	public ArrayList<Impression> getImpressions() {
-		return mImpressions;
+		return impressions;
 	}
 
 	public ArrayList<Creative> getCreatives() {
-		return mCreatives;
+		return creatives;
 	}
 
 	public void setCreatives(ArrayList<Creative> creatives) {
-		mCreatives = creatives;
+		this.creatives = creatives;
 	}
 
 	public Extensions getExtensions() {
-		return mExtensions;
+		return extensions;
 	}
 
 	public AdVerifications getAdVerifications() {
-		return mAdVerifications;
+		return adVerifications;
 	}
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/Linear.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/Linear.java
@@ -24,6 +24,7 @@ import java.util.ArrayList;
 
 public class Linear extends VASTParserBase
 {
+
 	private final static String VAST_LINEAR = "Linear";
 	private final static String VAST_ADPARAMETERS = "AdParameters";
 	private final static String VAST_DURATION = "Duration";
@@ -32,24 +33,22 @@ public class Linear extends VASTParserBase
 	private final static String VAST_VIDEOCLICKS = "VideoClicks";
 	private final static String VAST_ICONS = "Icons";
 
-    private String mSkipOffset;
+	private String skipOffset;
 
-    private AdParameters mAdParameters;
-    private Duration mDuration;
-    private ArrayList<MediaFile> mMediaFiles;
-    private ArrayList<Tracking> mTrackingEvents;
-    private VideoClicks mVideoClicks;
-    private ArrayList<Icon> mIcons;
+	private AdParameters adParameters;
+	private Duration duration;
+	private ArrayList<MediaFile> mediaFiles;
+	private ArrayList<Tracking> trackingEvents;
+	private VideoClicks videoClicks;
+	private ArrayList<Icon> icons;
 
-	public Linear(XmlPullParser p) throws XmlPullParserException, IOException
-	{
+	public Linear(XmlPullParser p) throws XmlPullParserException, IOException {
 
 		p.require(XmlPullParser.START_TAG, null, VAST_LINEAR);
 
-        mSkipOffset = p.getAttributeValue(null, "skipoffset");
+		skipOffset = p.getAttributeValue(null, "skipoffset");
 
-		while (p.next() != XmlPullParser.END_TAG)
-		{
+		while (p.next() != XmlPullParser.END_TAG) {
 			if (p.getEventType() != XmlPullParser.START_TAG)
 			{
 				continue;
@@ -58,37 +57,37 @@ public class Linear extends VASTParserBase
 			if (name != null && name.equals(VAST_ADPARAMETERS))
 			{
 				p.require(XmlPullParser.START_TAG, null, VAST_ADPARAMETERS);
-                mAdParameters = new AdParameters(p);
+				adParameters = new AdParameters(p);
 				p.require(XmlPullParser.END_TAG, null, VAST_ADPARAMETERS);
 			}
 			else if (name != null && name.equals(VAST_DURATION))
 			{
 				p.require(XmlPullParser.START_TAG, null, VAST_DURATION);
-                mDuration = new Duration(p);
+				duration = new Duration(p);
 				p.require(XmlPullParser.END_TAG, null, VAST_DURATION);
 			}
 			else if (name != null && name.equals(VAST_MEDIAFILES))
 			{
 				p.require(XmlPullParser.START_TAG, null, VAST_MEDIAFILES);
-                mMediaFiles = (new MediaFiles(p)).getMediaFiles();
+				mediaFiles = (new MediaFiles(p)).getMediaFiles();
 				p.require(XmlPullParser.END_TAG, null, VAST_MEDIAFILES);
 			}
 			else if (name != null && name.equals(VAST_TRACKINGEVENTS))
 			{
 				p.require(XmlPullParser.START_TAG, null, VAST_TRACKINGEVENTS);
-                mTrackingEvents = (new TrackingEvents(p)).getTrackingEvents();
+				trackingEvents = (new TrackingEvents(p)).getTrackingEvents();
 				p.require(XmlPullParser.END_TAG, null, VAST_TRACKINGEVENTS);
 			}
 			else if (name != null && name.equals(VAST_VIDEOCLICKS))
 			{
 				p.require(XmlPullParser.START_TAG, null, VAST_VIDEOCLICKS);
-                mVideoClicks = new VideoClicks(p);
+				videoClicks = new VideoClicks(p);
 				p.require(XmlPullParser.END_TAG, null, VAST_VIDEOCLICKS);
 			}
 			else if (name != null && name.equals(VAST_ICONS))
 			{
 				p.require(XmlPullParser.START_TAG, null, VAST_ICONS);
-                mIcons = (new Icons(p)).getIcons();
+				icons = (new Icons(p)).getIcons();
 				p.require(XmlPullParser.END_TAG, null, VAST_ICONS);
 			}
 			else
@@ -100,30 +99,30 @@ public class Linear extends VASTParserBase
 	}
 
     public String getSkipOffset() {
-        return mSkipOffset;
+		return skipOffset;
     }
 
     public AdParameters getAdParameters() {
-        return mAdParameters;
+		return adParameters;
     }
 
     public Duration getDuration() {
-        return mDuration;
+		return duration;
     }
 
     public ArrayList<MediaFile> getMediaFiles() {
-        return mMediaFiles;
+		return mediaFiles;
     }
 
     public ArrayList<Tracking> getTrackingEvents() {
-        return mTrackingEvents;
+		return trackingEvents;
     }
 
     public VideoClicks getVideoClicks() {
-        return mVideoClicks;
+		return videoClicks;
     }
 
     public ArrayList<Icon> getIcons() {
-        return mIcons;
+		return icons;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/MediaFile.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/MediaFile.java
@@ -21,95 +21,94 @@ import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.IOException;
 
-public class MediaFile extends VASTParserBase
-{
-    private String mId;
-    private String mValue;
-    private String mDelivery;
-    private String mType;
-    private String mBitrate;
-    private String mMinBitrate;
-    private String mMaxBitrate;
-    private String mWidth;
-    private String mHeight;
-    private String mXPosition;
-    private String mYPosition;
-    private String mDuration;
-    private String mOffset;
-    private String mApiFramework;
+public class MediaFile extends VASTParserBase {
 
-	public MediaFile(XmlPullParser p) throws XmlPullParserException, IOException
-	{
+    private String id;
+    private String value;
+    private String delivery;
+    private String type;
+    private String bitrate;
+    private String minBitrate;
+    private String maxBitrate;
+    private String width;
+    private String height;
+    private String xPosition;
+    private String yPosition;
+    private String duration;
+    private String offset;
+    private String apiFramework;
 
-        mId = p.getAttributeValue(null, "id");
-        mDelivery = p.getAttributeValue(null, "delivery");
-        mType = p.getAttributeValue(null, "type");
-        mBitrate = p.getAttributeValue(null, "bitrate");
-        mMinBitrate = p.getAttributeValue(null, "minBitrate");
-        mMaxBitrate = p.getAttributeValue(null, "maxBitrate");
-        mWidth = p.getAttributeValue(null, "width");
-        mHeight = p.getAttributeValue(null, "height");
-        mXPosition = p.getAttributeValue(null, "xPosition");
-        mYPosition = p.getAttributeValue(null, "yPosition");
-        mDuration = p.getAttributeValue(null, "duration");
-        mOffset = p.getAttributeValue(null, "offset");
-        mApiFramework = p.getAttributeValue(null, "apiFramework");
-        mValue = readText(p);
+    public MediaFile(XmlPullParser p) throws XmlPullParserException, IOException {
+
+        id = p.getAttributeValue(null, "id");
+        delivery = p.getAttributeValue(null, "delivery");
+        type = p.getAttributeValue(null, "type");
+        bitrate = p.getAttributeValue(null, "bitrate");
+        minBitrate = p.getAttributeValue(null, "minBitrate");
+        maxBitrate = p.getAttributeValue(null, "maxBitrate");
+        width = p.getAttributeValue(null, "width");
+        height = p.getAttributeValue(null, "height");
+        xPosition = p.getAttributeValue(null, "xPosition");
+        yPosition = p.getAttributeValue(null, "yPosition");
+        duration = p.getAttributeValue(null, "duration");
+        offset = p.getAttributeValue(null, "offset");
+        apiFramework = p.getAttributeValue(null, "apiFramework");
+        value = readText(p);
     }
 
     public String getId() {
-        return mId;
+        return id;
     }
 
     public String getValue() {
-        return mValue;
+        return value;
     }
 
     public String getDelivery() {
-        return mDelivery;
+        return delivery;
     }
 
     public String getType() {
-        return mType;
+        return type;
     }
 
     public String getBitrate() {
-        return mBitrate;
+        return bitrate;
     }
 
     public String getMinBitrate() {
-        return mMinBitrate;
+        return minBitrate;
     }
 
     public String getMaxBitrate() {
-        return mMaxBitrate;
+        return maxBitrate;
     }
 
     public String getWidth() {
-        return mWidth;
+        return width;
     }
 
     public String getHeight() {
-        return mHeight;
+        return height;
     }
 
     public String getXPosition() {
-        return mXPosition;
+        return xPosition;
     }
 
     public String getYPosition() {
-        return mYPosition;
+        return yPosition;
     }
 
     public String getDuration() {
-        return mDuration;
+        return duration;
     }
 
     public String getOffset() {
-        return mOffset;
+        return offset;
     }
 
     public String getApiFramework() {
-        return mApiFramework;
+        return apiFramework;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/MediaFiles.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/MediaFiles.java
@@ -27,12 +27,12 @@ public class MediaFiles extends VASTParserBase
     private final static String VAST_MEDIAFILES = "MediaFiles";
     private final static String VAST_MEDIAFILE = "MediaFile";
 
-    private ArrayList<MediaFile> mMediaFiles;
+    private ArrayList<MediaFile> mediaFiles;
 
 	public MediaFiles(XmlPullParser p) throws XmlPullParserException, IOException
 	{
 
-		mMediaFiles = new ArrayList<>();
+		mediaFiles = new ArrayList<>();
 
 		p.require(XmlPullParser.START_TAG, null, VAST_MEDIAFILES);
 		while (p.next() != XmlPullParser.END_TAG)
@@ -45,7 +45,7 @@ public class MediaFiles extends VASTParserBase
 			if (name != null && name.equals(VAST_MEDIAFILE))
 			{
 				p.require(XmlPullParser.START_TAG, null, VAST_MEDIAFILE);
-                mMediaFiles.add(new MediaFile(p));
+				mediaFiles.add(new MediaFile(p));
 
 				p.require(XmlPullParser.END_TAG, null, VAST_MEDIAFILE);
 
@@ -59,6 +59,6 @@ public class MediaFiles extends VASTParserBase
 	}
 
     public ArrayList<MediaFile> getMediaFiles() {
-        return mMediaFiles;
+		return mediaFiles;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/NonLinear.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/NonLinear.java
@@ -21,90 +21,86 @@ import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.IOException;
 
-public class NonLinear extends VASTParserBase
-{
-	private final static String VAST_NONLINEAR = "NonLinear";
-	private final static String VAST_STATICRESOURCE = "StaticResource";
-	private final static String VAST_IFRAMERESOUCE = "IFrameResource";
-	private final static String VAST_HTMLRESOURCE = "HTMLResource";
-	private final static String VAST_ADPARAMETERS = "AdParameters";
-	private final static String VAST_NONLINEARCLICKTHROUGH = "NonLinearClickThrough";
-	private final static String VAST_NONLINEARCLICKTRACKING = "NonLinearClickTracking";
+public class NonLinear extends VASTParserBase {
 
-    private String mId;
-    private String mWidth;
-    private String mHeight;
-    private String mExpandedWidth;
-    private String mExpandedHeight;
-    private String mScalable;
-    private String mMaintainAspectRatio;
-    private String mMinSuggestedDuration;
-    private String mApiFramework;
+    private final static String VAST_NONLINEAR = "NonLinear";
+    private final static String VAST_STATICRESOURCE = "StaticResource";
+    private final static String VAST_IFRAMERESOUCE = "IFrameResource";
+    private final static String VAST_HTMLRESOURCE = "HTMLResource";
+    private final static String VAST_ADPARAMETERS = "AdParameters";
+    private final static String VAST_NONLINEARCLICKTHROUGH = "NonLinearClickThrough";
+    private final static String VAST_NONLINEARCLICKTRACKING = "NonLinearClickTracking";
 
-    private StaticResource mStaticResource;
-    private IFrameResource mIFrameResource;
-    private HTMLResource mHTMLResource;
-    private AdParameters mAdParameters;
-    private NonLinearClickThrough mNonLinearClickThrough;
-    private NonLinearClickTracking mNonLinearClickTracking;
+    private String id;
+    private String width;
+    private String height;
+    private String expandedWidth;
+    private String expandedHeight;
+    private String scalable;
+    private String maintainAspectRatio;
+    private String minSuggestedDuration;
+    private String apiFramework;
 
-	public NonLinear(XmlPullParser p) throws XmlPullParserException, IOException
-	{
+    private StaticResource staticResource;
+    private IFrameResource iFrameResource;
+    private HTMLResource HTMLResource;
+    private AdParameters adParameters;
+    private NonLinearClickThrough nonLinearClickThrough;
+    private NonLinearClickTracking nonLinearClickTracking;
 
-		p.require(XmlPullParser.START_TAG, null, VAST_NONLINEAR);
+    public NonLinear(XmlPullParser p) throws XmlPullParserException, IOException {
 
-        mId = p.getAttributeValue(null, "id");
-        mWidth = p.getAttributeValue(null, "width");
-        mHeight = p.getAttributeValue(null, "height");
-        mExpandedWidth = p.getAttributeValue(null, "expandedWidth");
-        mExpandedHeight = p.getAttributeValue(null, "expandedHeight");
-        mScalable = p.getAttributeValue(null, "scalable");
-        mMaintainAspectRatio = p.getAttributeValue(null, "maintainAspectRatio");
-        mMinSuggestedDuration = p.getAttributeValue(null, "minSuggestedDuration");
-        mApiFramework = p.getAttributeValue(null, "apiFramework");
+        p.require(XmlPullParser.START_TAG, null, VAST_NONLINEAR);
 
-		while (p.next() != XmlPullParser.END_TAG)
-		{
-			if (p.getEventType() != XmlPullParser.START_TAG)
-			{
-				continue;
-			}
-			String name = p.getName();
-			if (name != null && name.equals(VAST_STATICRESOURCE))
-			{
-				p.require(XmlPullParser.START_TAG, null, VAST_STATICRESOURCE);
-                mStaticResource = new StaticResource(p);
-				p.require(XmlPullParser.END_TAG, null, VAST_STATICRESOURCE);
+        id = p.getAttributeValue(null, "id");
+        width = p.getAttributeValue(null, "width");
+        height = p.getAttributeValue(null, "height");
+        expandedWidth = p.getAttributeValue(null, "expandedWidth");
+        expandedHeight = p.getAttributeValue(null, "expandedHeight");
+        scalable = p.getAttributeValue(null, "scalable");
+        maintainAspectRatio = p.getAttributeValue(null, "maintainAspectRatio");
+        minSuggestedDuration = p.getAttributeValue(null, "minSuggestedDuration");
+        apiFramework = p.getAttributeValue(null, "apiFramework");
+
+        while (p.next() != XmlPullParser.END_TAG) {
+            if (p.getEventType() != XmlPullParser.START_TAG) {
+                continue;
+            }
+            String name = p.getName();
+            if (name != null && name.equals(VAST_STATICRESOURCE)) {
+                p.require(XmlPullParser.START_TAG, null, VAST_STATICRESOURCE);
+                staticResource = new StaticResource(p);
+                p.require(XmlPullParser.END_TAG, null, VAST_STATICRESOURCE);
 			}
 			else if (name != null && name.equals(VAST_IFRAMERESOUCE))
 			{
-				p.require(XmlPullParser.START_TAG, null, VAST_IFRAMERESOUCE);
-                mIFrameResource = new IFrameResource(p);
-				p.require(XmlPullParser.END_TAG, null, VAST_IFRAMERESOUCE);
+                p.require(XmlPullParser.START_TAG, null, VAST_IFRAMERESOUCE);
+                iFrameResource = new IFrameResource(p);
+                p.require(XmlPullParser.END_TAG, null, VAST_IFRAMERESOUCE);
 			}
 			else if (name != null && name.equals(VAST_HTMLRESOURCE))
 			{
-				p.require(XmlPullParser.START_TAG, null, VAST_HTMLRESOURCE);
-                mHTMLResource = new HTMLResource(p);
-				p.require(XmlPullParser.END_TAG, null, VAST_HTMLRESOURCE);
+                p.require(XmlPullParser.START_TAG, null, VAST_HTMLRESOURCE);
+                HTMLResource = new HTMLResource(p);
+                p.require(XmlPullParser.END_TAG, null, VAST_HTMLRESOURCE);
 			}
 			else if (name != null && name.equals(VAST_ADPARAMETERS))
 			{
-				p.require(XmlPullParser.START_TAG, null, VAST_ADPARAMETERS);
-                mAdParameters = new AdParameters(p);
-				p.require(XmlPullParser.END_TAG, null, VAST_ADPARAMETERS);
+                p.require(XmlPullParser.START_TAG, null, VAST_ADPARAMETERS);
+                adParameters = new AdParameters(p);
+                p.require(XmlPullParser.END_TAG, null, VAST_ADPARAMETERS);
 			}
 			else if (name != null && name.equals(VAST_NONLINEARCLICKTHROUGH))
 			{
-				p.require(XmlPullParser.START_TAG, null, VAST_NONLINEARCLICKTHROUGH);
-                mNonLinearClickThrough = new NonLinearClickThrough(p);
-				p.require(XmlPullParser.END_TAG, null, VAST_NONLINEARCLICKTHROUGH);
+                p.require(XmlPullParser.START_TAG, null, VAST_NONLINEARCLICKTHROUGH);
+                nonLinearClickThrough = new NonLinearClickThrough(p);
+                p.require(XmlPullParser.END_TAG, null, VAST_NONLINEARCLICKTHROUGH);
 			}
 			else if (name != null && name.equals(VAST_NONLINEARCLICKTRACKING))
 			{
-				p.require(XmlPullParser.START_TAG, null, VAST_NONLINEARCLICKTRACKING);
-                mNonLinearClickTracking = new NonLinearClickTracking(p);
-				p.require(XmlPullParser.END_TAG, null, VAST_NONLINEARCLICKTRACKING);
+                p.require(XmlPullParser.START_TAG, null, VAST_NONLINEARCLICKTRACKING);
+                nonLinearClickTracking = new NonLinearClickTracking(p);
+                p.require(XmlPullParser.END_TAG, null, VAST_NONLINEARCLICKTRACKING);
 			}
 			else
 			{
@@ -115,62 +111,62 @@ public class NonLinear extends VASTParserBase
 	}
 
     public String getId() {
-        return mId;
+        return id;
     }
 
     public String getWidth() {
-        return mWidth;
+        return width;
     }
 
     public String getHeight() {
-        return mHeight;
+        return height;
     }
 
     public String getExpandedWidth() {
-        return mExpandedWidth;
+        return expandedWidth;
     }
 
     public String getExpandedHeight() {
-        return mExpandedHeight;
+        return expandedHeight;
     }
 
     public String getScalable() {
-        return mScalable;
+        return scalable;
     }
 
     public String getMaintainAspectRatio() {
-        return mMaintainAspectRatio;
+        return maintainAspectRatio;
     }
 
     public String getMinSuggestedDuration() {
-        return mMinSuggestedDuration;
+        return minSuggestedDuration;
     }
 
     public String getApiFramework() {
-        return mApiFramework;
+        return apiFramework;
     }
 
     public StaticResource getStaticResource() {
-        return mStaticResource;
+        return staticResource;
     }
 
     public IFrameResource getIFrameResource() {
-        return mIFrameResource;
+        return iFrameResource;
     }
 
     public HTMLResource getHTMLResource() {
-        return mHTMLResource;
+        return HTMLResource;
     }
 
     public AdParameters getAdParameters() {
-        return mAdParameters;
+        return adParameters;
     }
 
     public NonLinearClickThrough getNonLinearClickThrough() {
-        return mNonLinearClickThrough;
+        return nonLinearClickThrough;
     }
 
     public NonLinearClickTracking getNonLinearClickTracking() {
-        return mNonLinearClickTracking;
+        return nonLinearClickTracking;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/NonLinearAds.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/NonLinearAds.java
@@ -22,24 +22,22 @@ import org.xmlpull.v1.XmlPullParserException;
 import java.io.IOException;
 import java.util.ArrayList;
 
-public class NonLinearAds extends VASTParserBase
-{
+public class NonLinearAds extends VASTParserBase {
+
 	private final static String VAST_NONLINEAERADS = "NonLinearAds";
 	private final static String VAST_NONLINEAR = "NonLinear";
 	private final static String VAST_TRACKINGEVENTS = "TrackingEvents";
 
-    private ArrayList<NonLinear> mNonLinearAds;
-    private ArrayList<Tracking> mTrackingEvents;
+	private ArrayList<NonLinear> nonLinearAds;
+	private ArrayList<Tracking> trackingEvents;
 
-	public NonLinearAds(XmlPullParser p) throws XmlPullParserException, IOException
-	{
+	public NonLinearAds(XmlPullParser p) throws XmlPullParserException, IOException {
 
-		mNonLinearAds = new ArrayList<>();
+		nonLinearAds = new ArrayList<>();
 
 		p.require(XmlPullParser.START_TAG, null, VAST_NONLINEAERADS);
 
-		while (p.next() != XmlPullParser.END_TAG)
-		{
+		while (p.next() != XmlPullParser.END_TAG) {
 			if (p.getEventType() != XmlPullParser.START_TAG)
 			{
 				continue;
@@ -48,13 +46,13 @@ public class NonLinearAds extends VASTParserBase
 			if (name != null && name.equals(VAST_NONLINEAR))
 			{
 				p.require(XmlPullParser.START_TAG, null, VAST_NONLINEAR);
-                mNonLinearAds.add(new NonLinear(p));
+				nonLinearAds.add(new NonLinear(p));
 				p.require(XmlPullParser.END_TAG, null, VAST_NONLINEAR);
 			}
 			else if (name != null && name.equals(VAST_TRACKINGEVENTS))
 			{
 				p.require(XmlPullParser.START_TAG, null, VAST_TRACKINGEVENTS);
-                mTrackingEvents = (new TrackingEvents(p)).getTrackingEvents();
+				trackingEvents = (new TrackingEvents(p)).getTrackingEvents();
 				p.require(XmlPullParser.END_TAG, null, VAST_TRACKINGEVENTS);
 			}
 			else
@@ -66,10 +64,10 @@ public class NonLinearAds extends VASTParserBase
 	}
 
     public ArrayList<NonLinear> getNonLinearAds() {
-        return mNonLinearAds;
+		return nonLinearAds;
     }
 
     public ArrayList<Tracking> getTrackingEvents() {
-        return mTrackingEvents;
+		return trackingEvents;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/Pricing.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/Pricing.java
@@ -21,28 +21,27 @@ import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.IOException;
 
-public class Pricing extends VASTParserBase
-{
-    private String mModel;
-    private String mCurrency;
-    private String mValue;
+public class Pricing extends VASTParserBase {
 
-	public Pricing(XmlPullParser p) throws XmlPullParserException, IOException
-	{
-        mModel = p.getAttributeValue(null, "model");
-        mCurrency = p.getAttributeValue(null, "currency");
-        mValue = readText(p);
+    private String model;
+    private String currency;
+    private String value;
+
+    public Pricing(XmlPullParser p) throws XmlPullParserException, IOException {
+        model = p.getAttributeValue(null, "model");
+        currency = p.getAttributeValue(null, "currency");
+        value = readText(p);
     }
 
     public String getModel() {
-        return mModel;
+        return model;
     }
 
     public String getCurrency() {
-        return mCurrency;
+        return currency;
     }
 
     public String getValue() {
-        return mValue;
+        return value;
 	}
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/StaticResource.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/StaticResource.java
@@ -21,22 +21,21 @@ import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.IOException;
 
-public class StaticResource extends VASTParserBase
-{
-    private String mCreativeType;
-    private String mValue;
+public class StaticResource extends VASTParserBase {
 
-	public StaticResource(XmlPullParser p) throws XmlPullParserException, IOException
-	{
-        mCreativeType = p.getAttributeValue(null, "creativeType");
-        mValue = readText(p);
+    private String creativeType;
+    private String value;
+
+    public StaticResource(XmlPullParser p) throws XmlPullParserException, IOException {
+        creativeType = p.getAttributeValue(null, "creativeType");
+        value = readText(p);
     }
 
     public String getCreativeType() {
-        return mCreativeType;
+        return creativeType;
     }
 
     public String getValue() {
-        return mValue;
+        return value;
 	}
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/Tracking.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/Tracking.java
@@ -21,26 +21,25 @@ import org.xmlpull.v1.XmlPullParserException;
 
 import java.io.IOException;
 
-public class Tracking extends VASTParserBase
-{
-    private String mEvent;
-    private String mValue;
+public class Tracking extends VASTParserBase {
 
-	public Tracking(XmlPullParser p) throws XmlPullParserException, IOException
-	{
-        mEvent = p.getAttributeValue(null, "event");
-        mValue = readText(p);
+    private String event;
+    private String value;
+
+    public Tracking(XmlPullParser p) throws XmlPullParserException, IOException {
+        event = p.getAttributeValue(null, "event");
+        value = readText(p);
     }
 
     public String getEvent() {
-        return mEvent;
+        return event;
     }
 
     public void setEvent(String event) {
-        mEvent = event;
+        this.event = event;
     }
 
     public String getValue() {
-        return mValue;
+        return value;
 	}
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/TrackingEvents.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/TrackingEvents.java
@@ -27,11 +27,11 @@ public class TrackingEvents extends VASTParserBase
     private final static String VAST_TRACKINGEVENTS = "TrackingEvents";
     private final static String VAST_TRACKING = "Tracking";
 
-    private ArrayList<Tracking> mTrackingEvents;
+    private ArrayList<Tracking> trackingEvents;
 
     public TrackingEvents(XmlPullParser p) throws XmlPullParserException, IOException {
 
-        mTrackingEvents = new ArrayList<>();
+        trackingEvents = new ArrayList<>();
 
         p.require(XmlPullParser.START_TAG, null, VAST_TRACKINGEVENTS);
         while (p.next() != XmlPullParser.END_TAG) {
@@ -42,7 +42,7 @@ public class TrackingEvents extends VASTParserBase
             if (name != null && name.equals(VAST_TRACKING)) {
 
                 p.require(XmlPullParser.START_TAG, null, VAST_TRACKING);
-                mTrackingEvents.add(new Tracking(p));
+                trackingEvents.add(new Tracking(p));
 
                 p.require(XmlPullParser.END_TAG, null, VAST_TRACKING);
             }
@@ -53,6 +53,6 @@ public class TrackingEvents extends VASTParserBase
     }
 
     public ArrayList<Tracking> getTrackingEvents() {
-        return mTrackingEvents;
+        return trackingEvents;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/VAST.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/VAST.java
@@ -22,23 +22,22 @@ import org.xmlpull.v1.XmlPullParserException;
 import java.io.IOException;
 import java.util.ArrayList;
 
-public class VAST extends VASTParserBase
-{
+public class VAST extends VASTParserBase {
+
 	private final static String VAST_START = "VAST";
 	private final static String VAST_ERROR = "Error";
 	private final static String VAST_AD = "Ad";
 
-    private Error mError;
-    private ArrayList<Ad> mAds;
+	private Error error;
+	private ArrayList<Ad> ads;
 
-    private String mVersion;
+	private String version;
 
-	public VAST(XmlPullParser p) throws XmlPullParserException, IOException
-	{
+	public VAST(XmlPullParser p) throws XmlPullParserException, IOException {
 
 		p.require(XmlPullParser.START_TAG, null, VAST_START);
 
-        mVersion = p.getAttributeValue(null, "version");
+		version = p.getAttributeValue(null, "version");
 
 		while (p.next() != XmlPullParser.END_TAG)
 		{
@@ -50,19 +49,18 @@ public class VAST extends VASTParserBase
 			if (name != null && name.equals(VAST_ERROR))
 			{
 				p.require(XmlPullParser.START_TAG, null, VAST_ERROR);
-                mError = new Error(p);
+				error = new Error(p);
 				p.require(XmlPullParser.END_TAG, null, VAST_ERROR);
 			}
 			else if (name != null && name.equals(VAST_AD))
 			{
 
-                if (mAds == null)
-				{
-					mAds = new ArrayList<>();
+				if (ads == null) {
+					ads = new ArrayList<>();
 				}
 
 				p.require(XmlPullParser.START_TAG, null, VAST_AD);
-                mAds.add(new Ad(p));
+				ads.add(new Ad(p));
 				p.require(XmlPullParser.END_TAG, null, VAST_AD);
 			}
 			else
@@ -73,14 +71,14 @@ public class VAST extends VASTParserBase
 	}
 
     public Error getError() {
-        return mError;
+		return error;
     }
 
     public ArrayList<Ad> getAds() {
-        return mAds;
+		return ads;
     }
 
     public String getVersion() {
-        return mVersion;
+		return version;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/VASTErrorCodes.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/VASTErrorCodes.java
@@ -41,16 +41,16 @@ public enum VASTErrorCodes {
     //TODO: linear, vpaid & companion error codes
     UNDEFINED_ERROR("Undefined Error.");
 
-    private final String mMessage;
+    private final String message;
 
     VASTErrorCodes(String message) {
-        mMessage = message;
+        this.message = message;
     }
 
     @NonNull
     @Override
     public final String toString() {
-        return mMessage;
+        return message;
     }
 }
 

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/VideoClicks.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/VideoClicks.java
@@ -22,48 +22,45 @@ import org.xmlpull.v1.XmlPullParserException;
 import java.io.IOException;
 import java.util.ArrayList;
 
-public class VideoClicks extends VASTParserBase
-{
+public class VideoClicks extends VASTParserBase {
+
 	private final static String VAST_VIDEOCLICKS = "VideoClicks";
 	private final static String VAST_CLICKTHROUGH = "ClickThrough";
 	private final static String VAST_CLICKTRACKING = "ClickTracking";
 	private final static String VAST_CUSTOMCLICK = "CustomClick";
 
-	private ClickThrough mClickThrough;
-	private ArrayList<ClickTracking> mClickTrackings;
-	private ArrayList<CustomClick> mCustomClicks;
+	private ClickThrough clickThrough;
+	private ArrayList<ClickTracking> clickTrackings;
+	private ArrayList<CustomClick> customClicks;
 
-	public VideoClicks(XmlPullParser p) throws XmlPullParserException, IOException
-	{
+	public VideoClicks(XmlPullParser p) throws XmlPullParserException, IOException {
 
-        mClickTrackings = new ArrayList<>();
-        mCustomClicks = new ArrayList<>();
+		clickTrackings = new ArrayList<>();
+		customClicks = new ArrayList<>();
 
 		p.require(XmlPullParser.START_TAG, null, VAST_VIDEOCLICKS);
-		while (p.next() != XmlPullParser.END_TAG)
-		{
-			if (p.getEventType() != XmlPullParser.START_TAG)
-			{
+		while (p.next() != XmlPullParser.END_TAG) {
+			if (p.getEventType() != XmlPullParser.START_TAG) {
 				continue;
 			}
 			String name = p.getName();
 			if (name != null && name.equals(VAST_CLICKTHROUGH))
 			{
 				p.require(XmlPullParser.START_TAG, null, VAST_CLICKTHROUGH);
-				mClickThrough = new ClickThrough(p);
+				clickThrough = new ClickThrough(p);
 				p.require(XmlPullParser.END_TAG, null, VAST_CLICKTHROUGH);
 			}
 			else if (name != null && name.equals(VAST_CLICKTRACKING))
 			{
 				p.require(XmlPullParser.START_TAG, null, VAST_CLICKTRACKING);
-				mClickTrackings.add(new ClickTracking(p));
+				clickTrackings.add(new ClickTracking(p));
 				
 				p.require(XmlPullParser.END_TAG, null, VAST_CLICKTRACKING);
 			}
 			else if (name != null && name.equals(VAST_CUSTOMCLICK))
 			{
 				p.require(XmlPullParser.START_TAG, null, VAST_CUSTOMCLICK);
-				mCustomClicks.add(new CustomClick(p));
+				customClicks.add(new CustomClick(p));
 				
 				p.require(XmlPullParser.END_TAG, null, VAST_CUSTOMCLICK);
 			}
@@ -76,14 +73,14 @@ public class VideoClicks extends VASTParserBase
 	}
 
 	public ClickThrough getClickThrough() {
-		return mClickThrough;
+		return clickThrough;
 	}
 
 	public ArrayList<ClickTracking> getClickTrackings() {
-		return mClickTrackings;
+		return clickTrackings;
 	}
 
 	public ArrayList<CustomClick> getCustomClicks() {
-		return mCustomClicks;
+		return customClicks;
 	}
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/Wrapper.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/vast/Wrapper.java
@@ -33,25 +33,25 @@ public class Wrapper extends VASTParserBase {
     private final static String VAST_CREATIVES = "Creatives";
     private final static String VAST_EXTENSIONS = "Extensions";
 
-    private String mFollowAdditionalWrappers;
-    private String mAllowMultipleAds;
-    private String mFallbackOnNoAd;
-    private AdSystem mAdSystem;
-    private VastUrl mVastUrl;
-    private Error mError;
-    private ArrayList<Impression> mImpressions;
+    private String followAdditionalWrappers;
+    private String allowMultipleAds;
+    private String fallbackOnNoAd;
+    private AdSystem adSystem;
+    private VastUrl vastUrl;
+    private Error error;
+    private ArrayList<Impression> impressions;
     //SDK considers this to be an "optional" param in the video creative, right now.
     //https://github.com/InteractiveAdvertisingBureau/vast/blob/master/vast4.xsd#L1411
-    private ArrayList<Creative> mCreatives;
-    private Extensions mExtensions;
+    private ArrayList<Creative> creatives;
+    private Extensions extensions;
 
     public Wrapper(XmlPullParser p) throws XmlPullParserException, IOException {
 
         p.require(XmlPullParser.START_TAG, null, VAST_WRAPPER);
 
-        mFollowAdditionalWrappers = p.getAttributeValue(null, "followAdditionalWrappers");
-        mAllowMultipleAds = p.getAttributeValue(null, "allowMultipleAds");
-        mFallbackOnNoAd = p.getAttributeValue(null, "fallbackOnNoAd");
+        followAdditionalWrappers = p.getAttributeValue(null, "followAdditionalWrappers");
+        allowMultipleAds = p.getAttributeValue(null, "allowMultipleAds");
+        fallbackOnNoAd = p.getAttributeValue(null, "fallbackOnNoAd");
 
         while (p.next() != XmlPullParser.END_TAG) {
             if (p.getEventType() != XmlPullParser.START_TAG) {
@@ -60,35 +60,35 @@ public class Wrapper extends VASTParserBase {
             String name = p.getName();
             if (name != null && name.equals(VAST_ADSYSTEM)) {
                 p.require(XmlPullParser.START_TAG, null, VAST_ADSYSTEM);
-                mAdSystem = new AdSystem(p);
+                adSystem = new AdSystem(p);
                 p.require(XmlPullParser.END_TAG, null, VAST_ADSYSTEM);
             }
             else if (name != null && name.equals(VAST_ERROR)) {
                 p.require(XmlPullParser.START_TAG, null, VAST_ERROR);
-                mError = new Error(p);
+                error = new Error(p);
                 p.require(XmlPullParser.END_TAG, null, VAST_ERROR);
             }
             else if (name != null && name.equals(VAST_VASTADTAGURI)) {
                 p.require(XmlPullParser.START_TAG, null, VAST_VASTADTAGURI);
-                mVastUrl = new VastUrl(p);
+                vastUrl = new VastUrl(p);
                 p.require(XmlPullParser.END_TAG, null, VAST_VASTADTAGURI);
             }
             else if (name != null && name.equals(VAST_IMPRESSION)) {
-                if (mImpressions == null) {
-                    mImpressions = new ArrayList<>();
+                if (impressions == null) {
+                    impressions = new ArrayList<>();
                 }
                 p.require(XmlPullParser.START_TAG, null, VAST_IMPRESSION);
-                mImpressions.add(new Impression(p));
+                impressions.add(new Impression(p));
                 p.require(XmlPullParser.END_TAG, null, VAST_IMPRESSION);
             }
             else if (name != null && name.equals(VAST_CREATIVES)) {
                 p.require(XmlPullParser.START_TAG, null, VAST_CREATIVES);
-                mCreatives = (new Creatives(p)).getCreatives();
+                creatives = (new Creatives(p)).getCreatives();
                 p.require(XmlPullParser.END_TAG, null, VAST_CREATIVES);
             }
             else if (name != null && name.equals(VAST_EXTENSIONS)) {
                 p.require(XmlPullParser.START_TAG, null, VAST_EXTENSIONS);
-                mExtensions = new Extensions(p);
+                extensions = new Extensions(p);
                 p.require(XmlPullParser.END_TAG, null, VAST_EXTENSIONS);
             }
             else {
@@ -98,34 +98,34 @@ public class Wrapper extends VASTParserBase {
     }
 
     public String getAllowMultipleAds() {
-        return mAllowMultipleAds;
+        return allowMultipleAds;
     }
 
     public String getFallbackOnNoAd() {
-        return mFallbackOnNoAd;
+        return fallbackOnNoAd;
     }
 
     public AdSystem getAdSystem() {
-        return mAdSystem;
+        return adSystem;
     }
 
     public VastUrl getVastUrl() {
-        return mVastUrl;
+        return vastUrl;
     }
 
     public Error getError() {
-        return mError;
+        return error;
     }
 
     public ArrayList<Impression> getImpressions() {
-        return mImpressions;
+        return impressions;
     }
 
     public ArrayList<Creative> getCreatives() {
-        return mCreatives;
+        return creatives;
     }
 
     public Extensions getExtensions() {
-        return mExtensions;
+        return extensions;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/views/VolumeControlView.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/views/VolumeControlView.java
@@ -24,18 +24,23 @@ import org.prebid.mobile.core.R;
 
 
 public class VolumeControlView extends ImageView {
-    private VolumeState mVolumeState = VolumeState.MUTED;
-    private VolumeControlListener mVolumeControlListener;
 
-    public VolumeControlView(Context context, VolumeState initialState) {
+    private VolumeState volumeState = VolumeState.MUTED;
+    private VolumeControlListener volumeControlListener;
+
+    public VolumeControlView(
+            Context context,
+            VolumeState initialState
+    ) {
         super(context);
         updateVolumeState(initialState);
         init();
     }
 
-    public VolumeControlView(Context context,
-                             @Nullable
-                                 AttributeSet attrs) {
+    public VolumeControlView(
+            Context context,
+            @Nullable AttributeSet attrs
+    ) {
         super(context, attrs);
         init();
     }
@@ -48,7 +53,7 @@ public class VolumeControlView extends ImageView {
     }
 
     public void setVolumeControlListener(VolumeControlListener volumeControlListener) {
-        mVolumeControlListener = volumeControlListener;
+        this.volumeControlListener = volumeControlListener;
     }
 
     public void mute() {
@@ -70,22 +75,21 @@ public class VolumeControlView extends ImageView {
 
     private void init() {
         setOnClickListener(view -> {
-            if (mVolumeState == VolumeState.MUTED) {
+            if (volumeState == VolumeState.MUTED) {
                 unMute();
-            }
-            else {
+            } else {
                 mute();
             }
         });
     }
 
     private void updateVolumeState(VolumeState volumeState) {
-        mVolumeState = volumeState;
+        this.volumeState = volumeState;
 
-        updateIcon(mVolumeState);
+        updateIcon(this.volumeState);
 
-        if (mVolumeControlListener != null) {
-            mVolumeControlListener.onStateChange(mVolumeState);
+        if (volumeControlListener != null) {
+            volumeControlListener.onStateChange(this.volumeState);
         }
     }
 

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/views/base/BaseAdView.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/views/base/BaseAdView.java
@@ -34,21 +34,25 @@ import org.prebid.mobile.rendering.views.interstitial.InterstitialManager;
  * This class provides common functionality for Interstitial and Banner ads.
  */
 public abstract class BaseAdView extends FrameLayout {
+
     private static final String TAG = BaseAdView.class.getSimpleName();
 
-    protected AdViewManager mAdViewManager;
-    protected InterstitialManager mInterstitialManager = new InterstitialManager();
+    protected AdViewManager adViewManager;
+    protected InterstitialManager interstitialManager = new InterstitialManager();
 
-    private EventForwardingLocalBroadcastReceiver mEventForwardingReceiver;
-    private final EventForwardingLocalBroadcastReceiver.EventForwardingBroadcastListener mBroadcastListener = this::handleBroadcastAction;
+    private EventForwardingLocalBroadcastReceiver eventForwardingReceiver;
+    private final EventForwardingLocalBroadcastReceiver.EventForwardingBroadcastListener broadcastListener = this::handleBroadcastAction;
 
-    private int mScreenVisibility;
+    private int screenVisibility;
 
     public BaseAdView(Context context) {
         super(context);
     }
 
-    public BaseAdView(Context context, AttributeSet attrs) {
+    public BaseAdView(
+            Context context,
+            AttributeSet attrs
+    ) {
         super(context, attrs);
     }
 
@@ -59,25 +63,25 @@ public abstract class BaseAdView extends FrameLayout {
     }
 
     public long getMediaDuration() {
-        if (mAdViewManager != null) {
-            return mAdViewManager.getMediaDuration();
+        if (adViewManager != null) {
+            return adViewManager.getMediaDuration();
         }
         return 0;
     }
 
     public long getMediaOffset() {
-        if (mAdViewManager != null) {
-            return mAdViewManager.getSkipOffset();
+        if (adViewManager != null) {
+            return adViewManager.getSkipOffset();
         }
         return AdUnitConfiguration.SKIP_OFFSET_NOT_ASSIGNED;
     }
 
     public void setAppContent(ContentObject contentObject) {
-        if (mAdViewManager == null) {
+        if (adViewManager == null) {
             LogUtil.error(TAG, "setContentUrl: Failed. AdViewManager is null. Can't set content object. ");
             return;
         }
-        mAdViewManager.getAdConfiguration().setAppContent(contentObject);
+        adViewManager.getAdConfiguration().setAppContent(contentObject);
     }
 
     /**
@@ -95,13 +99,13 @@ public abstract class BaseAdView extends FrameLayout {
     }
 
     protected void registerEventBroadcast() {
-        final int broadcastId = mAdViewManager.getAdConfiguration().getBroadcastId();
-        mEventForwardingReceiver = new EventForwardingLocalBroadcastReceiver(broadcastId, mBroadcastListener);
-        mEventForwardingReceiver.register(getContext(), mEventForwardingReceiver);
+        final int broadcastId = adViewManager.getAdConfiguration().getBroadcastId();
+        eventForwardingReceiver = new EventForwardingLocalBroadcastReceiver(broadcastId, broadcastListener);
+        eventForwardingReceiver.register(getContext(), eventForwardingReceiver);
     }
 
     protected void setScreenVisibility(int screenVisibility) {
-        mScreenVisibility = screenVisibility;
+        this.screenVisibility = screenVisibility;
     }
 
     protected void handleBroadcastAction(String action) {
@@ -110,22 +114,22 @@ public abstract class BaseAdView extends FrameLayout {
 
     protected void handleWindowFocusChange(boolean hasWindowFocus) {
         int visibility = (!hasWindowFocus ? View.INVISIBLE : View.VISIBLE);
-        if (Utils.hasScreenVisibilityChanged(mScreenVisibility, visibility) && mAdViewManager != null) {
-            mScreenVisibility = visibility;
-            mAdViewManager.setAdVisibility(mScreenVisibility);
+        if (Utils.hasScreenVisibilityChanged(screenVisibility, visibility) && adViewManager != null) {
+            screenVisibility = visibility;
+            adViewManager.setAdVisibility(screenVisibility);
         }
     }
 
     protected abstract void notifyErrorListeners(final AdException adException);
 
     public void destroy() {
-        if (mAdViewManager != null) {
-            mAdViewManager.destroy();
+        if (adViewManager != null) {
+            adViewManager.destroy();
         }
 
-        if (mEventForwardingReceiver != null) {
-            mEventForwardingReceiver.unregister(mEventForwardingReceiver);
-            mEventForwardingReceiver = null;
+        if (eventForwardingReceiver != null) {
+            eventForwardingReceiver.unregister(eventForwardingReceiver);
+            eventForwardingReceiver = null;
         }
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/views/browser/AdBrowserActivity.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/views/browser/AdBrowserActivity.java
@@ -54,21 +54,24 @@ public final class AdBrowserActivity extends Activity
 
     private static final int BROWSER_CONTROLS_ID = 235799;
 
-    private WebView mWebView;
-    private VideoView mVideoView;
-    private BrowserControls mBrowserControls;
+    private WebView webView;
+    private VideoView videoView;
+    private BrowserControls browserControls;
 
-    private boolean mIsVideo;
-    private boolean mShouldFireEvents;
-    private int mBroadcastId;
-    private String mUrl;
+    private boolean isVideo;
+    private boolean shouldFireEvents;
+    private int broadcastId;
+    private String url;
 
     //jira/browse/MOBILE-1222 - Enable physical BACK button of the device in the in-app browser in Android
     @Override
-    public boolean onKeyDown(int keyCode, KeyEvent event) {
+    public boolean onKeyDown(
+            int keyCode,
+            KeyEvent event
+    ) {
         if ((keyCode == KeyEvent.KEYCODE_BACK)) {
-            if (mWebView != null) {
-                mWebView.goBack();
+            if (webView != null) {
+                webView.goBack();
             }
             finish();
         }
@@ -78,16 +81,16 @@ public final class AdBrowserActivity extends Activity
     @Override
     protected void onPause() {
         super.onPause();
-        if (mVideoView != null) {
-            mVideoView.suspend();
+        if (videoView != null) {
+            videoView.suspend();
         }
     }
 
     @Override
     protected void onResume() {
         super.onResume();
-        if (mVideoView != null) {
-            mVideoView.resume();
+        if (videoView != null) {
+            videoView.resume();
         }
     }
 
@@ -100,10 +103,9 @@ public final class AdBrowserActivity extends Activity
         final Bundle extras = getIntent().getExtras();
         claimExtras(extras);
 
-        if (mIsVideo) {
+        if (isVideo) {
             handleVideoDisplay();
-        }
-        else {
+        } else {
             handleWebViewDisplay();
         }
     }
@@ -112,27 +114,27 @@ public final class AdBrowserActivity extends Activity
     protected void onDestroy() {
         super.onDestroy();
         // Solves memory leak
-        if (mWebView != null) {
-            mWebView.destroy();
+        if (webView != null) {
+            webView.destroy();
         }
 
-        if (mVideoView != null) {
-            mVideoView.suspend();
+        if (videoView != null) {
+            videoView.suspend();
         }
     }
 
     // Ignore back press on ad browser, except on video since there is no close
     @Override
     public void onBackPressed() {
-        if (mIsVideo) {
+        if (isVideo) {
             super.onBackPressed();
         }
     }
 
     @Override
     public void onPageFinished() {
-        if (mBrowserControls != null) {
-            mBrowserControls.updateNavigationButtonsState();
+        if (browserControls != null) {
+            browserControls.updateNavigationButtonsState();
         }
     }
 
@@ -154,10 +156,10 @@ public final class AdBrowserActivity extends Activity
             return;
         }
 
-        mUrl = extras.getString(EXTRA_URL, null);
-        mShouldFireEvents = extras.getBoolean(EXTRA_SHOULD_FIRE_EVENTS, true);
-        mIsVideo = extras.getBoolean(EXTRA_IS_VIDEO, false);
-        mBroadcastId = extras.getInt(EXTRA_BROADCAST_ID, -1);
+        url = extras.getString(EXTRA_URL, null);
+        shouldFireEvents = extras.getBoolean(EXTRA_SHOULD_FIRE_EVENTS, true);
+        isVideo = extras.getBoolean(EXTRA_IS_VIDEO, false);
+        broadcastId = extras.getInt(EXTRA_BROADCAST_ID, -1);
     }
 
     private void handleWebViewDisplay() {
@@ -166,67 +168,70 @@ public final class AdBrowserActivity extends Activity
         RelativeLayout contentLayout = new RelativeLayout(this);
         RelativeLayout.LayoutParams barLayoutParams = null;
         RelativeLayout.LayoutParams webViewLayoutParams = new RelativeLayout.LayoutParams(LayoutParams.MATCH_PARENT,
-                                                                                          LayoutParams.MATCH_PARENT);
+                LayoutParams.MATCH_PARENT
+        );
 
-        if (!TextUtils.isEmpty(mUrl)) {
-            mWebView = new WebView(this);
+        if (!TextUtils.isEmpty(url)) {
+            webView = new WebView(this);
             setWebViewSettings();
 
-            mWebView.setWebViewClient(new AdBrowserActivityWebViewClient(AdBrowserActivity.this));
-            mWebView.loadUrl(mUrl);
+            webView.setWebViewClient(new AdBrowserActivityWebViewClient(AdBrowserActivity.this));
+            webView.loadUrl(url);
 
-            barLayoutParams = new RelativeLayout.LayoutParams(LayoutParams.MATCH_PARENT,
-                                                              LayoutParams.WRAP_CONTENT);
-            if (mBrowserControls != null) {
-                mBrowserControls.showNavigationControls();
+            barLayoutParams = new RelativeLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT);
+            if (browserControls != null) {
+                browserControls.showNavigationControls();
             }
 
             webViewLayoutParams.addRule(RelativeLayout.BELOW, BROWSER_CONTROLS_ID);
         }
 
-        if (mWebView != null) {
-            contentLayout.addView(mWebView, webViewLayoutParams);
+        if (webView != null) {
+            contentLayout.addView(webView, webViewLayoutParams);
         }
 
-        if (mBrowserControls != null) {
-            contentLayout.addView(mBrowserControls, barLayoutParams);
+        if (browserControls != null) {
+            contentLayout.addView(browserControls, barLayoutParams);
         }
 
         setContentView(contentLayout);
     }
 
     private void handleVideoDisplay() {
-        mVideoView = new VideoView(this);
+        videoView = new VideoView(this);
         RelativeLayout content = new RelativeLayout(this);
-        RelativeLayout.LayoutParams lp = new RelativeLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT);
+        RelativeLayout.LayoutParams lp = new RelativeLayout.LayoutParams(
+                LayoutParams.MATCH_PARENT,
+                LayoutParams.MATCH_PARENT
+        );
         lp.addRule(RelativeLayout.CENTER_IN_PARENT);
-        content.addView(mVideoView, lp);
+        content.addView(videoView, lp);
         setContentView(content);
         MediaController mc = new MediaController(this);
-        mVideoView.setMediaController(mc);
-        mVideoView.setVideoURI(Uri.parse(mUrl));
-        mVideoView.start();
+        videoView.setMediaController(mc);
+        videoView.setVideoURI(Uri.parse(url));
+        videoView.start();
     }
 
     @SuppressLint("SetJavaScriptEnabled")
     private void setWebViewSettings() {
 
-        if (mWebView != null) {
-            mWebView.getSettings().setJavaScriptEnabled(true);
-            mWebView.getSettings().setJavaScriptCanOpenWindowsAutomatically(false);
-            mWebView.getSettings().setPluginState(WebSettings.PluginState.OFF);
-            mWebView.setHorizontalScrollBarEnabled(false);
-            mWebView.setVerticalScrollBarEnabled(false);
-            mWebView.getSettings().setCacheMode(WebSettings.LOAD_NO_CACHE);
+        if (webView != null) {
+            webView.getSettings().setJavaScriptEnabled(true);
+            webView.getSettings().setJavaScriptCanOpenWindowsAutomatically(false);
+            webView.getSettings().setPluginState(WebSettings.PluginState.OFF);
+            webView.setHorizontalScrollBarEnabled(false);
+            webView.setVerticalScrollBarEnabled(false);
+            webView.getSettings().setCacheMode(WebSettings.LOAD_NO_CACHE);
 
-            mWebView.getSettings().setBuiltInZoomControls(true);
+            webView.getSettings().setBuiltInZoomControls(true);
 
             //MOB-2160 - Ad Browser: Leaking memory on zoom.(Though it looks like a chromiun webview problem)
             //Activity browser.AdBrowserActivity has leaked window android.widget.ZoomButtonsController$Container
-            mWebView.getSettings().setDisplayZoomControls(false);
+            webView.getSettings().setDisplayZoomControls(false);
 
-            mWebView.getSettings().setLoadWithOverviewMode(true);
-            mWebView.getSettings().setUseWideViewPort(true);
+            webView.getSettings().setLoadWithOverviewMode(true);
+            webView.getSettings().setUseWideViewPort(true);
         }
     }
 
@@ -235,29 +240,29 @@ public final class AdBrowserActivity extends Activity
 
             @Override
             public void onRelaod() {
-                if (mWebView != null) {
-                    mWebView.reload();
+                if (webView != null) {
+                    webView.reload();
                 }
             }
 
             @Override
             public void onGoForward() {
-                if (mWebView != null) {
-                    mWebView.goForward();
+                if (webView != null) {
+                    webView.goForward();
                 }
             }
 
             @Override
             public void onGoBack() {
-                if (mWebView != null) {
-                    mWebView.goBack();
+                if (webView != null) {
+                    webView.goBack();
                 }
             }
 
             @Override
             public String getCurrentURL() {
-                if (mWebView != null) {
-                    return mWebView.getUrl();
+                if (webView != null) {
+                    return webView.getUrl();
                 }
                 return null;
             }
@@ -270,31 +275,29 @@ public final class AdBrowserActivity extends Activity
 
             @Override
             public boolean canGoForward() {
-                if (mWebView != null) {
-                    return mWebView.canGoForward();
+                if (webView != null) {
+                    return webView.canGoForward();
                 }
                 return false;
             }
 
             @Override
             public boolean canGoBack() {
-                if (mWebView != null) {
-                    return mWebView.canGoBack();
+                if (webView != null) {
+                    return webView.canGoBack();
                 }
                 return false;
             }
         });
         controls.setId(BROWSER_CONTROLS_ID);
-        mBrowserControls = controls;
+        browserControls = controls;
     }
 
     private void sendLocalBroadcast(String action) {
-        if (!mShouldFireEvents) {
+        if (!shouldFireEvents) {
             return;
         }
 
-        BaseLocalBroadcastReceiver.sendLocalBroadcast(getApplicationContext(),
-                                                      mBroadcastId,
-                                                      action);
+        BaseLocalBroadcastReceiver.sendLocalBroadcast(getApplicationContext(), broadcastId, action);
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/views/browser/AdBrowserActivityWebViewClient.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/views/browser/AdBrowserActivityWebViewClient.java
@@ -27,18 +27,18 @@ import org.prebid.mobile.rendering.utils.url.action.UrlAction;
 class AdBrowserActivityWebViewClient extends WebViewClient {
     private static final String TAG = AdBrowserActivityWebViewClient.class.getSimpleName();
 
-    private AdBrowserWebViewClientListener mAdBrowserWebViewClientListener;
+    private AdBrowserWebViewClientListener adBrowserWebViewClientListener;
 
-    private boolean mUrlHandleInProgress;
+    private boolean urlHandleInProgress;
 
     AdBrowserActivityWebViewClient(AdBrowserWebViewClientListener adBrowserWebViewClientListener) {
-        mAdBrowserWebViewClientListener = adBrowserWebViewClientListener;
+        this.adBrowserWebViewClientListener = adBrowserWebViewClientListener;
     }
 
     @Override
     public void onPageFinished(WebView view, String url) {
-        if (mAdBrowserWebViewClientListener != null) {
-            mAdBrowserWebViewClientListener.onPageFinished();
+        if (adBrowserWebViewClientListener != null) {
+            adBrowserWebViewClientListener.onPageFinished();
         }
         super.onPageFinished(view, url);
     }
@@ -46,16 +46,11 @@ class AdBrowserActivityWebViewClient extends WebViewClient {
     @Override
     public boolean shouldOverrideUrlLoading(WebView view, String url) {
         UrlHandler urlHandler = createUrlHandler();
-        if (mUrlHandleInProgress) {
+        if (urlHandleInProgress) {
             return false;
-        }
-        else {
-            mUrlHandleInProgress = true;
-            return urlHandler
-                .handleResolvedUrl(view.getContext(),
-                                   url,
-                                   null,
-                                   true); // navigation is performed by user
+        } else {
+            urlHandleInProgress = true;
+            return urlHandler.handleResolvedUrl(view.getContext(), url, null, true); // navigation is performed by user
         }
     }
 
@@ -66,16 +61,16 @@ class AdBrowserActivityWebViewClient extends WebViewClient {
             .withResultListener(new UrlHandler.UrlHandlerResultListener() {
                 @Override
                 public void onSuccess(String url, UrlAction urlAction) {
-                    mUrlHandleInProgress = false;
-                    if (mAdBrowserWebViewClientListener != null) {
-                        mAdBrowserWebViewClientListener.onUrlHandleSuccess();
+                    urlHandleInProgress = false;
+                    if (adBrowserWebViewClientListener != null) {
+                        adBrowserWebViewClientListener.onUrlHandleSuccess();
                     }
                 }
 
                 @Override
                 public void onFailure(String url) {
                     LogUtil.debug(TAG, "Failed to handleUrl: " + url);
-                    mUrlHandleInProgress = false;
+                    urlHandleInProgress = false;
                 }
             })
             .build();

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/views/browser/BrowserControls.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/views/browser/BrowserControls.java
@@ -33,18 +33,19 @@ import org.prebid.mobile.core.R;
 import org.prebid.mobile.rendering.utils.helpers.Utils;
 
 final class BrowserControls extends TableLayout {
+
     private static String TAG = BrowserControls.class.getSimpleName();
     private final static int BROWSER_CONTROLS_PANEL_COLOR = Color.rgb(43, 47, 50);
 
-    private Button mCloseBtn;
-    private Button mBackBtn;
-    private Button mForthBtn;
-    private Button mRefreshBtn;
-    private Button mOpenInExternalBrowserBtn;
-    private LinearLayout mLeftPart;
-    private LinearLayout mRightPart;
-    private Handler mUIHandler;
-    private BrowserControlsEventsListener mBrowserControlsEventsListener;
+    private Button closeBtn;
+    private Button backBtn;
+    private Button forthBtn;
+    private Button refreshBtn;
+    private Button openInExternalBrowserBtn;
+    private LinearLayout leftPart;
+    private LinearLayout rightPart;
+    private Handler UIHandler;
+    private BrowserControlsEventsListener browserControlsEventsListener;
 
     /**
      * Create browser controls
@@ -52,7 +53,10 @@ final class BrowserControls extends TableLayout {
      * @param context  for which controls will be created
      * @param listener responsible for callbacks
      */
-    public BrowserControls(Context context, BrowserControlsEventsListener listener) {
+    public BrowserControls(
+            Context context,
+            BrowserControlsEventsListener listener
+    ) {
         super(context);
         init(listener);
     }
@@ -61,66 +65,67 @@ final class BrowserControls extends TableLayout {
      * Update navigation controls (back and forth buttons)
      */
     public void updateNavigationButtonsState() {
-        mUIHandler.post(() -> {
-            if (mBrowserControlsEventsListener == null) {
-                LogUtil.error(TAG, "updateNavigationButtonsState: Unable to update state. mBrowserControlsEventsListener is null");
+        UIHandler.post(() -> {
+            if (browserControlsEventsListener == null) {
+                LogUtil.error(
+                        TAG,
+                        "updateNavigationButtonsState: Unable to update state. browserControlsEventsListener is null"
+                );
                 return;
             }
 
-            if (mBrowserControlsEventsListener.canGoBack()) {
-                mBackBtn.setBackgroundResource(R.drawable.prebid_ic_back_active);
-            }
-            else {
-                mBackBtn.setBackgroundResource(R.drawable.prebid_ic_back_inactive);
+            if (browserControlsEventsListener.canGoBack()) {
+                backBtn.setBackgroundResource(R.drawable.prebid_ic_back_active);
+            } else {
+                backBtn.setBackgroundResource(R.drawable.prebid_ic_back_inactive);
             }
 
-            if (mBrowserControlsEventsListener.canGoForward()) {
-                mForthBtn.setBackgroundResource(R.drawable.prebid_ic_forth_active);
-            }
-            else {
-                mForthBtn.setBackgroundResource(R.drawable.prebid_ic_forth_inactive);
+            if (browserControlsEventsListener.canGoForward()) {
+                forthBtn.setBackgroundResource(R.drawable.prebid_ic_forth_active);
+            } else {
+                forthBtn.setBackgroundResource(R.drawable.prebid_ic_forth_inactive);
             }
         });
     }
 
     private void bindEventListeners() {
-        mCloseBtn.setOnClickListener(v -> {
-            if (mBrowserControlsEventsListener == null) {
-                LogUtil.error(TAG, "Close button click failed: mBrowserControlsEventsListener is null");
+        closeBtn.setOnClickListener(v -> {
+            if (browserControlsEventsListener == null) {
+                LogUtil.error(TAG, "Close button click failed: browserControlsEventsListener is null");
                 return;
             }
-            mBrowserControlsEventsListener.closeBrowser();
+            browserControlsEventsListener.closeBrowser();
         });
 
-        mBackBtn.setOnClickListener(v -> {
-            if (mBrowserControlsEventsListener == null) {
-                LogUtil.error(TAG, "Back button click failed: mBrowserControlsEventsListener is null");
+        backBtn.setOnClickListener(v -> {
+            if (browserControlsEventsListener == null) {
+                LogUtil.error(TAG, "Back button click failed: browserControlsEventsListener is null");
                 return;
             }
-            mBrowserControlsEventsListener.onGoBack();
+            browserControlsEventsListener.onGoBack();
         });
 
-        mForthBtn.setOnClickListener(v -> {
-            if (mBrowserControlsEventsListener == null) {
-                LogUtil.error(TAG, "Forward button click failed: mBrowserControlsEventsListener is null");
+        forthBtn.setOnClickListener(v -> {
+            if (browserControlsEventsListener == null) {
+                LogUtil.error(TAG, "Forward button click failed: browserControlsEventsListener is null");
                 return;
             }
-            mBrowserControlsEventsListener.onGoForward();
+            browserControlsEventsListener.onGoForward();
         });
 
-        mRefreshBtn.setOnClickListener(v -> {
-            if (mBrowserControlsEventsListener == null) {
-                LogUtil.error(TAG, "Refresh button click failed: mBrowserControlsEventsListener is null");
+        refreshBtn.setOnClickListener(v -> {
+            if (browserControlsEventsListener == null) {
+                LogUtil.error(TAG, "Refresh button click failed: browserControlsEventsListener is null");
                 return;
             }
-            mBrowserControlsEventsListener.onRelaod();
+            browserControlsEventsListener.onRelaod();
         });
 
-        mOpenInExternalBrowserBtn.setOnClickListener(v -> {
+        openInExternalBrowserBtn.setOnClickListener(v -> {
             String url = null;
 
-            if (mBrowserControlsEventsListener != null) {
-                url = mBrowserControlsEventsListener.getCurrentURL();
+            if (browserControlsEventsListener != null) {
+                url = browserControlsEventsListener.getCurrentURL();
             }
 
             if (url == null) {
@@ -151,15 +156,15 @@ final class BrowserControls extends TableLayout {
     }
 
     private void init(BrowserControlsEventsListener listener) {
-        mUIHandler = new Handler();
-        mBrowserControlsEventsListener = listener;
+        UIHandler = new Handler();
+        browserControlsEventsListener = listener;
         if (getContext() != null) {
             TableRow controlsSet = new TableRow(getContext());
-            mLeftPart = new LinearLayout(getContext());
-            mRightPart = new LinearLayout(getContext());
+            leftPart = new LinearLayout(getContext());
+            rightPart = new LinearLayout(getContext());
 
-            mLeftPart.setVisibility(GONE);
-            mRightPart.setGravity(Gravity.RIGHT);
+            leftPart.setVisibility(GONE);
+            rightPart.setGravity(Gravity.RIGHT);
 
             setBackgroundColor(BROWSER_CONTROLS_PANEL_COLOR);
 
@@ -167,56 +172,62 @@ final class BrowserControls extends TableLayout {
 
             bindEventListeners();
 
-            mLeftPart.addView(mBackBtn);
-            mLeftPart.addView(mForthBtn);
-            mLeftPart.addView(mRefreshBtn);
-            mLeftPart.addView(mOpenInExternalBrowserBtn);
-            mRightPart.addView(mCloseBtn);
+            leftPart.addView(backBtn);
+            leftPart.addView(forthBtn);
+            leftPart.addView(refreshBtn);
+            leftPart.addView(openInExternalBrowserBtn);
+            rightPart.addView(closeBtn);
 
-            controlsSet.addView(mLeftPart, new TableRow.LayoutParams(LayoutParams.FILL_PARENT, LayoutParams.FILL_PARENT, Gravity.LEFT));
-            controlsSet.addView(mRightPart, new TableRow.LayoutParams(LayoutParams.FILL_PARENT, LayoutParams.FILL_PARENT, Gravity.RIGHT));
+            controlsSet.addView(
+                    leftPart,
+                    new TableRow.LayoutParams(LayoutParams.FILL_PARENT, LayoutParams.FILL_PARENT, Gravity.LEFT)
+            );
+            controlsSet.addView(
+                    rightPart,
+                    new TableRow.LayoutParams(LayoutParams.FILL_PARENT, LayoutParams.FILL_PARENT, Gravity.RIGHT)
+            );
 
             BrowserControls.this.addView(controlsSet);
         }
     }
 
     private void setAllButtons() {
-        mCloseBtn = new Button(getContext());
-        mCloseBtn.setContentDescription("close");
-        setButtonDefaultSize(mCloseBtn);
-        mCloseBtn.setBackgroundResource(R.drawable.prebid_ic_close_browser);
+        closeBtn = new Button(getContext());
+        closeBtn.setContentDescription("close");
+        setButtonDefaultSize(closeBtn);
+        closeBtn.setBackgroundResource(R.drawable.prebid_ic_close_browser);
 
-        mBackBtn = new Button(getContext());
-        mBackBtn.setContentDescription("back");
-        setButtonDefaultSize(mBackBtn);
-        mBackBtn.setBackgroundResource(R.drawable.prebid_ic_back_inactive);
+        backBtn = new Button(getContext());
+        backBtn.setContentDescription("back");
+        setButtonDefaultSize(backBtn);
+        backBtn.setBackgroundResource(R.drawable.prebid_ic_back_inactive);
 
-        mForthBtn = new Button(getContext());
-        mForthBtn.setContentDescription("forth");
-        setButtonDefaultSize(mForthBtn);
-        mForthBtn.setBackgroundResource(R.drawable.prebid_ic_forth_inactive);
+        forthBtn = new Button(getContext());
+        forthBtn.setContentDescription("forth");
+        setButtonDefaultSize(forthBtn);
+        forthBtn.setBackgroundResource(R.drawable.prebid_ic_forth_inactive);
 
-        mRefreshBtn = new Button(getContext());
-        mRefreshBtn.setContentDescription("refresh");
-        setButtonDefaultSize(mRefreshBtn);
-        mRefreshBtn.setBackgroundResource(R.drawable.prebid_ic_refresh);
+        refreshBtn = new Button(getContext());
+        refreshBtn.setContentDescription("refresh");
+        setButtonDefaultSize(refreshBtn);
+        refreshBtn.setBackgroundResource(R.drawable.prebid_ic_refresh);
 
-        mOpenInExternalBrowserBtn = new Button(getContext());
-        mOpenInExternalBrowserBtn.setContentDescription("openInExternalBrowser");
-        setButtonDefaultSize(mOpenInExternalBrowserBtn);
-        mOpenInExternalBrowserBtn.setBackgroundResource(R.drawable.prebid_ic_open_in_browser);
+        openInExternalBrowserBtn = new Button(getContext());
+        openInExternalBrowserBtn.setContentDescription("openInExternalBrowser");
+        setButtonDefaultSize(openInExternalBrowserBtn);
+        openInExternalBrowserBtn.setBackgroundResource(R.drawable.prebid_ic_open_in_browser);
     }
 
     public void showNavigationControls() {
-        mLeftPart.setVisibility(VISIBLE);
+        leftPart.setVisibility(VISIBLE);
     }
 
     public void hideNavigationControls() {
-        mLeftPart.setVisibility(GONE);
+        leftPart.setVisibility(GONE);
     }
 
     @VisibleForTesting
     public BrowserControlsEventsListener getBrowserControlsEventsListener() {
-        return mBrowserControlsEventsListener;
+        return browserControlsEventsListener;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/views/video/VideoDialog.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/views/video/VideoDialog.java
@@ -29,31 +29,35 @@ import org.prebid.mobile.rendering.views.AdViewManager;
 import org.prebid.mobile.rendering.views.interstitial.InterstitialManager;
 
 public class VideoDialog extends AdBaseDialog {
+
     private static final String TAG = "VideoDialog";
 
-    private final AdViewManager mAdViewManager;
+    private final AdViewManager adViewManager;
 
-    private VideoCreativeView mAdView;
-    private VideoDialogListener mVideoDialogListener;
+    private VideoCreativeView adView;
+    private VideoDialogListener videoDialogListener;
 
-    public VideoDialog(Context context,
-                       VideoCreativeView videoCreativeView,
-                       AdViewManager adViewManager,
-                       InterstitialManager interstitialManager,
-                       FrameLayout adViewContainer) {
+    public VideoDialog(
+            Context context,
+            VideoCreativeView videoCreativeView,
+            AdViewManager adViewManager,
+            InterstitialManager interstitialManager,
+            FrameLayout adViewContainer
+    ) {
         super(context, android.R.style.Theme_Black_NoTitleBar_Fullscreen, interstitialManager);
-        mAdViewContainer = adViewContainer;
-        mAdViewManager = adViewManager;
-        mAdViewContainer.setLayoutParams(new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
-                                                                      ViewGroup.LayoutParams.MATCH_PARENT));
-        mAdView = videoCreativeView;
-        setContentView(mAdViewContainer);
+        this.adViewContainer = adViewContainer;
+        this.adViewManager = adViewManager;
+        this.adViewContainer.setLayoutParams(new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+        ));
+        adView = videoCreativeView;
+        setContentView(this.adViewContainer);
 
         initListeners();
     }
 
     public void setVideoDialogListener(VideoDialogListener videoDialogListener) {
-        mVideoDialogListener = videoDialogListener;
+        this.videoDialogListener = videoDialogListener;
     }
 
     @Override
@@ -61,8 +65,8 @@ public class VideoDialog extends AdBaseDialog {
         dismiss();
         unApplyOrientation();
 
-        if (mVideoDialogListener != null) {
-            mVideoDialogListener.onVideoDialogClosed();
+        if (videoDialogListener != null) {
+            videoDialogListener.onVideoDialogClosed();
         }
     }
 
@@ -72,14 +76,15 @@ public class VideoDialog extends AdBaseDialog {
     }
 
     public void showBannerCreative(View creativeView) {
-        mAdViewContainer.removeAllViews();
+        adViewContainer.removeAllViews();
         creativeView.setLayoutParams(new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT,
-                                                                  ViewGroup.LayoutParams.MATCH_PARENT));
+                ViewGroup.LayoutParams.MATCH_PARENT
+        ));
         lockOrientation();
-        mAdViewContainer.addView(creativeView);
-        mDisplayView = creativeView;
+        adViewContainer.addView(creativeView);
+        displayView = creativeView;
         addCloseView();
-        mAdView = null;
+        adView = null;
     }
 
     private void initListeners() {
@@ -87,12 +92,12 @@ public class VideoDialog extends AdBaseDialog {
     }
 
     private void handleShowAction() {
-        mAdViewManager.trackVideoStateChange(InternalPlayerState.EXPANDED);
-        mAdView.unMute();
+        adViewManager.trackVideoStateChange(InternalPlayerState.EXPANDED);
+        adView.unMute();
 
         changeCloseViewVisibility(View.VISIBLE);
-        mAdView.showCallToAction();
+        adView.showCallToAction();
 
-        mAdViewManager.updateAdView(mAdViewContainer);
+        adViewManager.updateAdView(adViewContainer);
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/views/webview/AdWebView.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/views/webview/AdWebView.java
@@ -30,11 +30,12 @@ import org.prebid.mobile.rendering.views.webview.AdWebViewClient.AdAssetsLoadedL
 import org.prebid.mobile.rendering.views.webview.mraid.MraidWebViewClient;
 
 public class AdWebView extends WebView {
+
     private static final String TAG = AdWebView.class.getSimpleName();
-    private Integer mScale;
-    private AdWebViewClient mAdWebViewClient;
-    protected int mWidth, mHeight;
-    protected String mDomain;
+    private Integer scale;
+    private AdWebViewClient adWebViewClient;
+    protected int width, height;
+    protected String domain;
 
     public AdWebView(Context context) {
         super(context);
@@ -45,12 +46,12 @@ public class AdWebView extends WebView {
 
     @Override
     public void setInitialScale(int scaleInPercent) {
-        mScale = scaleInPercent;
+        scale = scaleInPercent;
     }
 
     public String getInitialScaleValue() {
-        if (mScale != null) {
-            return String.valueOf((float) mScale / 100f);
+        if (scale != null) {
+            return String.valueOf((float) scale / 100f);
         }
 
         return null;
@@ -58,10 +59,10 @@ public class AdWebView extends WebView {
 
     public void setMraidAdAssetsLoadListener(AdAssetsLoadedListener adAssetsLoadedListener,
                                              String mraidScript) {
-        if (mAdWebViewClient == null) {
-            mAdWebViewClient = new MraidWebViewClient(adAssetsLoadedListener, mraidScript);
+        if (adWebViewClient == null) {
+            adWebViewClient = new MraidWebViewClient(adAssetsLoadedListener, mraidScript);
         }
-        setWebViewClient(mAdWebViewClient);
+        setWebViewClient(adWebViewClient);
     }
 
     protected void init() {
@@ -91,7 +92,7 @@ public class AdWebView extends WebView {
         int deviceWidth = Math.min(screenWidth, screenHeight);
         int deviceHeight = Math.max(screenWidth, screenHeight);
 
-        float factor = calculateFactor(deviceWidth, deviceHeight, mWidth);
+        float factor = calculateFactor(deviceWidth, deviceHeight, width);
         setInitialScale(Math.round(factor));
 
         initBaseWebSettings(webSettings);
@@ -154,6 +155,6 @@ public class AdWebView extends WebView {
     }
 
     public void setDomain(String domain) {
-        mDomain = domain;
+        this.domain = domain;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/views/webview/AdWebViewClient.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/views/webview/AdWebViewClient.java
@@ -31,28 +31,30 @@ import static android.webkit.WebView.HitTestResult.SRC_ANCHOR_TYPE;
 import static android.webkit.WebView.HitTestResult.SRC_IMAGE_ANCHOR_TYPE;
 
 public class AdWebViewClient extends WebViewClient {
+
     private static final String TAG = AdWebViewClient.class.getSimpleName();
 
-    private static final String JS__GET_RENDERED_HTML = "javascript:window.HtmlViewer.showHTML"
-                                                        + "('<html>'+document.getElementsByTagName('html')[0].innerHTML+'</html>');";
+    private static final String JS__GET_RENDERED_HTML = "javascript:window.HtmlViewer.showHTML" + "('<html>'+document.getElementsByTagName('html')[0].innerHTML+'</html>');";
 
-    protected AdAssetsLoadedListener mAdAssetsLoadedListener;
+    protected AdAssetsLoadedListener adAssetsLoadedListener;
 
-    private boolean mLoadingFinished = true;
+    private boolean loadingFinished = true;
 
-    private HashSet<String> mUrls = new HashSet<>();
-    private String mPageUrl;
+    private HashSet<String> urls = new HashSet<>();
+    private String pageUrl;
 
     public interface AdAssetsLoadedListener {
+
         void startLoadingAssets();
 
         void adAssetsLoaded();
 
         void notifyMraidScriptInjected();
+
     }
 
     public AdWebViewClient(AdAssetsLoadedListener adAssetsLoadedListener) {
-        mAdAssetsLoadedListener = adAssetsLoadedListener;
+        this.adAssetsLoadedListener = adAssetsLoadedListener;
     }
 
     @Override
@@ -65,11 +67,11 @@ public class AdWebViewClient extends WebViewClient {
         try {
             super.onPageStarted(view, url, favicon);
 
-            mPageUrl = url;
+            pageUrl = url;
 
-            mLoadingFinished = false;
+            loadingFinished = false;
 
-            mAdAssetsLoadedListener.startLoadingAssets();
+            adAssetsLoadedListener.startLoadingAssets();
         }
         catch (Exception e) {
             LogUtil.error(TAG, "onPageStarted failed for url: " + url + " : " + Log.getStackTraceString(e));
@@ -85,7 +87,7 @@ public class AdWebViewClient extends WebViewClient {
         LogUtil.debug(TAG, "onPageFinished: " + view);
         try {
 
-            mAdAssetsLoadedListener.adAssetsLoaded();
+            adAssetsLoadedListener.adAssetsLoaded();
 
             view.setBackgroundColor(Color.TRANSPARENT);
         }
@@ -101,7 +103,7 @@ public class AdWebViewClient extends WebViewClient {
             return;
         }
 
-        if (url != null && url.equals(mPageUrl)) {
+        if (url != null && url.equals(pageUrl)) {
             return;
         }
         try {
@@ -111,11 +113,9 @@ public class AdWebViewClient extends WebViewClient {
             // Need to check webViewBase.containsIFrame() because displayed ad could contain another
             // injected script (for example OpenMeasurement) that initializes own resources.
             // Otherwise, we could get an error: jira/browse/MOBILE-5100
-            if (webViewBase.containsIFrame()
-                && webViewBase.isClicked()
-                && !mUrls.contains(url)
-                && view.getHitTestResult() != null
-                && (view.getHitTestResult().getType() == SRC_ANCHOR_TYPE || view.getHitTestResult().getType() == SRC_IMAGE_ANCHOR_TYPE)) {
+            if (webViewBase.containsIFrame() && webViewBase.isClicked() && !urls.contains(url) && view.getHitTestResult() != null && (view.getHitTestResult()
+                                                                                                                                          .getType() == SRC_ANCHOR_TYPE || view.getHitTestResult()
+                                                                                                                                                                               .getType() == SRC_IMAGE_ANCHOR_TYPE)) {
 
                 // stop loading the iframe or whatever
                 // instead simply change the location of the webview - this will
@@ -123,7 +123,7 @@ public class AdWebViewClient extends WebViewClient {
                 reloadUrl(view, url);
             }
 
-            mUrls.add(url);
+            urls.add(url);
             super.onLoadResource(view, url);
         }
         catch (Exception e) {
@@ -158,7 +158,7 @@ public class AdWebViewClient extends WebViewClient {
     }
 
     boolean isLoadingFinished() {
-        return mLoadingFinished;
+        return loadingFinished;
     }
 
     @Override
@@ -179,19 +179,19 @@ public class AdWebViewClient extends WebViewClient {
     }
 
     private void handleWebViewClick(String url, WebViewBase webViewBase) {
-        mUrls.clear();
+        urls.clear();
 
-        mLoadingFinished = false;
+        loadingFinished = false;
 
         String targetUrl = webViewBase.getTargetUrl();
         url = TextUtils.isEmpty(targetUrl) ? url : targetUrl;
 
         if (webViewBase.canHandleClick()) {
-            mLoadingFinished = true;
-            mUrls.clear();
+            loadingFinished = true;
+            urls.clear();
 
             //all(generally non-mraid) comes here - open/click here
-            webViewBase.mMraidListener.openExternalLink(url);
+            webViewBase.mraidListener.openExternalLink(url);
         }
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/views/webview/PrebidWebViewBanner.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/views/webview/PrebidWebViewBanner.java
@@ -36,7 +36,7 @@ public class PrebidWebViewBanner extends PrebidWebViewBase
 
     private static final String TAG = PrebidWebViewBanner.class.getSimpleName();
 
-    private final FetchPropertiesHandler.FetchPropertyCallback mExpandPropertiesCallback = new FetchPropertiesHandler.FetchPropertyCallback() {
+    private final FetchPropertiesHandler.FetchPropertyCallback expandPropertiesCallback = new FetchPropertiesHandler.FetchPropertyCallback() {
         @Override
         public void onResult(String propertyJson) {
             handleExpandPropertiesResult(propertyJson);
@@ -68,12 +68,12 @@ public class PrebidWebViewBanner extends PrebidWebViewBase
          * properties and then the layout gets built based on these things.
          */
         //Fix MOBILE-2944 App crash navigating MRAID ad
-        final WebViewBase currentWebView = (mWebView != null) ? mWebView : mMraidWebView;
+        final WebViewBase currentWebView = (webView != null) ? webView : mraidWebView;
 
         if (currentWebView != null) {
             currentWebView.getMRAIDInterface()
                           .getJsExecutor()
-                          .executeGetExpandProperties(new FetchPropertiesHandler(mExpandPropertiesCallback));
+                          .executeGetExpandProperties(new FetchPropertiesHandler(expandPropertiesCallback));
         }
         else {
             LogUtil.warning(TAG, "Error getting expand properties");
@@ -83,35 +83,36 @@ public class PrebidWebViewBanner extends PrebidWebViewBase
     @Override
     public void initTwoPartAndLoad(String url) {
 
-        LayoutParams layoutParams = new LayoutParams(
-            LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT);
+        LayoutParams layoutParams = new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT);
 
         setLayoutParams(layoutParams);
         //A null context can crash with an exception in webView creation through WebViewBanner. Catch it
-        mMraidWebView = new WebViewBanner(mContext, this, this);
-        mMraidWebView.setJSName("twopart");
+        mraidWebView = new WebViewBanner(context, this, this);
+        mraidWebView.setJSName("twopart");
 
-        String script = JSLibraryManager.getInstance(mMraidWebView.getContext()).getMRAIDScript();
+        String script = JSLibraryManager.getInstance(mraidWebView.getContext()).getMRAIDScript();
         //inject mraid.js
-        mMraidWebView.setMraidAdAssetsLoadListener(mMraidWebView, script);
+        mraidWebView.setMraidAdAssetsLoadListener(mraidWebView, script);
 
-        mMraidWebView.loadUrl(url);
+        mraidWebView.loadUrl(url);
     }
 
     @Override
     public void loadHTML(String html, int width, int height) {
         FrameLayout.LayoutParams layoutParams = new FrameLayout.LayoutParams(
-            FrameLayout.LayoutParams.MATCH_PARENT, FrameLayout.LayoutParams.MATCH_PARENT);
+                FrameLayout.LayoutParams.MATCH_PARENT,
+                FrameLayout.LayoutParams.MATCH_PARENT
+        );
 
         setLayoutParams(layoutParams);
-        mWidth = width;
-        mHeight = height;
+        this.width = width;
+        this.height = height;
         //A null context can crash with an exception in webView creation through WebViewBanner. Catch it
-        mWebView = new WebViewBanner(mContext, html, width, height, this, this);
-        mWebView.setJSName("1part");
-        mWebView.initContainsIFrame(mCreative.getCreativeModel().getHtml());
-        mWebView.setTargetUrl(mCreative.getCreativeModel().getTargetUrl());
-        mWebView.loadAd();
+        webView = new WebViewBanner(context, html, width, height, this, this);
+        webView.setJSName("1part");
+        webView.initContainsIFrame(creative.getCreativeModel().getHtml());
+        webView.setTargetUrl(creative.getCreativeModel().getTargetUrl());
+        webView.loadAd();
     }
 
     @Override
@@ -122,18 +123,20 @@ public class PrebidWebViewBanner extends PrebidWebViewBase
             //This should never happen.
             LogUtil.error(TAG, "Failed to preload a banner ad. Webview is null.");
 
-            if (mWebViewDelegate != null) {
-                mWebViewDelegate.webViewFailedToLoad(new AdException(AdException.INTERNAL_ERROR, "Preloaded adview is null!"));
+            if (webViewDelegate != null) {
+                webViewDelegate.webViewFailedToLoad(new AdException(
+                        AdException.INTERNAL_ERROR,
+                        "Preloaded adview is null!"
+                ));
             }
 
             return;
         }
-        mCurrentWebViewBase = adBaseView;
-        if (mCurrentWebViewBase.mMRAIDBridgeName.equals("twopart")) {
+        currentWebViewBase = adBaseView;
+        if (currentWebViewBase.MRAIDBridgeName.equals("twopart")) {
             //SHould have expanded url here, as last param
-            mInterstitialManager.displayPrebidWebViewForMraid(mMraidWebView, true);
-        }
-        else {
+            interstitialManager.displayPrebidWebViewForMraid(mraidWebView, true);
+        } else {
             if (adBaseView.getParent() == null) {
 
                 if (getChildCount() >= 1) {
@@ -166,25 +169,28 @@ public class PrebidWebViewBanner extends PrebidWebViewBase
          * This postInvalidate fixes the cosmetic issue that KitKat created with the white banner
          * fragment/remnant showing up at the bottom of the screen.
          */
-        if (mContext instanceof Activity) {
-            ((Activity) mContext).getWindow().getDecorView().findViewById(android.R.id.content).postInvalidate();
-            ((Activity) mContext).getWindow().getDecorView().findViewById(android.R.id.content).postInvalidateDelayed(100);
+        if (context instanceof Activity) {
+            ((Activity) context).getWindow().getDecorView().findViewById(android.R.id.content).postInvalidate();
+            ((Activity) context).getWindow()
+                                .getDecorView()
+                                .findViewById(android.R.id.content)
+                                .postInvalidateDelayed(100);
         }
 
-        if (mWebViewDelegate != null) {
-            mWebViewDelegate.webViewReadyToDisplay();
+        if (webViewDelegate != null) {
+            webViewDelegate.webViewReadyToDisplay();
         }
     }
 
     protected void swapWebViews() {
         if (getContext() != null) {
-            mFadeOutAnimation = AnimationUtils.loadAnimation(getContext(), android.R.anim.fade_out);
+            fadeOutAnimation = AnimationUtils.loadAnimation(getContext(), android.R.anim.fade_out);
         }
         final WebViewBase frontAdView = (WebViewBase) getChildAt(0);
         WebViewBase backAdView = (WebViewBase) getChildAt(1);
 
         if (frontAdView != null) {
-            frontAdView.startAnimation(mFadeOutAnimation);
+            frontAdView.startAnimation(fadeOutAnimation);
             frontAdView.setVisibility(GONE);
         }
 
@@ -197,21 +203,20 @@ public class PrebidWebViewBanner extends PrebidWebViewBase
     private void handleExpandPropertiesResult(String expandProperties) {
         JSONObject jsonExpandProperties;
 
-        WebViewBase currentWebView = (mWebView != null)
-                                     ? mWebView
-                                     : mMraidWebView;
-        final MraidVariableContainer mraidVariableContainer = currentWebView.getMRAIDInterface().getMraidVariableContainer();
+        WebViewBase currentWebView = (webView != null) ? webView : mraidWebView;
+        final MraidVariableContainer mraidVariableContainer = currentWebView.getMRAIDInterface()
+                                                                            .getMraidVariableContainer();
         mraidVariableContainer.setExpandProperties(expandProperties);
 
         try {
             jsonExpandProperties = new JSONObject(expandProperties);
 
-            mDefinedWidthForExpand = jsonExpandProperties.optInt("width", 0);
-            mDefinedHeightForExpand = jsonExpandProperties.optInt("height", 0);
+            definedWidthForExpand = jsonExpandProperties.optInt("width", 0);
+            definedHeightForExpand = jsonExpandProperties.optInt("height", 0);
 
-            if (mInterstitialManager.getInterstitialDisplayProperties() != null) {
-                mInterstitialManager.getInterstitialDisplayProperties().expandWidth = mDefinedWidthForExpand;
-                mInterstitialManager.getInterstitialDisplayProperties().expandHeight = mDefinedHeightForExpand;
+            if (interstitialManager.getInterstitialDisplayProperties() != null) {
+                interstitialManager.getInterstitialDisplayProperties().expandWidth = definedWidthForExpand;
+                interstitialManager.getInterstitialDisplayProperties().expandHeight = definedHeightForExpand;
             }
         }
         catch (Exception e) {

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/views/webview/PrebidWebViewInterstitial.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/views/webview/PrebidWebViewInterstitial.java
@@ -32,18 +32,17 @@ public class PrebidWebViewInterstitial extends PrebidWebViewBase
 
     @Override
     public void loadHTML(String html, int width, int height) {
-        LayoutParams layoutParams = new LayoutParams(
-            LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT);
+        LayoutParams layoutParams = new LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.MATCH_PARENT);
 
         setLayoutParams(layoutParams);
-        mWidth = width;
-        mHeight = height;
+        this.width = width;
+        this.height = height;
         //A null context can crash with an exception in webView creation through WebViewBanner. Catch it
-        mWebView = new WebViewInterstitial(mContext, html, width, height, this, this);
-        mWebView.setJSName("WebViewInterstitial");
-        mWebView.initContainsIFrame(mCreative.getCreativeModel().getHtml());
-        mWebView.setTargetUrl(mCreative.getCreativeModel().getTargetUrl());
-        mWebView.loadAd();
+        webView = new WebViewInterstitial(context, html, width, height, this, this);
+        webView.setJSName("WebViewInterstitial");
+        webView.initContainsIFrame(creative.getCreativeModel().getHtml());
+        webView.setTargetUrl(creative.getCreativeModel().getTargetUrl());
+        webView.loadAd();
     }
 
     @Override
@@ -52,15 +51,18 @@ public class PrebidWebViewInterstitial extends PrebidWebViewBase
             //This should never happen.
             LogUtil.error(TAG, "Failed to preload an interstitial. Webview is null.");
 
-            if (mWebViewDelegate != null) {
-                mWebViewDelegate.webViewFailedToLoad(new AdException(AdException.INTERNAL_ERROR, "Preloaded adview is null!"));
+            if (webViewDelegate != null) {
+                webViewDelegate.webViewFailedToLoad(new AdException(
+                        AdException.INTERNAL_ERROR,
+                        "Preloaded adview is null!"
+                ));
             }
             return;
         }
-        mCurrentWebViewBase = adBaseView;
+        currentWebViewBase = adBaseView;
 
-        if (mWebViewDelegate != null) {
-            mWebViewDelegate.webViewReadyToDisplay();
+        if (webViewDelegate != null) {
+            webViewDelegate.webViewReadyToDisplay();
         }
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/views/webview/WebViewBanner.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/views/webview/WebViewBanner.java
@@ -29,7 +29,7 @@ import org.prebid.mobile.rendering.views.webview.mraid.JsExecutor;
 public class WebViewBanner extends WebViewBase {
 
     private static final String TAG = WebViewBanner.class.getSimpleName();
-    private MraidEvent mMraidEvent;
+    private MraidEvent mraidEvent;
 
     public WebViewBanner(Context context, String html, int width, int height, PreloadManager.PreloadedListener preloadedListener, MraidEventsManager.MraidListener mraidListener) {
         super(context, html, width, height, preloadedListener, mraidListener);
@@ -50,11 +50,11 @@ public class WebViewBanner extends WebViewBase {
     }
 
     public MraidEvent getMraidEvent() {
-        return mMraidEvent;
+        return mraidEvent;
     }
 
     public void setMraidEvent(MraidEvent event) {
-        mMraidEvent = event;
+        mraidEvent = event;
     }
 
     public void setMRAIDInterface() {

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/views/webview/WebViewBase.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/views/webview/WebViewBase.java
@@ -36,75 +36,83 @@ import java.util.regex.Pattern;
 import static org.prebid.mobile.rendering.views.webview.AdWebViewClient.AdAssetsLoadedListener;
 
 public class WebViewBase extends AdWebView implements AdAssetsLoadedListener {
+
     private static final String TAG = WebViewBase.class.getSimpleName();
 
     private static final String REGEX_IFRAME = "(<iframe[^>]*)>";
 
-    protected MraidEventsManager.MraidListener mMraidListener;
-    protected String mMRAIDBridgeName;
+    protected MraidEventsManager.MraidListener mraidListener;
+    protected String MRAIDBridgeName;
 
-    private PreloadManager.PreloadedListener mPreloadedListener;
+    private PreloadManager.PreloadedListener preloadedListener;
 
-    private BaseJSInterface mMraidInterface;
-    private String mAdHTML;
-    private AdBaseDialog mDialog;
+    private BaseJSInterface mraidInterface;
+    private String adHTML;
+    private AdBaseDialog dialog;
 
-    private boolean mContainsIFrame;
-    private boolean mIsClicked = false;
-    protected boolean mIsMRAID;
+    private boolean containsIFrame;
+    private boolean isClicked = false;
+    protected boolean isMRAID;
 
-    private String mTargetUrl;
+    private String targetUrl;
 
-    public WebViewBase(Context context, String html, int width, int height, PreloadManager.PreloadedListener preloadedListener, MraidEventsManager.MraidListener mraidInterface) {
+    public WebViewBase(
+            Context context,
+            String html,
+            int width,
+            int height,
+            PreloadManager.PreloadedListener preloadedListener,
+            MraidEventsManager.MraidListener mraidInterface
+    ) {
         super(context);
 
-        mWidth = width;
-        mHeight = height;
-        mAdHTML = html;
-        mPreloadedListener = preloadedListener;
-        mMraidListener = mraidInterface;
+        this.width = width;
+        this.height = height;
+        adHTML = html;
+        this.preloadedListener = preloadedListener;
+        mraidListener = mraidInterface;
         initWebView();
     }
 
     public WebViewBase(Context context, PreloadManager.PreloadedListener preloadedListener, MraidEventsManager.MraidListener mraidHelper) {
         super(context);
-        mPreloadedListener = preloadedListener;
-        mMraidListener = mraidHelper;
+        this.preloadedListener = preloadedListener;
+        mraidListener = mraidHelper;
     }
 
     @Override
     public void onWindowFocusChanged(boolean hasWindowFocus) {
         super.onWindowFocusChanged(hasWindowFocus);
-        mMraidListener.onAdWebViewWindowFocusChanged(hasWindowFocus);
+        mraidListener.onAdWebViewWindowFocusChanged(hasWindowFocus);
     }
 
     @Override
     public void startLoadingAssets() {
-        mMraidInterface.loading();
+        mraidInterface.loading();
     }
 
     @Override
     public void adAssetsLoaded() {
 
-        if (mIsMRAID) {
+        if (isMRAID) {
             getMRAIDInterface().prepareAndSendReady();
         }
 
-        if (mPreloadedListener != null) {
+        if (preloadedListener != null) {
 
-            mPreloadedListener.preloaded(this);
+            preloadedListener.preloaded(this);
         }
     }
 
     @Override
     public void notifyMraidScriptInjected() {
-        mIsMRAID = true;
+        isMRAID = true;
     }
 
     @Override
     public void destroy() {
         super.destroy();
-        mMraidInterface.destroy();
+        mraidInterface.destroy();
     }
 
     @Override
@@ -137,44 +145,43 @@ public class WebViewBase extends AdWebView implements AdAssetsLoadedListener {
          * ://stackoverflow.com/questions/2969949/cant-loadAdConfiguration-image-in-webview-
          * via-javascript
          * ***/
-        loadDataWithBaseURL(PrebidMobile.SCHEME_HTTPS + "://" + mDomain + "/", mAdHTML,
-                "text/html", "utf-8", null);
+        loadDataWithBaseURL(PrebidMobile.SCHEME_HTTPS + "://" + domain + "/", adHTML, "text/html", "utf-8", null);
     }
 
     public void setJSName(String name) {
-        mMRAIDBridgeName = name;
+        MRAIDBridgeName = name;
     }
 
     public String getJSName() {
-        return mMRAIDBridgeName;
+        return MRAIDBridgeName;
     }
 
     public MraidEventsManager.MraidListener getMraidListener() {
-        return mMraidListener;
+        return mraidListener;
     }
 
     public void setDialog(AdBaseDialog dialog) {
-        mDialog = dialog;
+        this.dialog = dialog;
     }
 
     public AdBaseDialog getDialog() {
-        return mDialog;
+        return dialog;
     }
 
     public boolean isClicked() {
-        return mIsClicked;
+        return isClicked;
     }
 
     public void setIsClicked(boolean isClicked) {
-        mIsClicked = isClicked;
+        this.isClicked = isClicked;
     }
 
     public PreloadManager.PreloadedListener getPreloadedListener() {
-        return mPreloadedListener;
+        return preloadedListener;
     }
 
     /**
-     * Initializes {@link #mContainsIFrame}. Sets true if <iframe> tag was found in html
+     * Initializes {@link #containsIFrame}. Sets true if <iframe> tag was found in html
      *
      * @param html html without injected {@link R.raw#omsdk_v1} NOTE: Without injected {@link R.raw#omsdk_v1}
      *             because {@link R.raw#omsdk_v1} contains <iframe>
@@ -182,14 +189,14 @@ public class WebViewBase extends AdWebView implements AdAssetsLoadedListener {
     public void initContainsIFrame(String html) {
         Pattern iframePattern = Pattern.compile(REGEX_IFRAME, Pattern.CASE_INSENSITIVE);
         Matcher matcher = iframePattern.matcher(html);
-        mContainsIFrame = matcher.find();
+        containsIFrame = matcher.find();
     }
 
     /**
      * @return true if html in {@link #initContainsIFrame(String)} contained <iframe>
      */
     public boolean containsIFrame() {
-        return mContainsIFrame;
+        return containsIFrame;
     }
 
     public ViewGroup getParentContainer() {
@@ -209,39 +216,39 @@ public class WebViewBase extends AdWebView implements AdAssetsLoadedListener {
     }
 
     public BaseJSInterface getMRAIDInterface() {
-        return mMraidInterface;
+        return mraidInterface;
     }
 
     public void setBaseJSInterface(BaseJSInterface mraid) {
-        mMraidInterface = mraid;
+        mraidInterface = mraid;
     }
 
     public void setAdWidth(int width) {
-        mWidth = width;
+        this.width = width;
     }
 
     public int getAdWidth() {
-        return mWidth;
+        return width;
     }
 
     public void setAdHeight(int height) {
-        mHeight = height;
+        this.height = height;
     }
 
     public int getAdHeight() {
-        return mHeight;
+        return height;
     }
 
     public boolean isMRAID() {
-        return mIsMRAID;
+        return isMRAID;
     }
 
     public void setTargetUrl(String targetUrl) {
-        mTargetUrl = targetUrl;
+        this.targetUrl = targetUrl;
     }
 
     public String getTargetUrl() {
-        return mTargetUrl;
+        return targetUrl;
     }
 
     public void initLoad() {
@@ -262,11 +269,11 @@ public class WebViewBase extends AdWebView implements AdAssetsLoadedListener {
         //adHTML = Utils.loadStringFromFile(getResources(), R.raw.testmraidfullad);
         // adHTML = Utils.loadStringFromFile(getResources(), R.raw.html);
 
-        mAdHTML = createAdHTML(mAdHTML);
+        adHTML = createAdHTML(adHTML);
     }
 
     public void sendClickCallBack(String url) {
-        post(() -> mMraidListener.openMraidExternalLink(url));
+        post(() -> mraidListener.openMraidExternalLink(url));
     }
 
     public boolean canHandleClick() {

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/views/webview/WebViewInterstitial.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/views/webview/WebViewInterstitial.java
@@ -35,7 +35,7 @@ public class WebViewInterstitial extends WebViewBase {
     }
 
     public void setJSName(String name) {
-        mMRAIDBridgeName = name;
+        MRAIDBridgeName = name;
     }
 
     @Override

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/views/webview/mraid/MraidWebViewClient.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/views/webview/mraid/MraidWebViewClient.java
@@ -36,11 +36,11 @@ public class MraidWebViewClient extends AdWebViewClient {
     private static String TAG = MraidWebViewClient.class.getSimpleName();
     private static final String MRAID_JS = "mraid.js";
 
-    private String mMraidInjectionJavascript;
+    private String mraidInjectionJavascript;
 
     public MraidWebViewClient(AdAssetsLoadedListener adAssetsLoadedListener, String mraidScript) {
         super(adAssetsLoadedListener);
-        mMraidInjectionJavascript = "javascript:" + MraidEnv.getWindowMraidEnv() + mraidScript;
+        mraidInjectionJavascript = "javascript:" + MraidEnv.getWindowMraidEnv() + mraidScript;
     }
 
     @Override
@@ -61,12 +61,11 @@ public class MraidWebViewClient extends AdWebViewClient {
     }
 
     private WebResourceResponse createMraidInjectionResponse() {
-        if (Utils.isNotBlank(mMraidInjectionJavascript)) {
-            mAdAssetsLoadedListener.notifyMraidScriptInjected();
-            InputStream data = new ByteArrayInputStream(mMraidInjectionJavascript.getBytes());
+        if (Utils.isNotBlank(mraidInjectionJavascript)) {
+            adAssetsLoadedListener.notifyMraidScriptInjected();
+            InputStream data = new ByteArrayInputStream(mraidInjectionJavascript.getBytes());
             return new WebResourceResponse("text/javascript", "UTF-8", data);
-        }
-        else {
+        } else {
             LogUtil.error(TAG, "Failed to inject mraid.js into twoPart mraid webview");
         }
         return null;

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/views/webview/mraid/OriginalUrlResponseCallBack.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/views/webview/mraid/OriginalUrlResponseCallBack.java
@@ -24,10 +24,10 @@ import org.prebid.mobile.rendering.networking.ResponseHandler;
 class OriginalUrlResponseCallBack implements ResponseHandler {
     private static final String TAG = OriginalUrlResponseCallBack.class.getSimpleName();
 
-    private RedirectUrlListener mRedirectUrlListener;
+    private RedirectUrlListener redirectUrlListener;
 
     OriginalUrlResponseCallBack(RedirectUrlListener redirectUrlListener) {
-        mRedirectUrlListener = redirectUrlListener;
+        this.redirectUrlListener = redirectUrlListener;
     }
 
     @Override
@@ -38,8 +38,8 @@ class OriginalUrlResponseCallBack implements ResponseHandler {
             return;
         }
 
-        if (mRedirectUrlListener != null) {
-            mRedirectUrlListener.onSuccess(result.originalUrl, result.contentType);
+        if (redirectUrlListener != null) {
+            redirectUrlListener.onSuccess(result.originalUrl, result.contentType);
         }
     }
 
@@ -56,8 +56,8 @@ class OriginalUrlResponseCallBack implements ResponseHandler {
     }
 
     private void notifyFailureListener() {
-        if (mRedirectUrlListener != null) {
-            mRedirectUrlListener.onFailed();
+        if (redirectUrlListener != null) {
+            redirectUrlListener.onFailed();
         }
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/mediation/MediationBannerAdUnitTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/mediation/MediationBannerAdUnitTest.java
@@ -47,24 +47,24 @@ import static org.mockito.Mockito.*;
 @Config(sdk = 19)
 public class MediationBannerAdUnitTest {
 
-    private Context mContext;
-    private MediationBannerAdUnit mMediationBannerAdUnit;
+    private Context context;
+    private MediationBannerAdUnit mediationBannerAdUnit;
     @Mock
-    private ScreenStateReceiver mMockScreenStateReceiver;
+    private ScreenStateReceiver mockScreenStateReceiver;
     @Mock
-    private BidLoader mMockBidLoader;
+    private BidLoader mockBidLoader;
 
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
-        mContext = Robolectric.buildActivity(Activity.class).create().get();
+        context = Robolectric.buildActivity(Activity.class).create().get();
         PrebidMobile.setPrebidServerAccountId("id");
-        mMediationBannerAdUnit = new MediationBannerAdUnit(mContext, "config", mock(AdSize.class), new MockMediationUtils());
+        mediationBannerAdUnit = new MediationBannerAdUnit(context, "config", mock(AdSize.class), new MockMediationUtils());
 
-        WhiteBox.setInternalState(mMediationBannerAdUnit, "mBidLoader", mMockBidLoader);
-        WhiteBox.setInternalState(mMediationBannerAdUnit, "mScreenStateReceiver", mMockScreenStateReceiver);
+        WhiteBox.setInternalState(mediationBannerAdUnit, "bidLoader", mockBidLoader);
+        WhiteBox.setInternalState(mediationBannerAdUnit, "screenStateReceiver", mockScreenStateReceiver);
 
-        assertEquals(BannerAdPosition.UNDEFINED.getValue(), mMediationBannerAdUnit.getAdPosition().getValue());
+        assertEquals(BannerAdPosition.UNDEFINED.getValue(), mediationBannerAdUnit.getAdPosition().getValue());
     }
 
     @After
@@ -75,8 +75,8 @@ public class MediationBannerAdUnitTest {
     @Test
     public void whenInitAdConfig_PrepareAdConfigForBanner() {
         AdSize adSize = new AdSize(1, 2);
-        mMediationBannerAdUnit.initAdConfig("config", adSize);
-        AdUnitConfiguration adConfiguration = mMediationBannerAdUnit.mAdUnitConfig;
+        mediationBannerAdUnit.initAdConfig("config", adSize);
+        AdUnitConfiguration adConfiguration = mediationBannerAdUnit.adUnitConfig;
         assertEquals("config", adConfiguration.getConfigId());
         assertEquals(EnumSet.of(AdFormat.BANNER), adConfiguration.getAdFormats());
         assertTrue(adConfiguration.getSizes().contains(adSize));
@@ -84,41 +84,41 @@ public class MediationBannerAdUnitTest {
 
     @Test
     public void whenSetRefreshInterval_ChangeRefreshIntervalInAdConfig() {
-        assertEquals(30_000, mMediationBannerAdUnit.mAdUnitConfig.getAutoRefreshDelay());
-        mMediationBannerAdUnit.setRefreshInterval(15);
-        assertEquals(30_000, mMediationBannerAdUnit.mAdUnitConfig.getAutoRefreshDelay());
+        assertEquals(30_000, mediationBannerAdUnit.adUnitConfig.getAutoRefreshDelay());
+        mediationBannerAdUnit.setRefreshInterval(15);
+        assertEquals(30_000, mediationBannerAdUnit.adUnitConfig.getAutoRefreshDelay());
     }
 
     @Test
     public void whenDestroy_UnregisterReceiver() {
-        mMediationBannerAdUnit.destroy();
+        mediationBannerAdUnit.destroy();
 
-        verify(mMockScreenStateReceiver, times(1)).unregister();
+        verify(mockScreenStateReceiver, times(1)).unregister();
     }
 
     @Test
     public void whenStopRefresh_BidLoaderCancelRefresh() {
-        mMediationBannerAdUnit.stopRefresh();
+        mediationBannerAdUnit.stopRefresh();
 
-        verify(mMockBidLoader, times(1)).cancelRefresh();
+        verify(mockBidLoader, times(1)).cancelRefresh();
     }
 
     @Test
     public void setAdPosition_EqualsGetAdPosition() {
-        mMediationBannerAdUnit.setAdPosition(null);
-        assertEquals(BannerAdPosition.UNDEFINED, mMediationBannerAdUnit.getAdPosition());
+        mediationBannerAdUnit.setAdPosition(null);
+        assertEquals(BannerAdPosition.UNDEFINED, mediationBannerAdUnit.getAdPosition());
 
-        mMediationBannerAdUnit.setAdPosition(BannerAdPosition.FOOTER);
-        assertEquals(BannerAdPosition.FOOTER, mMediationBannerAdUnit.getAdPosition());
+        mediationBannerAdUnit.setAdPosition(BannerAdPosition.FOOTER);
+        assertEquals(BannerAdPosition.FOOTER, mediationBannerAdUnit.getAdPosition());
 
-        mMediationBannerAdUnit.setAdPosition(BannerAdPosition.HEADER);
-        assertEquals(BannerAdPosition.HEADER, mMediationBannerAdUnit.getAdPosition());
+        mediationBannerAdUnit.setAdPosition(BannerAdPosition.HEADER);
+        assertEquals(BannerAdPosition.HEADER, mediationBannerAdUnit.getAdPosition());
 
-        mMediationBannerAdUnit.setAdPosition(BannerAdPosition.SIDEBAR);
-        assertEquals(BannerAdPosition.SIDEBAR, mMediationBannerAdUnit.getAdPosition());
+        mediationBannerAdUnit.setAdPosition(BannerAdPosition.SIDEBAR);
+        assertEquals(BannerAdPosition.SIDEBAR, mediationBannerAdUnit.getAdPosition());
 
-        mMediationBannerAdUnit.setAdPosition(BannerAdPosition.UNKNOWN);
-        assertEquals(BannerAdPosition.UNKNOWN, mMediationBannerAdUnit.getAdPosition());
+        mediationBannerAdUnit.setAdPosition(BannerAdPosition.UNKNOWN);
+        assertEquals(BannerAdPosition.UNKNOWN, mediationBannerAdUnit.getAdPosition());
     }
 
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/mediation/MediationBaseAdUnitTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/mediation/MediationBaseAdUnitTest.java
@@ -52,23 +52,23 @@ import static org.mockito.Mockito.verify;
 @Config(sdk = 19)
 public class MediationBaseAdUnitTest {
 
-    private MediationBaseAdUnit mBaseAdUnit;
-    private Context mContext;
-    private Object mMopubView = new Object();
+    private MediationBaseAdUnit baseAdUnit;
+    private Context context;
+    private Object mopubView = new Object();
     @Mock
-    private AdSize mMockAdSize;
+    private AdSize mockAdSize;
     @Mock
-    private BidLoader mMockBidLoader;
+    private BidLoader mockBidLoader;
 
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
 
-        mContext = Robolectric.buildActivity(Activity.class).create().get();
-        mBaseAdUnit = createAdUnit("config");
+        context = Robolectric.buildActivity(Activity.class).create().get();
+        baseAdUnit = createAdUnit("config");
         PrebidMobile.setPrebidServerHost(Host.APPNEXUS);
 
-        assertEquals(BannerAdPosition.UNDEFINED.getValue(), mBaseAdUnit.mAdUnitConfig.getAdPositionValue());
+        assertEquals(BannerAdPosition.UNDEFINED.getValue(), baseAdUnit.adUnitConfig.getAdPositionValue());
     }
 
     @After
@@ -79,13 +79,13 @@ public class MediationBaseAdUnitTest {
     @Test
     public void whenFetchDemandAndNotMoPubViewPassed_InvalidAdObjectResult() {
         PrebidMobile.setPrebidServerAccountId("testAccountId");
-        new MediationBaseAdUnit(mContext, "123", mMockAdSize, new MockMediationUtils()) {
+        new MediationBaseAdUnit(context, "123", mockAdSize, new MockMediationUtils()) {
             @Override
             protected void initAdConfig(
                 String configId,
                 AdSize adSize
             ) {
-                mAdUnitConfig.setConfigId(configId);
+                adUnitConfig.setConfigId(configId);
             }
         }.fetchDemand(result -> {
             assertEquals(FetchDemandResult.INVALID_AD_OBJECT, result);
@@ -94,7 +94,7 @@ public class MediationBaseAdUnitTest {
 
     @Test
     public void whenFetchDemandAndNoAccountId_InvalidAccountIdResult() {
-        mBaseAdUnit.fetchDemand(result -> {
+        baseAdUnit.fetchDemand(result -> {
             assertEquals(FetchDemandResult.INVALID_ACCOUNT_ID, result);
         });
     }
@@ -102,8 +102,8 @@ public class MediationBaseAdUnitTest {
     @Test
     public void whenFetchDemandAndNoConfigId_InvalidConfigIdResult() {
         PrebidMobile.setPrebidServerAccountId("id");
-        mBaseAdUnit = createAdUnit("");
-        mBaseAdUnit.fetchDemand(result -> {
+        baseAdUnit = createAdUnit("");
+        baseAdUnit.fetchDemand(result -> {
             assertEquals(FetchDemandResult.INVALID_CONFIG_ID, result);
         });
     }
@@ -114,8 +114,8 @@ public class MediationBaseAdUnitTest {
         final Host custom = Host.CUSTOM;
         custom.setHostUrl("");
         PrebidMobile.setPrebidServerHost(custom);
-        mBaseAdUnit = createAdUnit("123");
-        mBaseAdUnit.fetchDemand(result -> {
+        baseAdUnit = createAdUnit("123");
+        baseAdUnit.fetchDemand(result -> {
             assertEquals(FetchDemandResult.INVALID_HOST_URL, result);
         });
     }
@@ -123,15 +123,15 @@ public class MediationBaseAdUnitTest {
     @Test
     public void whenFetchDemandAndEverythingOK_BidLoaderLoadCalled() {
         PrebidMobile.setPrebidServerAccountId("id");
-        mBaseAdUnit.fetchDemand(result -> {
+        baseAdUnit.fetchDemand(result -> {
         });
-        verify(mMockBidLoader).load();
+        verify(mockBidLoader).load();
     }
 
     @Test
     public void whenDestroy_DestroyBidLoader() {
-        mBaseAdUnit.destroy();
-        verify(mMockBidLoader).destroy();
+        baseAdUnit.destroy();
+        verify(mockBidLoader).destroy();
     }
 
     @Test
@@ -140,8 +140,8 @@ public class MediationBaseAdUnitTest {
         OnFetchCompleteListener mockListener = mock(OnFetchCompleteListener.class);
         AdException adException = new AdException(AdException.INTERNAL_ERROR, "");
 
-        mBaseAdUnit.fetchDemand(mockListener);
-        mBaseAdUnit.onErrorReceived(adException);
+        baseAdUnit.fetchDemand(mockListener);
+        baseAdUnit.onErrorReceived(adException);
         verify(mockListener).onComplete(FetchDemandResult.SERVER_ERROR);
     }
 
@@ -156,27 +156,27 @@ public class MediationBaseAdUnitTest {
         expectedMap.put("key2", value2);
 
         // add
-        mBaseAdUnit.addContextData("key1", "value1");
-        mBaseAdUnit.addContextData("key2", "value2");
+        baseAdUnit.addContextData("key1", "value1");
+        baseAdUnit.addContextData("key2", "value2");
 
-        assertEquals(expectedMap, mBaseAdUnit.getContextDataDictionary());
+        assertEquals(expectedMap, baseAdUnit.getContextDataDictionary());
 
         // update
         HashSet<String> updateSet = new HashSet<>();
         updateSet.add("value3");
-        mBaseAdUnit.updateContextData("key1", updateSet);
+        baseAdUnit.updateContextData("key1", updateSet);
         expectedMap.replace("key1", updateSet);
 
-        assertEquals(expectedMap, mBaseAdUnit.getContextDataDictionary());
+        assertEquals(expectedMap, baseAdUnit.getContextDataDictionary());
 
         // remove
-        mBaseAdUnit.removeContextData("key1");
+        baseAdUnit.removeContextData("key1");
         expectedMap.remove("key1");
-        assertEquals(expectedMap, mBaseAdUnit.getContextDataDictionary());
+        assertEquals(expectedMap, baseAdUnit.getContextDataDictionary());
 
         // clear
-        mBaseAdUnit.clearContextData();
-        assertTrue(mBaseAdUnit.getContextDataDictionary().isEmpty());
+        baseAdUnit.clearContextData();
+        assertTrue(baseAdUnit.getContextDataDictionary().isEmpty());
     }
 
     @Test
@@ -186,56 +186,56 @@ public class MediationBaseAdUnitTest {
         expectedSet.add("key2");
 
         // add
-        mBaseAdUnit.addContextKeyword("key1");
-        mBaseAdUnit.addContextKeyword("key2");
+        baseAdUnit.addContextKeyword("key1");
+        baseAdUnit.addContextKeyword("key2");
 
-        assertEquals(expectedSet, mBaseAdUnit.getContextKeywordsSet());
+        assertEquals(expectedSet, baseAdUnit.getContextKeywordsSet());
 
         // remove
-        mBaseAdUnit.removeContextKeyword("key2");
+        baseAdUnit.removeContextKeyword("key2");
         expectedSet.remove("key2");
-        assertEquals(expectedSet, mBaseAdUnit.getContextKeywordsSet());
+        assertEquals(expectedSet, baseAdUnit.getContextKeywordsSet());
 
         // clear
-        mBaseAdUnit.clearContextKeywords();
-        assertTrue(mBaseAdUnit.getContextKeywordsSet().isEmpty());
+        baseAdUnit.clearContextKeywords();
+        assertTrue(baseAdUnit.getContextKeywordsSet().isEmpty());
 
         // add all
-        mBaseAdUnit.addContextKeywords(expectedSet);
-        assertEquals(expectedSet, mBaseAdUnit.getContextKeywordsSet());
+        baseAdUnit.addContextKeywords(expectedSet);
+        assertEquals(expectedSet, baseAdUnit.getContextKeywordsSet());
     }
 
     @Test
     public void setPbAdSlot_EqualsGetPbAdSlot() {
         final String expected = "12345";
-        mBaseAdUnit.setPbAdSlot(expected);
-        assertEquals(expected, mBaseAdUnit.getPbAdSlot());
+        baseAdUnit.setPbAdSlot(expected);
+        assertEquals(expected, baseAdUnit.getPbAdSlot());
     }
 
     private MediationBaseAdUnit createAdUnit(String configId) {
-        MediationBaseAdUnit baseAdUnit = new MediationBaseAdUnit(mContext, configId, mMockAdSize, new MockMediationUtils()) {
+        MediationBaseAdUnit baseAdUnit = new MediationBaseAdUnit(context, configId, mockAdSize, new MockMediationUtils()) {
             @Override
             protected void initAdConfig(
                 String configId,
                 AdSize adSize
             ) {
-                mAdUnitConfig.setConfigId(configId);
+                adUnitConfig.setConfigId(configId);
             }
         };
-        WhiteBox.setInternalState(baseAdUnit, "mBidLoader", mMockBidLoader);
+        WhiteBox.setInternalState(baseAdUnit, "bidLoader", mockBidLoader);
         return baseAdUnit;
     }
 
     public static class MediationViewMock {
 
-        private String mKeywords;
+        private String keywords;
 
         public void setKeywords(String keywords) {
-            mKeywords = keywords;
+            this.keywords = keywords;
         }
 
         public String getKeywords() {
-            return mKeywords;
+            return keywords;
         }
 
     }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/mediation/MediationInterstitialAdUnitTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/mediation/MediationInterstitialAdUnitTest.java
@@ -40,14 +40,14 @@ import static org.junit.Assert.assertEquals;
 @Config(sdk = 19)
 public class MediationInterstitialAdUnitTest {
 
-    private Context mContext;
-    private MediationInterstitialAdUnit mMediationInterstitialAdUnit;
+    private Context context;
+    private MediationInterstitialAdUnit mediationInterstitialAdUnit;
 
     @Before
     public void setUp() throws Exception {
-        mContext = Robolectric.buildActivity(Activity.class).create().get();
+        context = Robolectric.buildActivity(Activity.class).create().get();
         PrebidMobile.setPrebidServerAccountId("id");
-        mMediationInterstitialAdUnit = new MediationInterstitialAdUnit(mContext, "config", new AdSize(1, 2), new MockMediationUtils());
+        mediationInterstitialAdUnit = new MediationInterstitialAdUnit(context, "config", new AdSize(1, 2), new MockMediationUtils());
     }
 
     @After
@@ -58,8 +58,8 @@ public class MediationInterstitialAdUnitTest {
     @Test
     public void whenInitAdConfig_PrepareAdConfigForInterstitial() {
         AdSize adSize = new AdSize(1, 2);
-        mMediationInterstitialAdUnit.initAdConfig("config", adSize);
-        AdUnitConfiguration adConfiguration = mMediationInterstitialAdUnit.mAdUnitConfig;
+        mediationInterstitialAdUnit.initAdConfig("config", adSize);
+        AdUnitConfiguration adConfiguration = mediationInterstitialAdUnit.adUnitConfig;
         assertEquals("config", adConfiguration.getConfigId());
         assertEquals(EnumSet.of(AdFormat.INTERSTITIAL), adConfiguration.getAdFormats());
         assertEquals(adSize, adConfiguration.getMinSizePercentage());
@@ -67,13 +67,13 @@ public class MediationInterstitialAdUnitTest {
 
     @Test
     public void whenConstructorAndAdUnitFormatVideo_AdUnitIdentifierTypeVideo() {
-        mMediationInterstitialAdUnit = new MediationInterstitialAdUnit(
-            mContext,
+        mediationInterstitialAdUnit = new MediationInterstitialAdUnit(
+            context,
             "config",
             EnumSet.of(AdUnitFormat.VIDEO),
             new MockMediationUtils()
         );
-        assertEquals(EnumSet.of(AdFormat.VAST), mMediationInterstitialAdUnit.mAdUnitConfig.getAdFormats());
+        assertEquals(EnumSet.of(AdFormat.VAST), mediationInterstitialAdUnit.adUnitConfig.getAdFormats());
     }
 
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/mediation/MediationRewardedVideoAdUnitTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/mediation/MediationRewardedVideoAdUnitTest.java
@@ -42,15 +42,15 @@ import static org.mockito.Mockito.mock;
 @Config(sdk = 19)
 public class MediationRewardedVideoAdUnitTest {
 
-    private Context mContext;
-    private MediationRewardedVideoAdUnit mMopubRewardedAdUnit;
+    private Context context;
+    private MediationRewardedVideoAdUnit mopubRewardedAdUnit;
 
     @Before
     public void setUp() throws Exception {
-        mContext = Robolectric.buildActivity(Activity.class).create().get();
+        context = Robolectric.buildActivity(Activity.class).create().get();
         PrebidMobile.setPrebidServerAccountId("id");
-        mMopubRewardedAdUnit = new MediationRewardedVideoAdUnit(mContext, "config", new MockMediationUtils());
-        WhiteBox.setInternalState(mMopubRewardedAdUnit, "mBidLoader", mock(BidLoader.class));
+        mopubRewardedAdUnit = new MediationRewardedVideoAdUnit(context, "config", new MockMediationUtils());
+        WhiteBox.setInternalState(mopubRewardedAdUnit, "bidLoader", mock(BidLoader.class));
     }
 
     @After
@@ -60,8 +60,8 @@ public class MediationRewardedVideoAdUnitTest {
 
     @Test
     public void whenInitAdConfig_PrepareAdConfigForInterstitial() {
-        mMopubRewardedAdUnit.initAdConfig("config", null);
-        AdUnitConfiguration adConfiguration = mMopubRewardedAdUnit.mAdUnitConfig;
+        mopubRewardedAdUnit.initAdConfig("config", null);
+        AdUnitConfiguration adConfiguration = mopubRewardedAdUnit.adUnitConfig;
         assertEquals("config", adConfiguration.getConfigId());
         assertEquals(EnumSet.of(AdFormat.VAST), adConfiguration.getAdFormats());
         assertTrue(adConfiguration.isRewarded());

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/BannerViewTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/BannerViewTest.java
@@ -64,40 +64,40 @@ public class BannerViewTest {
     private static final String AD_UNIT_ID = "12345678";
     private static final AdSize AD_SIZE = new AdSize(320, 50);
 
-    private BannerView mBannerView;
+    private BannerView bannerView;
 
-    private Context mMockContext;
+    private Context mockContext;
     @Mock
-    private BidLoader mMockBidLoader;
+    private BidLoader mockBidLoader;
     @Mock
-    private BannerEventHandler mMockEventHandler;
+    private BannerEventHandler mockEventHandler;
     @Mock
-    private BannerViewListener mMockBannerListener;
+    private BannerViewListener mockBannerListener;
     @Mock
-    private DisplayView mMockDisplayView;
+    private DisplayView mockDisplayView;
     @Mock
-    private ScreenStateReceiver mMockScreenStateReceiver;
+    private ScreenStateReceiver mockScreenStateReceiver;
 
     @Before
     public void setup() throws Exception {
         MockitoAnnotations.initMocks(this);
-        mMockContext = Robolectric.buildActivity(Activity.class).create().get();
+        mockContext = Robolectric.buildActivity(Activity.class).create().get();
 
-        when(mMockEventHandler.getAdSizeArray()).thenReturn(new AdSize[]{AD_SIZE});
-        mBannerView = new BannerView(mMockContext, AD_UNIT_ID, mMockEventHandler);
-        WhiteBox.field(BannerView.class, "mBidLoader").set(mBannerView, mMockBidLoader);
-        WhiteBox.field(BannerView.class, "mDisplayView").set(mBannerView, mMockDisplayView);
-        WhiteBox.field(BannerView.class, "mDisplayView").set(mBannerView, mMockDisplayView);
-        WhiteBox.field(BannerView.class, "mScreenStateReceiver").set(mBannerView, mMockScreenStateReceiver);
-        mBannerView.setBannerListener(mMockBannerListener);
+        when(mockEventHandler.getAdSizeArray()).thenReturn(new AdSize[]{AD_SIZE});
+        bannerView = new BannerView(mockContext, AD_UNIT_ID, mockEventHandler);
+        WhiteBox.field(BannerView.class, "bidLoader").set(bannerView, mockBidLoader);
+        WhiteBox.field(BannerView.class, "displayView").set(bannerView, mockDisplayView);
+        WhiteBox.field(BannerView.class, "displayView").set(bannerView, mockDisplayView);
+        WhiteBox.field(BannerView.class, "screenStateReceiver").set(bannerView, mockScreenStateReceiver);
+        bannerView.setBannerListener(mockBannerListener);
 
-        assertEquals(BannerAdPosition.UNDEFINED.getValue(), mBannerView.getAdPosition().getValue());
+        assertEquals(BannerAdPosition.UNDEFINED.getValue(), bannerView.getAdPosition().getValue());
     }
 
     @Test
     public void createPrebidBannerViewWithAttributes_InstanceCreated() {
         AttributeSet attributes = Robolectric.buildAttributeSet().build();
-        BannerView bannerView = new BannerView(mMockContext, attributes);
+        BannerView bannerView = new BannerView(mockContext, attributes);
 
         assertNotNull(bannerView);
     }
@@ -105,10 +105,10 @@ public class BannerViewTest {
     @Test
     public void createPrebidBannerViewNoEventHandler_InstanceCreatedAndBidLoaderIsNotNullAndStandaloneEventHandlerProvided()
         throws IllegalAccessException {
-        BannerView bannerView = new BannerView(mMockContext, AD_UNIT_ID, AD_SIZE);
+        BannerView bannerView = new BannerView(mockContext, AD_UNIT_ID, AD_SIZE);
 
-        Object eventHandler = WhiteBox.field(BannerView.class, "mEventHandler").get(bannerView);
-        BidLoader bidLoader = ((BidLoader) WhiteBox.field(BannerView.class, "mBidLoader").get(bannerView));
+        Object eventHandler = WhiteBox.field(BannerView.class, "eventHandler").get(bannerView);
+        BidLoader bidLoader = ((BidLoader) WhiteBox.field(BannerView.class, "bidLoader").get(bannerView));
 
         assertNotNull(bannerView);
         assertTrue(eventHandler instanceof StandaloneBannerEventHandler);
@@ -117,57 +117,57 @@ public class BannerViewTest {
 
     @Test
     public void loadAdWithNullBidLoader_NoExceptionIsThrown() throws IllegalAccessException {
-        WhiteBox.field(BannerView.class, "mBidLoader").set(mBannerView, null);
+        WhiteBox.field(BannerView.class, "bidLoader").set(bannerView, null);
 
-        mBannerView.loadAd();
+        bannerView.loadAd();
     }
 
     @Test
     public void loadAdWithPrimaryAdServerRequestInProgress_DoNothing() {
         changePrimaryAdServerRequestStatus(true);
-        mBannerView.loadAd();
+        bannerView.loadAd();
 
-        verifyZeroInteractions(mMockBidLoader);
+        verifyZeroInteractions(mockBidLoader);
     }
 
     @Test
     public void loadAd_bidResponseIsInitialized() {
-        mBannerView.loadAd();
+        bannerView.loadAd();
 
-        BidResponse response = mBannerView.getBidResponse();
+        BidResponse response = bannerView.getBidResponse();
         System.out.println(response);
     }
 
     @Test
     public void loadAdWithValidBidLoaderAndPrimaryAdRequestNotInProgress_ExecuteBidLoad() {
-        mBannerView.loadAd();
+        bannerView.loadAd();
 
-        verify(mMockBidLoader, times(1)).load();
+        verify(mockBidLoader, times(1)).load();
     }
 
     @Test
     public void destroy_DestroyEventHandlerAndBidLoader() {
-        mBannerView.destroy();
+        bannerView.destroy();
 
-        verify(mMockEventHandler).destroy();
-        verify(mMockBidLoader).destroy();
-        verify(mMockScreenStateReceiver).unregister();
+        verify(mockEventHandler).destroy();
+        verify(mockBidLoader).destroy();
+        verify(mockScreenStateReceiver).unregister();
     }
 
     @Test
     public void setAutoRefreshDelayInSec_EqualsGetAutoRefreshDelayInMs() {
         final int interval = 30;
-        mBannerView.setAutoRefreshDelay(interval);
+        bannerView.setAutoRefreshDelay(interval);
 
-        assertEquals(interval * 1000, mBannerView.getAutoRefreshDelayInMs());
+        assertEquals(interval * 1000, bannerView.getAutoRefreshDelayInMs());
     }
 
     @Test
     public void setRefreshIntervalInSecSmallerThanZero_ExpectDefaultRefresh() {
         final int interval = -1;
-        mBannerView.setAutoRefreshDelay(interval);
+        bannerView.setAutoRefreshDelay(interval);
 
-        assertEquals(0, mBannerView.getAutoRefreshDelayInMs());
+        assertEquals(0, bannerView.getAutoRefreshDelayInMs());
     }
 
     @Test
@@ -177,9 +177,9 @@ public class BannerViewTest {
         expectedSet.add(AD_SIZE); // from eventHandler
         expectedSet.add(adSize);
 
-        mBannerView.addAdditionalSizes(adSize);
+        bannerView.addAdditionalSizes(adSize);
 
-        assertEquals(expectedSet, mBannerView.getAdditionalSizes());
+        assertEquals(expectedSet, bannerView.getAdditionalSizes());
     }
 
     @Test
@@ -187,9 +187,9 @@ public class BannerViewTest {
         throws IllegalAccessException {
         final VideoPlacementType videoPlacement = VideoPlacementType.IN_BANNER;
         AdUnitConfiguration mockAdConfiguration = mock(AdUnitConfiguration.class);
-        WhiteBox.field(BannerView.class, "mAdUnitConfig").set(mBannerView, mockAdConfiguration);
+        WhiteBox.field(BannerView.class, "adUnitConfig").set(bannerView, mockAdConfiguration);
 
-        mBannerView.setVideoPlacementType(videoPlacement);
+        bannerView.setVideoPlacementType(videoPlacement);
 
         verify(mockAdConfiguration, times(1)).setPlacementType(eq(VideoPlacementType.mapToPlacementType(videoPlacement)));
         verify(mockAdConfiguration, times(1)).setAdFormat(eq(AdFormat.VAST));
@@ -197,17 +197,17 @@ public class BannerViewTest {
 
     @Test
     public void setAdVideoPlacement_EqualsGetVideoPlacement() {
-        mBannerView.setVideoPlacementType(null);
-        assertNull(mBannerView.getVideoPlacementType());
+        bannerView.setVideoPlacementType(null);
+        assertNull(bannerView.getVideoPlacementType());
 
-        mBannerView.setVideoPlacementType(VideoPlacementType.IN_ARTICLE);
-        assertEquals(VideoPlacementType.IN_ARTICLE, mBannerView.getVideoPlacementType());
+        bannerView.setVideoPlacementType(VideoPlacementType.IN_ARTICLE);
+        assertEquals(VideoPlacementType.IN_ARTICLE, bannerView.getVideoPlacementType());
 
-        mBannerView.setVideoPlacementType(VideoPlacementType.IN_BANNER);
-        assertEquals(VideoPlacementType.IN_BANNER, mBannerView.getVideoPlacementType());
+        bannerView.setVideoPlacementType(VideoPlacementType.IN_BANNER);
+        assertEquals(VideoPlacementType.IN_BANNER, bannerView.getVideoPlacementType());
 
-        mBannerView.setVideoPlacementType(VideoPlacementType.IN_FEED);
-        assertEquals(VideoPlacementType.IN_FEED, mBannerView.getVideoPlacementType());
+        bannerView.setVideoPlacementType(VideoPlacementType.IN_FEED);
+        assertEquals(VideoPlacementType.IN_FEED, bannerView.getVideoPlacementType());
     }
 
     //region ======================= BidRequestListener tests
@@ -221,13 +221,13 @@ public class BannerViewTest {
         BidRequesterListener listener = getBidRequesterListener();
         listener.onFetchCompleted(mockBidResponse);
 
-        Bid winningBid = mBannerView.getWinnerBid();
-        BidResponse actualResponse = mBannerView.getBidResponse();
+        Bid winningBid = bannerView.getWinnerBid();
+        BidResponse actualResponse = bannerView.getBidResponse();
 
         assertEquals(winningBid, mockBid);
         assertEquals(mockBidResponse, actualResponse);
-        verify(mMockEventHandler, times(1)).requestAdWithBid(eq(mockBid));
-        assertTrue(mBannerView.isPrimaryAdServerRequestInProgress());
+        verify(mockEventHandler, times(1)).requestAdWithBid(eq(mockBid));
+        assertTrue(bannerView.isPrimaryAdServerRequestInProgress());
     }
 
     @Test
@@ -236,14 +236,14 @@ public class BannerViewTest {
         final Bid mockBid = mock(Bid.class);
 
         when(mockBidResponse.getWinningBid()).thenReturn(mockBid);
-        mBannerView.setBidResponse(mockBidResponse);
+        bannerView.setBidResponse(mockBidResponse);
 
         BidRequesterListener listener = getBidRequesterListener();
         listener.onError(any());
 
-        assertNull(mBannerView.getWinnerBid());
-        assertNull(mBannerView.getBidResponse());
-        verify(mMockEventHandler, times(1)).requestAdWithBid(eq(null));
+        assertNull(bannerView.getWinnerBid());
+        assertNull(bannerView.getBidResponse());
+        verify(mockEventHandler, times(1)).requestAdWithBid(eq(null));
     }
     //endregion ======================= BidRequestListener tests
 
@@ -252,12 +252,12 @@ public class BannerViewTest {
     public void onPrebidSdkWinAndWinnerBidIsNull_AdRequestStatusIsFinishedNotifyErrorListener() {
         changePrimaryAdServerRequestStatus(true);
         final BannerEventListener bannerEventListener = getBannerEventListener();
-        mBannerView.setBidResponse(null);
+        bannerView.setBidResponse(null);
 
         bannerEventListener.onPrebidSdkWin();
 
-        verify(mMockBannerListener, times(1)).onAdFailed(eq(mBannerView), any(AdException.class));
-        assertFalse(mBannerView.isPrimaryAdServerRequestInProgress());
+        verify(mockBannerListener, times(1)).onAdFailed(eq(bannerView), any(AdException.class));
+        assertFalse(bannerView.isPrimaryAdServerRequestInProgress());
     }
 
     @Test
@@ -270,11 +270,11 @@ public class BannerViewTest {
         when(mockBidResponse.getWinningBid()).thenReturn(mockBid);
         when(mockBidResponse.getWinningBidWidthHeightPairDips(any())).thenReturn(Pair.create(0, 0));
 
-        mBannerView.setBidResponse(mockBidResponse);
+        bannerView.setBidResponse(mockBidResponse);
 
         bannerEventListener.onPrebidSdkWin();
 
-        assertFalse(mBannerView.isPrimaryAdServerRequestInProgress());
+        assertFalse(bannerView.isPrimaryAdServerRequestInProgress());
     }
 
     @Test
@@ -286,22 +286,22 @@ public class BannerViewTest {
 
         bannerEventListener.onAdServerWin(mockView);
 
-        assertFalse(mBannerView.isPrimaryAdServerRequestInProgress());
-        verify(mMockBannerListener, times(1)).onAdLoaded(mBannerView);
+        assertFalse(bannerView.isPrimaryAdServerRequestInProgress());
+        verify(mockBannerListener, times(1)).onAdLoaded(bannerView);
         // verify(spyBannerView).displayAdServerView(mockView);
     }
 
     @Test
     public void onFailedAndNoWinnerBid_AdRequestStatusIsFinishedNotifyErrorListener() {
         changePrimaryAdServerRequestStatus(true);
-        mBannerView.setBidResponse(null);
+        bannerView.setBidResponse(null);
 
         final AdException exception = new AdException(AdException.INTERNAL_ERROR, "Test");
         final BannerEventListener bannerEventListener = getBannerEventListener();
 
         bannerEventListener.onAdFailed(exception);
 
-        verify(mMockBannerListener, times(1)).onAdFailed(mBannerView, exception);
+        verify(mockBannerListener, times(1)).onAdFailed(bannerView, exception);
     }
 
     @Test
@@ -314,10 +314,10 @@ public class BannerViewTest {
         when(mockBidResponse.getWinningBid()).thenReturn(mockBid);
         when(mockBidResponse.getWinningBidWidthHeightPairDips(any())).thenReturn(Pair.create(0, 0));
 
-        mBannerView.setBidResponse(mockBidResponse);
+        bannerView.setBidResponse(mockBidResponse);
         spyEventListener.onAdFailed(new AdException(AdException.INTERNAL_ERROR, "Test"));
 
-        assertFalse(mBannerView.isPrimaryAdServerRequestInProgress());
+        assertFalse(bannerView.isPrimaryAdServerRequestInProgress());
         verify(spyEventListener, times(1)).onPrebidSdkWin();
     }
 
@@ -326,7 +326,7 @@ public class BannerViewTest {
         final BannerEventListener bannerEventListener = getBannerEventListener();
         bannerEventListener.onAdClicked();
 
-        verify(mMockBannerListener, times(1)).onAdClicked(mBannerView);
+        verify(mockBannerListener, times(1)).onAdClicked(bannerView);
     }
 
     @Test
@@ -334,13 +334,13 @@ public class BannerViewTest {
         final BannerEventListener bannerEventListener = getBannerEventListener();
         bannerEventListener.onAdClosed();
 
-        verify(mMockBannerListener, times(1)).onAdClosed(mBannerView);
+        verify(mockBannerListener, times(1)).onAdClosed(bannerView);
     }
     //endregion ================= BannerEventListener test
 
     private void changePrimaryAdServerRequestStatus(boolean isLoading) {
         try {
-            WhiteBox.field(BannerView.class, "mIsPrimaryAdServerRequestInProgress").set(mBannerView, isLoading);
+            WhiteBox.field(BannerView.class, "isPrimaryAdServerRequestInProgress").set(bannerView, isLoading);
         } catch (IllegalAccessException e) {
             e.printStackTrace();
         }
@@ -348,51 +348,51 @@ public class BannerViewTest {
 
     @Test
     public void whenLoadAd_CallBidLoaderLoad() {
-        mBannerView.loadAd();
-        verify(mMockBidLoader).load();
+        bannerView.loadAd();
+        verify(mockBidLoader).load();
     }
 
     @Test
     public void whenDisplayViewOnAdLoaded_CallBannerListenerOnAdLoaded()
         throws IllegalAccessException {
         getDisplayViewListener().onAdLoaded();
-        verify(mMockBannerListener).onAdLoaded(mBannerView);
+        verify(mockBannerListener).onAdLoaded(bannerView);
     }
 
     @Test
     public void whenDisplayViewOnAdDisplayed_CallBannerListenerOnAdDisplayedAndTrackImpression()
         throws IllegalAccessException {
         getDisplayViewListener().onAdDisplayed();
-        verify(mMockBannerListener).onAdDisplayed(mBannerView);
-        verify(mMockEventHandler).trackImpression();
+        verify(mockBannerListener).onAdDisplayed(bannerView);
+        verify(mockEventHandler).trackImpression();
     }
 
     @Test
     public void whenDisplayViewOnAdFailed_CallBannerListenerOnAdFailed()
         throws IllegalAccessException {
         getDisplayViewListener().onAdFailed(new AdException(AdException.INTERNAL_ERROR, ""));
-        verify(mMockBannerListener).onAdFailed(eq(mBannerView), any(AdException.class));
+        verify(mockBannerListener).onAdFailed(eq(bannerView), any(AdException.class));
     }
 
     @Test
     public void whenDisplayViewOnAdOpened_CallBannerListenerOnAdClicked()
         throws IllegalAccessException {
         getDisplayViewListener().onAdClicked();
-        verify(mMockBannerListener).onAdClicked(mBannerView);
+        verify(mockBannerListener).onAdClicked(bannerView);
     }
 
     @Test
     public void whenDisplayViewOnAdClosed_CallBannerListenerOnAdClosed()
         throws IllegalAccessException {
         getDisplayViewListener().onAdClosed();
-        verify(mMockBannerListener).onAdClosed(mBannerView);
+        verify(mockBannerListener).onAdClosed(bannerView);
     }
 
     @Test
     public void whenStopRefresh_BidLoaderCancelRefresh() {
-        mBannerView.stopRefresh();
+        bannerView.stopRefresh();
 
-        verify(mMockBidLoader, times(1)).cancelRefresh();
+        verify(mockBidLoader, times(1)).cancelRefresh();
     }
 
     @Test
@@ -406,27 +406,27 @@ public class BannerViewTest {
         expectedMap.put("key2", value2);
 
         // add
-        mBannerView.addContextData("key1", "value1");
-        mBannerView.addContextData("key2", "value2");
+        bannerView.addContextData("key1", "value1");
+        bannerView.addContextData("key2", "value2");
 
-        assertEquals(expectedMap, mBannerView.getContextDataDictionary());
+        assertEquals(expectedMap, bannerView.getContextDataDictionary());
 
         // update
         HashSet<String> updateSet = new HashSet<>();
         updateSet.add("value3");
-        mBannerView.updateContextData("key1", updateSet);
+        bannerView.updateContextData("key1", updateSet);
         expectedMap.replace("key1", updateSet);
 
-        assertEquals(expectedMap, mBannerView.getContextDataDictionary());
+        assertEquals(expectedMap, bannerView.getContextDataDictionary());
 
         // remove
-        mBannerView.removeContextData("key1");
+        bannerView.removeContextData("key1");
         expectedMap.remove("key1");
-        assertEquals(expectedMap, mBannerView.getContextDataDictionary());
+        assertEquals(expectedMap, bannerView.getContextDataDictionary());
 
         // clear
-        mBannerView.clearContextData();
-        assertTrue(mBannerView.getContextDataDictionary().isEmpty());
+        bannerView.clearContextData();
+        assertTrue(bannerView.getContextDataDictionary().isEmpty());
     }
 
     @Test
@@ -436,53 +436,53 @@ public class BannerViewTest {
         expectedSet.add("key2");
 
         // add
-        mBannerView.addContextKeyword("key1");
-        mBannerView.addContextKeyword("key2");
+        bannerView.addContextKeyword("key1");
+        bannerView.addContextKeyword("key2");
 
-        assertEquals(expectedSet, mBannerView.getContextKeywordsSet());
+        assertEquals(expectedSet, bannerView.getContextKeywordsSet());
 
         // remove
-        mBannerView.removeContextKeyword("key2");
+        bannerView.removeContextKeyword("key2");
         expectedSet.remove("key2");
-        assertEquals(expectedSet, mBannerView.getContextKeywordsSet());
+        assertEquals(expectedSet, bannerView.getContextKeywordsSet());
 
         // clear
-        mBannerView.clearContextKeywords();
-        assertTrue(mBannerView.getContextKeywordsSet().isEmpty());
+        bannerView.clearContextKeywords();
+        assertTrue(bannerView.getContextKeywordsSet().isEmpty());
 
         // add all
-        mBannerView.addContextKeywords(expectedSet);
-        assertEquals(expectedSet, mBannerView.getContextKeywordsSet());
+        bannerView.addContextKeywords(expectedSet);
+        assertEquals(expectedSet, bannerView.getContextKeywordsSet());
     }
 
     @Test
     public void setAdPosition_EqualsGetAdPosition() {
-        mBannerView.setAdPosition(null);
-        assertEquals(BannerAdPosition.UNDEFINED, mBannerView.getAdPosition());
+        bannerView.setAdPosition(null);
+        assertEquals(BannerAdPosition.UNDEFINED, bannerView.getAdPosition());
 
-        mBannerView.setAdPosition(BannerAdPosition.FOOTER);
-        assertEquals(BannerAdPosition.FOOTER, mBannerView.getAdPosition());
+        bannerView.setAdPosition(BannerAdPosition.FOOTER);
+        assertEquals(BannerAdPosition.FOOTER, bannerView.getAdPosition());
 
-        mBannerView.setAdPosition(BannerAdPosition.HEADER);
-        assertEquals(BannerAdPosition.HEADER, mBannerView.getAdPosition());
+        bannerView.setAdPosition(BannerAdPosition.HEADER);
+        assertEquals(BannerAdPosition.HEADER, bannerView.getAdPosition());
 
-        mBannerView.setAdPosition(BannerAdPosition.SIDEBAR);
-        assertEquals(BannerAdPosition.SIDEBAR, mBannerView.getAdPosition());
+        bannerView.setAdPosition(BannerAdPosition.SIDEBAR);
+        assertEquals(BannerAdPosition.SIDEBAR, bannerView.getAdPosition());
 
-        mBannerView.setAdPosition(BannerAdPosition.UNKNOWN);
-        assertEquals(BannerAdPosition.UNKNOWN, mBannerView.getAdPosition());
+        bannerView.setAdPosition(BannerAdPosition.UNKNOWN);
+        assertEquals(BannerAdPosition.UNKNOWN, bannerView.getAdPosition());
     }
 
     @Test
     public void setPbAdSlot_EqualsGetPbAdSlot() {
         final String expected = "12345";
-        mBannerView.setPbAdSlot(expected);
-        assertEquals(expected, mBannerView.getPbAdSlot());
+        bannerView.setPbAdSlot(expected);
+        assertEquals(expected, bannerView.getPbAdSlot());
     }
 
     private BidRequesterListener getBidRequesterListener() {
         try {
-            return (BidRequesterListener) WhiteBox.field(BannerView.class, "mBidRequesterListener").get(mBannerView);
+            return (BidRequesterListener) WhiteBox.field(BannerView.class, "bidRequesterListener").get(bannerView);
         } catch (IllegalAccessException e) {
             e.printStackTrace();
         }
@@ -491,7 +491,7 @@ public class BannerViewTest {
 
     private DisplayViewListener getDisplayViewListener() {
         try {
-            return (DisplayViewListener) WhiteBox.field(BannerView.class, "mDisplayViewListener").get(mBannerView);
+            return (DisplayViewListener) WhiteBox.field(BannerView.class, "displayViewListener").get(bannerView);
         } catch (IllegalAccessException e) {
             e.printStackTrace();
         }
@@ -500,7 +500,7 @@ public class BannerViewTest {
 
     private BannerEventListener getBannerEventListener() {
         try {
-            return (BannerEventListener) WhiteBox.field(BannerView.class, "mBannerEventListener").get(mBannerView);
+            return (BannerEventListener) WhiteBox.field(BannerView.class, "bannerEventListener").get(bannerView);
         } catch (IllegalAccessException e) {
             e.printStackTrace();
         }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/BaseInterstitialAdUnitTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/BaseInterstitialAdUnitTest.java
@@ -46,12 +46,12 @@ import static org.mockito.Mockito.when;
 @Config(sdk = 19)
 public class BaseInterstitialAdUnitTest {
 
-    private BaseInterstitialAdUnit mBaseInterstitialAdUnit;
+    private BaseInterstitialAdUnit baseInterstitialAdUnit;
 
     @Before
     public void setUp() throws Exception {
         Context context = Robolectric.buildActivity(Activity.class).create().get();
-        mBaseInterstitialAdUnit = new BaseInterstitialAdUnit(context) {
+        baseInterstitialAdUnit = new BaseInterstitialAdUnit(context) {
             @Override
             void requestAdWithBid(
                 @Nullable
@@ -76,7 +76,7 @@ public class BaseInterstitialAdUnitTest {
             }
         };
         final AdUnitConfiguration adUnitConfiguration = new AdUnitConfiguration();
-        mBaseInterstitialAdUnit.init(adUnitConfiguration);
+        baseInterstitialAdUnit.init(adUnitConfiguration);
         assertEquals(AdPosition.FULLSCREEN.getValue(), adUnitConfiguration.getAdPositionValue());
     }
 
@@ -91,27 +91,27 @@ public class BaseInterstitialAdUnitTest {
         expectedMap.put("key2", value2);
 
         // add
-        mBaseInterstitialAdUnit.addContextData("key1", "value1");
-        mBaseInterstitialAdUnit.addContextData("key2", "value2");
+        baseInterstitialAdUnit.addContextData("key1", "value1");
+        baseInterstitialAdUnit.addContextData("key2", "value2");
 
-        assertEquals(expectedMap, mBaseInterstitialAdUnit.getContextDataDictionary());
+        assertEquals(expectedMap, baseInterstitialAdUnit.getContextDataDictionary());
 
         // update
         HashSet<String> updateSet = new HashSet<>();
         updateSet.add("value3");
-        mBaseInterstitialAdUnit.updateContextData("key1", updateSet);
+        baseInterstitialAdUnit.updateContextData("key1", updateSet);
         expectedMap.replace("key1", updateSet);
 
-        assertEquals(expectedMap, mBaseInterstitialAdUnit.getContextDataDictionary());
+        assertEquals(expectedMap, baseInterstitialAdUnit.getContextDataDictionary());
 
         // remove
-        mBaseInterstitialAdUnit.removeContextData("key1");
+        baseInterstitialAdUnit.removeContextData("key1");
         expectedMap.remove("key1");
-        assertEquals(expectedMap, mBaseInterstitialAdUnit.getContextDataDictionary());
+        assertEquals(expectedMap, baseInterstitialAdUnit.getContextDataDictionary());
 
         // clear
-        mBaseInterstitialAdUnit.clearContextData();
-        assertTrue(mBaseInterstitialAdUnit.getContextDataDictionary().isEmpty());
+        baseInterstitialAdUnit.clearContextData();
+        assertTrue(baseInterstitialAdUnit.getContextDataDictionary().isEmpty());
     }
 
     @Test
@@ -121,35 +121,35 @@ public class BaseInterstitialAdUnitTest {
         expectedSet.add("key2");
 
         // add
-        mBaseInterstitialAdUnit.addContextKeyword("key1");
-        mBaseInterstitialAdUnit.addContextKeyword("key2");
+        baseInterstitialAdUnit.addContextKeyword("key1");
+        baseInterstitialAdUnit.addContextKeyword("key2");
 
-        assertEquals(expectedSet, mBaseInterstitialAdUnit.getContextKeywordsSet());
+        assertEquals(expectedSet, baseInterstitialAdUnit.getContextKeywordsSet());
 
         // remove
-        mBaseInterstitialAdUnit.removeContextKeyword("key2");
+        baseInterstitialAdUnit.removeContextKeyword("key2");
         expectedSet.remove("key2");
-        assertEquals(expectedSet, mBaseInterstitialAdUnit.getContextKeywordsSet());
+        assertEquals(expectedSet, baseInterstitialAdUnit.getContextKeywordsSet());
 
         // clear
-        mBaseInterstitialAdUnit.clearContextKeywords();
-        assertTrue(mBaseInterstitialAdUnit.getContextKeywordsSet().isEmpty());
+        baseInterstitialAdUnit.clearContextKeywords();
+        assertTrue(baseInterstitialAdUnit.getContextKeywordsSet().isEmpty());
 
         // add all
-        mBaseInterstitialAdUnit.addContextKeywords(expectedSet);
-        assertEquals(expectedSet, mBaseInterstitialAdUnit.getContextKeywordsSet());
+        baseInterstitialAdUnit.addContextKeywords(expectedSet);
+        assertEquals(expectedSet, baseInterstitialAdUnit.getContextKeywordsSet());
     }
 
     @Test
     public void setPbAdSlot_EqualsGetPbAdSlot() {
         final String expected = "12345";
-        mBaseInterstitialAdUnit.setPbAdSlot(expected);
-        assertEquals(expected, mBaseInterstitialAdUnit.getPbAdSlot());
+        baseInterstitialAdUnit.setPbAdSlot(expected);
+        assertEquals(expected, baseInterstitialAdUnit.getPbAdSlot());
     }
 
     @Test
     public void loadAd_BidResponseIsInitialized() {
-        BidResponse bidResponse = mBaseInterstitialAdUnit.getBidResponse();
+        BidResponse bidResponse = baseInterstitialAdUnit.getBidResponse();
         assertNull(bidResponse);
 
         final BidResponse mockBidResponse = mock(BidResponse.class);
@@ -158,30 +158,30 @@ public class BaseInterstitialAdUnitTest {
         BidRequesterListener listener = getBidRequesterListener();
         listener.onFetchCompleted(mockBidResponse);
 
-        mBaseInterstitialAdUnit.loadAd();
+        baseInterstitialAdUnit.loadAd();
 
-        BidResponse actualBidResponse = mBaseInterstitialAdUnit.getBidResponse();
+        BidResponse actualBidResponse = baseInterstitialAdUnit.getBidResponse();
         assertEquals(mockBidResponse, actualBidResponse);
     }
 
     @Test
     public void loadAdWithError_BidResponseIsNull() {
-        BidResponse bidResponse = mBaseInterstitialAdUnit.getBidResponse();
+        BidResponse bidResponse = baseInterstitialAdUnit.getBidResponse();
         assertNull(bidResponse);
 
         final AdException adException = mock(AdException.class);
         BidRequesterListener listener = getBidRequesterListener();
         listener.onError(adException);
-        mBaseInterstitialAdUnit.loadAd();
+        baseInterstitialAdUnit.loadAd();
 
-        bidResponse = mBaseInterstitialAdUnit.getBidResponse();
+        bidResponse = baseInterstitialAdUnit.getBidResponse();
         assertNull(bidResponse);
     }
 
     private BidRequesterListener getBidRequesterListener() {
         try {
             return (BidRequesterListener) WhiteBox.field(BaseInterstitialAdUnit.class, "bidRequesterListener")
-                .get(mBaseInterstitialAdUnit);
+                .get(baseInterstitialAdUnit);
         } catch (IllegalAccessException e) {
             e.printStackTrace();
         }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/DisplayViewTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/DisplayViewTest.java
@@ -46,37 +46,34 @@ import static org.mockito.Mockito.*;
 @Config(sdk = 19)
 public class DisplayViewTest {
 
-    private DisplayView mDisplayView;
-    private Context mContext;
-    private AdUnitConfiguration mAdUnitConfiguration;
-    @Mock
-    private BidResponse mBidResponse;
-    @Mock
-    private DisplayViewListener mMockDisplayViewListener;
-    @Mock
-    private AdViewManager mMockAdViewManager;
+    private DisplayView displayView;
+    private Context context;
+    private AdUnitConfiguration adUnitConfiguration;
+    @Mock private BidResponse bidResponse;
+    @Mock private DisplayViewListener mockDisplayViewListener;
+    @Mock private AdViewManager mockAdViewManager;
 
     @Before
     public void setup() throws Exception {
         MockitoAnnotations.initMocks(DisplayViewTest.this);
 
-        mContext = Robolectric.buildActivity(Activity.class).create().get();
+        context = Robolectric.buildActivity(Activity.class).create().get();
 
-        mAdUnitConfiguration = new AdUnitConfiguration();
-        mAdUnitConfiguration.setAdFormat(AdFormat.BANNER);
+        adUnitConfiguration = new AdUnitConfiguration();
+        adUnitConfiguration.setAdFormat(AdFormat.BANNER);
 
         BidResponse mockResponse = mock(BidResponse.class);
         Bid mockBid = mock(Bid.class);
         when(mockBid.getAdm()).thenReturn("adm");
         when(mockResponse.getWinningBid()).thenReturn(mockBid);
 
-        mDisplayView = new DisplayView(mContext, mMockDisplayViewListener, mAdUnitConfiguration, mockResponse);
-        reset(mMockDisplayViewListener);
+        displayView = new DisplayView(context, mockDisplayViewListener, adUnitConfiguration, mockResponse);
+        reset(mockDisplayViewListener);
     }
 
     @Test
     public void whenDisplayAd_LoadBidTransaction() {
-        Assert.assertNotNull(WhiteBox.getInternalState(mDisplayView, "mAdViewManager"));
+        Assert.assertNotNull(WhiteBox.getInternalState(displayView, "adViewManager"));
     }
 
     @Test
@@ -84,7 +81,7 @@ public class DisplayViewTest {
         throws IllegalAccessException {
         AdViewManagerListener adViewManagerListener = getAdViewManagerListener();
         adViewManagerListener.adLoaded(mock(AdDetails.class));
-        verify(mMockDisplayViewListener).onAdLoaded();
+        verify(mockDisplayViewListener).onAdLoaded();
     }
 
     @Test
@@ -92,7 +89,7 @@ public class DisplayViewTest {
         throws IllegalAccessException {
         AdViewManagerListener adViewManagerListener = getAdViewManagerListener();
         adViewManagerListener.viewReadyForImmediateDisplay(mock(View.class));
-        verify(mMockDisplayViewListener).onAdDisplayed();
+        verify(mockDisplayViewListener).onAdDisplayed();
     }
 
     @Test
@@ -100,7 +97,7 @@ public class DisplayViewTest {
         throws IllegalAccessException {
         AdViewManagerListener adViewManagerListener = getAdViewManagerListener();
         adViewManagerListener.failedToLoad(new AdException(AdException.INTERNAL_ERROR, "Test"));
-        verify(mMockDisplayViewListener).onAdFailed(any(AdException.class));
+        verify(mockDisplayViewListener).onAdFailed(any(AdException.class));
     }
 
     @Test
@@ -108,7 +105,7 @@ public class DisplayViewTest {
         throws IllegalAccessException {
         AdViewManagerListener adViewManagerListener = getAdViewManagerListener();
         adViewManagerListener.creativeClicked("");
-        verify(mMockDisplayViewListener).onAdClicked();
+        verify(mockDisplayViewListener).onAdClicked();
     }
 
     @Test
@@ -116,7 +113,7 @@ public class DisplayViewTest {
         throws IllegalAccessException {
         AdViewManagerListener adViewManagerListener = getAdViewManagerListener();
         adViewManagerListener.creativeInterstitialClosed();
-        verify(mMockDisplayViewListener).onAdClosed();
+        verify(mockDisplayViewListener).onAdClosed();
     }
 
     @Test
@@ -124,11 +121,11 @@ public class DisplayViewTest {
         throws IllegalAccessException {
         AdViewManagerListener adViewManagerListener = getAdViewManagerListener();
         adViewManagerListener.creativeCollapsed();
-        verify(mMockDisplayViewListener).onAdClosed();
+        verify(mockDisplayViewListener).onAdClosed();
     }
 
     private AdViewManagerListener getAdViewManagerListener() throws IllegalAccessException {
-        return (AdViewManagerListener) WhiteBox.field(DisplayView.class, "mAdViewManagerListener").get(mDisplayView);
+        return (AdViewManagerListener) WhiteBox.field(DisplayView.class, "adViewManagerListener").get(displayView);
     }
 
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/InterstitialAdUnitTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/InterstitialAdUnitTest.java
@@ -55,39 +55,39 @@ public class InterstitialAdUnitTest {
     private static final String CONFIGURATION_ID = "12345678";
     private static final AdSize AD_SIZE = new AdSize(320, 480);
 
-    private InterstitialAdUnit mInterstitialAdUnit;
-    private Context mContext;
+    private InterstitialAdUnit interstitialAdUnit;
+    private Context context;
 
     @Mock
-    BidLoader mMockBidLoader;
+    BidLoader mockBidLoader;
     @Mock
-    InterstitialAdUnitListener mMockInterstitialAdUnitListener;
+    InterstitialAdUnitListener mockInterstitialAdUnitListener;
     @Mock
-    InterstitialEventHandler mMockInterstitialEventHandler;
+    InterstitialEventHandler mockInterstitialEventHandler;
     @Mock
-    InterstitialController mMockInterstitialController;
+    InterstitialController mockInterstitialController;
 
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
 
-        mContext = Robolectric.buildActivity(Activity.class).create().get();
+        context = Robolectric.buildActivity(Activity.class).create().get();
 
-        mInterstitialAdUnit = new InterstitialAdUnit(mContext, CONFIGURATION_ID, mMockInterstitialEventHandler);
-        mInterstitialAdUnit.setMinSizePercentage(AD_SIZE);
+        interstitialAdUnit = new InterstitialAdUnit(context, CONFIGURATION_ID, mockInterstitialEventHandler);
+        interstitialAdUnit.setMinSizePercentage(AD_SIZE);
 
-        mInterstitialAdUnit.setInterstitialAdUnitListener(mMockInterstitialAdUnitListener);
-        WhiteBox.setInternalState(mInterstitialAdUnit, "bidLoader", mMockBidLoader);
-        WhiteBox.setInternalState(mInterstitialAdUnit, "interstitialController", mMockInterstitialController);
+        interstitialAdUnit.setInterstitialAdUnitListener(mockInterstitialAdUnitListener);
+        WhiteBox.setInternalState(interstitialAdUnit, "bidLoader", mockBidLoader);
+        WhiteBox.setInternalState(interstitialAdUnit, "interstitialController", mockInterstitialController);
 
-        final AdUnitConfiguration adUnitConfig = mInterstitialAdUnit.adUnitConfig;
+        final AdUnitConfiguration adUnitConfig = interstitialAdUnit.adUnitConfig;
         assertEquals(AdPosition.FULLSCREEN.getValue(), adUnitConfig.getAdPositionValue());
     }
 
     @Test
     public void createInterstitialAdUnitNoEventHandler_InstanceCreatedStandaloneEventHandlerProvidedBidLoaderIsNotNull() {
         InterstitialAdUnit interstitialAdUnit = new InterstitialAdUnit(
-            mContext,
+            context,
             CONFIGURATION_ID,
             EnumSet.of(AdUnitFormat.VIDEO)
         );
@@ -102,51 +102,51 @@ public class InterstitialAdUnitTest {
 
     @Test
     public void loadAdWithNullBidLoader_NoExceptionIsThrown() {
-        WhiteBox.setInternalState(mInterstitialAdUnit, "bidLoader", null);
+        WhiteBox.setInternalState(interstitialAdUnit, "bidLoader", null);
 
-        mInterstitialAdUnit.loadAd();
+        interstitialAdUnit.loadAd();
     }
 
     @Test
     public void loadAdWithInvalidInterstitialAdState_DoNothing() {
         changeInterstitialState(LOADING);
-        mInterstitialAdUnit.loadAd();
-        verifyZeroInteractions(mMockBidLoader);
+        interstitialAdUnit.loadAd();
+        verifyZeroInteractions(mockBidLoader);
 
         changeInterstitialState(BaseInterstitialAdUnit.InterstitialAdUnitState.READY_TO_DISPLAY_PREBID);
-        mInterstitialAdUnit.loadAd();
-        verifyZeroInteractions(mMockBidLoader);
+        interstitialAdUnit.loadAd();
+        verifyZeroInteractions(mockBidLoader);
 
         changeInterstitialState(BaseInterstitialAdUnit.InterstitialAdUnitState.READY_TO_DISPLAY_GAM);
-        mInterstitialAdUnit.loadAd();
-        verifyZeroInteractions(mMockBidLoader);
+        interstitialAdUnit.loadAd();
+        verifyZeroInteractions(mockBidLoader);
 
         changeInterstitialState(BaseInterstitialAdUnit.InterstitialAdUnitState.PREBID_LOADING);
-        mInterstitialAdUnit.loadAd();
-        verifyZeroInteractions(mMockBidLoader);
+        interstitialAdUnit.loadAd();
+        verifyZeroInteractions(mockBidLoader);
     }
 
     @Test
     public void loadAdWithValidBidLoaderAndAdUnitState_ExecuteBidLoad() {
-        mInterstitialAdUnit.loadAd();
+        interstitialAdUnit.loadAd();
 
-        verify(mMockBidLoader, times(1)).load();
+        verify(mockBidLoader, times(1)).load();
     }
 
     @Test
     public void showWhenAuctionWinnerIsNotReadyToDisplay_DoNothing() {
-        mInterstitialAdUnit.show();
+        interstitialAdUnit.show();
 
-        verify(mMockInterstitialEventHandler, times(0)).show();
+        verify(mockInterstitialEventHandler, times(0)).show();
     }
 
     @Test
     public void showWhenAuctionWinnerIsGAM_ShowGam() {
         changeInterstitialState(READY_TO_DISPLAY_GAM);
 
-        mInterstitialAdUnit.show();
+        interstitialAdUnit.show();
 
-        verify(mMockInterstitialEventHandler, times(1)).show();
+        verify(mockInterstitialEventHandler, times(1)).show();
     }
 
     @Test
@@ -155,8 +155,8 @@ public class InterstitialAdUnitTest {
 
         changeInterstitialState(READY_TO_DISPLAY_PREBID);
 
-        WhiteBox.setInternalState(mInterstitialAdUnit, "interstitialController", mockInterstitialController);
-        mInterstitialAdUnit.show();
+        WhiteBox.setInternalState(interstitialAdUnit, "interstitialController", mockInterstitialController);
+        interstitialAdUnit.show();
 
         verify(mockInterstitialController, times(1)).show();
     }
@@ -164,31 +164,31 @@ public class InterstitialAdUnitTest {
     @Test
     public void isLoadedWhenAuctionIsNotReadyForDisplay_ReturnFalse() {
         changeInterstitialState(READY_FOR_LOAD);
-        assertFalse(mInterstitialAdUnit.isLoaded());
+        assertFalse(interstitialAdUnit.isLoaded());
 
         changeInterstitialState(LOADING);
-        assertFalse(mInterstitialAdUnit.isLoaded());
+        assertFalse(interstitialAdUnit.isLoaded());
 
         changeInterstitialState(PREBID_LOADING);
-        assertFalse(mInterstitialAdUnit.isLoaded());
+        assertFalse(interstitialAdUnit.isLoaded());
     }
 
     @Test
     public void isLoadedWhenAuctionIsReadyForDisplay_ReturnTrue() {
         changeInterstitialState(READY_TO_DISPLAY_PREBID);
-        assertTrue(mInterstitialAdUnit.isLoaded());
+        assertTrue(interstitialAdUnit.isLoaded());
 
         changeInterstitialState(READY_TO_DISPLAY_GAM);
-        assertTrue(mInterstitialAdUnit.isLoaded());
+        assertTrue(interstitialAdUnit.isLoaded());
     }
 
     @Test
     public void destroy_DestroyEventHandlerAndBidLoader() {
-        mInterstitialAdUnit.destroy();
+        interstitialAdUnit.destroy();
 
-        verify(mMockInterstitialEventHandler).destroy();
-        verify(mMockBidLoader).destroy();
-        verify(mMockInterstitialController).destroy();
+        verify(mockInterstitialEventHandler).destroy();
+        verify(mockBidLoader).destroy();
+        verify(mockInterstitialController).destroy();
     }
 
     //region ======================= BidRequestListener tests
@@ -202,8 +202,8 @@ public class InterstitialAdUnitTest {
         BidRequesterListener listener = getBidRequesterListener();
         listener.onFetchCompleted(mockBidResponse);
 
-        verify(mMockInterstitialEventHandler, times(1)).requestAdWithBid(eq(mockBid));
-        assertEquals(LOADING, mInterstitialAdUnit.getAdUnitState());
+        verify(mockInterstitialEventHandler, times(1)).requestAdWithBid(eq(mockBid));
+        assertEquals(LOADING, interstitialAdUnit.getAdUnitState());
     }
 
     @Test
@@ -211,7 +211,7 @@ public class InterstitialAdUnitTest {
         BidRequesterListener listener = getBidRequesterListener();
         listener.onError(any());
 
-        verify(mMockInterstitialEventHandler, times(1)).requestAdWithBid(eq(null));
+        verify(mockInterstitialEventHandler, times(1)).requestAdWithBid(eq(null));
     }
     //endregion ======================= BidRequestListener tests
 
@@ -222,8 +222,8 @@ public class InterstitialAdUnitTest {
 
         eventListener.onPrebidSdkWin();
 
-        verify(mMockInterstitialAdUnitListener, times(1)).onAdFailed(eq(mInterstitialAdUnit), any(AdException.class));
-        assertEquals(READY_FOR_LOAD, mInterstitialAdUnit.getAdUnitState());
+        verify(mockInterstitialAdUnitListener, times(1)).onAdFailed(eq(interstitialAdUnit), any(AdException.class));
+        assertEquals(READY_FOR_LOAD, interstitialAdUnit.getAdUnitState());
     }
 
     @Test
@@ -232,8 +232,8 @@ public class InterstitialAdUnitTest {
 
         eventListener.onAdServerWin();
 
-        assertEquals(BaseInterstitialAdUnit.InterstitialAdUnitState.READY_TO_DISPLAY_GAM, mInterstitialAdUnit.getAdUnitState());
-        verify(mMockInterstitialAdUnitListener, times(1)).onAdLoaded(mInterstitialAdUnit);
+        assertEquals(BaseInterstitialAdUnit.InterstitialAdUnitState.READY_TO_DISPLAY_GAM, interstitialAdUnit.getAdUnitState());
+        verify(mockInterstitialAdUnitListener, times(1)).onAdLoaded(interstitialAdUnit);
     }
 
     @Test
@@ -243,8 +243,8 @@ public class InterstitialAdUnitTest {
 
         eventListener.onAdFailed(exception);
 
-        verify(mMockInterstitialAdUnitListener, times(1)).onAdFailed(mInterstitialAdUnit, exception);
-        assertEquals(READY_FOR_LOAD, mInterstitialAdUnit.getAdUnitState());
+        verify(mockInterstitialAdUnitListener, times(1)).onAdFailed(interstitialAdUnit, exception);
+        assertEquals(READY_FOR_LOAD, interstitialAdUnit.getAdUnitState());
     }
 
     @Test
@@ -255,8 +255,8 @@ public class InterstitialAdUnitTest {
         final InterstitialEventListener spyEventListener = spy(getEventListener());
         when(mockBidResponse.getWinningBid()).thenReturn(mockBid);
 
-        WhiteBox.setInternalState(mInterstitialAdUnit, "bidResponse", mockBidResponse);
-        WhiteBox.setInternalState(mInterstitialAdUnit, "interstitialController", mockInterstitialController);
+        WhiteBox.setInternalState(interstitialAdUnit, "bidResponse", mockBidResponse);
+        WhiteBox.setInternalState(interstitialAdUnit, "interstitialController", mockInterstitialController);
 
         spyEventListener.onAdFailed(new AdException(AdException.INTERNAL_ERROR, "Test"));
 
@@ -269,20 +269,20 @@ public class InterstitialAdUnitTest {
         final InterstitialEventListener eventListener = getEventListener();
         eventListener.onAdClosed();
 
-        verify(mMockInterstitialAdUnitListener, times(1)).onAdClosed(mInterstitialAdUnit);
+        verify(mockInterstitialAdUnitListener, times(1)).onAdClosed(interstitialAdUnit);
     }
     //endregion ================= EventListener tests
 
     private BidRequesterListener getBidRequesterListener() {
-        return (BidRequesterListener) WhiteBox.getInternalState(mInterstitialAdUnit, "bidRequesterListener");
+        return (BidRequesterListener) WhiteBox.getInternalState(interstitialAdUnit, "bidRequesterListener");
     }
 
     private InterstitialEventListener getEventListener() {
-        return (InterstitialEventListener) WhiteBox.getInternalState(mInterstitialAdUnit, "interstitialEventListener");
+        return (InterstitialEventListener) WhiteBox.getInternalState(interstitialAdUnit, "interstitialEventListener");
     }
 
     private void changeInterstitialState(BaseInterstitialAdUnit.InterstitialAdUnitState adUnitState) {
-        WhiteBox.setInternalState(mInterstitialAdUnit, "interstitialAdUnitState", adUnitState);
+        WhiteBox.setInternalState(interstitialAdUnit, "interstitialAdUnitState", adUnitState);
     }
 
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/InterstitialViewTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/InterstitialViewTest.java
@@ -38,9 +38,8 @@ import static org.mockito.Mockito.*;
 @RunWith(RobolectricTestRunner.class)
 public class InterstitialViewTest {
 
-    private InterstitialView mSpyBidInterstitialView;
-    @Mock
-    private AdViewManager mMockAdViewManager;
+    private InterstitialView spyBidInterstitialView;
+    @Mock private AdViewManager mockAdViewManager;
 
     @Before
     public void setup() throws AdException, IllegalAccessException {
@@ -48,10 +47,10 @@ public class InterstitialViewTest {
 
         Context context = Robolectric.buildActivity(Activity.class).create().get();
 
-        mSpyBidInterstitialView = spy(new InterstitialView(context));
+        spyBidInterstitialView = spy(new InterstitialView(context));
 
-        when(mMockAdViewManager.getAdConfiguration()).thenReturn(mock(AdUnitConfiguration.class));
-        WhiteBox.field(InterstitialView.class, "mAdViewManager").set(mSpyBidInterstitialView, mMockAdViewManager);
+        when(mockAdViewManager.getAdConfiguration()).thenReturn(mock(AdUnitConfiguration.class));
+        WhiteBox.field(InterstitialView.class, "adViewManager").set(spyBidInterstitialView, mockAdViewManager);
     }
 
     @Test
@@ -59,18 +58,18 @@ public class InterstitialViewTest {
         AdUnitConfiguration mockAdUnitConfiguration = mock(AdUnitConfiguration.class);
         BidResponse mockBidResponse = mock(BidResponse.class);
 
-        mSpyBidInterstitialView.loadAd(mockAdUnitConfiguration, mockBidResponse);
+        spyBidInterstitialView.loadAd(mockAdUnitConfiguration, mockBidResponse);
 
-        verify(mMockAdViewManager, times(1)).loadBidTransaction(eq(mockAdUnitConfiguration), eq(mockBidResponse));
+        verify(mockAdViewManager, times(1)).loadBidTransaction(eq(mockAdUnitConfiguration), eq(mockBidResponse));
     }
 
     @Test
     public void setInterstitialViewListener_ExecuteAddEventListener() {
         final InterstitialViewListener mockInterstitialViewListener = mock(InterstitialViewListener.class);
 
-        mSpyBidInterstitialView.setInterstitialViewListener(mockInterstitialViewListener);
+        spyBidInterstitialView.setInterstitialViewListener(mockInterstitialViewListener);
 
-        verify(mSpyBidInterstitialView, times(1)).setInterstitialViewListener(eq(mockInterstitialViewListener));
+        verify(spyBidInterstitialView, times(1)).setInterstitialViewListener(eq(mockInterstitialViewListener));
     }
 
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/RewardedAdUnitTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/RewardedAdUnitTest.java
@@ -50,38 +50,38 @@ public class RewardedAdUnitTest {
 
     private static final String CONFIGURATION_ID = "12345678";
 
-    private RewardedAdUnit mRewardedAdUnit;
-    private Context mContext;
+    private RewardedAdUnit rewardedAdUnit;
+    private Context context;
 
     @Mock
-    BidLoader mMockBidLoader;
+    BidLoader mockBidLoader;
     @Mock
-    RewardedAdUnitListener mMockRewardedAdUnitListener;
+    RewardedAdUnitListener mockRewardedAdUnitListener;
     @Mock
-    RewardedEventHandler mMockRewardedEventHandler;
+    RewardedEventHandler mockRewardedEventHandler;
     @Mock
-    InterstitialController mMockInterstitialController;
+    InterstitialController mockInterstitialController;
 
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
 
-        mContext = Robolectric.buildActivity(Activity.class).create().get();
+        context = Robolectric.buildActivity(Activity.class).create().get();
 
-        mRewardedAdUnit = new RewardedAdUnit(mContext, CONFIGURATION_ID, mMockRewardedEventHandler);
+        rewardedAdUnit = new RewardedAdUnit(context, CONFIGURATION_ID, mockRewardedEventHandler);
 
-        mRewardedAdUnit.setRewardedAdUnitListener(mMockRewardedAdUnitListener);
+        rewardedAdUnit.setRewardedAdUnitListener(mockRewardedAdUnitListener);
 
-        WhiteBox.setInternalState(mRewardedAdUnit, "bidLoader", mMockBidLoader);
-        WhiteBox.setInternalState(mRewardedAdUnit, "interstitialController", mMockInterstitialController);
+        WhiteBox.setInternalState(rewardedAdUnit, "bidLoader", mockBidLoader);
+        WhiteBox.setInternalState(rewardedAdUnit, "interstitialController", mockInterstitialController);
 
-        final AdUnitConfiguration adUnitConfig = mRewardedAdUnit.adUnitConfig;
+        final AdUnitConfiguration adUnitConfig = rewardedAdUnit.adUnitConfig;
         assertEquals(AdPosition.FULLSCREEN.getValue(), adUnitConfig.getAdPositionValue());
     }
 
     @Test
     public void createRewardedAdUnitNoEventHandler_InstanceCreatedStandaloneEventHandlerProvidedBidLoaderIsNotNull() {
-        RewardedAdUnit rewardedAdUnit = new RewardedAdUnit(mContext, CONFIGURATION_ID);
+        RewardedAdUnit rewardedAdUnit = new RewardedAdUnit(context, CONFIGURATION_ID);
 
         Object eventHandler = WhiteBox.getInternalState(rewardedAdUnit, "eventHandler");
         BidLoader bidLoader = ((BidLoader) WhiteBox.getInternalState(rewardedAdUnit, "bidLoader"));
@@ -93,51 +93,51 @@ public class RewardedAdUnitTest {
 
     @Test
     public void loadAdWithNullBidLoader_NoExceptionIsThrown() {
-        WhiteBox.setInternalState(mRewardedAdUnit, "bidLoader", null);
+        WhiteBox.setInternalState(rewardedAdUnit, "bidLoader", null);
 
-        mRewardedAdUnit.loadAd();
+        rewardedAdUnit.loadAd();
     }
 
     @Test
     public void loadAdWithInvalidInterstitialAdState_DoNothing() {
         changeInterstitialState(LOADING);
-        mRewardedAdUnit.loadAd();
-        verifyZeroInteractions(mMockBidLoader);
+        rewardedAdUnit.loadAd();
+        verifyZeroInteractions(mockBidLoader);
 
         changeInterstitialState(BaseInterstitialAdUnit.InterstitialAdUnitState.READY_TO_DISPLAY_PREBID);
-        mRewardedAdUnit.loadAd();
-        verifyZeroInteractions(mMockBidLoader);
+        rewardedAdUnit.loadAd();
+        verifyZeroInteractions(mockBidLoader);
 
         changeInterstitialState(BaseInterstitialAdUnit.InterstitialAdUnitState.READY_TO_DISPLAY_GAM);
-        mRewardedAdUnit.loadAd();
-        verifyZeroInteractions(mMockBidLoader);
+        rewardedAdUnit.loadAd();
+        verifyZeroInteractions(mockBidLoader);
 
         changeInterstitialState(BaseInterstitialAdUnit.InterstitialAdUnitState.PREBID_LOADING);
-        mRewardedAdUnit.loadAd();
-        verifyZeroInteractions(mMockBidLoader);
+        rewardedAdUnit.loadAd();
+        verifyZeroInteractions(mockBidLoader);
     }
 
     @Test
     public void loadAdWithValidBidLoaderAndAdUnitState_ExecuteBidLoad() {
-        mRewardedAdUnit.loadAd();
+        rewardedAdUnit.loadAd();
 
-        verify(mMockBidLoader, times(1)).load();
+        verify(mockBidLoader, times(1)).load();
     }
 
     @Test
     public void showWhenAuctionWinnerIsNotReadyToDisplay_DoNothing() {
-        mRewardedAdUnit.show();
+        rewardedAdUnit.show();
 
-        verify(mMockRewardedEventHandler, times(0)).show();
+        verify(mockRewardedEventHandler, times(0)).show();
     }
 
     @Test
     public void showWhenAuctionWinnerIsGAM_ShowGam() {
         changeInterstitialState(READY_TO_DISPLAY_GAM);
 
-        mRewardedAdUnit.show();
+        rewardedAdUnit.show();
 
-        verify(mMockRewardedEventHandler, times(1)).show();
+        verify(mockRewardedEventHandler, times(1)).show();
     }
 
     @Test
@@ -146,8 +146,8 @@ public class RewardedAdUnitTest {
 
         changeInterstitialState(READY_TO_DISPLAY_PREBID);
 
-        WhiteBox.setInternalState(mRewardedAdUnit, "interstitialController", mockInterstitialController);
-        mRewardedAdUnit.show();
+        WhiteBox.setInternalState(rewardedAdUnit, "interstitialController", mockInterstitialController);
+        rewardedAdUnit.show();
 
         verify(mockInterstitialController, times(1)).show();
     }
@@ -155,31 +155,31 @@ public class RewardedAdUnitTest {
     @Test
     public void isLoadedWhenAuctionIsNotReadyForDisplay_ReturnFalse() {
         changeInterstitialState(READY_FOR_LOAD);
-        assertFalse(mRewardedAdUnit.isLoaded());
+        assertFalse(rewardedAdUnit.isLoaded());
 
         changeInterstitialState(LOADING);
-        assertFalse(mRewardedAdUnit.isLoaded());
+        assertFalse(rewardedAdUnit.isLoaded());
 
         changeInterstitialState(PREBID_LOADING);
-        assertFalse(mRewardedAdUnit.isLoaded());
+        assertFalse(rewardedAdUnit.isLoaded());
     }
 
     @Test
     public void isLoadedWhenAuctionIsReadyForDisplay_ReturnTrue() {
         changeInterstitialState(READY_TO_DISPLAY_PREBID);
-        assertTrue(mRewardedAdUnit.isLoaded());
+        assertTrue(rewardedAdUnit.isLoaded());
 
         changeInterstitialState(READY_TO_DISPLAY_GAM);
-        assertTrue(mRewardedAdUnit.isLoaded());
+        assertTrue(rewardedAdUnit.isLoaded());
     }
 
     @Test
     public void destroy_DestroyEventHandlerAndBidLoader() {
-        mRewardedAdUnit.destroy();
+        rewardedAdUnit.destroy();
 
-        verify(mMockRewardedEventHandler).destroy();
-        verify(mMockBidLoader).destroy();
-        verify(mMockInterstitialController).destroy();
+        verify(mockRewardedEventHandler).destroy();
+        verify(mockBidLoader).destroy();
+        verify(mockInterstitialController).destroy();
     }
 
     //region ======================= BidRequestListener tests
@@ -193,8 +193,8 @@ public class RewardedAdUnitTest {
         BidRequesterListener listener = getBidRequesterListener();
         listener.onFetchCompleted(mockBidResponse);
 
-        verify(mMockRewardedEventHandler, times(1)).requestAdWithBid(eq(mockBid));
-        assertEquals(LOADING, mRewardedAdUnit.getAdUnitState());
+        verify(mockRewardedEventHandler, times(1)).requestAdWithBid(eq(mockBid));
+        assertEquals(LOADING, rewardedAdUnit.getAdUnitState());
     }
 
     @Test
@@ -202,7 +202,7 @@ public class RewardedAdUnitTest {
         BidRequesterListener listener = getBidRequesterListener();
         listener.onError(any());
 
-        verify(mMockRewardedEventHandler, times(1)).requestAdWithBid(eq(null));
+        verify(mockRewardedEventHandler, times(1)).requestAdWithBid(eq(null));
     }
     //endregion ======================= BidRequestListener tests
 
@@ -213,8 +213,8 @@ public class RewardedAdUnitTest {
 
         eventListener.onPrebidSdkWin();
 
-        verify(mMockRewardedAdUnitListener, times(1)).onAdFailed(eq(mRewardedAdUnit), any(AdException.class));
-        assertEquals(READY_FOR_LOAD, mRewardedAdUnit.getAdUnitState());
+        verify(mockRewardedAdUnitListener, times(1)).onAdFailed(eq(rewardedAdUnit), any(AdException.class));
+        assertEquals(READY_FOR_LOAD, rewardedAdUnit.getAdUnitState());
     }
 
     @Test
@@ -223,8 +223,8 @@ public class RewardedAdUnitTest {
 
         eventListener.onAdServerWin(any());
 
-        assertEquals(BaseInterstitialAdUnit.InterstitialAdUnitState.READY_TO_DISPLAY_GAM, mRewardedAdUnit.getAdUnitState());
-        verify(mMockRewardedAdUnitListener, times(1)).onAdLoaded(mRewardedAdUnit);
+        assertEquals(BaseInterstitialAdUnit.InterstitialAdUnitState.READY_TO_DISPLAY_GAM, rewardedAdUnit.getAdUnitState());
+        verify(mockRewardedAdUnitListener, times(1)).onAdLoaded(rewardedAdUnit);
     }
 
     @Test
@@ -234,8 +234,8 @@ public class RewardedAdUnitTest {
 
         eventListener.onAdFailed(exception);
 
-        verify(mMockRewardedAdUnitListener, times(1)).onAdFailed(mRewardedAdUnit, exception);
-        assertEquals(READY_FOR_LOAD, mRewardedAdUnit.getAdUnitState());
+        verify(mockRewardedAdUnitListener, times(1)).onAdFailed(rewardedAdUnit, exception);
+        assertEquals(READY_FOR_LOAD, rewardedAdUnit.getAdUnitState());
     }
 
     @Test
@@ -247,8 +247,8 @@ public class RewardedAdUnitTest {
         final RewardedVideoEventListener spyEventListener = spy(getEventListener());
         when(mockBidResponse.getWinningBid()).thenReturn(mockBid);
 
-        WhiteBox.setInternalState(mRewardedAdUnit, "bidResponse", mockBidResponse);
-        WhiteBox.setInternalState(mRewardedAdUnit, "interstitialController", mockInterstitialController);
+        WhiteBox.setInternalState(rewardedAdUnit, "bidResponse", mockBidResponse);
+        WhiteBox.setInternalState(rewardedAdUnit, "interstitialController", mockInterstitialController);
 
         spyEventListener.onAdFailed(new AdException(AdException.INTERNAL_ERROR, "Test"));
 
@@ -261,7 +261,7 @@ public class RewardedAdUnitTest {
         final RewardedVideoEventListener eventListener = getEventListener();
         eventListener.onAdClicked();
 
-        verify(mMockRewardedAdUnitListener, times(1)).onAdClicked(mRewardedAdUnit);
+        verify(mockRewardedAdUnitListener, times(1)).onAdClicked(rewardedAdUnit);
     }
 
     @Test
@@ -269,20 +269,20 @@ public class RewardedAdUnitTest {
         final RewardedVideoEventListener eventListener = getEventListener();
         eventListener.onAdClosed();
 
-        verify(mMockRewardedAdUnitListener, times(1)).onAdClosed(mRewardedAdUnit);
+        verify(mockRewardedAdUnitListener, times(1)).onAdClosed(rewardedAdUnit);
     }
     //endregion ================= EventListener tests
 
     private BidRequesterListener getBidRequesterListener() {
-        return (BidRequesterListener) WhiteBox.getInternalState(mRewardedAdUnit, "bidRequesterListener");
+        return (BidRequesterListener) WhiteBox.getInternalState(rewardedAdUnit, "bidRequesterListener");
     }
 
     private RewardedVideoEventListener getEventListener() {
-        return (RewardedVideoEventListener) WhiteBox.getInternalState(mRewardedAdUnit, "eventListener");
+        return (RewardedVideoEventListener) WhiteBox.getInternalState(rewardedAdUnit, "eventListener");
     }
 
     private void changeInterstitialState(BaseInterstitialAdUnit.InterstitialAdUnitState adUnitState) {
-        WhiteBox.setInternalState(mRewardedAdUnit, "interstitialAdUnitState", adUnitState);
+        WhiteBox.setInternalState(rewardedAdUnit, "interstitialAdUnitState", adUnitState);
     }
 
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/VideoViewTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/VideoViewTest.java
@@ -65,38 +65,35 @@ public class VideoViewTest {
         true
     );
 
-    private Context mContext;
+    private Context context;
 
-    private VideoView mVideoView;
-    private AdViewManagerListener mAdViewManagerListener;
+    private VideoView videoView;
+    private AdViewManagerListener adViewManagerListener;
 
-    @Mock
-    public AdViewManager mMockAdViewManager;
-    @Mock
-    public VideoViewListener mMockVideoViewListener;
-    @Mock
-    private CreativeVisibilityTracker mMockVisibilityTracker;
-    private CreativeVisibilityTracker.VisibilityTrackerListener mVisibilityTrackerListener;
+    @Mock public AdViewManager mockAdViewManager;
+    @Mock public VideoViewListener mockVideoViewListener;
+    @Mock private CreativeVisibilityTracker mockVisibilityTracker;
+    private CreativeVisibilityTracker.VisibilityTrackerListener visibilityTrackerListener;
 
     @Before
     public void setup() throws AdException {
         MockitoAnnotations.initMocks(this);
-        mContext = Robolectric.buildActivity(Activity.class).create().get();
+        context = Robolectric.buildActivity(Activity.class).create().get();
 
-        mVideoView = new VideoView(mContext);
+        videoView = new VideoView(context);
 
-        WhiteBox.setInternalState(mVideoView, "mVisibilityTracker", mMockVisibilityTracker);
-        WhiteBox.setInternalState(mVideoView, "mAdViewManager", mMockAdViewManager);
-        mVisibilityTrackerListener = WhiteBox.getInternalState(mVideoView, "mVisibilityTrackerListener");
-        mAdViewManagerListener = WhiteBox.getInternalState(mVideoView, "mOnAdViewManagerListener");
+        WhiteBox.setInternalState(videoView, "visibilityTracker", mockVisibilityTracker);
+        WhiteBox.setInternalState(videoView, "adViewManager", mockAdViewManager);
+        visibilityTrackerListener = WhiteBox.getInternalState(videoView, "visibilityTrackerListener");
+        adViewManagerListener = WhiteBox.getInternalState(videoView, "onAdViewManagerListener");
 
-        mVideoView.setVideoViewListener(mMockVideoViewListener);
+        videoView.setVideoViewListener(mockVideoViewListener);
     }
 
     @Test
     public void videoViewConstructor_InstanceNotNull() throws Exception {
-        VideoView videoView = new VideoView(mContext);
-        VideoView secondVideoView = new VideoView(mContext, mock(AdUnitConfiguration.class));
+        VideoView videoView = new VideoView(context);
+        VideoView secondVideoView = new VideoView(context, mock(AdUnitConfiguration.class));
 
         assertNotNull(videoView);
         assertNotNull(secondVideoView);
@@ -105,44 +102,44 @@ public class VideoViewTest {
     @Test
     public void notifyErrorListeners_InvokeOnLoadFailed() {
         AdException adException = new AdException(AdException.INTERNAL_ERROR, AdException.INIT_ERROR);
-        mVideoView.notifyErrorListeners(adException);
+        videoView.notifyErrorListeners(adException);
 
-        verify(mMockVideoViewListener).onLoadFailed(mVideoView, adException);
+        verify(mockVideoViewListener).onLoadFailed(videoView, adException);
     }
 
     @Test
     public void destroy() {
-        mVideoView.destroy();
+        videoView.destroy();
     }
 
     @Test
     public void play_StateNotStarted_AdViewManagerShow() {
         changeVideoViewState(PLAYBACK_NOT_STARTED);
 
-        mVideoView.play();
+        videoView.play();
 
-        verify(mMockAdViewManager).show();
+        verify(mockAdViewManager).show();
         assertEquals(PLAYING, getVideoViewState());
     }
 
     @Test
     public void play_StateInvalid_DoNothing() {
         // initial state
-        mVideoView.play();
+        videoView.play();
 
         changeVideoViewState(PLAYING);
-        mVideoView.play();
+        videoView.play();
 
         changeVideoViewState(PAUSED_BY_USER);
-        mVideoView.play();
+        videoView.play();
 
         changeVideoViewState(PAUSED_AUTO);
-        mVideoView.play();
+        videoView.play();
 
         changeVideoViewState(PLAYBACK_FINISHED);
-        mVideoView.play();
+        videoView.play();
 
-        verifyZeroInteractions(mMockAdViewManager);
+        verifyZeroInteractions(mockAdViewManager);
     }
 
     @Test
@@ -150,101 +147,101 @@ public class VideoViewTest {
         final AdUnitConfiguration adUnitConfiguration = new AdUnitConfiguration();
         final BidResponse bidResponse = new BidResponse("");
 
-        mVideoView.loadAd(adUnitConfiguration, bidResponse);
+        videoView.loadAd(adUnitConfiguration, bidResponse);
 
-        verify(mMockAdViewManager).loadBidTransaction(adUnitConfiguration, bidResponse);
+        verify(mockAdViewManager).loadBidTransaction(adUnitConfiguration, bidResponse);
     }
 
     @Test
     public void loadAd_vastXml_StopVisibilityTrackingChangeStateToUndefined() {
         changeVideoViewState(PAUSED_AUTO);
 
-        mVideoView.loadAd(new AdUnitConfiguration(), "somexml");
-        VideoView.State stateAfterLoad = WhiteBox.getInternalState(mVideoView, "mVideoViewState");
+        videoView.loadAd(new AdUnitConfiguration(), "somexml");
+        VideoView.State stateAfterLoad = WhiteBox.getInternalState(videoView, "videoViewState");
 
         assertEquals(UNDEFINED, stateAfterLoad);
-        verify(mMockVisibilityTracker).stopVisibilityCheck();
+        verify(mockVisibilityTracker).stopVisibilityCheck();
     }
 
     @Test
     public void mute_InvokeAdViewManager() {
-        mVideoView.mute(true);
-        verify(mMockAdViewManager).mute();
+        videoView.mute(true);
+        verify(mockAdViewManager).mute();
 
-        mVideoView.mute(false);
-        verify(mMockAdViewManager).unmute();
+        videoView.mute(false);
+        verify(mockAdViewManager).unmute();
     }
 
     @Test
     public void setAutoPlayDisabled_StopVisibilityTracker() {
-        mVideoView.setAutoPlay(false);
+        videoView.setAutoPlay(false);
 
-        verify(mMockVisibilityTracker).stopVisibilityCheck();
+        verify(mockVisibilityTracker).stopVisibilityCheck();
     }
 
     @Test
     public void setAutoPlayEnabled_DoNothing() {
-        mVideoView.setAutoPlay(true);
+        videoView.setAutoPlay(true);
 
-        verifyZeroInteractions(mMockVisibilityTracker);
+        verifyZeroInteractions(mockVisibilityTracker);
     }
 
     @Test
     public void pause_StatePlaying_InvokeAdViewManagerAndChangeState() {
         changeVideoViewState(PLAYING);
-        mVideoView.pause();
+        videoView.pause();
 
-        verify(mMockAdViewManager).pause();
+        verify(mockAdViewManager).pause();
         assertEquals(PAUSED_BY_USER, getVideoViewState());
     }
 
     @Test
     public void pause_StateInvalid_DoNothing() {
         changeVideoViewState(PLAYBACK_FINISHED);
-        mVideoView.pause();
+        videoView.pause();
 
         changeVideoViewState(UNDEFINED);
-        mVideoView.pause();
+        videoView.pause();
 
         changeVideoViewState(PAUSED_AUTO);
-        mVideoView.pause();
+        videoView.pause();
 
         changeVideoViewState(PAUSED_BY_USER);
-        mVideoView.pause();
+        videoView.pause();
 
         changeVideoViewState(PLAYBACK_NOT_STARTED);
-        mVideoView.pause();
+        videoView.pause();
 
-        verifyZeroInteractions(mMockAdViewManager);
+        verifyZeroInteractions(mockAdViewManager);
     }
 
     @Test
     public void resume_StatePausedAutoOrManual_InvokeAdViewManagerAndChangeState() {
         changeVideoViewState(PAUSED_AUTO);
-        mVideoView.resume();
+        videoView.resume();
 
         changeVideoViewState(PAUSED_BY_USER);
-        mVideoView.resume();
+        videoView.resume();
 
-        verify(mMockAdViewManager, times(2)).resume();
+        verify(mockAdViewManager, times(2)).resume();
         assertEquals(PLAYING, getVideoViewState());
     }
 
     @Test
     public void resume_StateInvalid_DoNothing() {
         changeVideoViewState(PLAYBACK_NOT_STARTED);
-        mVideoView.resume();
+        videoView.resume();
 
         changeVideoViewState(UNDEFINED);
-        mVideoView.resume();
+        videoView.resume();
 
         changeVideoViewState(PLAYING);
-        mVideoView.resume();
+        videoView.resume();
 
         changeVideoViewState(PLAYBACK_FINISHED);
-        mVideoView.resume();
+        videoView.resume();
 
-        verifyZeroInteractions(mMockAdViewManager);
+        verifyZeroInteractions(mockAdViewManager);
     }
 
     @Test
@@ -258,9 +255,9 @@ public class VideoViewTest {
             true
         );
 
-        mVisibilityTrackerListener.onVisibilityChanged(result);
+        visibilityTrackerListener.onVisibilityChanged(result);
 
-        verify(mMockAdViewManager).show();
+        verify(mockAdViewManager).show();
         assertEquals(PLAYING, getVideoViewState());
     }
 
@@ -268,9 +265,9 @@ public class VideoViewTest {
     public void handleVisibilityChange_visible_validAutoResumeState_ExecuteResume() {
         changeVideoViewState(PAUSED_AUTO);
 
-        mVisibilityTrackerListener.onVisibilityChanged(VISIBLE_RESULT);
+        visibilityTrackerListener.onVisibilityChanged(VISIBLE_RESULT);
 
-        verify(mMockAdViewManager).resume();
+        verify(mockAdViewManager).resume();
         assertEquals(PLAYING, getVideoViewState());
     }
 
@@ -278,112 +275,112 @@ public class VideoViewTest {
     public void handleVisibilityChange_visible_validAutoPauseState_ExecutePause() {
         changeVideoViewState(PLAYING);
 
-        mVisibilityTrackerListener.onVisibilityChanged(INVISIBLE_RESULT);
+        visibilityTrackerListener.onVisibilityChanged(INVISIBLE_RESULT);
 
-        verify(mMockAdViewManager).pause();
+        verify(mockAdViewManager).pause();
         assertEquals(PAUSED_AUTO, getVideoViewState());
     }
 
     @Test
     public void handleVisibilityChange_visible_invalidState_DoNothing() {
         changeVideoViewState(PAUSED_BY_USER);
-        mVisibilityTrackerListener.onVisibilityChanged(INVISIBLE_RESULT);
-        mVisibilityTrackerListener.onVisibilityChanged(VISIBLE_RESULT);
+        visibilityTrackerListener.onVisibilityChanged(INVISIBLE_RESULT);
+        visibilityTrackerListener.onVisibilityChanged(VISIBLE_RESULT);
 
         changeVideoViewState(UNDEFINED);
-        mVisibilityTrackerListener.onVisibilityChanged(INVISIBLE_RESULT);
-        mVisibilityTrackerListener.onVisibilityChanged(VISIBLE_RESULT);
+        visibilityTrackerListener.onVisibilityChanged(INVISIBLE_RESULT);
+        visibilityTrackerListener.onVisibilityChanged(VISIBLE_RESULT);
 
         changeVideoViewState(PLAYBACK_FINISHED);
-        mVisibilityTrackerListener.onVisibilityChanged(INVISIBLE_RESULT);
-        mVisibilityTrackerListener.onVisibilityChanged(VISIBLE_RESULT);
+        visibilityTrackerListener.onVisibilityChanged(INVISIBLE_RESULT);
+        visibilityTrackerListener.onVisibilityChanged(VISIBLE_RESULT);
 
-        verifyZeroInteractions(mMockAdViewManager);
+        verifyZeroInteractions(mockAdViewManager);
     }
 
     @Test
     public void handleWindowFocusChange_autoPlayEnabled_DoNothing() {
         changeVideoViewState(PLAYING);
-        mVideoView.setAutoPlay(true);
-        mVideoView.handleWindowFocusChange(false);
+        videoView.setAutoPlay(true);
+        videoView.handleWindowFocusChange(false);
 
         changeVideoViewState(PAUSED_AUTO);
-        mVideoView.handleWindowFocusChange(true);
+        videoView.handleWindowFocusChange(true);
 
-        verifyZeroInteractions(mMockAdViewManager);
+        verifyZeroInteractions(mockAdViewManager);
     }
 
     @Test
     public void handleWindowFocusChange_invisible_autoPlayDisabled_stateValid_ExecutePause() {
-        mVideoView.setAutoPlay(false);
+        videoView.setAutoPlay(false);
         changeVideoViewState(PLAYING);
 
-        mVideoView.handleWindowFocusChange(false);
+        videoView.handleWindowFocusChange(false);
 
-        verify(mMockAdViewManager).pause();
+        verify(mockAdViewManager).pause();
         assertEquals(PAUSED_AUTO, getVideoViewState());
     }
 
     @Test
     public void handleWindowFocusChange_visible_autoPlayDisabled_stateValid_ExecuteResume() {
-        mVideoView.setAutoPlay(false);
+        videoView.setAutoPlay(false);
         changeVideoViewState(PAUSED_AUTO);
 
-        mVideoView.handleWindowFocusChange(true);
+        videoView.handleWindowFocusChange(true);
 
-        verify(mMockAdViewManager).resume();
+        verify(mockAdViewManager).resume();
         assertEquals(PLAYING, getVideoViewState());
     }
 
     @Test
     public void handleWindowFocusChange_autoPlayDisabled_stateInValid_DoNothing() {
         changeVideoViewState(PAUSED_BY_USER);
-        mVideoView.handleWindowFocusChange(true);
-        mVideoView.handleWindowFocusChange(false);
+        videoView.handleWindowFocusChange(true);
+        videoView.handleWindowFocusChange(false);
 
         changeVideoViewState(UNDEFINED);
-        mVideoView.handleWindowFocusChange(true);
-        mVideoView.handleWindowFocusChange(false);
+        videoView.handleWindowFocusChange(true);
+        videoView.handleWindowFocusChange(false);
 
         changeVideoViewState(PLAYBACK_FINISHED);
-        mVideoView.handleWindowFocusChange(true);
-        mVideoView.handleWindowFocusChange(false);
+        videoView.handleWindowFocusChange(true);
+        videoView.handleWindowFocusChange(false);
 
-        verifyZeroInteractions(mMockAdViewManager);
+        verifyZeroInteractions(mockAdViewManager);
     }
 
     // region =============== AdViewManagerListener
     @Test
     public void adLoaded_autoPlayEnabled_NotifyListener_changeState() {
 
-        mAdViewManagerListener.adLoaded(null);
+        adViewManagerListener.adLoaded(null);
 
-        verify(mMockVideoViewListener).onLoaded(mVideoView, null);
+        verify(mockVideoViewListener).onLoaded(videoView, null);
         assertEquals(PLAYBACK_NOT_STARTED, getVideoViewState());
     }
 
     @Test
     public void adLoaded_autoPlayDisabled_NotifyListener_changeState() {
-        mVideoView.setAutoPlay(false);
-        reset(mMockVisibilityTracker);
+        videoView.setAutoPlay(false);
+        reset(mockVisibilityTracker);
 
-        mAdViewManagerListener.adLoaded(null);
+        adViewManagerListener.adLoaded(null);
 
-        verify(mMockVideoViewListener).onLoaded(mVideoView, null);
+        verify(mockVideoViewListener).onLoaded(videoView, null);
         assertEquals(PLAYBACK_NOT_STARTED, getVideoViewState());
-        verifyZeroInteractions(mMockVisibilityTracker);
+        verifyZeroInteractions(mockVisibilityTracker);
     }
 
     @Test
     public void viewReadyForImmediateDisplay_notShowingEndCard_ShowVideoCreative() {
         final VideoCreativeView mockVideoCreativeView = mock(VideoCreativeView.class);
-        when(mMockAdViewManager.isNotShowingEndCard()).thenReturn(true);
+        when(mockAdViewManager.isNotShowingEndCard()).thenReturn(true);
 
-        mVideoView.setVideoPlayerClick(true);
+        videoView.setVideoPlayerClick(true);
 
-        mAdViewManagerListener.viewReadyForImmediateDisplay(mockVideoCreativeView);
+        adViewManagerListener.viewReadyForImmediateDisplay(mockVideoCreativeView);
 
-        verify(mMockVideoViewListener).onDisplayed(eq(mVideoView));
+        verify(mockVideoViewListener).onDisplayed(eq(videoView));
         verify(mockVideoCreativeView).enableVideoPlayerClick();
         verify(mockVideoCreativeView).showVolumeControls();
     }
@@ -392,85 +389,85 @@ public class VideoViewTest {
     public void viewReadyForImmediateDisplay_hasEndCard_ShowEndCard_noListenerInvocation() {
         final View mockView = mock(View.class);
         reset(mockView);
-        when(mMockAdViewManager.isNotShowingEndCard()).thenReturn(false);
-        when(mMockAdViewManager.hasEndCard()).thenReturn(true);
+        when(mockAdViewManager.isNotShowingEndCard()).thenReturn(false);
+        when(mockAdViewManager.hasEndCard()).thenReturn(true);
 
-        mAdViewManagerListener.viewReadyForImmediateDisplay(mockView);
+        adViewManagerListener.viewReadyForImmediateDisplay(mockView);
 
         verify(mockView, times(2)).setLayoutParams(any(FrameLayout.LayoutParams.class));
-        verifyZeroInteractions(mMockVideoViewListener);
+        verifyZeroInteractions(mockVideoViewListener);
     }
 
     @Test
     public void failedToLoad_NotifyListener() {
         final AdException expectedException = new AdException(AdException.INTERNAL_ERROR, "message");
 
-        mAdViewManagerListener.failedToLoad(expectedException);
+        adViewManagerListener.failedToLoad(expectedException);
 
-        verify(mMockVideoViewListener).onLoadFailed(mVideoView, expectedException);
+        verify(mockVideoViewListener).onLoadFailed(videoView, expectedException);
     }
 
     @Test
     public void videoCreativePlaybackFinished_noEndCard__StopVisibilityTracking_changeState_notifyListener_addWatchAgain() {
-        when(mMockAdViewManager.isNotShowingEndCard()).thenReturn(true);
+        when(mockAdViewManager.isNotShowingEndCard()).thenReturn(true);
 
-        mAdViewManagerListener.videoCreativePlaybackFinished();
+        adViewManagerListener.videoCreativePlaybackFinished();
 
-        verify(mMockVisibilityTracker).stopVisibilityCheck();
+        verify(mockVisibilityTracker).stopVisibilityCheck();
         assertEquals(PLAYBACK_FINISHED, getVideoViewState());
-        verify(mMockVideoViewListener).onPlayBackCompleted(mVideoView);
-        verify(mMockAdViewManager).addObstructions(any());
+        verify(mockVideoViewListener).onPlayBackCompleted(videoView);
+        verify(mockAdViewManager).addObstructions(any());
     }
 
     @Test
     public void videoCreativePlaybackFinished_hasEndCard__StopVisibilityTracking_changeState_notifyListener() {
-        when(mMockAdViewManager.isNotShowingEndCard()).thenReturn(false);
+        when(mockAdViewManager.isNotShowingEndCard()).thenReturn(false);
 
-        mAdViewManagerListener.videoCreativePlaybackFinished();
+        adViewManagerListener.videoCreativePlaybackFinished();
 
-        verify(mMockVisibilityTracker).stopVisibilityCheck();
+        verify(mockVisibilityTracker).stopVisibilityCheck();
         assertEquals(PLAYBACK_FINISHED, getVideoViewState());
-        verify(mMockVideoViewListener).onPlayBackCompleted(mVideoView);
-        verify(mMockAdViewManager, times(0)).addObstructions(any());
+        verify(mockVideoViewListener).onPlayBackCompleted(videoView);
+        verify(mockAdViewManager, times(0)).addObstructions(any());
     }
 
     @Test
     public void creativeClicked_NotifyListener() {
-        mAdViewManagerListener.creativeClicked("test");
-        verify(mMockVideoViewListener).onClickThroughOpened(mVideoView);
+        adViewManagerListener.creativeClicked("test");
+        verify(mockVideoViewListener).onClickThroughOpened(videoView);
     }
 
     @Test
     public void creativeMuted_NotifyListener() {
-        mAdViewManagerListener.creativeMuted();
-        verify(mMockVideoViewListener).onVideoMuted();
+        adViewManagerListener.creativeMuted();
+        verify(mockVideoViewListener).onVideoMuted();
     }
 
     @Test
     public void creativeUnMuted_NotifyListener() {
-        mAdViewManagerListener.creativeUnMuted();
-        verify(mMockVideoViewListener).onVideoUnMuted();
+        adViewManagerListener.creativeUnMuted();
+        verify(mockVideoViewListener).onVideoUnMuted();
     }
 
     @Test
     public void creativePaused_NotifyListener() {
-        mAdViewManagerListener.creativePaused();
-        verify(mMockVideoViewListener).onPlaybackPaused();
+        adViewManagerListener.creativePaused();
+        verify(mockVideoViewListener).onPlaybackPaused();
     }
 
     @Test
     public void creativeResumed_NotifyListener() {
-        mAdViewManagerListener.creativeResumed();
-        verify(mMockVideoViewListener).onPlaybackResumed();
+        adViewManagerListener.creativeResumed();
+        verify(mockVideoViewListener).onPlaybackResumed();
     }
     // endregion =============== AdViewManagerListener
 
     private void changeVideoViewState(VideoView.State state) {
-        WhiteBox.setInternalState(mVideoView, "mVideoViewState", state);
+        WhiteBox.setInternalState(videoView, "videoViewState", state);
     }
 
     private VideoView.State getVideoViewState() {
-        return WhiteBox.getInternalState(mVideoView, "mVideoViewState");
+        return WhiteBox.getInternalState(videoView, "videoViewState");
     }
 
     // TODO: 2/8/21 Remove or refactor in scope of expand-on-click task
@@ -479,65 +476,65 @@ public class VideoViewTest {
     //     AdViewManager mockAdViewManager = getMockAdViewManager();
     //     when(mockAdViewManager.canShowFullScreen()).thenReturn(true);
     //
-    //     VideoView spyVideoAdView = spy(mVideoAdView);
+    //     VideoView spyVideoAdView = spy(videoAdView);
     //
-    //     when(spyVideoAdView.getChildAt(anyInt())).thenReturn(mMockVideoCreativeView);
+    //     when(spyVideoAdView.getChildAt(anyInt())).thenReturn(mockVideoCreativeView);
     //
     //     WhiteBox.method(VideoView.class, "showFullScreen").invoke(spyVideoAdView);
-    //     verify(spyVideoAdView).createDialog(mMockContext, mMockVideoCreativeView);
+    //     verify(spyVideoAdView).createDialog(mockContext, mockVideoCreativeView);
     // }
 
     // @Test
     // public void isFullScreen() throws IllegalAccessException, InvocationTargetException {
-    //     boolean fullScreen = ((boolean) WhiteBox.method(VideoView.class, "isFullScreen").invoke(mVideoAdView));
+    //     boolean fullScreen = ((boolean) WhiteBox.method(VideoView.class, "isFullScreen").invoke(videoAdView));
     //     assertFalse(fullScreen);
     //
     //     VideoDialog mock = mock(VideoDialog.class);
     //     when(mock.isShowing()).thenReturn(true);
-    //     WhiteBox.field(VideoView.class, "mVideoDialog").set(mVideoAdView, mock);
-    //     fullScreen = ((boolean) WhiteBox.method(VideoView.class, "isFullScreen").invoke(mVideoAdView));
+    //     WhiteBox.field(VideoView.class, "videoDialog").set(videoAdView, mock);
+    //     fullScreen = ((boolean) WhiteBox.method(VideoView.class, "isFullScreen").invoke(videoAdView));
     //     assertTrue(fullScreen);
     // }
 
     // @Test
     // public void whenClickthroughBrowserClosed_CallCallback() {
     //
-    //     mManagerDelegate.onClickThroughClosed();
-    //     verify(mMockVideoViewListener).onClickThroughClosed(any(VideoView.class));
+    //     managerDelegate.onClickThroughClosed();
+    //     verify(mockVideoViewListener).onClickThroughClosed(any(VideoView.class));
     // }
     //
     // @Test
     // public void whenInterstitialAdClosed_CallCallback() throws IllegalAccessException {
     //     getMockAdViewManager();
     //
-    //     mManagerDelegate.onInterstitialAdClosed();
-    //     verify(mMockAdViewManager).resetTransactionState();
-    //     verify(mMockVideoViewListener).onInterstitialClosed(any(VideoView.class));
+    //     managerDelegate.onInterstitialAdClosed();
+    //     verify(mockAdViewManager).resetTransactionState();
+    //     verify(mockVideoViewListener).onInterstitialClosed(any(VideoView.class));
     // }
     //
     // @Test
     // public void whenShowFullScreen_CallCallback() throws Exception {
     //     getMockAdViewManager();
     //
-    //     mManagerDelegate.onAdClicked();
-    //     verify(mMockAdViewManager).canShowFullScreen();
-    //     verify(mMockVideoViewListener).onInterstitialOpened(any(VideoView.class));
+    //     managerDelegate.onAdClicked();
+    //     verify(mockAdViewManager).canShowFullScreen();
+    //     verify(mockVideoViewListener).onInterstitialOpened(any(VideoView.class));
     // }
     //
     // @Test
     // public void whenShowWatchAgain_WatchAgainButtonSetup() throws IllegalAccessException {
     //     getMockAdViewManager();
     //
-    //     mManagerDelegate.onVideoCompleted();
+    //     managerDelegate.onVideoCompleted();
     //
-    //     verify(mMockAdViewManager).addObstructions(any(InternalFriendlyObstruction.class));
-    //     assertNotNull(mVideoAdView.getChildAt(0));
+    //     verify(mockAdViewManager).addObstructions(any(InternalFriendlyObstruction.class));
+    //     assertNotNull(videoAdView.getChildAt(0));
     // }
     //
     // @Test
     // public void whenCollapse_CallCallback() {
-    //     mManagerDelegate.onVideoDialogClosed();
-    //     verify(mMockVideoViewListener).onInterstitialClosed(any(VideoView.class));
+    //     managerDelegate.onVideoDialogClosed();
+    //     verify(mockVideoViewListener).onInterstitialClosed(any(VideoView.class));
     // }
 
     // private VideoCreative getSimpleVideoCreative() throws IllegalAccessException {
@@ -547,7 +544,7 @@ public class VideoViewTest {
     //
     //     when(simpleVideoCreative.getCreativeModel())
     //         .thenReturn(new VideoCreativeModel(mock(TrackingManager.class), mock(OmEventTracker.class), adConfiguration));
-    //     WhiteBox.field(VideoView.class, "mCurrentCreativeShown").set(mVideoView, simpleVideoCreative);
+    //     WhiteBox.field(VideoView.class, "currentCreativeShown").set(videoView, simpleVideoCreative);
     //     return simpleVideoCreative;
     // }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/HTMLCreativeViewTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/HTMLCreativeViewTest.java
@@ -35,13 +35,13 @@ import static org.mockito.Mockito.mock;
 @Config(sdk = 19)
 public class HTMLCreativeViewTest {
 
-    private Activity mTestActivity;
-    private Context mMockContext;
+    private Activity testActivity;
+    private Context mockContext;
 
     @Before
     public void setUp() throws Exception {
-        mTestActivity = Robolectric.buildActivity(Activity.class).create().get();
-        mMockContext = mTestActivity.getApplicationContext();
+        testActivity = Robolectric.buildActivity(Activity.class).create().get();
+        mockContext = testActivity.getApplicationContext();
     }
 
     @After
@@ -52,7 +52,7 @@ public class HTMLCreativeViewTest {
     @Test
     public void testSetMediaUrl() throws Exception {
 
-        PrebidWebViewBase mockHTMLCreativeView = new PrebidWebViewBase(mMockContext, mock(InterstitialManager.class));
+        PrebidWebViewBase mockHTMLCreativeView = new PrebidWebViewBase(mockContext, mock(InterstitialManager.class));
         //mockHTMLCreativeView.start();
         assertNotNull(mockHTMLCreativeView);
     }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/MockServerTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/MockServerTest.java
@@ -28,30 +28,30 @@ import static org.junit.Assert.assertEquals;
 
 public class MockServerTest {
 
-    private MockWebServer mServer;
+    private MockWebServer server;
 
     @Before
     public void setUp() throws Exception {
-        mServer = new MockWebServer();
+        server = new MockWebServer();
     }
 
     @After
     public void tearDown() throws Exception {
-        mServer.shutdown();
+        server.shutdown();
     }
 
     @Test
     public void redirectResponseCodeTest() throws Exception {
-        mServer.enqueue(new MockResponse().setResponseCode(302));
-        mServer.enqueue(new MockResponse().setResponseCode(307));
-        mServer.start();
+        server.enqueue(new MockResponse().setResponseCode(302));
+        server.enqueue(new MockResponse().setResponseCode(307));
+        server.start();
 
         BaseNetworkTask.GetUrlParams params = new BaseNetworkTask.GetUrlParams();
         params.name = "foo";
         params.requestType = "GET";
         params.userAgent = "user-agent";
 
-        HttpUrl baseUrl = mServer.url("/test");
+        HttpUrl baseUrl = server.url("/test");
         params.url = baseUrl.url().toString();
 
         // HTTP 302

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/bidding/config/AdUnitConfigurationTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/bidding/config/AdUnitConfigurationTest.java
@@ -33,74 +33,74 @@ import static org.junit.Assert.*;
 @Config(sdk = 19)
 public class AdUnitConfigurationTest {
 
-    private AdUnitConfiguration mAdUnitConfig;
+    private AdUnitConfiguration adUnitConfig;
 
     @Before
     public void setUp() throws Exception {
-        mAdUnitConfig = new AdUnitConfiguration();
+        adUnitConfig = new AdUnitConfiguration();
     }
 
     @Test
     public void whenAddSize_SetContainsSize() {
         AdSize adSize = new AdSize(0, 0);
-        assertTrue(mAdUnitConfig.getSizes().isEmpty());
+        assertTrue(adUnitConfig.getSizes().isEmpty());
 
-        mAdUnitConfig.addSize(adSize);
-        assertEquals(1, mAdUnitConfig.getSizes().size());
-        assertTrue(mAdUnitConfig.getSizes().contains(adSize));
+        adUnitConfig.addSize(adSize);
+        assertEquals(1, adUnitConfig.getSizes().size());
+        assertTrue(adUnitConfig.getSizes().contains(adSize));
     }
 
     @Test
     public void whenAddSizes_SetContainsSizes() {
         AdSize adSize = new AdSize(0, 0);
         AdSize adSize1 = new AdSize(1, 1);
-        assertTrue(mAdUnitConfig.getSizes().isEmpty());
+        assertTrue(adUnitConfig.getSizes().isEmpty());
 
-        mAdUnitConfig.addSizes(adSize, adSize1);
-        assertEquals(2, mAdUnitConfig.getSizes().size());
-        assertTrue(mAdUnitConfig.getSizes().contains(adSize));
-        assertTrue(mAdUnitConfig.getSizes().contains(adSize1));
+        adUnitConfig.addSizes(adSize, adSize1);
+        assertEquals(2, adUnitConfig.getSizes().size());
+        assertTrue(adUnitConfig.getSizes().contains(adSize));
+        assertTrue(adUnitConfig.getSizes().contains(adSize1));
     }
 
     @Test
     public void whenAddContextData_ContextDataAdded() {
-        mAdUnitConfig.addContextData("key", "value");
-        assertTrue(mAdUnitConfig.getContextDataDictionary().containsKey("key"));
-        assertTrue(mAdUnitConfig.getContextDataDictionary().get("key").contains("value"));
+        adUnitConfig.addContextData("key", "value");
+        assertTrue(adUnitConfig.getContextDataDictionary().containsKey("key"));
+        assertTrue(adUnitConfig.getContextDataDictionary().get("key").contains("value"));
     }
 
     @Test
     public void whenUpdateContextData_ContextDataUpdated() {
-        mAdUnitConfig.addContextData("key", "test");
+        adUnitConfig.addContextData("key", "test");
         Set<String> stringSet = new HashSet<>();
         stringSet.add("value0");
         stringSet.add("value1");
-        mAdUnitConfig.addContextData("key", stringSet);
-        assertTrue(mAdUnitConfig.getContextDataDictionary().get("key").containsAll(stringSet));
+        adUnitConfig.addContextData("key", stringSet);
+        assertTrue(adUnitConfig.getContextDataDictionary().get("key").containsAll(stringSet));
     }
 
     @Test
     public void whenRemoveContextData_ContextDataRemoved() {
-        mAdUnitConfig.addContextData("key", "value");
-        mAdUnitConfig.addContextData("key1", "value");
-        assertTrue(mAdUnitConfig.getContextDataDictionary().containsKey("key"));
-        mAdUnitConfig.removeContextData("key");
-        assertFalse(mAdUnitConfig.getContextDataDictionary().containsKey("key"));
+        adUnitConfig.addContextData("key", "value");
+        adUnitConfig.addContextData("key1", "value");
+        assertTrue(adUnitConfig.getContextDataDictionary().containsKey("key"));
+        adUnitConfig.removeContextData("key");
+        assertFalse(adUnitConfig.getContextDataDictionary().containsKey("key"));
     }
 
     @Test
     public void whenClearContextData_ContextDataCleared() {
-        mAdUnitConfig.addContextData("key", "value");
-        mAdUnitConfig.addContextData("key1", "value");
-        assertFalse(mAdUnitConfig.getContextDataDictionary().isEmpty());
-        mAdUnitConfig.clearContextData();
-        assertTrue(mAdUnitConfig.getContextDataDictionary().isEmpty());
+        adUnitConfig.addContextData("key", "value");
+        adUnitConfig.addContextData("key1", "value");
+        assertFalse(adUnitConfig.getContextDataDictionary().isEmpty());
+        adUnitConfig.clearContextData();
+        assertTrue(adUnitConfig.getContextDataDictionary().isEmpty());
     }
 
     @Test
     public void whenAddContextKeyword_ContextKeywordAdded() {
-        mAdUnitConfig.addContextKeyword("test");
-        assertTrue(mAdUnitConfig.getContextKeywordsSet().contains("test"));
+        adUnitConfig.addContextKeyword("test");
+        assertTrue(adUnitConfig.getContextKeywordsSet().contains("test"));
     }
 
     @Test
@@ -108,26 +108,26 @@ public class AdUnitConfigurationTest {
         Set<String> stringSet = new HashSet<>();
         stringSet.add("value0");
         stringSet.add("value1");
-        mAdUnitConfig.addContextKeywords(stringSet);
-        assertTrue(mAdUnitConfig.getContextKeywordsSet().containsAll(stringSet));
+        adUnitConfig.addContextKeywords(stringSet);
+        assertTrue(adUnitConfig.getContextKeywordsSet().containsAll(stringSet));
     }
 
     @Test
     public void whenRemoveContextKeyword_ContextKeywordRemoved() {
-        mAdUnitConfig.addContextKeyword("test");
-        mAdUnitConfig.addContextKeyword("keyword");
-        mAdUnitConfig.removeContextKeyword("test");
-        assertFalse(mAdUnitConfig.getContextKeywordsSet().isEmpty());
-        assertFalse(mAdUnitConfig.getContextKeywordsSet().contains("test"));
+        adUnitConfig.addContextKeyword("test");
+        adUnitConfig.addContextKeyword("keyword");
+        adUnitConfig.removeContextKeyword("test");
+        assertFalse(adUnitConfig.getContextKeywordsSet().isEmpty());
+        assertFalse(adUnitConfig.getContextKeywordsSet().contains("test"));
     }
 
     @Test
     public void whenClearContextKeyword_ContextKeywordCleared() {
-        mAdUnitConfig.addContextKeyword("test");
-        mAdUnitConfig.addContextKeyword("keyword");
-        assertFalse(mAdUnitConfig.getContextKeywordsSet().isEmpty());
+        adUnitConfig.addContextKeyword("test");
+        adUnitConfig.addContextKeyword("keyword");
+        assertFalse(adUnitConfig.getContextKeywordsSet().isEmpty());
 
-        mAdUnitConfig.clearContextKeywords();
-        assertTrue(mAdUnitConfig.getContextKeywordsSet().isEmpty());
+        adUnitConfig.clearContextKeywords();
+        assertTrue(adUnitConfig.getContextKeywordsSet().isEmpty());
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/bidding/display/InterstitialControllerTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/bidding/display/InterstitialControllerTest.java
@@ -42,18 +42,18 @@ import static org.mockito.Mockito.*;
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 19)
 public class InterstitialControllerTest {
-    private InterstitialController mInterstitialController;
+    private InterstitialController interstitialController;
 
-    @Mock
-    private InterstitialControllerListener mMockListener;
-    @Mock
-    private InterstitialView mMockInterstitialView;
+    @Mock private InterstitialControllerListener mockListener;
+    @Mock private InterstitialView mockInterstitialView;
 
     @Before
     public void setup() throws Exception {
         MockitoAnnotations.initMocks(this);
-        mInterstitialController = new InterstitialController(Robolectric.buildActivity(Activity.class).create().get(), mMockListener);
-        WhiteBox.setInternalState(mInterstitialController, "mBidInterstitialView", mMockInterstitialView);
+        interstitialController = new InterstitialController(Robolectric.buildActivity(Activity.class).create().get(),
+                mockListener
+        );
+        WhiteBox.setInternalState(interstitialController, "bidInterstitialView", mockInterstitialView);
     }
 
     @Test
@@ -61,41 +61,41 @@ public class InterstitialControllerTest {
         final AdUnitConfiguration mockAdUnitConfiguration = mock(AdUnitConfiguration.class);
         final BidResponse mockBidResponse = mock(BidResponse.class);
 
-        mInterstitialController.loadAd(mockAdUnitConfiguration, mockBidResponse);
+        interstitialController.loadAd(mockAdUnitConfiguration, mockBidResponse);
 
-        verify(mMockInterstitialView, times(1)).loadAd(eq(mockAdUnitConfiguration), eq(mockBidResponse));
+        verify(mockInterstitialView, times(1)).loadAd(eq(mockAdUnitConfiguration), eq(mockBidResponse));
     }
 
     @Test
     public void showInterstitialType_ExecuteInterstitialViewShowInterstitialFromRoot() {
-        WhiteBox.setInternalState(mInterstitialController, "mAdUnitIdentifierType", AdFormat.INTERSTITIAL);
-        mInterstitialController.show();
+        WhiteBox.setInternalState(interstitialController, "adUnitIdentifierType", AdFormat.INTERSTITIAL);
+        interstitialController.show();
 
-        verify(mMockInterstitialView, times(1)).showAsInterstitialFromRoot();
+        verify(mockInterstitialView, times(1)).showAsInterstitialFromRoot();
     }
 
     @Test
     public void showVastType_ExecuteInterstitialViewShowVideoAsInterstitial() {
-        WhiteBox.setInternalState(mInterstitialController, "mAdUnitIdentifierType", AdFormat.VAST);
-        mInterstitialController.show();
+        WhiteBox.setInternalState(interstitialController, "adUnitIdentifierType", AdFormat.VAST);
+        interstitialController.show();
 
-        verify(mMockInterstitialView, times(1)).showVideoAsInterstitial();
+        verify(mockInterstitialView, times(1)).showVideoAsInterstitial();
     }
 
     @Test
     public void showNullType_DoNothing() {
-        reset(mMockInterstitialView);
+        reset(mockInterstitialView);
 
-        mInterstitialController.show();
+        interstitialController.show();
 
-        verifyNoMoreInteractions(mMockInterstitialView);
+        verifyNoMoreInteractions(mockInterstitialView);
     }
 
     @Test
     public void destroy_ExecuteInterstitialViewDestroy() {
-        mInterstitialController.destroy();
+        interstitialController.destroy();
 
-        verify(mMockInterstitialView, times(1)).destroy();
+        verify(mockInterstitialView, times(1)).destroy();
     }
 
     //region ===================== InterstitialViewListener tests
@@ -103,39 +103,39 @@ public class InterstitialControllerTest {
     public void adDidLoad_NotifyInterstitialReadyForDisplay() {
         getInterstitialViewListener().onAdLoaded(mock(InterstitialView.class), mock(AdDetails.class));
 
-        verify(mMockListener, times(1)).onInterstitialReadyForDisplay();
+        verify(mockListener, times(1)).onInterstitialReadyForDisplay();
     }
 
     @Test
     public void adDidFailLoad_NotifyInterstitialFailedToLoad() {
         getInterstitialViewListener().onAdFailed(mock(InterstitialView.class), mock(AdException.class));
 
-        verify(mMockListener, times(1)).onInterstitialFailedToLoad(any());
+        verify(mockListener, times(1)).onInterstitialFailedToLoad(any());
     }
 
     @Test
     public void adDidDisplay_NotifyInterstitialDisplayed() {
         getInterstitialViewListener().onAdDisplayed(mock(InterstitialView.class));
 
-        verify(mMockListener, times(1)).onInterstitialDisplayed();
+        verify(mockListener, times(1)).onInterstitialDisplayed();
     }
 
     @Test
     public void adWasClicked_NotifyInterstitialClicked() {
         getInterstitialViewListener().onAdClicked(mock(InterstitialView.class));
 
-        verify(mMockListener, times(1)).onInterstitialClicked();
+        verify(mockListener, times(1)).onInterstitialClicked();
     }
 
     @Test
     public void adInterstitialDidClose_NotifyInterstitialDidClose() {
         getInterstitialViewListener().onAdClosed(mock(InterstitialView.class));
 
-        verify(mMockListener, times(1)).onInterstitialClosed();
+        verify(mockListener, times(1)).onInterstitialClosed();
     }
     //endregion ===================== InterstitialViewListener tests
 
     private InterstitialViewListener getInterstitialViewListener() {
-        return (InterstitialViewListener) WhiteBox.getInternalState(mInterstitialController, "mInterstitialViewListener");
+        return (InterstitialViewListener) WhiteBox.getInternalState(interstitialController, "interstitialViewListener");
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/bidding/loader/BidLoaderTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/bidding/loader/BidLoaderTest.java
@@ -42,79 +42,75 @@ import static org.mockito.Mockito.*;
 @Config(sdk = 19)
 public class BidLoaderTest {
 
-    private BidLoader mBidLoader;
-    private Context mContext;
-    @Mock
-    private AdUnitConfiguration mMockAdConfiguration;
-    @Mock
-    private BidRequesterListener mBidRequesterListener;
-    @Mock
-    private BidRequester mMockRequester;
-    @Mock
-    private RefreshTimerTask mMockTimerTask;
+    private BidLoader bidLoader;
+    private Context context;
+    @Mock private AdUnitConfiguration mockAdConfiguration;
+    @Mock private BidRequesterListener bidRequesterListener;
+    @Mock private BidRequester mockRequester;
+    @Mock private RefreshTimerTask mockTimerTask;
 
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        mContext = Robolectric.buildActivity(Activity.class).create().get();
-        when(mMockAdConfiguration.isAdType(any(AdFormat.class))).thenReturn(true);
-        when(mMockAdConfiguration.getAutoRefreshDelay()).thenReturn(60000);
-        mBidLoader = createBidLoader(mContext, mMockAdConfiguration, mBidRequesterListener);
+        context = Robolectric.buildActivity(Activity.class).create().get();
+        when(mockAdConfiguration.isAdType(any(AdFormat.class))).thenReturn(true);
+        when(mockAdConfiguration.getAutoRefreshDelay()).thenReturn(60000);
+        bidLoader = createBidLoader(context, mockAdConfiguration, bidRequesterListener);
     }
 
     @Test
     public void whenLoadAndNoContext_NoStartAdRequestCall() {
-        mBidLoader = createBidLoader(mContext, null, mBidRequesterListener);
-        mBidLoader.load();
-        verify(mMockRequester, never()).startAdRequest();
+        bidLoader = createBidLoader(context, null, bidRequesterListener);
+        bidLoader.load();
+        verify(mockRequester, never()).startAdRequest();
     }
 
     @Test
     public void whenLoadAndNoAdConfiguration_NoStartAdRequestCall() {
-        mBidLoader = createBidLoader(null, mMockAdConfiguration, mBidRequesterListener);
-        mBidLoader.load();
-        verify(mMockRequester, never()).startAdRequest();
+        bidLoader = createBidLoader(null, mockAdConfiguration, bidRequesterListener);
+        bidLoader.load();
+        verify(mockRequester, never()).startAdRequest();
     }
 
     @Test
     public void whenLoadAndNoListener_NoStartAdRequestCall() {
-        mBidLoader = createBidLoader(mContext, mMockAdConfiguration, null);
-        mBidLoader.load();
-        verify(mMockRequester, never()).startAdRequest();
+        bidLoader = createBidLoader(context, mockAdConfiguration, null);
+        bidLoader.load();
+        verify(mockRequester, never()).startAdRequest();
     }
 
     @Test
     public void whenFreshLoadAndAdUnitConfigPassed_CallStartAdRequest() {
-        mBidLoader.load();
-        verify(mMockRequester).startAdRequest();
+        bidLoader.load();
+        verify(mockRequester).startAdRequest();
     }
 
     @Test
     public void whenLoadAndCurrentlyLoading_NoStartAdRequestCall() {
-        WhiteBox.setInternalState(mBidLoader, "mCurrentlyLoading", new AtomicBoolean(true));
-        mBidLoader.load();
-        verify(mMockRequester, never()).startAdRequest();
+        WhiteBox.setInternalState(bidLoader, "currentlyLoading", new AtomicBoolean(true));
+        bidLoader.load();
+        verify(mockRequester, never()).startAdRequest();
     }
 
     @Test
     public void whenDestroy_RequesterAndTimerTaskDestroyed() throws IllegalAccessException {
-        WhiteBox.field(BidLoader.class, "mBidRequester").set(mBidLoader, mMockRequester);
-        mBidLoader.destroy();
-        verify(mMockRequester).destroy();
-        verify(mMockTimerTask).cancelRefreshTimer();
-        verify(mMockTimerTask).destroy();
+        WhiteBox.field(BidLoader.class, "bidRequester").set(bidLoader, mockRequester);
+        bidLoader.destroy();
+        verify(mockRequester).destroy();
+        verify(mockTimerTask).cancelRefreshTimer();
+        verify(mockTimerTask).destroy();
     }
 
     @Test
-    public void whenCancelRefresh_CancelRefreshTimerTask(){
-        mBidLoader.cancelRefresh();
-        verify(mMockTimerTask).cancelRefreshTimer();
+    public void whenCancelRefresh_CancelRefreshTimerTask() {
+        bidLoader.cancelRefresh();
+        verify(mockTimerTask).cancelRefreshTimer();
     }
 
     private BidLoader createBidLoader(Context context, AdUnitConfiguration adConfiguration, BidRequesterListener requestListener) {
         BidLoader bidLoader = new BidLoader(context, adConfiguration, requestListener);
-        WhiteBox.setInternalState(bidLoader, "mBidRequester", mMockRequester);
-        WhiteBox.setInternalState(bidLoader, "mRefreshTimerTask", mMockTimerTask);
+        WhiteBox.setInternalState(bidLoader, "bidRequester", mockRequester);
+        WhiteBox.setInternalState(bidLoader, "refreshTimerTask", mockTimerTask);
         return bidLoader;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/interstitial/AdBaseDialogTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/interstitial/AdBaseDialogTest.java
@@ -56,33 +56,33 @@ import static org.mockito.Mockito.*;
 @Config(sdk = 19)
 public class AdBaseDialogTest {
 
-    private AdBaseDialog mAdBaseDialog;
+    private AdBaseDialog adBaseDialog;
 
     @Mock
-    Activity mMockActivity;
-    Context mMockContext;
+    Activity mockActivity;
+    Context mockContext;
     @Mock
-    WebViewBase mMockWebViewBase;
+    WebViewBase mockWebViewBase;
     @Mock
-    BaseJSInterface mMockBaseJSInterface;
+    BaseJSInterface mockBaseJSInterface;
     @Mock
-    JsExecutor mMockJsExecutor;
+    JsExecutor mockJsExecutor;
     @Mock
-    InterstitialManager mMockInterstitialManager;
+    InterstitialManager mockInterstitialManager;
     @Mock
-    MraidVariableContainer mMockMraidVariableContainer;
+    MraidVariableContainer mockMraidVariableContainer;
 
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
-        mMockContext = Robolectric.buildActivity(Activity.class).create().get().getApplicationContext();
+        mockContext = Robolectric.buildActivity(Activity.class).create().get().getApplicationContext();
 
-        when(mMockWebViewBase.getMRAIDInterface()).thenReturn(mMockBaseJSInterface);
-        when(mMockBaseJSInterface.getJsExecutor()).thenReturn(mMockJsExecutor);
-        when(mMockBaseJSInterface.getMraidVariableContainer()).thenReturn(mMockMraidVariableContainer);
-        when(mMockInterstitialManager.getInterstitialDisplayProperties()).thenReturn(mock(InterstitialDisplayPropertiesInternal.class));
+        when(mockWebViewBase.getMRAIDInterface()).thenReturn(mockBaseJSInterface);
+        when(mockBaseJSInterface.getJsExecutor()).thenReturn(mockJsExecutor);
+        when(mockBaseJSInterface.getMraidVariableContainer()).thenReturn(mockMraidVariableContainer);
+        when(mockInterstitialManager.getInterstitialDisplayProperties()).thenReturn(mock(InterstitialDisplayPropertiesInternal.class));
 
-        mAdBaseDialog = spy(new AdBaseDialog(mMockContext, mMockWebViewBase, mMockInterstitialManager) {
+        adBaseDialog = spy(new AdBaseDialog(mockContext, mockWebViewBase, mockInterstitialManager) {
             @Override
             protected void handleCloseClick() {
 
@@ -94,57 +94,57 @@ public class AdBaseDialogTest {
             }
         });
 
-        when(mAdBaseDialog.getActivity()).thenReturn(mMockActivity);
+        when(adBaseDialog.getActivity()).thenReturn(mockActivity);
     }
 
     @Test
     public void preInitTest() throws Exception {
 
         FrameLayout mockAdContainer = mock(FrameLayout.class);
-        Field adContainerField = WhiteBox.field(AdBaseDialog.class, "mAdViewContainer");
-        adContainerField.set(mAdBaseDialog, mockAdContainer);
+        Field adContainerField = WhiteBox.field(AdBaseDialog.class, "adViewContainer");
+        adContainerField.set(adBaseDialog, mockAdContainer);
 
-        when(mMockWebViewBase.isMRAID()).thenReturn(false);
-        mAdBaseDialog.preInit();
-        verify(mAdBaseDialog, times(1)).init();
-        verify(mAdBaseDialog, times(0)).MraidContinue();
-        verify(mockAdContainer, atLeastOnce()).addView(eq(mMockWebViewBase), anyInt());
+        when(mockWebViewBase.isMRAID()).thenReturn(false);
+        adBaseDialog.preInit();
+        verify(adBaseDialog, times(1)).init();
+        verify(adBaseDialog, times(0)).MraidContinue();
+        verify(mockAdContainer, atLeastOnce()).addView(eq(mockWebViewBase), anyInt());
 
-        reset(mAdBaseDialog);
-        when(mMockWebViewBase.isMRAID()).thenReturn(true);
-        mAdBaseDialog.preInit();
-        verify(mAdBaseDialog, times(0)).init();
-        verify(mAdBaseDialog, times(1)).MraidContinue();
-        verify(mockAdContainer, atLeastOnce()).addView(eq(mMockWebViewBase), anyInt());
+        reset(adBaseDialog);
+        when(mockWebViewBase.isMRAID()).thenReturn(true);
+        adBaseDialog.preInit();
+        verify(adBaseDialog, times(0)).init();
+        verify(adBaseDialog, times(1)).MraidContinue();
+        verify(mockAdContainer, atLeastOnce()).addView(eq(mockWebViewBase), anyInt());
     }
 
     @Test
     public void onWindowFocusChangedTest() {
-        mAdBaseDialog.onWindowFocusChanged(true);
-        verify(mMockJsExecutor, times(0)).executeOnViewableChange(anyBoolean());
+        adBaseDialog.onWindowFocusChanged(true);
+        verify(mockJsExecutor, times(0)).executeOnViewableChange(anyBoolean());
 
-        mAdBaseDialog.onWindowFocusChanged(false);
-        verify(mMockJsExecutor, times(1)).executeOnViewableChange(anyBoolean());
+        adBaseDialog.onWindowFocusChanged(false);
+        verify(mockJsExecutor, times(1)).executeOnViewableChange(anyBoolean());
     }
 
     @Test
     public void MRAIDContinueTest() throws Exception {
-        Field hasExpandPropertiesField = WhiteBox.field(AdBaseDialog.class, "mHasExpandProperties");
+        Field hasExpandPropertiesField = WhiteBox.field(AdBaseDialog.class, "hasExpandProperties");
         String expandedProperties = "{\"width\":0,\"height\":0,\"useCustomClose\":false,\"isModal\":true}";
 
         doAnswer(prepareHandlerAnswer(expandedProperties))
-            .when(mMockJsExecutor).executeGetExpandProperties(any(Handler.class));
+                .when(mockJsExecutor).executeGetExpandProperties(any(Handler.class));
 
         //MRAIDGetExpandProperties()
-        hasExpandPropertiesField.set(mAdBaseDialog, false);
-        mAdBaseDialog.MraidContinue();
-        verify(mAdBaseDialog, times(1)).loadExpandProperties();
+        hasExpandPropertiesField.set(adBaseDialog, false);
+        adBaseDialog.MraidContinue();
+        verify(adBaseDialog, times(1)).loadExpandProperties();
 
         //init()
-        reset(mAdBaseDialog);
-        hasExpandPropertiesField.set(mAdBaseDialog, true);
-        mAdBaseDialog.MraidContinue();
-        verify(mAdBaseDialog, times(1)).init();
+        reset(adBaseDialog);
+        hasExpandPropertiesField.set(adBaseDialog, true);
+        adBaseDialog.MraidContinue();
+        verify(adBaseDialog, times(1)).init();
     }
 
     private Answer<Object> prepareHandlerAnswer(final String jsonString) {
@@ -163,64 +163,64 @@ public class AdBaseDialogTest {
 
     @Test
     public void initTest() {
-        mAdBaseDialog.init();
+        adBaseDialog.init();
 
-        verify(mMockWebViewBase).requestLayout();
+        verify(mockWebViewBase).requestLayout();
     }
 
     @Test
     public void lockOrientationTest() throws AdException {
-        mAdBaseDialog.lockOrientation(0);
+        adBaseDialog.lockOrientation(0);
 
-        verify(mMockActivity).setRequestedOrientation(0);
+        verify(mockActivity).setRequestedOrientation(0);
     }
 
     @Test
     public void renderCustomCloseTest() {
         View mockCloseView = mock(View.class);
-        mAdBaseDialog.setCloseView(mockCloseView);
+        adBaseDialog.setCloseView(mockCloseView);
 
-        mAdBaseDialog.changeCloseViewVisibility(View.VISIBLE);
+        adBaseDialog.changeCloseViewVisibility(View.VISIBLE);
 
         verify(mockCloseView).setVisibility(View.VISIBLE);
     }
 
     @Test
     public void handleSetOrientationProperties() throws AdException, IllegalAccessException {
-        Field forceOrientationField = WhiteBox.field(AdBaseDialog.class, "mForceOrientation");
-        Field allowOrientationChangeField = WhiteBox.field(AdBaseDialog.class, "mAllowOrientationChange");
+        Field forceOrientationField = WhiteBox.field(AdBaseDialog.class, "forceOrientation");
+        Field allowOrientationChangeField = WhiteBox.field(AdBaseDialog.class, "allowOrientationChange");
         String orientationProperties = "{\"allowOrientationChange\":true,\"forceOrientation\":\"landscape\"}";
-        when(mMockMraidVariableContainer.getOrientationProperties()).thenReturn(orientationProperties);
+        when(mockMraidVariableContainer.getOrientationProperties()).thenReturn(orientationProperties);
 
-        when(mMockWebViewBase.isMRAID()).thenReturn(true);
+        when(mockWebViewBase.isMRAID()).thenReturn(true);
 
-        mAdBaseDialog.handleSetOrientationProperties();
-        assertTrue(allowOrientationChangeField.getBoolean(mAdBaseDialog));
-        assertEquals(OrientationManager.ForcedOrientation.landscape, forceOrientationField.get(mAdBaseDialog));
-        verify(mMockBaseJSInterface).updateScreenMetricsAsync(null);
+        adBaseDialog.handleSetOrientationProperties();
+        assertTrue(allowOrientationChangeField.getBoolean(adBaseDialog));
+        assertEquals(OrientationManager.ForcedOrientation.landscape, forceOrientationField.get(adBaseDialog));
+        verify(mockBaseJSInterface).updateScreenMetricsAsync(null);
     }
 
     @Test
     public void cleanup() {
-        mAdBaseDialog.cleanup();
+        adBaseDialog.cleanup();
 
-        verify(mAdBaseDialog).cancel();
+        verify(adBaseDialog).cancel();
     }
 
     @Test
     public void getActivity() {
-        assertEquals(mMockActivity, mAdBaseDialog.getActivity());
+        assertEquals(mockActivity, adBaseDialog.getActivity());
     }
 
     @Test
     public void testAddSoundView() {
         FrameLayout wrapper = mock(FrameLayout.class);
-        Reflection.setVariableTo(mAdBaseDialog, "mAdViewContainer", wrapper);
+        Reflection.setVariableTo(adBaseDialog, "adViewContainer", wrapper);
 
         ImageView view = mock(ImageView.class);
-        doReturn(view).when(mAdBaseDialog).createSoundView(any());
+        doReturn(view).when(adBaseDialog).createSoundView(any());
 
-        mAdBaseDialog.addSoundView(true);
+        adBaseDialog.addSoundView(true);
 
         verify(view).setVisibility(View.VISIBLE);
         verify(view).setImageResource(R.drawable.ic_volume_on);

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/interstitial/AdExpandedDialogTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/interstitial/AdExpandedDialogTest.java
@@ -43,46 +43,46 @@ import static org.mockito.Mockito.*;
 @Config(sdk = 19)
 public class AdExpandedDialogTest {
 
-    private AdExpandedDialog mAdExpandedDialog;
+    private AdExpandedDialog adExpandedDialog;
 
-    private Context mMockContext;
-    private WebViewBase mMockWebViewBase;
-    private BaseJSInterface mMockBaseJSInterface;
-    private PrebidWebViewBase mMockPrebidWebView;
-    private InterstitialManager mMockInterstitialManager;
+    private Context mockContext;
+    private WebViewBase mockWebViewBase;
+    private BaseJSInterface mockBaseJSInterface;
+    private PrebidWebViewBase mockPrebidWebView;
+    private InterstitialManager mockInterstitialManager;
 
     @Before
     public void setUp() throws Exception {
-        mMockContext = Robolectric.buildActivity(Activity.class).create().get();
-        mMockWebViewBase = mock(WebViewBase.class);
-        mMockBaseJSInterface = mock(BaseJSInterface.class);
-        mMockInterstitialManager = mock(InterstitialManager.class);
+        mockContext = Robolectric.buildActivity(Activity.class).create().get();
+        mockWebViewBase = mock(WebViewBase.class);
+        mockBaseJSInterface = mock(BaseJSInterface.class);
+        mockInterstitialManager = mock(InterstitialManager.class);
 
-        mMockPrebidWebView = mock(PrebidWebViewBase.class);
+        mockPrebidWebView = mock(PrebidWebViewBase.class);
 
-        when(mMockWebViewBase.getMRAIDInterface()).thenReturn(mMockBaseJSInterface);
-        when(mMockWebViewBase.getPreloadedListener()).thenReturn(mMockPrebidWebView);
+        when(mockWebViewBase.getMRAIDInterface()).thenReturn(mockBaseJSInterface);
+        when(mockWebViewBase.getPreloadedListener()).thenReturn(mockPrebidWebView);
 
-        mAdExpandedDialog = new AdExpandedDialog(mMockContext, mMockWebViewBase, mMockInterstitialManager);
+        adExpandedDialog = new AdExpandedDialog(mockContext, mockWebViewBase, mockInterstitialManager);
     }
 
     @Test
     public void handleCloseClick() throws IllegalAccessException {
         InterstitialManager interstitialManager = mock(InterstitialManager.class);
-        Field interstitialManagerField = WhiteBox.field(AdInterstitialDialog.class, "mInterstitialManager");
-        interstitialManagerField.set(mAdExpandedDialog, interstitialManager);
+        Field interstitialManagerField = WhiteBox.field(AdInterstitialDialog.class, "interstitialManager");
+        interstitialManagerField.set(adExpandedDialog, interstitialManager);
 
-        mAdExpandedDialog.handleCloseClick();
-        verify(interstitialManager).interstitialClosed(eq(mMockWebViewBase));
+        adExpandedDialog.handleCloseClick();
+        verify(interstitialManager).interstitialClosed(eq(mockWebViewBase));
     }
 
     @Test
     public void cancelTest() {
-        when(mMockPrebidWebView.getCreative()).thenReturn(mock(HTMLCreative.class));
-        when(mMockWebViewBase.getJSName()).thenReturn("");
+        when(mockPrebidWebView.getCreative()).thenReturn(mock(HTMLCreative.class));
+        when(mockWebViewBase.getJSName()).thenReturn("");
 
-        mAdExpandedDialog.cancel();
-        verify(mMockPrebidWebView, atLeast(1)).addView(any(View.class));
-        verify(mMockBaseJSInterface).onStateChange(eq(JSInterface.STATE_DEFAULT));
+        adExpandedDialog.cancel();
+        verify(mockPrebidWebView, atLeast(1)).addView(any(View.class));
+        verify(mockBaseJSInterface).onStateChange(eq(JSInterface.STATE_DEFAULT));
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/interstitial/AdInterstitialDialogTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/interstitial/AdInterstitialDialogTest.java
@@ -40,52 +40,56 @@ import static org.mockito.Mockito.*;
 @Config(sdk = 19)
 public class AdInterstitialDialogTest {
 
-    private AdInterstitialDialog mAdInterstitialDialog;
+    private AdInterstitialDialog adInterstitialDialog;
 
-    private Context mMockContext;
-    private WebViewBase mMockWebViewBase;
-    private BaseJSInterface mMockBaseJSInterface;
-    private FrameLayout mMockAdContainer;
-    private InterstitialManager mMockInterstitialManager;
+    private Context mockContext;
+    private WebViewBase mockWebViewBase;
+    private BaseJSInterface mockBaseJSInterface;
+    private FrameLayout mockAdContainer;
+    private InterstitialManager mockInterstitialManager;
 
     @Before
     public void setUp() throws Exception {
-        mMockContext = Robolectric.buildActivity(Activity.class).create().get();
-        mMockWebViewBase = mock(WebViewBase.class);
-        mMockAdContainer = mock(FrameLayout.class);
-        mMockBaseJSInterface = mock(BaseJSInterface.class);
-        mMockInterstitialManager = mock(InterstitialManager.class);
+        mockContext = Robolectric.buildActivity(Activity.class).create().get();
+        mockWebViewBase = mock(WebViewBase.class);
+        mockAdContainer = mock(FrameLayout.class);
+        mockBaseJSInterface = mock(BaseJSInterface.class);
+        mockInterstitialManager = mock(InterstitialManager.class);
 
-        when(mMockWebViewBase.getMRAIDInterface()).thenReturn(mMockBaseJSInterface);
-        when(mMockBaseJSInterface.getJsExecutor()).thenReturn(mock(JsExecutor.class));
+        when(mockWebViewBase.getMRAIDInterface()).thenReturn(mockBaseJSInterface);
+        when(mockBaseJSInterface.getJsExecutor()).thenReturn(mock(JsExecutor.class));
 
-        mAdInterstitialDialog = spy(new AdInterstitialDialog(mMockContext, mMockWebViewBase, mMockAdContainer, mMockInterstitialManager));
+        adInterstitialDialog = spy(new AdInterstitialDialog(mockContext,
+                mockWebViewBase,
+                mockAdContainer,
+                mockInterstitialManager
+        ));
     }
 
     @Test
     public void handleCloseClick() throws IllegalAccessException {
         InterstitialManager interstitialManager = mock(InterstitialManager.class);
-        Field interstitialManagerField = WhiteBox.field(AdInterstitialDialog.class, "mInterstitialManager");
-        interstitialManagerField.set(mAdInterstitialDialog, interstitialManager);
+        Field interstitialManagerField = WhiteBox.field(AdInterstitialDialog.class, "interstitialManager");
+        interstitialManagerField.set(adInterstitialDialog, interstitialManager);
 
-        mAdInterstitialDialog.handleCloseClick();
-        verify(interstitialManager).interstitialClosed(mMockWebViewBase);
+        adInterstitialDialog.handleCloseClick();
+        verify(interstitialManager).interstitialClosed(mockWebViewBase);
     }
 
     @Test
     public void nullifyDialog() {
-        mAdInterstitialDialog.nullifyDialog();
+        adInterstitialDialog.nullifyDialog();
 
-        verify(mAdInterstitialDialog, atLeastOnce()).cancel();
-        verify(mAdInterstitialDialog).cleanup();
+        verify(adInterstitialDialog, atLeastOnce()).cancel();
+        verify(adInterstitialDialog).cleanup();
     }
 
     @Test
     public void cancelTest() {
-        when(mMockWebViewBase.isMRAID()).thenReturn(true);
+        when(mockWebViewBase.isMRAID()).thenReturn(true);
 
-        mAdInterstitialDialog.cancel();
-        verify(mMockBaseJSInterface).onStateChange(JSInterface.STATE_DEFAULT);
-        verify(mMockWebViewBase).detachFromParent();
+        adInterstitialDialog.cancel();
+        verify(mockBaseJSInterface).onStateChange(JSInterface.STATE_DEFAULT);
+        verify(mockWebViewBase).detachFromParent();
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/interstitial/InterstitialLayoutConfiguratorTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/interstitial/InterstitialLayoutConfiguratorTest.java
@@ -32,8 +32,8 @@ import static org.junit.Assert.*;
 @Config(sdk = 19)
 public class InterstitialLayoutConfiguratorTest {
 
-    private InterstitialDisplayPropertiesInternal mDisplayProperties = new InterstitialDisplayPropertiesInternal();
-    private AdUnitConfiguration mAdConfiguration = new AdUnitConfiguration();
+    private InterstitialDisplayPropertiesInternal displayProperties = new InterstitialDisplayPropertiesInternal();
+    private AdUnitConfiguration adConfiguration = new AdUnitConfiguration();
 
     @Before
     public void setUp() throws Exception {
@@ -42,32 +42,32 @@ public class InterstitialLayoutConfiguratorTest {
 
     @Test
     public void orientationPortrait_whenNoLayoutAndSize() {
-        InterstitialLayoutConfigurator.configureDisplayProperties(mAdConfiguration, mDisplayProperties);
-        assertEquals(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT, mDisplayProperties.orientation);
-        assertFalse(mDisplayProperties.isRotationEnabled);
+        InterstitialLayoutConfigurator.configureDisplayProperties(adConfiguration, displayProperties);
+        assertEquals(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT, displayProperties.orientation);
+        assertFalse(displayProperties.isRotationEnabled);
     }
 
     @Test
     public void rotationEnabled_whenNoLayoutAndSizeIsAspectRatio() {
-        mAdConfiguration.setInterstitialSize(InterstitialSizes.InterstitialSize.ASPECT_RATIO_300x200);
-        InterstitialLayoutConfigurator.configureDisplayProperties(mAdConfiguration, mDisplayProperties);
-        assertEquals(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT, mDisplayProperties.orientation);
-        assertTrue(mDisplayProperties.isRotationEnabled);
+        adConfiguration.setInterstitialSize(InterstitialSizes.InterstitialSize.ASPECT_RATIO_300x200);
+        InterstitialLayoutConfigurator.configureDisplayProperties(adConfiguration, displayProperties);
+        assertEquals(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT, displayProperties.orientation);
+        assertTrue(displayProperties.isRotationEnabled);
     }
 
     @Test
     public void orientationLandscapeAndNoRotation_whenSizeIsLandscape() {
-        mAdConfiguration.setInterstitialSize(InterstitialSizes.InterstitialSize.LANDSCAPE_480x320);
-        InterstitialLayoutConfigurator.configureDisplayProperties(mAdConfiguration, mDisplayProperties);
-        assertEquals(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE, mDisplayProperties.orientation);
-        assertFalse(mDisplayProperties.isRotationEnabled);
+        adConfiguration.setInterstitialSize(InterstitialSizes.InterstitialSize.LANDSCAPE_480x320);
+        InterstitialLayoutConfigurator.configureDisplayProperties(adConfiguration, displayProperties);
+        assertEquals(ActivityInfo.SCREEN_ORIENTATION_LANDSCAPE, displayProperties.orientation);
+        assertFalse(displayProperties.isRotationEnabled);
     }
 
     @Test
     public void orientationPortraitAndNoRotation_whenSizeIsVertical() {
-        mAdConfiguration.setInterstitialSize(InterstitialSizes.InterstitialSize.VERTICAL_270x480);
-        InterstitialLayoutConfigurator.configureDisplayProperties(mAdConfiguration, mDisplayProperties);
-        assertEquals(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT, mDisplayProperties.orientation);
-        assertFalse(mDisplayProperties.isRotationEnabled);
+        adConfiguration.setInterstitialSize(InterstitialSizes.InterstitialSize.VERTICAL_270x480);
+        InterstitialLayoutConfigurator.configureDisplayProperties(adConfiguration, displayProperties);
+        assertEquals(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT, displayProperties.orientation);
+        assertFalse(displayProperties.isRotationEnabled);
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/loading/CreativeFactoryTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/loading/CreativeFactoryTest.java
@@ -51,19 +51,20 @@ import static org.prebid.mobile.rendering.models.CreativeModelsMakerVast.HTML_CR
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 19)
 public class CreativeFactoryTest {
-    private Context mMockContext;
-    private CreativeModel mMockModel;
-    private CreativeFactory.Listener mMockListener;
-    private OmAdSessionManager mMockOmAdSessionManager;
-    private InterstitialManager mMockInterstitialManager;
+
+    private Context mockContext;
+    private CreativeModel mockModel;
+    private CreativeFactory.Listener mockListener;
+    private OmAdSessionManager mockOmAdSessionManager;
+    private InterstitialManager mockInterstitialManager;
 
     @Before
     public void setUp() throws Exception {
-        mMockContext = Robolectric.buildActivity(Activity.class).create().get();
-        mMockModel = mock(CreativeModel.class);
-        mMockListener = mock(CreativeFactory.Listener.class);
-        mMockOmAdSessionManager = mock(OmAdSessionManager.class);
-        mMockInterstitialManager = mock(InterstitialManager.class);
+        mockContext = Robolectric.buildActivity(Activity.class).create().get();
+        mockModel = mock(CreativeModel.class);
+        mockListener = mock(CreativeFactory.Listener.class);
+        mockOmAdSessionManager = mock(OmAdSessionManager.class);
+        mockInterstitialManager = mock(InterstitialManager.class);
     }
 
     @Test
@@ -71,12 +72,12 @@ public class CreativeFactoryTest {
         boolean hasException;
 
         // Valid
-        new CreativeFactory(mMockContext, mMockModel, mMockListener, mMockOmAdSessionManager, mMockInterstitialManager);
+        new CreativeFactory(mockContext, mockModel, mockListener, mockOmAdSessionManager, mockInterstitialManager);
 
         // Null context
         hasException = false;
         try {
-            new CreativeFactory(null, mMockModel, mMockListener, mMockOmAdSessionManager, mMockInterstitialManager);
+            new CreativeFactory(null, mockModel, mockListener, mockOmAdSessionManager, mockInterstitialManager);
         }
         catch (AdException e) {
             hasException = true;
@@ -86,7 +87,7 @@ public class CreativeFactoryTest {
         // Null creative model
         hasException = false;
         try {
-            new CreativeFactory(mMockContext, null, mMockListener, mMockOmAdSessionManager, mMockInterstitialManager);
+            new CreativeFactory(mockContext, null, mockListener, mockOmAdSessionManager, mockInterstitialManager);
         }
         catch (AdException e) {
             hasException = true;
@@ -96,7 +97,7 @@ public class CreativeFactoryTest {
         // Null listener
         hasException = false;
         try {
-            new CreativeFactory(mMockContext, mMockModel, null, mMockOmAdSessionManager, mMockInterstitialManager);
+            new CreativeFactory(mockContext, mockModel, null, mockOmAdSessionManager, mockInterstitialManager);
         }
         catch (AdException e) {
             hasException = true;
@@ -109,14 +110,19 @@ public class CreativeFactoryTest {
         AdUnitConfiguration adConfiguration = new AdUnitConfiguration();
         adConfiguration.setAdFormat(AdFormat.BANNER);
         Handler mockHandler = mock(Handler.class);
-        when(mMockModel.getAdConfiguration()).thenReturn(adConfiguration);
-        when(mMockModel.getName()).thenReturn(HTML_CREATIVE_TAG);
-        when(mMockModel.getImpressionUrl()).thenReturn("impressionUrl");
-        when(mMockModel.getClickUrl()).thenReturn("clickUrl");
+        when(mockModel.getAdConfiguration()).thenReturn(adConfiguration);
+        when(mockModel.getName()).thenReturn(HTML_CREATIVE_TAG);
+        when(mockModel.getImpressionUrl()).thenReturn("impressionUrl");
+        when(mockModel.getClickUrl()).thenReturn("clickUrl");
 
         //Run the creativeFactory
-        CreativeFactory creativeFactory = new CreativeFactory(mMockContext, mMockModel, mMockListener, mMockOmAdSessionManager, mMockInterstitialManager);
-        WhiteBox.field(CreativeFactory.class, "mTimeoutHandler").set(creativeFactory, mockHandler);
+        CreativeFactory creativeFactory = new CreativeFactory(mockContext,
+                mockModel,
+                mockListener,
+                mockOmAdSessionManager,
+                mockInterstitialManager
+        );
+        WhiteBox.field(CreativeFactory.class, "timeoutHandler").set(creativeFactory, mockHandler);
         creativeFactory.start();
 
         AbstractCreative creative = creativeFactory.getCreative();
@@ -132,22 +138,31 @@ public class CreativeFactoryTest {
         Handler mockHandler = mock(Handler.class);
         adConfiguration.setAdFormat(AdFormat.VAST);
         HashMap<VideoAdEvent.Event, ArrayList<String>> videoEventsUrls = new HashMap<>();
-        videoEventsUrls.put(VideoAdEvent.Event.AD_EXPAND,
-                            new ArrayList<>(Arrays.asList("AD_EXPAND")));
+        videoEventsUrls.put(VideoAdEvent.Event.AD_EXPAND, new ArrayList<>(Arrays.asList("AD_EXPAND")));
         when(mockVideoModel.getVideoEventUrls()).thenReturn(videoEventsUrls);
         when(mockVideoModel.getAdConfiguration()).thenReturn(adConfiguration);
         CreativeFactory creativeFactory;
 
         // Blank media URL
         when(mockVideoModel.getMediaUrl()).thenReturn("");
-        creativeFactory = new CreativeFactory(mMockContext, mockVideoModel, mMockListener, mMockOmAdSessionManager, mMockInterstitialManager);
+        creativeFactory = new CreativeFactory(mockContext,
+                mockVideoModel,
+                mockListener,
+                mockOmAdSessionManager,
+                mockInterstitialManager
+        );
         creativeFactory.start();
-        assertNull(WhiteBox.getInternalState(creativeFactory, "mCreative"));
+        assertNull(WhiteBox.getInternalState(creativeFactory, "creative"));
 
         // Valid
         when(mockVideoModel.getMediaUrl()).thenReturn("mediaUrl");
-        creativeFactory = new CreativeFactory(mMockContext, mockVideoModel, mMockListener, mMockOmAdSessionManager, mMockInterstitialManager);
-        WhiteBox.field(CreativeFactory.class, "mTimeoutHandler").set(creativeFactory, mockHandler);
+        creativeFactory = new CreativeFactory(mockContext,
+                mockVideoModel,
+                mockListener,
+                mockOmAdSessionManager,
+                mockInterstitialManager
+        );
+        WhiteBox.field(CreativeFactory.class, "timeoutHandler").set(creativeFactory, mockHandler);
         creativeFactory.start();
 
         AbstractCreative creative = creativeFactory.getCreative();
@@ -160,10 +175,11 @@ public class CreativeFactoryTest {
     public void testCreativeFactoryCreativeResolutionListener() throws Exception {
         CreativeFactory mockCreativeFactory = mock(CreativeFactory.class);
         CreativeFactory.Listener mockCreativeFactoryListener = mock(CreativeFactory.Listener.class);
-        CreativeFactory.CreativeFactoryCreativeResolutionListener creativeResolutionListener = new CreativeFactory.CreativeFactoryCreativeResolutionListener(mockCreativeFactory);
+        CreativeFactory.CreativeFactoryCreativeResolutionListener creativeResolutionListener = new CreativeFactory.CreativeFactoryCreativeResolutionListener(
+                mockCreativeFactory);
 
-        WhiteBox.field(CreativeFactory.class, "mListener").set(mockCreativeFactory, mockCreativeFactoryListener);
-        WhiteBox.field(CreativeFactory.class, "mTimeoutHandler").set(mockCreativeFactory, mock(Handler.class));
+        WhiteBox.field(CreativeFactory.class, "listener").set(mockCreativeFactory, mockCreativeFactoryListener);
+        WhiteBox.field(CreativeFactory.class, "timeoutHandler").set(mockCreativeFactory, mock(Handler.class));
 
         // Success
         creativeResolutionListener.creativeReady(mock(AbstractCreative.class));
@@ -182,10 +198,11 @@ public class CreativeFactoryTest {
         CreativeFactory mockCreativeFactory = mock(CreativeFactory.class);
         CreativeFactory.Listener mockCreativeFactoryListener = mock(CreativeFactory.Listener.class);
         CreativeFactory.TimeoutState expired = CreativeFactory.TimeoutState.EXPIRED;
-        CreativeFactory.CreativeFactoryCreativeResolutionListener creativeResolutionListener = new CreativeFactory.CreativeFactoryCreativeResolutionListener(mockCreativeFactory);
+        CreativeFactory.CreativeFactoryCreativeResolutionListener creativeResolutionListener = new CreativeFactory.CreativeFactoryCreativeResolutionListener(
+                mockCreativeFactory);
 
-        WhiteBox.field(CreativeFactory.class, "mListener").set(mockCreativeFactory, mockCreativeFactoryListener);
-        WhiteBox.field(CreativeFactory.class, "mTimeoutState").set(mockCreativeFactory, expired);
+        WhiteBox.field(CreativeFactory.class, "listener").set(mockCreativeFactory, mockCreativeFactoryListener);
+        WhiteBox.field(CreativeFactory.class, "timeoutState").set(mockCreativeFactory, expired);
 
         creativeResolutionListener.creativeReady(mock(AbstractCreative.class));
 
@@ -195,10 +212,15 @@ public class CreativeFactoryTest {
     @Test
     public void destroyCalled_removeCallbacksCalled()
     throws IllegalAccessException, AdException {
-        CreativeFactory creativeFactory = new CreativeFactory(mMockContext, mMockModel, mMockListener, mMockOmAdSessionManager, mMockInterstitialManager);
+        CreativeFactory creativeFactory = new CreativeFactory(mockContext,
+                mockModel,
+                mockListener,
+                mockOmAdSessionManager,
+                mockInterstitialManager
+        );
         Handler mockHandler = mock(Handler.class);
 
-        WhiteBox.field(CreativeFactory.class, "mTimeoutHandler").set(creativeFactory, mockHandler);
+        WhiteBox.field(CreativeFactory.class, "timeoutHandler").set(creativeFactory, mockHandler);
 
         creativeFactory.destroy();
 

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/loading/FileDownloadTaskTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/loading/FileDownloadTaskTest.java
@@ -34,67 +34,67 @@ import static org.junit.Assert.assertNotNull;
 
 @RunWith(RobolectricTestRunner.class)
 public class FileDownloadTaskTest {
-    private BaseNetworkTask.GetUrlParams mParams;
-    private MockWebServer mServer;
-    private String mPath;
-    private String mError;
-    private File mFile;
+    private BaseNetworkTask.GetUrlParams params;
+    private MockWebServer server;
+    private String path;
+    private String error;
+    private File file;
 
-    private FileDownloadListener mListener = new FileDownloadListener() {
+    private FileDownloadListener listener = new FileDownloadListener() {
         @Override
         public void onFileDownloaded(String path) {
-            mPath = path;
+            FileDownloadTaskTest.this.path = path;
         }
 
         @Override
         public void onFileDownloadError(String error) {
-            mError = error;
+            FileDownloadTaskTest.this.error = error;
         }
     };
 
     @Before
     public void setup() {
-        mFile = new File("test");
-        mServer = new MockWebServer();
-        mParams = new BaseNetworkTask.GetUrlParams();
-        mPath = null;
-        mError = null;
-        mParams.name = BaseNetworkTask.DOWNLOAD_TASK;
-        mParams.userAgent = "user-agent";
-        HttpUrl baseUrl = mServer.url("/first");
-        mParams.url = baseUrl.url().toString();
-        mParams.requestType = "GET";
+        file = new File("test");
+        server = new MockWebServer();
+        params = new BaseNetworkTask.GetUrlParams();
+        path = null;
+        error = null;
+        params.name = BaseNetworkTask.DOWNLOAD_TASK;
+        params.userAgent = "user-agent";
+        HttpUrl baseUrl = server.url("/first");
+        params.url = baseUrl.url().toString();
+        params.requestType = "GET";
     }
 
     @After
     public void tearDown() throws IOException {
-        mServer.shutdown();
-        mFile.delete();
+        server.shutdown();
+        file.delete();
     }
 
     @Test
     public void testSuccessDoInBackground() throws IOException {
         String body = ResourceUtils.convertResourceToString("mraid.js");
-        mServer.enqueue(new MockResponse().setResponseCode(200).setBody(body));
+        server.enqueue(new MockResponse().setResponseCode(200).setBody(body));
 
-        FileDownloadTask baseNetworkTask = new FileDownloadTask(mListener, mFile);
+        FileDownloadTask baseNetworkTask = new FileDownloadTask(listener, file);
 
-        baseNetworkTask.execute(mParams);
+        baseNetworkTask.execute(params);
 
-        assertNotNull(mPath);
+        assertNotNull(path);
     }
 
     @Test(expected = NullPointerException.class)
     public void testNullFile() {
-        FileDownloadTask task = new FileDownloadTask(mListener, null);
-        task.execute(mParams);
+        FileDownloadTask task = new FileDownloadTask(listener, null);
+        task.execute(params);
     }
 
     @Test
     public void testWrongData() {
-        mServer.enqueue(new MockResponse().setResponseCode(401).setBody("Not found"));
-        FileDownloadTask task = new FileDownloadTask(mListener, mFile);
-        task.execute(mParams);
-        assertNotNull(mError);
+        server.enqueue(new MockResponse().setResponseCode(401).setBody("Not found"));
+        FileDownloadTask task = new FileDownloadTask(listener, file);
+        task.execute(params);
+        assertNotNull(error);
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/loading/TransactionManagerTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/loading/TransactionManagerTest.java
@@ -46,72 +46,70 @@ import static org.mockito.Mockito.*;
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 19)
 public class TransactionManagerTest {
-    @Mock
-    private TransactionManagerListener mMockListener;
-    @Mock
-    private Transaction mMockTransaction;
+    @Mock private TransactionManagerListener mockListener;
+    @Mock private Transaction mockTransaction;
 
-    private TransactionManager mTransactionManager;
+    private TransactionManager transactionManager;
 
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
         Context context = Robolectric.buildActivity(Activity.class).create().get();
-        mTransactionManager = new TransactionManager(context, mMockListener, mock(InterstitialManager.class));
+        transactionManager = new TransactionManager(context, mockListener, mock(InterstitialManager.class));
     }
 
     @Test
     public void whenGetCurrentTransaction_NullResult() {
-        Transaction transaction = mTransactionManager.getCurrentTransaction();
+        Transaction transaction = transactionManager.getCurrentTransaction();
         assertNull(transaction);
-        mTransactionManager.onTransactionSuccess(mMockTransaction);
-        transaction = mTransactionManager.getCurrentTransaction();
+        transactionManager.onTransactionSuccess(mockTransaction);
+        transaction = transactionManager.getCurrentTransaction();
         assertNotNull(transaction);
-        assertEquals(mMockTransaction, transaction);
+        assertEquals(mockTransaction, transaction);
     }
 
     @Test
     public void whenGetCurrentTransaction_NotNullResult() {
-        mTransactionManager.onTransactionSuccess(mMockTransaction);
-        Transaction transaction = mTransactionManager.getCurrentTransaction();
+        transactionManager.onTransactionSuccess(mockTransaction);
+        Transaction transaction = transactionManager.getCurrentTransaction();
         assertNotNull(transaction);
-        assertEquals(mMockTransaction, transaction);
+        assertEquals(mockTransaction, transaction);
     }
 
     @Test
     public void whenDismissTransaction_NullResult() {
-        Transaction transaction = mTransactionManager.dismissCurrentTransaction();
+        Transaction transaction = transactionManager.dismissCurrentTransaction();
         assertNull(transaction);
     }
 
     @Test
     public void whenDismissTransaction_NotNullResult() {
-        mTransactionManager.onTransactionSuccess(mMockTransaction);
+        transactionManager.onTransactionSuccess(mockTransaction);
         Transaction transaction = mock(Transaction.class);
-        mTransactionManager.onTransactionSuccess(transaction);
-        Transaction secondTransaction = mTransactionManager.dismissCurrentTransaction();
+        transactionManager.onTransactionSuccess(transaction);
+        Transaction secondTransaction = transactionManager.dismissCurrentTransaction();
         assertEquals(transaction, secondTransaction);
     }
 
     @Test
     public void whenResetState_TriggerTransactionDestroy() {
-        mTransactionManager.onTransactionSuccess(mMockTransaction);
-        mTransactionManager.resetState();
-        verify(mMockTransaction).destroy();
+        transactionManager.onTransactionSuccess(mockTransaction);
+        transactionManager.resetState();
+        verify(mockTransaction).destroy();
     }
 
     @Test
     public void whenHasTransaction_ResultFalse() {
-        assertFalse(mTransactionManager.hasTransaction());
-        mTransactionManager.onTransactionSuccess(mMockTransaction);
-        assertTrue(mTransactionManager.hasTransaction());
+        assertFalse(transactionManager.hasTransaction());
+        transactionManager.onTransactionSuccess(mockTransaction);
+        assertTrue(transactionManager.hasTransaction());
     }
 
     @Test
     public void whenDestroy_TriggerTransactionAndLoadManager() {
-        mTransactionManager.onTransactionSuccess(mMockTransaction);
-        mTransactionManager.destroy();
-        verify(mMockTransaction).destroy();
+        transactionManager.onTransactionSuccess(mockTransaction);
+        transactionManager.destroy();
+        verify(mockTransaction).destroy();
     }
 
     @Test
@@ -121,8 +119,8 @@ public class TransactionManagerTest {
         creativeFactories.add(mock(CreativeFactory.class));
         when(mockTransaction.getCreativeFactories()).thenReturn(creativeFactories);
 
-        mTransactionManager.onTransactionSuccess(mockTransaction);
-        assertFalse(mTransactionManager.hasNextCreative());
+        transactionManager.onTransactionSuccess(mockTransaction);
+        assertFalse(transactionManager.hasNextCreative());
     }
 
     @Test
@@ -133,13 +131,13 @@ public class TransactionManagerTest {
         creativeFactories.add(mock(CreativeFactory.class));
         when(mockTransaction.getCreativeFactories()).thenReturn(creativeFactories);
 
-        mTransactionManager.onTransactionSuccess(mockTransaction);
-        assertTrue(mTransactionManager.hasNextCreative());
+        transactionManager.onTransactionSuccess(mockTransaction);
+        assertTrue(transactionManager.hasNextCreative());
     }
 
     @Test
     public void whenCurrentTransactionIsNull_ReturnFalse() {
-        assertFalse(mTransactionManager.hasNextCreative());
+        assertFalse(transactionManager.hasNextCreative());
     }
 
     @Test
@@ -148,27 +146,27 @@ public class TransactionManagerTest {
         ArrayList<CreativeModel> models = new ArrayList<>();
         models.add(mock(CreativeModel.class));
         mockResult.creativeModels = models;
-        mTransactionManager.onCreativeModelReady(mockResult);
-        assertNotNull(WhiteBox.getInternalState(mTransactionManager, "mLatestTransaction"));
+        transactionManager.onCreativeModelReady(mockResult);
+        assertNotNull(WhiteBox.getInternalState(transactionManager, "latestTransaction"));
     }
 
     @Test
     public void whenOnFailedToLoad_NotifyListener() {
-        mTransactionManager.onFailedToLoadAd(new AdException("", ""), "");
-        verify(mMockListener).onFetchingFailed(any(AdException.class));
+        transactionManager.onFailedToLoadAd(new AdException("", ""), "");
+        verify(mockListener).onFetchingFailed(any(AdException.class));
     }
 
     @Test
     public void whenOnTransactionSuccess_TransactionAddedAndListenerCalled() {
-        mTransactionManager.onTransactionSuccess(mMockTransaction);
-        verify(mMockListener).onFetchingCompleted(mMockTransaction);
-        assertNotNull(mTransactionManager.getCurrentTransaction());
+        transactionManager.onTransactionSuccess(mockTransaction);
+        verify(mockListener).onFetchingCompleted(mockTransaction);
+        assertNotNull(transactionManager.getCurrentTransaction());
     }
 
     @Test
     public void whenOnTransactionFailed_CallListener() {
-        mTransactionManager.onTransactionFailure(new AdException("", ""), "");
-        verify(mMockListener).onFetchingFailed(any(AdException.class));
+        transactionManager.onTransactionFailure(new AdException("", ""), "");
+        verify(mockListener).onFetchingFailed(any(AdException.class));
     }
 
     @Test
@@ -176,7 +174,7 @@ public class TransactionManagerTest {
         BidResponse mockBidResponse = mock(BidResponse.class);
         when(mockBidResponse.getWinningBid()).thenReturn(mock(Bid.class));
         when(mockBidResponse.getWinningBid().getAdm()).thenReturn("adm");
-        mTransactionManager.fetchBidTransaction(mock(AdUnitConfiguration.class), mockBidResponse);
-        verify(mMockListener).onFetchingFailed(any(AdException.class));
+        transactionManager.fetchBidTransaction(mock(AdUnitConfiguration.class), mockBidResponse);
+        verify(mockListener).onFetchingFailed(any(AdException.class));
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/loading/TransactionTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/loading/TransactionTest.java
@@ -44,12 +44,12 @@ import static org.mockito.Mockito.*;
 @Config(sdk = 19)
 public class TransactionTest {
 
-    private Context mMockContext;
+    private Context mockContext;
 
     @Before
     public void setUp() throws Exception {
         Activity testActivity = Robolectric.buildActivity(Activity.class).create().get();
-        mMockContext = testActivity.getApplicationContext();
+        mockContext = testActivity.getApplicationContext();
     }
 
     @After
@@ -66,11 +66,11 @@ public class TransactionTest {
 
         // Valid
         InterstitialManager mockInterstitialManager = mock(InterstitialManager.class);
-        Transaction transaction = Transaction.createTransaction(
-            mMockContext,
-            createModelResult(creativeModels, "ts"),
-            mockInterstitialManager,
-            mockOxTransactionListener);
+        Transaction transaction = Transaction.createTransaction(mockContext,
+                createModelResult(creativeModels, "ts"),
+                mockInterstitialManager,
+                mockOxTransactionListener
+        );
         assertNotNull(transaction);
 
         // No context
@@ -90,11 +90,11 @@ public class TransactionTest {
         // No creative models
         hasException = false;
         try {
-            Transaction.createTransaction(
-                mMockContext,
-                createModelResult(null, "ts"),
-                mockInterstitialManager,
-                mockOxTransactionListener);
+            Transaction.createTransaction(mockContext,
+                    createModelResult(null, "ts"),
+                    mockInterstitialManager,
+                    mockOxTransactionListener
+            );
         }
         catch (AdException e) {
             hasException = true;
@@ -104,11 +104,11 @@ public class TransactionTest {
         // Empty creative models
         hasException = false;
         try {
-            Transaction.createTransaction(
-                mMockContext,
-                createModelResult(new ArrayList<>(), "ts"),
-                mockInterstitialManager,
-                mockOxTransactionListener);
+            Transaction.createTransaction(mockContext,
+                    createModelResult(new ArrayList<>(), "ts"),
+                    mockInterstitialManager,
+                    mockOxTransactionListener
+            );
         }
         catch (AdException e) {
             hasException = true;
@@ -118,11 +118,11 @@ public class TransactionTest {
         // No listener
         hasException = false;
         try {
-            Transaction.createTransaction(
-                mMockContext,
-                createModelResult(creativeModels, "ts"),
-                mockInterstitialManager,
-                null);
+            Transaction.createTransaction(mockContext,
+                    createModelResult(creativeModels, "ts"),
+                    mockInterstitialManager,
+                    null
+            );
         }
         catch (AdException e) {
             hasException = true;
@@ -137,7 +137,12 @@ public class TransactionTest {
         List<CreativeModel> creativeModels = new ArrayList<>();
         creativeModels.add(mockCreativeModel);
         Transaction.Listener mockOxTransactionListener = mock(Transaction.Listener.class);
-        final Transaction transaction = Transaction.createTransaction(mMockContext, createModelResult(creativeModels, "ts"), mock(InterstitialManager.class), mockOxTransactionListener);
+        final Transaction transaction = Transaction.createTransaction(
+                mockContext,
+                createModelResult(creativeModels, "ts"),
+                mock(InterstitialManager.class),
+                mockOxTransactionListener
+        );
 
         transaction.startCreativeFactories();
 
@@ -149,8 +154,14 @@ public class TransactionTest {
     public void testCreativeFactoryListener() throws Exception {
         List<CreativeModel> mockCreativeModels = Collections.singletonList(mock(CreativeModel.class));
         Transaction.Listener mockListener = mock(Transaction.Listener.class);
-        Transaction transaction = Transaction.createTransaction(mMockContext, createModelResult(mockCreativeModels, ""), mock(InterstitialManager.class), mockListener);
-        Transaction.CreativeFactoryListener creativeFactoryListener = new Transaction.CreativeFactoryListener(transaction);
+        Transaction transaction = Transaction.createTransaction(
+                mockContext,
+                createModelResult(mockCreativeModels, ""),
+                mock(InterstitialManager.class),
+                mockListener
+        );
+        Transaction.CreativeFactoryListener creativeFactoryListener = new Transaction.CreativeFactoryListener(
+                transaction);
 
         // No more Creatives to construct
         // Transaction.Listener.onSuccess is called
@@ -163,7 +174,7 @@ public class TransactionTest {
         Iterator<CreativeFactory> mockIterator = mock(Iterator.class);
         when(mockIterator.hasNext()).thenReturn(true);
         when(mockIterator.next()).thenReturn(mock(CreativeFactory.class));
-        WhiteBox.setInternalState(transaction, "mCreativeFactoryIterator", mockIterator);
+        WhiteBox.setInternalState(transaction, "creativeFactoryIterator", mockIterator);
         creativeFactoryListener.onSuccess();
         verify(mockListener, never()).onTransactionSuccess(transaction);
 
@@ -180,12 +191,18 @@ public class TransactionTest {
         Transaction.Listener mockListener = mock(Transaction.Listener.class);
         InterstitialManager mockInterstitialManager = mock(InterstitialManager.class);
 
-        Transaction transaction = Transaction.createTransaction(mMockContext, createModelResult(creativeModels, ""), mockInterstitialManager, mockListener);
-        Transaction.CreativeFactoryListener creativeFactoryListener = new Transaction.CreativeFactoryListener(transaction);
+        Transaction transaction = Transaction.createTransaction(
+                mockContext,
+                createModelResult(creativeModels, ""),
+                mockInterstitialManager,
+                mockListener
+        );
+        Transaction.CreativeFactoryListener creativeFactoryListener = new Transaction.CreativeFactoryListener(
+                transaction);
         Iterator<CreativeFactory> mockIterator = mock(Iterator.class);
         when(mockIterator.hasNext()).thenReturn(true);
         when(mockIterator.next()).thenReturn(mock(CreativeFactory.class));
-        WhiteBox.setInternalState(transaction, "mCreativeFactoryIterator", mockIterator);
+        WhiteBox.setInternalState(transaction, "creativeFactoryIterator", mockIterator);
         creativeFactoryListener.onSuccess();
         verify(mockListener, never()).onTransactionSuccess(transaction);
 

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/models/CreativeModelMakerBidsTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/models/CreativeModelMakerBidsTest.java
@@ -46,38 +46,38 @@ import static org.mockito.Mockito.*;
 @Config(sdk = 19)
 public class CreativeModelMakerBidsTest {
 
-    private CreativeModelMakerBids mModelMakerBids;
+    private CreativeModelMakerBids modelMakerBids;
     @Mock
-    private AdLoadListener mMockLoadListener;
+    private AdLoadListener mockLoadListener;
     @Mock
-    private VastParserExtractor mMockExtractor;
+    private VastParserExtractor mockExtractor;
 
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
-        mModelMakerBids = new CreativeModelMakerBids(mMockLoadListener);
+        modelMakerBids = new CreativeModelMakerBids(mockLoadListener);
 
-        WhiteBox.setInternalState(mModelMakerBids, "mParserExtractor", mMockExtractor);
+        WhiteBox.setInternalState(modelMakerBids, "parserExtractor", mockExtractor);
     }
 
     @Test
     public void whenMakeModelsAndNoAdConfiguration_CallErrorListener() {
-        mModelMakerBids.makeModels(null, mock(BidResponse.class));
-        verify(mMockLoadListener).onFailedToLoadAd(any(AdException.class), any());
+        modelMakerBids.makeModels(null, mock(BidResponse.class));
+        verify(mockLoadListener).onFailedToLoadAd(any(AdException.class), any());
     }
 
     @Test
     public void whenMakeModelsAndNoBidResponse_CallErrorListener() {
-        mModelMakerBids.makeModels(mock(AdUnitConfiguration.class), null);
-        verify(mMockLoadListener).onFailedToLoadAd(any(AdException.class), any());
+        modelMakerBids.makeModels(mock(AdUnitConfiguration.class), null);
+        verify(mockLoadListener).onFailedToLoadAd(any(AdException.class), any());
     }
 
     @Test
     public void whenMakeModelsAndBidResponseWithError_CallErrorListener() {
         BidResponse mockResponse = mock(BidResponse.class);
         when(mockResponse.hasParseError()).thenReturn(true);
-        mModelMakerBids.makeModels(null, mockResponse);
-        verify(mMockLoadListener).onFailedToLoadAd(any(AdException.class), any());
+        modelMakerBids.makeModels(null, mockResponse);
+        verify(mockLoadListener).onFailedToLoadAd(any(AdException.class), any());
     }
 
     @Test
@@ -90,8 +90,8 @@ public class CreativeModelMakerBidsTest {
 
         ArgumentCaptor<CreativeModelsMaker.Result> resultArgumentCaptor = ArgumentCaptor.forClass(CreativeModelsMaker.Result.class);
 
-        mModelMakerBids.makeModels(configuration, bidResponse);
-        verify(mMockLoadListener).onCreativeModelReady(resultArgumentCaptor.capture());
+        modelMakerBids.makeModels(configuration, bidResponse);
+        verify(mockLoadListener).onCreativeModelReady(resultArgumentCaptor.capture());
         CreativeModel creativeModel = resultArgumentCaptor.getValue().creativeModels.get(0);
         Bid bid = bidResponse.getSeatbids().get(0).getBids().get(0);
         assertEquals("HTML", creativeModel.getName());
@@ -106,16 +106,16 @@ public class CreativeModelMakerBidsTest {
         final AdUnitConfiguration mockConfig = mock(AdUnitConfiguration.class);
         final String vast = "1234";
 
-        mModelMakerBids.makeVideoModels(mockConfig, vast);
+        modelMakerBids.makeVideoModels(mockConfig, vast);
 
         verify(mockConfig).setAdFormat(eq(AdFormat.VAST));
-        verify(mMockExtractor).extract(eq(vast));
+        verify(mockExtractor).extract(eq(vast));
     }
 
     @Test
     public void cancel_CancelExtractor() {
-        mModelMakerBids.cancel();
+        modelMakerBids.cancel();
 
-        verify(mMockExtractor).cancel();
+        verify(mockExtractor).cancel();
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/models/CreativeModelTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/models/CreativeModelTest.java
@@ -44,7 +44,7 @@ public class CreativeModelTest {
         ArrayList<String> urls = new ArrayList<String>();
         urls.add("www.impression.url");
         creativeModel.registerTrackingEvent(TrackingEvent.Events.IMPRESSION, urls);
-        assertTrue(creativeModel.mTrackingURLs.size() == 1);
+        assertTrue(creativeModel.trackingURLs.size() == 1);
     }
 
     @Test

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/models/CreativeModelsMakerVastTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/models/CreativeModelsMakerVastTest.java
@@ -60,14 +60,14 @@ import static org.prebid.mobile.rendering.video.VideoAdEvent.Event.AD_IMPRESSION
 @SuppressWarnings("unchecked")
 public class CreativeModelsMakerVastTest {
 
-    private AdUnitConfiguration mAdConfiguration;
-    private AdLoadListener mMockListener;
+    private AdUnitConfiguration adConfiguration;
+    private AdLoadListener mockListener;
 
     @Before
     public void setUp() throws Exception {
-        mAdConfiguration = new AdUnitConfiguration();
-        mAdConfiguration.setRewarded(true);
-        mMockListener = mock(AdLoadListener.class);
+        adConfiguration = new AdUnitConfiguration();
+        adConfiguration.setRewarded(true);
+        mockListener = mock(AdLoadListener.class);
     }
 
     @Test
@@ -77,7 +77,7 @@ public class CreativeModelsMakerVastTest {
         BaseNetworkTask.GetUrlResult adResponse = new BaseNetworkTask.GetUrlResult();
         adResponse.responseString = ResourceUtils.convertResourceToString(testFileName);
 
-        CreativeModelsMakerVast creativeModelsMakerVast = new CreativeModelsMakerVast(null, mMockListener);
+        CreativeModelsMakerVast creativeModelsMakerVast = new CreativeModelsMakerVast(null, mockListener);
 
         List<AdResponseParserBase> parsers = getVastParsers(adResponse);
 
@@ -86,13 +86,13 @@ public class CreativeModelsMakerVastTest {
 
         // Null ad configuration
         creativeModelsMakerVast.makeModels(null, rootParser, latestParser);
-        verify(mMockListener).onFailedToLoadAd(any(AdException.class), any());
+        verify(mockListener).onFailedToLoadAd(any(AdException.class), any());
 
         // Valid - Inline
-        creativeModelsMakerVast.makeModels(mAdConfiguration, rootParser, latestParser);
+        creativeModelsMakerVast.makeModels(adConfiguration, rootParser, latestParser);
 
         ArgumentCaptor<CreativeModelsMaker.Result> argumentCaptor = ArgumentCaptor.forClass(CreativeModelsMaker.Result.class);
-        verify(mMockListener).onCreativeModelReady(argumentCaptor.capture());
+        verify(mockListener).onCreativeModelReady(argumentCaptor.capture());
 
         CreativeModelsMaker.Result result = argumentCaptor.getValue();
         assertVastInline(result.creativeModels, false);
@@ -128,12 +128,12 @@ public class CreativeModelsMakerVastTest {
         AdResponseParserVast latestParser = (AdResponseParserVast) parsers.get(1);
 
         // Execute makeModels()
-        CreativeModelsMakerVast creativeModelsMakerVast = new CreativeModelsMakerVast(null, mMockListener);
-        creativeModelsMakerVast.makeModels(mAdConfiguration, rootParser, latestParser);
+        CreativeModelsMakerVast creativeModelsMakerVast = new CreativeModelsMakerVast(null, mockListener);
+        creativeModelsMakerVast.makeModels(adConfiguration, rootParser, latestParser);
 
         // Get result
         ArgumentCaptor<CreativeModelsMaker.Result> argumentCaptor = ArgumentCaptor.forClass(CreativeModelsMaker.Result.class);
-        verify(mMockListener).onCreativeModelReady(argumentCaptor.capture());
+        verify(mockListener).onCreativeModelReady(argumentCaptor.capture());
 
         CreativeModelsMaker.Result result = argumentCaptor.getValue();
         VideoCreativeModel model = (VideoCreativeModel) result.creativeModels.get(0);
@@ -163,7 +163,7 @@ public class CreativeModelsMakerVastTest {
         BaseNetworkTask.GetUrlResult adResponse = new BaseNetworkTask.GetUrlResult();
         adResponse.responseString = ResourceUtils.convertResourceToString(testFileName);
 
-        CreativeModelsMakerVast creativeModelsMakerVast = new CreativeModelsMakerVast(null, mMockListener);
+        CreativeModelsMakerVast creativeModelsMakerVast = new CreativeModelsMakerVast(null, mockListener);
 
         List<AdResponseParserBase> parsers = getVastParsers(adResponse);
 
@@ -171,11 +171,11 @@ public class CreativeModelsMakerVastTest {
         AdResponseParserVast latestParser = (AdResponseParserVast) parsers.get(1);
 
         // Valid - Inline, non-opt-in
-        mAdConfiguration.setRewarded(false);
-        creativeModelsMakerVast.makeModels(mAdConfiguration, rootParser, latestParser);
+        adConfiguration.setRewarded(false);
+        creativeModelsMakerVast.makeModels(adConfiguration, rootParser, latestParser);
 
         ArgumentCaptor<CreativeModelsMaker.Result> argumentCaptor = ArgumentCaptor.forClass(CreativeModelsMaker.Result.class);
-        verify(mMockListener).onCreativeModelReady(argumentCaptor.capture());
+        verify(mockListener).onCreativeModelReady(argumentCaptor.capture());
 
         CreativeModelsMaker.Result result = argumentCaptor.getValue();
 
@@ -192,7 +192,7 @@ public class CreativeModelsMakerVastTest {
         BaseNetworkTask.GetUrlResult adResponse = new BaseNetworkTask.GetUrlResult();
         adResponse.responseString = ResourceUtils.convertResourceToString(testFileName);
 
-        CreativeModelsMakerVast creativeModelsMakerVast = new CreativeModelsMakerVast(null, mMockListener);
+        CreativeModelsMakerVast creativeModelsMakerVast = new CreativeModelsMakerVast(null, mockListener);
 
         List<AdResponseParserBase> parsers = getVastParsers(adResponse);
 
@@ -200,13 +200,13 @@ public class CreativeModelsMakerVastTest {
         AdResponseParserVast latestParser = (AdResponseParserVast) parsers.get(1);
 
         // Current video duration 96 sec
-        mAdConfiguration.setMaxVideoDuration(100);
+        adConfiguration.setMaxVideoDuration(100);
 
         // Run
-        creativeModelsMakerVast.makeModels(mAdConfiguration, rootParser, latestParser);
+        creativeModelsMakerVast.makeModels(adConfiguration, rootParser, latestParser);
 
         // Check
-        verify(mMockListener).onCreativeModelReady(any());
+        verify(mockListener).onCreativeModelReady(any());
     }
 
     @Test
@@ -217,7 +217,7 @@ public class CreativeModelsMakerVastTest {
         BaseNetworkTask.GetUrlResult adResponse = new BaseNetworkTask.GetUrlResult();
         adResponse.responseString = ResourceUtils.convertResourceToString(testFileName);
 
-        CreativeModelsMakerVast creativeModelsMakerVast = new CreativeModelsMakerVast(null, mMockListener);
+        CreativeModelsMakerVast creativeModelsMakerVast = new CreativeModelsMakerVast(null, mockListener);
 
         List<AdResponseParserBase> parsers = getVastParsers(adResponse);
 
@@ -225,14 +225,14 @@ public class CreativeModelsMakerVastTest {
         AdResponseParserVast latestParser = (AdResponseParserVast) parsers.get(1);
 
         // Current video duration 96 sec
-        mAdConfiguration.setMaxVideoDuration(90);
+        adConfiguration.setMaxVideoDuration(90);
 
         // Run
-        creativeModelsMakerVast.makeModels(mAdConfiguration, rootParser, latestParser);
+        creativeModelsMakerVast.makeModels(adConfiguration, rootParser, latestParser);
 
         // Check
         ArgumentCaptor<AdException> errorMessage = ArgumentCaptor.forClass(AdException.class);
-        verify(mMockListener).onFailedToLoadAd(errorMessage.capture(), any());
+        verify(mockListener).onFailedToLoadAd(errorMessage.capture(), any());
 
         MatcherAssert.assertThat(
                 errorMessage.getValue().getMessage(),
@@ -247,7 +247,7 @@ public class CreativeModelsMakerVastTest {
 
         AsyncVastLoader asyncVastLoader = spy(new AsyncVastLoader());
 
-        Field requesterVastField = VastParserExtractor.class.getDeclaredField("mAsyncVastLoader");
+        Field requesterVastField = VastParserExtractor.class.getDeclaredField("asyncVastLoader");
         requesterVastField.setAccessible(true);
         requesterVastField.set(parserExtractor, asyncVastLoader);
 
@@ -266,9 +266,11 @@ public class CreativeModelsMakerVastTest {
         assertEquals("http://i-cdn.prebid.com/5a7/5a731840-5ae7-4dca-ba66-6e959bb763e2/be2/be2cf3b2cf0648e0aa46c7c09afaf3f4.mp4",
                      videoModel.getMediaUrl());
         assertEquals(Utils.getMsFrom("00:01:36"), videoModel.getMediaDuration());
-        assertEquals("http://oxv4support-d3.prebidenterprise.com/v/1.0/rc?did.adid=2c544905-f613-46ac-95f4-7d81e8fc3505&ts=1fHU9MXxyaWQ9MmVkNDBjOGYtNjA4YS00ZDY5LWIyNzMtMDBjYWZiNjEyMWQ0fHJ0PTE0MzM4MDQ5Mjd8YXVpZD01MzcwNzQzNzN8YXVtPURNSUQuTElORUFSVklERU98c2lkPTUzNzA2NDIxMXxwdWI9NTM3MDcxNzg3fHBjPVVTRHxyYWlkPTVlOTk0N2E1LWM5YzItNDNjZi1hZTY3LTMzMjZjNWU2N2IwYnxhaWQ9NTM3MTI5MDI1fHQ9M3xhcz02NDB4MzYwfGxpZD01MzcxMDYzNzR8b2lkPTUzNzA4ODg4NnxwPTEwMDB8cHI9MTAwMHxhZHY9NTM3MDcxNzgyfGFjPVVTRHxwbT1QUklDSU5HLkNQTXxibT1CVVlJTkcuTk9OR1VBUkFOVEVFRHx1cj1XUTVDVHpydG51",
-                     videoModel.getVastClickthroughUrl());
-        assertEquals(mAdConfiguration, videoModel.getAdConfiguration());
+        assertEquals(
+                "http://oxv4support-d3.prebidenterprise.com/v/1.0/rc?did.adid=2c544905-f613-46ac-95f4-7d81e8fc3505&ts=1fHU9MXxyaWQ9MmVkNDBjOGYtNjA4YS00ZDY5LWIyNzMtMDBjYWZiNjEyMWQ0fHJ0PTE0MzM4MDQ5Mjd8YXVpZD01MzcwNzQzNzN8YXVtPURNSUQuTElORUFSVklERU98c2lkPTUzNzA2NDIxMXxwdWI9NTM3MDcxNzg3fHBjPVVTRHxyYWlkPTVlOTk0N2E1LWM5YzItNDNjZi1hZTY3LTMzMjZjNWU2N2IwYnxhaWQ9NTM3MTI5MDI1fHQ9M3xhcz02NDB4MzYwfGxpZD01MzcxMDYzNzR8b2lkPTUzNzA4ODg4NnxwPTEwMDB8cHI9MTAwMHxhZHY9NTM3MDcxNzgyfGFjPVVTRHxwbT1QUklDSU5HLkNQTXxibT1CVVlJTkcuTk9OR1VBUkFOVEVFRHx1cj1XUTVDVHpydG51",
+                videoModel.getVastClickthroughUrl()
+        );
+        assertEquals(adConfiguration, videoModel.getAdConfiguration());
         assertEquals(CreativeModelsMakerVast.VIDEO_CREATIVE_TAG, videoModel.getName());
 
         HashMap<VideoAdEvent.Event, ArrayList<String>> videoEventUrls = videoModel.getVideoEventUrls();
@@ -322,7 +324,7 @@ public class CreativeModelsMakerVastTest {
 
         assertEquals("http://www.tremormedia.com", endCardModel.getClickUrl());
 
-        HashMap<TrackingEvent.Events, ArrayList<String>> trackingURLs = endCardModel.mTrackingURLs;
+        HashMap<TrackingEvent.Events, ArrayList<String>> trackingURLs = endCardModel.trackingURLs;
         assertEquals("http://www.CompanionClickTracking.com",
                      trackingURLs.get(TrackingEvent.Events.CLICK).get(0));
         assertEquals("http://myTrackingURL/firstCompanionCreativeView",

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/models/HTMLCreativeTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/models/HTMLCreativeTest.java
@@ -63,36 +63,36 @@ import static org.mockito.Mockito.*;
 @Config(sdk = 19)
 public class HTMLCreativeTest {
 
-    private Context mContext;
+    private Context context;
     @Mock
-    AdUnitConfiguration mMockConfig;
+    AdUnitConfiguration mockConfig;
     @Mock
-    CreativeModel mMockModel;
+    CreativeModel mockModel;
     @Mock
-    OmAdSessionManager mMockOmAdSessionManager;
+    OmAdSessionManager mockOmAdSessionManager;
     @Mock
-    InterstitialManager mMockInterstitialManager;
+    InterstitialManager mockInterstitialManager;
     @Mock
-    MraidController mMockMraidController;
+    MraidController mockMraidController;
     @Mock
-    CreativeVisibilityTracker mMockCreativeVisibilityTracker;
+    CreativeVisibilityTracker mockCreativeVisibilityTracker;
     @Mock
-    PrebidWebViewBase mMockPrebidWebView;
+    PrebidWebViewBase mockPrebidWebView;
 
-    private HTMLCreative mHtmlCreative;
+    private HTMLCreative htmlCreative;
 
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
 
-        mContext = Robolectric.buildActivity(Activity.class).create().get();
+        context = Robolectric.buildActivity(Activity.class).create().get();
 
-        ManagersResolver.getInstance().prepare(mContext);
+        ManagersResolver.getInstance().prepare(context);
 
-        when(mMockModel.getAdConfiguration()).thenReturn(mMockConfig);
-        mHtmlCreative = new HTMLCreative(mContext, mMockModel, mMockOmAdSessionManager, mMockInterstitialManager);
-        mHtmlCreative.setCreativeView(mMockPrebidWebView);
-        WhiteBox.setInternalState(mHtmlCreative, "mMraidController", mMockMraidController);
+        when(mockModel.getAdConfiguration()).thenReturn(mockConfig);
+        htmlCreative = new HTMLCreative(context, mockModel, mockOmAdSessionManager, mockInterstitialManager);
+        htmlCreative.setCreativeView(mockPrebidWebView);
+        WhiteBox.setInternalState(htmlCreative, "mraidController", mockMraidController);
     }
 
     @After
@@ -108,7 +108,7 @@ public class HTMLCreativeTest {
     @Test
     public void constructorTest() {
         try {
-            new HTMLCreative(null, mMockModel, mMockOmAdSessionManager, mMockInterstitialManager);
+            new HTMLCreative(null, mockModel, mockOmAdSessionManager, mockInterstitialManager);
             fail("AdException was NOT thrown");
         }
         catch (AdException e) {
@@ -129,71 +129,71 @@ public class HTMLCreativeTest {
 
         // Test null context
         try {
-            WhiteBox.field(HTMLCreative.class, "mContextReference").set(mHtmlCreative, null);
-            mHtmlCreative.load();
+            WhiteBox.field(HTMLCreative.class, "contextReference").set(htmlCreative, null);
+            htmlCreative.load();
             fail("AdException was NOT thrown");
         }
         catch (AdException e) {
         }
-        mHtmlCreative = new HTMLCreative(mContext, mMockModel, mMockOmAdSessionManager, mMockInterstitialManager);
+        htmlCreative = new HTMLCreative(context, mockModel, mockOmAdSessionManager, mockInterstitialManager);
 
         EnumSet<AdFormat> result = EnumSet.noneOf(AdFormat.class);
         result.add(AdFormat.BANNER);
         // Test empty html
         try {
-            when(mMockConfig.getAdFormats()).thenReturn(result);
-            mHtmlCreative = new HTMLCreative(mContext, mMockModel, mMockOmAdSessionManager, mMockInterstitialManager);
-            mHtmlCreative.load();
+            when(mockConfig.getAdFormats()).thenReturn(result);
+            htmlCreative = new HTMLCreative(context, mockModel, mockOmAdSessionManager, mockInterstitialManager);
+            htmlCreative.load();
             fail("AdException was NOT thrown");
         } catch (AdException e) {
         }
 
         // Test non-empty html
-        when(mMockConfig.getAdFormats()).thenReturn(result);
-        when(mMockModel.getHtml()).thenReturn("foo");
+        when(mockConfig.getAdFormats()).thenReturn(result);
+        when(mockModel.getHtml()).thenReturn("foo");
 
-        mHtmlCreative = new HTMLCreative(mContext, mMockModel, mMockOmAdSessionManager, mMockInterstitialManager);
-        mHtmlCreative.load();
+        htmlCreative = new HTMLCreative(context, mockModel, mockOmAdSessionManager, mockInterstitialManager);
+        htmlCreative.load();
         verify(mockPrebidWebViewBanner).loadHTML(any(), anyInt(), anyInt());
-        assertEquals(mockPrebidWebViewBanner, mHtmlCreative.getCreativeView());
+        assertEquals(mockPrebidWebViewBanner, htmlCreative.getCreativeView());
     }
 
     @Test
     public void displayTest() throws Exception {
         // Null view
-        PrebidWebViewBase prebidWebViewBase = new PrebidWebViewBase(mContext, mMockInterstitialManager);
-        WhiteBox.setInternalState(prebidWebViewBase, "mWebView", mock(WebViewBase.class));
-        when(mMockPrebidWebView.getWebView()).thenReturn(mock(WebViewBase.class));
+        PrebidWebViewBase prebidWebViewBase = new PrebidWebViewBase(context, mockInterstitialManager);
+        WhiteBox.setInternalState(prebidWebViewBase, "webView", mock(WebViewBase.class));
+        when(mockPrebidWebView.getWebView()).thenReturn(mock(WebViewBase.class));
 
         EnumSet<AdFormat> result = EnumSet.noneOf(AdFormat.class);
         result.add(AdFormat.BANNER);
-        when(mMockConfig.getAdFormats()).thenReturn(result);
+        when(mockConfig.getAdFormats()).thenReturn(result);
 
-        mHtmlCreative.display();
-        verify(mMockModel, never()).trackDisplayAdEvent(TrackingEvent.Events.IMPRESSION);
+        htmlCreative.display();
+        verify(mockModel, never()).trackDisplayAdEvent(TrackingEvent.Events.IMPRESSION);
     }
 
     @Test
     public void adSessionSuccessInitializationTest() throws Exception {
-        PrebidWebViewBase prebidWebView = new PrebidWebViewBase(mContext, mMockInterstitialManager);
+        PrebidWebViewBase prebidWebView = new PrebidWebViewBase(context, mockInterstitialManager);
         WebViewBase mockWebViewBase = mock(WebViewBase.class);
         BaseJSInterface baseJSInterface = mock(BaseJSInterface.class);
         when(mockWebViewBase.getMRAIDInterface()).thenReturn(baseJSInterface);
-        WhiteBox.setInternalState(prebidWebView, "mWebView", mockWebViewBase);
+        WhiteBox.setInternalState(prebidWebView, "webView", mockWebViewBase);
 
-        mHtmlCreative.setCreativeView(prebidWebView);
-        mHtmlCreative.setCreativeView(prebidWebView);
-        HTMLCreative spyHtmlCreative = spy(mHtmlCreative);
+        htmlCreative.setCreativeView(prebidWebView);
+        htmlCreative.setCreativeView(prebidWebView);
+        HTMLCreative spyHtmlCreative = spy(htmlCreative);
 
         spyHtmlCreative.display();
     }
 
     @Test
     public void adSessionFailureInitializationTest() throws Exception {
-        PrebidWebViewBase prebidWebViewBase = new PrebidWebViewBase(mContext, mMockInterstitialManager);
-        WhiteBox.setInternalState(prebidWebViewBase, "mWebView", mock(WebViewBase.class));
-        mHtmlCreative.setCreativeView(prebidWebViewBase);
-        HTMLCreative spyHtmlCreative = spy(mHtmlCreative);
+        PrebidWebViewBase prebidWebViewBase = new PrebidWebViewBase(context, mockInterstitialManager);
+        WhiteBox.setInternalState(prebidWebViewBase, "webView", mock(WebViewBase.class));
+        htmlCreative.setCreativeView(prebidWebViewBase);
+        HTMLCreative spyHtmlCreative = spy(htmlCreative);
 
         spyHtmlCreative.display();
 
@@ -203,39 +203,39 @@ public class HTMLCreativeTest {
     @Test
     public void creativeViewListenerEventsTest() throws AdException {
         CreativeViewListener mockCreativeViewListener = mock(CreativeViewListener.class);
-        mHtmlCreative.setCreativeViewListener(mockCreativeViewListener);
+        htmlCreative.setCreativeViewListener(mockCreativeViewListener);
 
-        mHtmlCreative.interstitialAdClosed();
-        verify(mockCreativeViewListener).creativeInterstitialDidClose(mHtmlCreative);
+        htmlCreative.interstitialAdClosed();
+        verify(mockCreativeViewListener).creativeInterstitialDidClose(htmlCreative);
 
-        mHtmlCreative.mraidAdExpanded();
-        verify(mockCreativeViewListener).creativeDidExpand(mHtmlCreative);
+        htmlCreative.mraidAdExpanded();
+        verify(mockCreativeViewListener).creativeDidExpand(htmlCreative);
 
-        mHtmlCreative.mraidAdCollapsed();
-        verify(mockCreativeViewListener).creativeDidCollapse(mHtmlCreative);
+        htmlCreative.mraidAdCollapsed();
+        verify(mockCreativeViewListener).creativeDidCollapse(htmlCreative);
     }
 
     @Test
     public void changeVisibilityTrackerStateAdWebViewNoFocusVisibilityTrackerNotNull_StopVisibilityCheck()
     throws IllegalAccessException {
-        WhiteBox.setInternalState(mHtmlCreative, "mCreativeVisibilityTracker", mMockCreativeVisibilityTracker);
+        WhiteBox.setInternalState(htmlCreative, "creativeVisibilityTracker", mockCreativeVisibilityTracker);
 
-        mHtmlCreative.changeVisibilityTrackerState(false);
+        htmlCreative.changeVisibilityTrackerState(false);
 
-        verify(mMockCreativeVisibilityTracker, times(1)).stopVisibilityCheck();
-        verifyNoMoreInteractions(mMockCreativeVisibilityTracker);
+        verify(mockCreativeVisibilityTracker, times(1)).stopVisibilityCheck();
+        verifyNoMoreInteractions(mockCreativeVisibilityTracker);
     }
 
     @Test
     public void changeVisibilityTrackerStateAdWebViewHasFocusVisibilityTrackerNotNull_StartVisibilityCheck()
     throws IllegalAccessException {
-        WhiteBox.setInternalState(mHtmlCreative, "mCreativeVisibilityTracker", mMockCreativeVisibilityTracker);
+        WhiteBox.setInternalState(htmlCreative, "creativeVisibilityTracker", mockCreativeVisibilityTracker);
 
-        mHtmlCreative.changeVisibilityTrackerState(true);
+        htmlCreative.changeVisibilityTrackerState(true);
 
-        verify(mMockCreativeVisibilityTracker, times(1)).stopVisibilityCheck();
-        verify(mMockCreativeVisibilityTracker, times(1)).startVisibilityCheck(mContext);
-        verifyNoMoreInteractions(mMockCreativeVisibilityTracker);
+        verify(mockCreativeVisibilityTracker, times(1)).stopVisibilityCheck();
+        verify(mockCreativeVisibilityTracker, times(1)).startVisibilityCheck(context);
+        verifyNoMoreInteractions(mockCreativeVisibilityTracker);
     }
 
     @Test
@@ -243,7 +243,7 @@ public class HTMLCreativeTest {
     throws Exception {
         PrebidWebViewBase mockPrebidWebViewBase = mock(PrebidWebViewBase.class);
         when(mockPrebidWebViewBase.getWebView()).thenReturn(mock(WebViewBase.class));
-        mHtmlCreative.setCreativeView(mockPrebidWebViewBase);
+        htmlCreative.setCreativeView(mockPrebidWebViewBase);
 
         VisibilityTrackerResult result = new VisibilityTrackerResult(NativeEventTracker.EventType.IMPRESSION,
                                                                      null, false, false);
@@ -254,12 +254,12 @@ public class HTMLCreativeTest {
 
             listener.onVisibilityChanged(result);
             return null;
-        }).when(mMockCreativeVisibilityTracker)
+        }).when(mockCreativeVisibilityTracker)
           .setVisibilityTrackerListener(any(CreativeVisibilityTracker.VisibilityTrackerListener.class));
 
-        mHtmlCreative.onVisibilityEvent(result);
+        htmlCreative.onVisibilityEvent(result);
 
-        verify(mMockModel, never()).trackDisplayAdEvent(TrackingEvent.Events.IMPRESSION);
+        verify(mockModel, never()).trackDisplayAdEvent(TrackingEvent.Events.IMPRESSION);
         verify(mockPrebidWebViewBase, times(1)).onWindowFocusChanged(false);
         verify(mockPrebidWebViewBase, times(1)).onViewExposureChange(null);
     }
@@ -270,13 +270,13 @@ public class HTMLCreativeTest {
 
         PrebidWebViewBase mockPrebidWebViewBase = mock(PrebidWebViewBase.class);
         when(mockPrebidWebViewBase.getWebView()).thenReturn(mock(WebViewBase.class));
-        mHtmlCreative.setCreativeView(mockPrebidWebViewBase);
+        htmlCreative.setCreativeView(mockPrebidWebViewBase);
 
         VisibilityTrackerResult result = new VisibilityTrackerResult(NativeEventTracker.EventType.IMPRESSION,
                                                                      viewExposure, true, true);
-        mHtmlCreative.onVisibilityEvent(result);
+        htmlCreative.onVisibilityEvent(result);
 
-        verify(mMockModel, times(1)).trackDisplayAdEvent(TrackingEvent.Events.IMPRESSION);
+        verify(mockModel, times(1)).trackDisplayAdEvent(TrackingEvent.Events.IMPRESSION);
         verify(mockPrebidWebViewBase, times(1)).onWindowFocusChanged(true);
         verify(mockPrebidWebViewBase, times(1)).onViewExposureChange(viewExposure);
     }
@@ -284,32 +284,32 @@ public class HTMLCreativeTest {
     @Test
     public void webViewReadyToDisplayTest() throws Exception {
         CreativeResolutionListener mockResolutionListener = mock(CreativeResolutionListener.class);
-        mHtmlCreative.setResolutionListener(mockResolutionListener);
+        htmlCreative.setResolutionListener(mockResolutionListener);
 
         // Resolved
-        WhiteBox.field(HTMLCreative.class, "mResolved").set(mHtmlCreative, true);
-        mHtmlCreative.webViewReadyToDisplay();
+        WhiteBox.field(HTMLCreative.class, "resolved").set(htmlCreative, true);
+        htmlCreative.webViewReadyToDisplay();
         verify(mockResolutionListener, never()).creativeReady(any(AbstractCreative.class));
 
         // Not resolved
-        WhiteBox.field(HTMLCreative.class, "mResolved").set(mHtmlCreative, false);
-        mHtmlCreative.webViewReadyToDisplay();
+        WhiteBox.field(HTMLCreative.class, "resolved").set(htmlCreative, false);
+        htmlCreative.webViewReadyToDisplay();
         verify(mockResolutionListener).creativeReady(any(AbstractCreative.class));
     }
 
     @Test
     public void webViewFailedToLoadTest() throws Exception {
         CreativeResolutionListener mockResolutionListener = mock(CreativeResolutionListener.class);
-        mHtmlCreative.setResolutionListener(mockResolutionListener);
+        htmlCreative.setResolutionListener(mockResolutionListener);
 
         // Resolved
-        WhiteBox.field(HTMLCreative.class, "mResolved").set(mHtmlCreative, true);
-        mHtmlCreative.webViewFailedToLoad(new AdException("foo", "bar"));
+        WhiteBox.field(HTMLCreative.class, "resolved").set(htmlCreative, true);
+        htmlCreative.webViewFailedToLoad(new AdException("foo", "bar"));
         verify(mockResolutionListener, never()).creativeFailed(any(AdException.class));
 
         // Not resolved
-        WhiteBox.field(HTMLCreative.class, "mResolved").set(mHtmlCreative, false);
-        mHtmlCreative.webViewFailedToLoad(new AdException("foo", "bar"));
+        WhiteBox.field(HTMLCreative.class, "resolved").set(htmlCreative, false);
+        htmlCreative.webViewFailedToLoad(new AdException("foo", "bar"));
         verify(mockResolutionListener).creativeFailed(any(AdException.class));
     }
 
@@ -320,23 +320,23 @@ public class HTMLCreativeTest {
         Mockito.doNothing().when(mockPrebidWebViewBase).handleOpen(anyString());
         when(mockPrebidWebViewBase.post(any(Runnable.class))).thenReturn(anyBoolean());
 
-        mHtmlCreative.setCreativeView(mockPrebidWebViewBase);
-        mHtmlCreative.webViewShouldOpenExternalLink("foo");
+        htmlCreative.setCreativeView(mockPrebidWebViewBase);
+        htmlCreative.webViewShouldOpenExternalLink("foo");
         verify(mockPrebidWebViewBase).handleOpen(anyString());
 
         // MRAID link
         CreativeViewListener mockCreativeViewListener = mock(CreativeViewListener.class);
-        mHtmlCreative.setCreativeViewListener(mockCreativeViewListener);
-        mHtmlCreative.webViewShouldOpenMRAIDLink("foo");
+        htmlCreative.setCreativeViewListener(mockCreativeViewListener);
+        htmlCreative.webViewShouldOpenMRAIDLink("foo");
         verify(mockCreativeViewListener).creativeWasClicked(any(HTMLCreative.class), anyString());
         verify(mockPrebidWebViewBase).post(any(Runnable.class));
     }
 
     @Test
     public void handleMRAIDEventsInCreativeTest() throws Exception {
-        mHtmlCreative.handleMRAIDEventsInCreative(mock(MraidEvent.class), mock(WebViewBase.class));
-        verify(mMockMraidController).handleMraidEvent(any(MraidEvent.class),
-                                                      eq(mHtmlCreative),
+        htmlCreative.handleMRAIDEventsInCreative(mock(MraidEvent.class), mock(WebViewBase.class));
+        verify(mockMraidController).handleMraidEvent(any(MraidEvent.class),
+                                                      eq(htmlCreative),
                                                       any(WebViewBase.class),
                                                       any());
     }
@@ -344,10 +344,10 @@ public class HTMLCreativeTest {
     @Test
     public void destroyTest() {
         MraidController mockController = mock(MraidController.class);
-        WhiteBox.setInternalState(mHtmlCreative, "mMraidController", mockController);
+        WhiteBox.setInternalState(htmlCreative, "mraidController", mockController);
 
-        mHtmlCreative.destroy();
-        verify(mMockPrebidWebView).destroy();
+        htmlCreative.destroy();
+        verify(mockPrebidWebView).destroy();
         verify(mockController).destroy();
     }
 
@@ -356,32 +356,32 @@ public class HTMLCreativeTest {
         PrebidWebViewBase mockWebView = mock(PrebidWebViewBase.class);
         when(mockWebView.getWebView()).thenReturn(mock(WebViewBase.class));
 
-        mHtmlCreative.setCreativeView(mockWebView);
+        htmlCreative.setCreativeView(mockWebView);
 
-        mHtmlCreative.createOmAdSession();
-        verify(mMockOmAdSessionManager).initWebAdSessionManager(any(WebViewBase.class), any());
-        verify(mMockOmAdSessionManager).registerAdView(any(View.class));
-        verify(mMockOmAdSessionManager).startAdSession();
+        htmlCreative.createOmAdSession();
+        verify(mockOmAdSessionManager).initWebAdSessionManager(any(WebViewBase.class), any());
+        verify(mockOmAdSessionManager).registerAdView(any(View.class));
+        verify(mockOmAdSessionManager).startAdSession();
 
-        reset(mMockOmAdSessionManager);
-        mHtmlCreative.mWeakOmAdSessionManager = new WeakReference<>(null);
-        mHtmlCreative.createOmAdSession();
-        verify(mMockOmAdSessionManager, never()).startAdSession();
+        reset(mockOmAdSessionManager);
+        htmlCreative.weakOmAdSessionManager = new WeakReference<>(null);
+        htmlCreative.createOmAdSession();
+        verify(mockOmAdSessionManager, never()).startAdSession();
 
-        mHtmlCreative.setCreativeView(null);
-        mHtmlCreative.createOmAdSession();
-        verify(mMockOmAdSessionManager, never()).startAdSession();
+        htmlCreative.setCreativeView(null);
+        htmlCreative.createOmAdSession();
+        verify(mockOmAdSessionManager, never()).startAdSession();
     }
 
     @Test
     public void isResolvedTest() {
-        assertFalse(mHtmlCreative.isResolved());
+        assertFalse(htmlCreative.isResolved());
     }
 
     @Test
     public void htmlAdLoaded_TrackEvent() {
-        mHtmlCreative.trackAdLoaded();
+        htmlCreative.trackAdLoaded();
 
-        verify(mMockModel).trackDisplayAdEvent(TrackingEvent.Events.LOADED);
+        verify(mockModel).trackDisplayAdEvent(TrackingEvent.Events.LOADED);
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/models/ViewPoolTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/models/ViewPoolTest.java
@@ -45,66 +45,66 @@ import static org.mockito.Mockito.mock;
 @Config(sdk = 19)
 public class ViewPoolTest {
 
-    private ViewPool mViewPool;
-    private Context mContext;
-    private View mOccupiedView;
-    private View mUnoccupiedView;
-    private FrameLayout mContainer;
+    private ViewPool viewPool;
+    private Context context;
+    private View occupiedView;
+    private View unoccupiedView;
+    private FrameLayout container;
 
     @Before
     public void setUp() {
-        mContext = Robolectric.buildActivity(Activity.class).create().get();
-        mViewPool = ViewPool.getInstance();
-        mViewPool.clear();
-        mOccupiedView = new View(mContext);
-        mUnoccupiedView = new View(mContext);
-        mContainer = new FrameLayout(mContext);
-        mContainer.addView(mOccupiedView);
+        context = Robolectric.buildActivity(Activity.class).create().get();
+        viewPool = ViewPool.getInstance();
+        viewPool.clear();
+        occupiedView = new View(context);
+        unoccupiedView = new View(context);
+        container = new FrameLayout(context);
+        container.addView(occupiedView);
 
-        mViewPool.addToOccupied(mOccupiedView);
-        mViewPool.addToUnoccupied(mUnoccupiedView);
+        viewPool.addToOccupied(occupiedView);
+        viewPool.addToUnoccupied(unoccupiedView);
     }
 
     @After
     public void clearInstance() throws IllegalAccessException {
-        WhiteBox.setInternalState(mViewPool, "sInstance", null);
+        WhiteBox.setInternalState(viewPool, "sInstance", null);
     }
 
     @Test
     public void sizeOfOccupiedTest() {
-        assertEquals(1, mViewPool.sizeOfOccupied());
+        assertEquals(1, viewPool.sizeOfOccupied());
     }
 
     @Test
     public void sizeOfUnoccupiedTest() {
-        assertEquals(1, mViewPool.sizeOfUnoccupied());
+        assertEquals(1, viewPool.sizeOfUnoccupied());
     }
 
     @Test
     public void addToOccupiedTest() {
-        mViewPool.addToOccupied(new View(mContext));
-        assertEquals(2, mViewPool.sizeOfOccupied());
+        viewPool.addToOccupied(new View(context));
+        assertEquals(2, viewPool.sizeOfOccupied());
     }
 
     @Test
     public void addToUnoccupiedTest() {
-        mViewPool.addToUnoccupied(new View(mContext));
-        assertEquals(2, mViewPool.sizeOfUnoccupied());
+        viewPool.addToUnoccupied(new View(context));
+        assertEquals(2, viewPool.sizeOfUnoccupied());
     }
 
     @Test
     public void swapToUnoccupiedTest() {
-        mViewPool.swapToUnoccupied(mOccupiedView);
-        assertNull(mOccupiedView.getParent());
-        assertEquals(0, mViewPool.sizeOfOccupied());
-        assertEquals(2, mViewPool.sizeOfUnoccupied());
+        viewPool.swapToUnoccupied(occupiedView);
+        assertNull(occupiedView.getParent());
+        assertEquals(0, viewPool.sizeOfOccupied());
+        assertEquals(2, viewPool.sizeOfUnoccupied());
     }
 
     @Test
     public void clearTest() {
-        mViewPool.clear();
-        assertEquals(0, mViewPool.sizeOfUnoccupied());
-        assertEquals(0, mViewPool.sizeOfOccupied());
+        viewPool.clear();
+        assertEquals(0, viewPool.sizeOfUnoccupied());
+        assertEquals(0, viewPool.sizeOfOccupied());
     }
 
     @Test
@@ -113,26 +113,31 @@ public class ViewPoolTest {
         AdFormat adType = AdFormat.BANNER;
         InterstitialManager mockInterstitialManager = mock(InterstitialManager.class);
 
-        View result = mViewPool.getUnoccupiedView(mContext, mockVideoCreativeViewListener, adType, mockInterstitialManager);
-        assertEquals(mUnoccupiedView, result);
-        assertEquals(2, mViewPool.sizeOfOccupied());
-        assertEquals(0, mViewPool.sizeOfUnoccupied());
+        View result = viewPool.getUnoccupiedView(
+                context,
+                mockVideoCreativeViewListener,
+                adType,
+                mockInterstitialManager
+        );
+        assertEquals(unoccupiedView, result);
+        assertEquals(2, viewPool.sizeOfOccupied());
+        assertEquals(0, viewPool.sizeOfUnoccupied());
 
-        result = mViewPool.getUnoccupiedView(mContext, mockVideoCreativeViewListener, adType, mockInterstitialManager);
+        result = viewPool.getUnoccupiedView(context, mockVideoCreativeViewListener, adType, mockInterstitialManager);
         assertThat(result, instanceOf(PrebidWebViewBanner.class));
-        assertEquals(3, mViewPool.sizeOfOccupied());
-        assertEquals(0, mViewPool.sizeOfUnoccupied());
+        assertEquals(3, viewPool.sizeOfOccupied());
+        assertEquals(0, viewPool.sizeOfUnoccupied());
 
         adType = AdFormat.VAST;
-        result = mViewPool.getUnoccupiedView(mContext, mock(VideoCreative.class), adType, mockInterstitialManager);
+        result = viewPool.getUnoccupiedView(context, mock(VideoCreative.class), adType, mockInterstitialManager);
         assertThat(result, instanceOf(ExoPlayerView.class));
-        assertEquals(4, mViewPool.sizeOfOccupied());
-        assertEquals(0, mViewPool.sizeOfUnoccupied());
+        assertEquals(4, viewPool.sizeOfOccupied());
+        assertEquals(0, viewPool.sizeOfUnoccupied());
 
         adType = AdFormat.INTERSTITIAL;
-        result = mViewPool.getUnoccupiedView(mContext, mockVideoCreativeViewListener, adType, mockInterstitialManager);
+        result = viewPool.getUnoccupiedView(context, mockVideoCreativeViewListener, adType, mockInterstitialManager);
         assertThat(result, instanceOf(PrebidWebViewInterstitial.class));
-        assertEquals(5, mViewPool.sizeOfOccupied());
-        assertEquals(0, mViewPool.sizeOfUnoccupied());
+        assertEquals(5, viewPool.sizeOfOccupied());
+        assertEquals(0, viewPool.sizeOfUnoccupied());
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/models/openrtb/bidRequests/DeviceTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/models/openrtb/bidRequests/DeviceTest.java
@@ -25,52 +25,52 @@ import static junit.framework.Assert.*;
 
 public class DeviceTest {
 
-    private Device mTestDevice;
+    private Device testDevice;
 
     @Before
     public void setUp() {
-        mTestDevice = new Device();
+        testDevice = new Device();
     }
 
     @Test
     public void getJsonObjectTest() throws Exception {
         Geo testGeo = new Geo();
 
-        mTestDevice.setGeo(testGeo);
-        assertEquals(testGeo, mTestDevice.getGeo());
+        testDevice.setGeo(testGeo);
+        assertEquals(testGeo, testDevice.getGeo());
 
-        mTestDevice.lmt = 1;
-        mTestDevice.devicetype = 1;
-        mTestDevice.make = "LG";
-        mTestDevice.model = "Nexus 5";
-        mTestDevice.os = "5.0";
-        mTestDevice.osv = "5";
-        mTestDevice.hwv = "5";
-        mTestDevice.flashver = "1";
-        mTestDevice.language = "en";
-        mTestDevice.carrier = "T-mobile";
-        mTestDevice.mccmnc = "321-444";
-        mTestDevice.ifa = "1111";
-        mTestDevice.didsha1 = "3414dsfd";
-        mTestDevice.didmd5 = "didmd5";
-        mTestDevice.dpidsha1 = "didsha1";
-        mTestDevice.dpidmd5 = "dpidmd5";
-        mTestDevice.h = 1221;
-        mTestDevice.w = 567;
-        mTestDevice.ppi = 11;
-        mTestDevice.js = 1;
-        mTestDevice.connectiontype = 1;
-        mTestDevice.pxratio = 22f;
-        mTestDevice.geo = testGeo;
-        JSONObject actualObj = mTestDevice.getJsonObject();
+        testDevice.lmt = 1;
+        testDevice.devicetype = 1;
+        testDevice.make = "LG";
+        testDevice.model = "Nexus 5";
+        testDevice.os = "5.0";
+        testDevice.osv = "5";
+        testDevice.hwv = "5";
+        testDevice.flashver = "1";
+        testDevice.language = "en";
+        testDevice.carrier = "T-mobile";
+        testDevice.mccmnc = "321-444";
+        testDevice.ifa = "1111";
+        testDevice.didsha1 = "3414dsfd";
+        testDevice.didmd5 = "didmd5";
+        testDevice.dpidsha1 = "didsha1";
+        testDevice.dpidmd5 = "dpidmd5";
+        testDevice.h = 1221;
+        testDevice.w = 567;
+        testDevice.ppi = 11;
+        testDevice.js = 1;
+        testDevice.connectiontype = 1;
+        testDevice.pxratio = 22f;
+        testDevice.geo = testGeo;
+        JSONObject actualObj = testDevice.getJsonObject();
         String expectedString = "{\"os\":\"5.0\",\"didmd5\":\"didmd5\",\"ifa\":\"1111\",\"hwv\":\"5\",\"h\":1221,\"ppi\":11,\"js\":1,\"language\":\"en\",\"devicetype\":1,\"pxratio\":22,\"geo\":{},\"lmt\":1,\"carrier\":\"T-mobile\",\"osv\":\"5\",\"dpidmd5\":\"dpidmd5\",\"mccmnc\":\"321-444\",\"flashver\":\"1\",\"didsha1\":\"3414dsfd\",\"w\":567,\"model\":\"Nexus 5\",\"connectiontype\":1,\"make\":\"LG\",\"dpidsha1\":\"didsha1\"}";
         assertEquals("got: " + actualObj.toString(), expectedString, actualObj.toString());
-        mTestDevice.getJsonObject();
+        testDevice.getJsonObject();
     }
 
     @Test
     public void checkGeoTest() {
-        Geo actualGeo = mTestDevice.getGeo();
+        Geo actualGeo = testDevice.getGeo();
         assertNotNull("Geo isn't null.", actualGeo);
 
         Geo geo = new Geo();
@@ -86,8 +86,8 @@ public class DeviceTest {
         geo.city = "Los Angeles";
         geo.zip = "90049";
         geo.utcoffset = 1;
-        mTestDevice.setGeo(geo);
-        assertSame("Set and received geo values must match.", geo, mTestDevice.getGeo());
+        testDevice.setGeo(geo);
+        assertSame("Set and received geo values must match.", geo, testDevice.getGeo());
 
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/mraid/methods/MraidCalendarEventTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/mraid/methods/MraidCalendarEventTest.java
@@ -39,15 +39,15 @@ import static org.robolectric.Shadows.shadowOf;
 @Config(sdk = 19)
 public class MraidCalendarEventTest {
 
-    public final static String mCalendarFile = "calendar.txt";
-    private String mCalendarParameters = null;
-    private Activity mTestActivity;
+    public final static String calendarFile = "calendar.txt";
+    private String calendarParameters = null;
+    private Activity testActivity;
 
     @Before
     public void setUp() throws Exception {
-        mTestActivity = Robolectric.buildActivity(Activity.class).create().get();
-        mCalendarParameters = ResourceUtils.convertResourceToString(mCalendarFile);
-        ManagersResolver.getInstance().prepare(mTestActivity);
+        testActivity = Robolectric.buildActivity(Activity.class).create().get();
+        calendarParameters = ResourceUtils.convertResourceToString(calendarFile);
+        ManagersResolver.getInstance().prepare(testActivity);
     }
 
     @After
@@ -60,8 +60,8 @@ public class MraidCalendarEventTest {
         BaseJSInterface mockJs = mock(BaseJSInterface.class);
         MraidCalendarEvent event = new MraidCalendarEvent(mockJs);
 
-        event.createCalendarEvent(mCalendarParameters);
-        ShadowActivity shadowActivity = shadowOf(mTestActivity);
+        event.createCalendarEvent(calendarParameters);
+        ShadowActivity shadowActivity = shadowOf(testActivity);
         Intent startedIntent = shadowActivity.getNextStartedActivity();
 
         assertFalse("somecrap.calendar/event".equals(startedIntent.getType()));

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/mraid/methods/MraidCloseTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/mraid/methods/MraidCloseTest.java
@@ -47,66 +47,66 @@ import static org.mockito.Mockito.*;
 @Config(sdk = 19)
 public class MraidCloseTest {
 
-    private MraidClose mMraidClose;
-    private Activity mTestActivity;
-    private BaseJSInterface mSpyBaseJSInterface;
-    private WebViewBase mMockWebViewBase;
-    private JsExecutor mMockJsExecutor;
+    private MraidClose mraidClose;
+    private Activity testActivity;
+    private BaseJSInterface spyBaseJSInterface;
+    private WebViewBase mockWebViewBase;
+    private JsExecutor mockJsExecutor;
 
     @Before
     public void setUp() throws Exception {
-        mTestActivity = Robolectric.buildActivity(Activity.class).create().get();
-        mMockJsExecutor = mock(JsExecutor.class);
+        testActivity = Robolectric.buildActivity(Activity.class).create().get();
+        mockJsExecutor = mock(JsExecutor.class);
 
-        mMockWebViewBase = mock(WebViewBase.class);
-        when(mMockWebViewBase.isMRAID()).thenReturn(true);
-        when(mMockWebViewBase.getContext()).thenReturn(mTestActivity);
+        mockWebViewBase = mock(WebViewBase.class);
+        when(mockWebViewBase.isMRAID()).thenReturn(true);
+        when(mockWebViewBase.getContext()).thenReturn(testActivity);
 
-        mSpyBaseJSInterface = Mockito.spy(new BaseJSInterface(mTestActivity, mMockWebViewBase, mMockJsExecutor));
-        WhiteBox.setInternalState(mSpyBaseJSInterface, "mScreenMetricsWaiter", mock(ScreenMetricsWaiter.class));
-        doNothing().when(mSpyBaseJSInterface).onStateChange(anyString());
+        spyBaseJSInterface = Mockito.spy(new BaseJSInterface(testActivity, mockWebViewBase, mockJsExecutor));
+        WhiteBox.setInternalState(spyBaseJSInterface, "screenMetricsWaiter", mock(ScreenMetricsWaiter.class));
+        doNothing().when(spyBaseJSInterface).onStateChange(anyString());
 
-        mMraidClose = new MraidClose(mTestActivity, mSpyBaseJSInterface, mMockWebViewBase);
+        mraidClose = new MraidClose(testActivity, spyBaseJSInterface, mockWebViewBase);
     }
 
     @Test
     public void closeThroughJSTest() throws Exception {
         ViewGroup mockViewGroup = mock(ViewGroup.class);
-        when(mSpyBaseJSInterface.getRootView()).thenReturn(mockViewGroup);
-        final MraidVariableContainer mraidVariableContainer = mSpyBaseJSInterface.getMraidVariableContainer();
+        when(spyBaseJSInterface.getRootView()).thenReturn(mockViewGroup);
+        final MraidVariableContainer mraidVariableContainer = spyBaseJSInterface.getMraidVariableContainer();
 
-        mMraidClose = new MraidClose(null, mSpyBaseJSInterface, mMockWebViewBase);
+        mraidClose = new MraidClose(null, spyBaseJSInterface, mockWebViewBase);
         mraidVariableContainer.setCurrentState(JSInterface.STATE_DEFAULT);
-        mMraidClose.closeThroughJS();
-        verify(mSpyBaseJSInterface, times(0)).onStateChange(anyString());
+        mraidClose.closeThroughJS();
+        verify(spyBaseJSInterface, times(0)).onStateChange(anyString());
 
-        mMraidClose = new MraidClose(mTestActivity, mSpyBaseJSInterface, mMockWebViewBase);
+        mraidClose = new MraidClose(testActivity, spyBaseJSInterface, mockWebViewBase);
         mraidVariableContainer.setCurrentState(JSInterface.STATE_LOADING);
-        mMraidClose.closeThroughJS();
-        verify(mSpyBaseJSInterface, times(0)).onStateChange(anyString());
+        mraidClose.closeThroughJS();
+        verify(spyBaseJSInterface, times(0)).onStateChange(anyString());
 
         mraidVariableContainer.setCurrentState(JSInterface.STATE_DEFAULT);
-        mMraidClose.closeThroughJS();
-        verify(mSpyBaseJSInterface).onStateChange(eq(JSInterface.STATE_HIDDEN));
+        mraidClose.closeThroughJS();
+        verify(spyBaseJSInterface).onStateChange(eq(JSInterface.STATE_HIDDEN));
 
         mraidVariableContainer.setCurrentState(JSInterface.STATE_EXPANDED);
-        mMraidClose.closeThroughJS();
-        verify(mSpyBaseJSInterface).onStateChange(eq(JSInterface.STATE_DEFAULT));
+        mraidClose.closeThroughJS();
+        verify(spyBaseJSInterface).onStateChange(eq(JSInterface.STATE_DEFAULT));
         verify(mockViewGroup).removeView(any());
 
-        reset(mSpyBaseJSInterface);
+        reset(spyBaseJSInterface);
         AdBrowserActivity mockActivity = new AdBrowserActivity();
-        mMraidClose = new MraidClose(mockActivity, mSpyBaseJSInterface, mMockWebViewBase);
+        mraidClose = new MraidClose(mockActivity, spyBaseJSInterface, mockWebViewBase);
         mraidVariableContainer.setCurrentState(JSInterface.STATE_EXPANDED);
-        mMraidClose.closeThroughJS();
-        verify(mSpyBaseJSInterface).onStateChange(eq(JSInterface.STATE_DEFAULT));
+        mraidClose.closeThroughJS();
+        verify(spyBaseJSInterface).onStateChange(eq(JSInterface.STATE_DEFAULT));
     }
 
     @Test
     public void makeViewVisibleTest() throws InvocationTargetException, IllegalAccessException {
         Method method = WhiteBox.method(MraidClose.class, "makeViewInvisible");
 
-        method.invoke(mMraidClose);
-        verify(mMockWebViewBase, timeout(100)).setVisibility(eq(View.INVISIBLE));
+        method.invoke(mraidClose);
+        verify(mockWebViewBase, timeout(100)).setVisibility(eq(View.INVISIBLE));
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/mraid/methods/MraidControllerTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/mraid/methods/MraidControllerTest.java
@@ -59,18 +59,17 @@ import static org.mockito.Mockito.*;
 @Config(sdk = 19)
 public class MraidControllerTest {
 
-    @Mock
-    private InterstitialManager mMockInterstitialManager;
+    @Mock private InterstitialManager mockInterstitialManager;
 
-    private MraidController mMraidController;
-    private Context mContext;
+    private MraidController mraidController;
+    private Context context;
 
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
-        mMraidController = spy(new MraidController(mMockInterstitialManager));
-        mContext = Robolectric.buildActivity(Activity.class).create().get();
-        ManagersResolver.getInstance().prepare(mContext);
+        mraidController = spy(new MraidController(mockInterstitialManager));
+        context = Robolectric.buildActivity(Activity.class).create().get();
+        ManagersResolver.getInstance().prepare(context);
     }
 
     @After
@@ -81,7 +80,7 @@ public class MraidControllerTest {
     @Test
     public void handleMraidEventWhenCloseEvent_CallClose() {
         callControllerHandler(createMraidEvent(JSInterface.ACTION_CLOSE, null));
-        verify(mMockInterstitialManager).interstitialClosed(any(View.class));
+        verify(mockInterstitialManager).interstitialClosed(any(View.class));
     }
 
     @Test
@@ -90,12 +89,13 @@ public class MraidControllerTest {
         CreativeViewListener mockListener = mock(CreativeViewListener.class);
         when(mockCreative.getCreativeViewListener()).thenReturn(mockListener);
 
-        mMraidController.handleMraidEvent(createMraidEvent(JSInterface.ACTION_UNLOAD, null),
-                                          mockCreative,
-                                          mock(WebViewBase.class),
-                                          mock(PrebidWebViewBase.class));
+        mraidController.handleMraidEvent(createMraidEvent(JSInterface.ACTION_UNLOAD, null),
+                mockCreative,
+                mock(WebViewBase.class),
+                mock(PrebidWebViewBase.class)
+        );
 
-        verify(mMockInterstitialManager).interstitialClosed(any(View.class));
+        verify(mockInterstitialManager).interstitialClosed(any(View.class));
         verify(mockListener).creativeDidComplete(mockCreative);
     }
 
@@ -103,7 +103,7 @@ public class MraidControllerTest {
     public void handleMraidEventWhenCalendarEvent_CallCreateCalendarEvent() {
         String actionHelper = "{\"description\":\"Mayan Apocalypse/End of World\",\"location\":\"everywhere\",\"start\":\"2013-12-21T00:00-05:00\",\"end\":\"2013-12-22T00:00-05:00\"}";
         callControllerHandler(createMraidEvent(JSInterface.ACTION_CREATE_CALENDAR_EVENT, actionHelper));
-        assertNotNull(WhiteBox.getInternalState(mMraidController, "mMraidCalendarEvent"));
+        assertNotNull(WhiteBox.getInternalState(mraidController, "mraidCalendarEvent"));
     }
 
     @Test
@@ -113,12 +113,13 @@ public class MraidControllerTest {
         WebViewBase mockOldWebView = mock(WebViewBase.class);
 
         when(mockOldWebView.getMraidListener()).thenReturn(mock(MraidEventsManager.MraidListener.class));
-        when(mockOldWebView.getContext()).thenReturn(mContext);
+        when(mockOldWebView.getContext()).thenReturn(context);
 
-        mMraidController.handleMraidEvent(event, mockCreative, mockOldWebView, mock(PrebidWebViewBase.class));
-        verify(mMraidController).initMraidExpand(any(View.class),
-                                                 any(MraidController.DisplayCompletionListener.class),
-                                                 any(MraidEvent.class));
+        mraidController.handleMraidEvent(event, mockCreative, mockOldWebView, mock(PrebidWebViewBase.class));
+        verify(mraidController).initMraidExpand(any(View.class),
+                any(MraidController.DisplayCompletionListener.class),
+                any(MraidEvent.class)
+        );
     }
 
     @Test
@@ -128,11 +129,11 @@ public class MraidControllerTest {
         WebViewBase mockOldWebView = mock(WebViewBase.class);
 
         when(mockOldWebView.getMraidListener()).thenReturn(mock(MraidEventsManager.MraidListener.class));
-        when(mockOldWebView.getContext()).thenReturn(mContext);
+        when(mockOldWebView.getContext()).thenReturn(context);
 
-        mMraidController.handleMraidEvent(event, mockCreative, mockOldWebView, mock(PrebidWebViewBase.class));
+        mraidController.handleMraidEvent(event, mockCreative, mockOldWebView, mock(PrebidWebViewBase.class));
         ShadowLooper.runUiThreadTasks();
-        verify(mMraidController, times(1)).expand(any(WebViewBase.class), any(PrebidWebViewBase.class), eq(event));
+        verify(mraidController, times(1)).expand(any(WebViewBase.class), any(PrebidWebViewBase.class), eq(event));
     }
 
     @Test
@@ -145,7 +146,7 @@ public class MraidControllerTest {
         when(mockNewWebView.getMraidWebView()).thenReturn(mockBanner);
         when(mockOldWebView.getMraidListener()).thenReturn(mock(MraidEventsManager.MraidListener.class));
 
-        mMraidController.expand(mockOldWebView, mockNewWebView, event);
+        mraidController.expand(mockOldWebView, mockNewWebView, event);
         verify(mockNewWebView, times(1)).getMraidWebView();
         verify(mockBanner).setMraidEvent(eq(event));
     }
@@ -156,7 +157,7 @@ public class MraidControllerTest {
         MraidExpand mockMraidExpand = mock(MraidExpand.class);
         AdBaseDialog mockDialog = mock(AdBaseDialog.class);
         when(mockMraidExpand.getInterstitialViewController()).thenReturn(mockDialog);
-        WhiteBox.field(MraidController.class, "mMraidExpand").set(mMraidController, mockMraidExpand);
+        WhiteBox.field(MraidController.class, "mraidExpand").set(mraidController, mockMraidExpand);
 
         callControllerHandler(createMraidEvent(JSInterface.ACTION_ORIENTATION_CHANGE, null));
         verify(mockDialog).handleSetOrientationProperties();
@@ -165,7 +166,7 @@ public class MraidControllerTest {
     @Test
     public void handleMraidEventWhenOpenEvent_CallOpen() {
         callControllerHandler(createMraidEvent(JSInterface.ACTION_OPEN, "test"));
-        assertNotNull(WhiteBox.getInternalState(mMraidController, "mMraidUrlHandler"));
+        assertNotNull(WhiteBox.getInternalState(mraidController, "mraidUrlHandler"));
     }
 
     @Test
@@ -174,9 +175,10 @@ public class MraidControllerTest {
         callControllerHandler(event);
 
         // called when displaying interstitial
-        verify(mMraidController).initMraidExpand(any(View.class),
-                                                 any(MraidController.DisplayCompletionListener.class),
-                                                 any(MraidEvent.class));
+        verify(mraidController).initMraidExpand(any(View.class),
+                any(MraidController.DisplayCompletionListener.class),
+                any(MraidEvent.class)
+        );
     }
 
     @Test
@@ -187,16 +189,21 @@ public class MraidControllerTest {
         when(mockJsInterface.getMraidVariableContainer()).thenReturn(container);
 
         WebViewBase mockOldWebView = mock(WebViewBase.class);
-        when(mockOldWebView.getContext()).thenReturn(mContext);
+        when(mockOldWebView.getContext()).thenReturn(context);
         when(mockOldWebView.getMRAIDInterface()).thenReturn(mockJsInterface);
-        mMraidController.handleMraidEvent(createMraidEvent(JSInterface.ACTION_RESIZE, null), mock(HTMLCreative.class), mockOldWebView, mock(PrebidWebViewBase.class));
-        assertNotNull(WhiteBox.getInternalState(mMraidController, "mMraidResize"));
+        mraidController.handleMraidEvent(
+                createMraidEvent(JSInterface.ACTION_RESIZE, null),
+                mock(HTMLCreative.class),
+                mockOldWebView,
+                mock(PrebidWebViewBase.class)
+        );
+        assertNotNull(WhiteBox.getInternalState(mraidController, "mraidResize"));
     }
 
     @Test
     public void handleMraidEventWhenStorePictureEvent_CallStorePicture() throws Exception {
         callControllerHandler(createMraidEvent(JSInterface.ACTION_STORE_PICTURE, "test"));
-        assertNotNull(WhiteBox.getInternalState(mMraidController, "mMraidStorePicture"));
+        assertNotNull(WhiteBox.getInternalState(mraidController, "mraidStorePicture"));
     }
 
     @Test
@@ -204,10 +211,10 @@ public class MraidControllerTest {
         MraidResize mockMraidResize = mock(MraidResize.class);
         MraidUrlHandler mockMraidUrlHandler = mock(MraidUrlHandler.class);
 
-        WhiteBox.field(MraidController.class, "mMraidResize").set(mMraidController, mockMraidResize);
-        WhiteBox.field(MraidController.class, "mMraidUrlHandler").set(mMraidController, mockMraidUrlHandler);
+        WhiteBox.field(MraidController.class, "mraidResize").set(mraidController, mockMraidResize);
+        WhiteBox.field(MraidController.class, "mraidUrlHandler").set(mraidController, mockMraidUrlHandler);
 
-        mMraidController.destroy();
+        mraidController.destroy();
         verify(mockMraidResize).destroy();
         verify(mockMraidUrlHandler).destroy();
     }
@@ -215,7 +222,7 @@ public class MraidControllerTest {
     @Test
     public void delegateDisplayViewInInterstitialAndExpandNull_InitExpand()
     throws Exception {
-        mMraidController = new MraidController(mMockInterstitialManager);
+        mraidController = new MraidController(mockInterstitialManager);
         MraidEvent mockEvent = mock(MraidEvent.class);
 
         mockEvent.mraidAction = JSInterface.ACTION_EXPAND;
@@ -223,16 +230,17 @@ public class MraidControllerTest {
 
         InterstitialManagerMraidDelegate delegate = getMraidDelegate();
         delegate.displayViewInInterstitial(mock(WebViewBase.class),
-                                           true,
-                                           mockEvent,
-                                           mock(MraidController.DisplayCompletionListener.class));
-        assertNotNull(WhiteBox.getInternalState(mMraidController, "mMraidExpand"));
+                true,
+                mockEvent,
+                mock(MraidController.DisplayCompletionListener.class)
+        );
+        assertNotNull(WhiteBox.getInternalState(mraidController, "mraidExpand"));
     }
 
     @Test
     public void delegateDisplayViewInInterstitialAndExpandNotNull_SetExpandDisplayViewAndInitMraidExpanded()
     throws IllegalAccessException {
-        mMraidController = new MraidController(mMockInterstitialManager);
+        mraidController = new MraidController(mockInterstitialManager);
         WebViewBase mockWebView = mock(WebViewBase.class);
         MraidEvent mockEvent = mock(MraidEvent.class);
         MraidExpand mockMraidExpand = mock(MraidExpand.class);
@@ -244,7 +252,7 @@ public class MraidControllerTest {
         when(mockMraidExpand.getInterstitialViewController()).thenReturn(mock(AdBaseDialog.class));
         when(mockWebView.getPreloadedListener()).thenReturn(mockWebViewBase);
 
-        WhiteBox.field(MraidController.class, "mMraidExpand").set(mMraidController, mockMraidExpand);
+        WhiteBox.field(MraidController.class, "mraidExpand").set(mraidController, mockMraidExpand);
         getMraidDelegate().displayPrebidWebViewForMraid(mockWebView, true, mockEvent);
 
         verify(mockMraidExpand, times(1)).setDisplayView(mockWebView);
@@ -253,35 +261,35 @@ public class MraidControllerTest {
 
     @Test
     public void delegateOnInterstitialClosed_NullifyExpand() throws IllegalAccessException {
-        mMraidController = new MraidController(mMockInterstitialManager);
+        mraidController = new MraidController(mockInterstitialManager);
         MraidExpand mockMraidExpand = mock(MraidExpand.class);
         HTMLCreative mockCreative = mock(HTMLCreative.class);
 
         when(mockMraidExpand.isMraidExpanded()).thenReturn(true);
-        when(mMockInterstitialManager.getHtmlCreative()).thenReturn(mockCreative);
+        when(mockInterstitialManager.getHtmlCreative()).thenReturn(mockCreative);
 
-        Field expandField = WhiteBox.field(MraidController.class, "mMraidExpand");
-        expandField.set(mMraidController, mockMraidExpand);
+        Field expandField = WhiteBox.field(MraidController.class, "mraidExpand");
+        expandField.set(mraidController, mockMraidExpand);
 
         getMraidDelegate().collapseMraid();
         verify(mockCreative).mraidAdCollapsed();
         verify(mockMraidExpand).nullifyDialog();
-        assertNull(expandField.get(mMraidController));
+        assertNull(expandField.get(mraidController));
     }
 
     @Test
     public void delegateOnDestroy_DestroyMraidExpand() throws IllegalAccessException {
-        mMraidController = new MraidController(mMockInterstitialManager);
+        mraidController = new MraidController(mockInterstitialManager);
         MraidExpand mockMraidExpand = mock(MraidExpand.class);
 
         when(mockMraidExpand.isMraidExpanded()).thenReturn(true);
 
-        Field expandField = WhiteBox.field(MraidController.class, "mMraidExpand");
-        expandField.set(mMraidController, mockMraidExpand);
+        Field expandField = WhiteBox.field(MraidController.class, "mraidExpand");
+        expandField.set(mraidController, mockMraidExpand);
 
         getMraidDelegate().destroyMraidExpand();
         verify(mockMraidExpand).destroy();
-        assertNull(expandField.get(mMraidController));
+        assertNull(expandField.get(mraidController));
     }
 
     private void callControllerHandler(MraidEvent event) {
@@ -291,9 +299,9 @@ public class MraidControllerTest {
 
         when(mockCreative.getCreativeModel()).thenReturn(mockCreativeModel);
         when(mockCreativeModel.getAdConfiguration()).thenReturn(mock(AdUnitConfiguration.class));
-        when(mockOldWebView.getContext()).thenReturn(mContext);
+        when(mockOldWebView.getContext()).thenReturn(context);
 
-        mMraidController.handleMraidEvent(event, mockCreative, mockOldWebView, mock(PrebidWebViewBase.class));
+        mraidController.handleMraidEvent(event, mockCreative, mockOldWebView, mock(PrebidWebViewBase.class));
     }
 
     private MraidEvent createMraidEvent(String eventType, String helper) {
@@ -304,6 +312,9 @@ public class MraidControllerTest {
     }
 
     private InterstitialManagerMraidDelegate getMraidDelegate() throws IllegalAccessException {
-        return (InterstitialManagerMraidDelegate) WhiteBox.field(MraidController.class, "mInterstitialManagerMraidDelegate").get(mMraidController);
+        return (InterstitialManagerMraidDelegate) WhiteBox.field(
+                MraidController.class,
+                "interstitialManagerMraidDelegate"
+        ).get(mraidController);
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/mraid/methods/MraidEventHandlerNotifierRunnableTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/mraid/methods/MraidEventHandlerNotifierRunnableTest.java
@@ -34,49 +34,48 @@ import static org.mockito.Mockito.verifyZeroInteractions;
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 19)
 public class MraidEventHandlerNotifierRunnableTest {
-    private MraidEventHandlerNotifierRunnable mMraidEventHandlerNotifierRunnable;
+    private MraidEventHandlerNotifierRunnable mraidEventHandlerNotifierRunnable;
 
     @Mock
-    HTMLCreative mMockHTMLCreative;
+    HTMLCreative mockHTMLCreative;
     @Mock
-    WebViewBase mMockWebViewBase;
+    WebViewBase mockWebViewBase;
     @Mock
-    JsExecutor mMockJsExecutor;
+    JsExecutor mockJsExecutor;
     @Mock
-    MraidEvent mMockMraidEvent;
+    MraidEvent mockMraidEvent;
 
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
 
-        mMraidEventHandlerNotifierRunnable = new MraidEventHandlerNotifierRunnable(mMockHTMLCreative,
-                                                                                   mMockWebViewBase,
-                                                                                   mMockMraidEvent,
-                                                                                   mMockJsExecutor);
+        mraidEventHandlerNotifierRunnable = new MraidEventHandlerNotifierRunnable(
+                mockHTMLCreative, mockWebViewBase, mockMraidEvent, mockJsExecutor
+        );
     }
 
     @Test
     public void runWithValidHtmlCreativeAndWebViewBase_HandleMraidEventsInCreative() {
-        mMraidEventHandlerNotifierRunnable.run();
+        mraidEventHandlerNotifierRunnable.run();
 
-        verify(mMockHTMLCreative).handleMRAIDEventsInCreative(mMockMraidEvent, mMockWebViewBase);
+        verify(mockHTMLCreative).handleMRAIDEventsInCreative(mockMraidEvent, mockWebViewBase);
     }
 
     @Test
     public void runWithInValidHtmlCreativeOrWebViewBase_NoInteractions() {
         MraidEventHandlerNotifierRunnable mraidEventHandlerNotifierRunnable =
-            new MraidEventHandlerNotifierRunnable(null, mMockWebViewBase,
-                                                  mMockMraidEvent, mMockJsExecutor);
+            new MraidEventHandlerNotifierRunnable(null, mockWebViewBase, mockMraidEvent, mockJsExecutor
+            );
         mraidEventHandlerNotifierRunnable.run();
 
-        verifyZeroInteractions(mMockHTMLCreative);
-        verifyZeroInteractions(mMockJsExecutor);
+        verifyZeroInteractions(mockHTMLCreative);
+        verifyZeroInteractions(mockJsExecutor);
     }
 
     @Test
     public void runWithValidHtmlCreativeAndWebViewBase_ExecuteNativeCallComplete() {
-        mMraidEventHandlerNotifierRunnable.run();
+        mraidEventHandlerNotifierRunnable.run();
 
-        verify(mMockJsExecutor).executeNativeCallComplete();
+        verify(mockJsExecutor).executeNativeCallComplete();
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/mraid/methods/MraidExpandTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/mraid/methods/MraidExpandTest.java
@@ -46,31 +46,31 @@ import static org.mockito.Mockito.*;
 @Config(sdk = 19)
 public class MraidExpandTest {
 
-    private MraidExpand mMraidExpand;
+    private MraidExpand mraidExpand;
 
-    private Activity mTestActivity;
-    private WebViewBase mMockWebViewBase;
-    private BaseJSInterface mSpyBaseJsInterface;
-    private JsExecutor mSpyJsExecutor;
+    private Activity testActivity;
+    private WebViewBase mockWebViewBase;
+    private BaseJSInterface spyBaseJsInterface;
+    private JsExecutor spyJsExecutor;
 
     @Before
     public void setup() {
-        mTestActivity = Robolectric.buildActivity(Activity.class)
-                                   .setup()
-                                   .create()
-                                   .visible()
-                                   .resume()
-                                   .windowFocusChanged(true)
-                                   .get();
-        mSpyJsExecutor = spy(new JsExecutor(mMockWebViewBase, null, null));
+        testActivity = Robolectric.buildActivity(Activity.class)
+                                  .setup()
+                                  .create()
+                                  .visible()
+                                  .resume()
+                                  .windowFocusChanged(true)
+                                  .get();
+        spyJsExecutor = spy(new JsExecutor(mockWebViewBase, null, null));
 
-        mMockWebViewBase = mock(WebViewBase.class);
-        mSpyBaseJsInterface = Mockito.spy(new BaseJSInterface(mTestActivity, mMockWebViewBase, mSpyJsExecutor));
+        mockWebViewBase = mock(WebViewBase.class);
+        spyBaseJsInterface = Mockito.spy(new BaseJSInterface(testActivity, mockWebViewBase, spyJsExecutor));
 
-        when(mSpyBaseJsInterface.getJsExecutor()).thenReturn(mSpyJsExecutor);
-        when(mMockWebViewBase.getMRAIDInterface()).thenReturn(mSpyBaseJsInterface);
+        when(spyBaseJsInterface.getJsExecutor()).thenReturn(spyJsExecutor);
+        when(mockWebViewBase.getMRAIDInterface()).thenReturn(spyBaseJsInterface);
 
-        mMraidExpand = new MraidExpand(mTestActivity, mMockWebViewBase, mock(InterstitialManager.class));
+        mraidExpand = new MraidExpand(testActivity, mockWebViewBase, mock(InterstitialManager.class));
     }
 
     @Test
@@ -80,19 +80,19 @@ public class MraidExpandTest {
             RedirectUrlListener listener = invocation.getArgument(1);
             listener.onSuccess("test", "html");
             return null;
-        }).when(mSpyBaseJsInterface).followToOriginalUrl(anyString(), any(RedirectUrlListener.class));
+        }).when(spyBaseJsInterface).followToOriginalUrl(anyString(), any(RedirectUrlListener.class));
 
         PrebidWebViewBase mockPreloadedListener = mock(PrebidWebViewBase.class);
         HTMLCreative mockCreative = mock(HTMLCreative.class);
 
         when(mockPreloadedListener.getCreative()).thenReturn(mockCreative);
-        when(mMockWebViewBase.getPreloadedListener()).thenReturn(mockPreloadedListener);
+        when(mockWebViewBase.getPreloadedListener()).thenReturn(mockPreloadedListener);
 
         CompletedCallBack callBack = mock(CompletedCallBack.class);
-        final MraidVariableContainer mraidVariableContainer = mSpyBaseJsInterface.getMraidVariableContainer();
+        final MraidVariableContainer mraidVariableContainer = spyBaseJsInterface.getMraidVariableContainer();
         mraidVariableContainer.setCurrentState(JSInterface.STATE_DEFAULT);
 
-        MraidExpand spyExpand = spy(mMraidExpand);
+        MraidExpand spyExpand = spy(mraidExpand);
 
         doAnswer(invocation -> {
             CompletedCallBack completedCallBack = invocation.getArgument(1);
@@ -102,7 +102,7 @@ public class MraidExpandTest {
 
         spyExpand.expand("test", callBack);
 
-        verify(mSpyBaseJsInterface).followToOriginalUrl(anyString(), any(RedirectUrlListener.class));
+        verify(spyBaseJsInterface).followToOriginalUrl(anyString(), any(RedirectUrlListener.class));
         assertEquals(mraidVariableContainer.getUrlForLaunching(), "test");
         verify(callBack).expandDialogShown();
         verify(spyExpand).showExpandDialog(any(), any());
@@ -111,9 +111,9 @@ public class MraidExpandTest {
     @Test
     public void nullifyDialogTest() throws IllegalAccessException {
         AdBaseDialog mockDialog = mock(AdBaseDialog.class);
-        WhiteBox.field(MraidExpand.class, "mExpandedDialog").set(mMraidExpand, mockDialog);
+        WhiteBox.field(MraidExpand.class, "expandedDialog").set(mraidExpand, mockDialog);
 
-        mMraidExpand.nullifyDialog();
+        mraidExpand.nullifyDialog();
 
         verify(mockDialog).cleanup();
         verify(mockDialog).cancel();
@@ -121,7 +121,7 @@ public class MraidExpandTest {
 
     @Test
     public void setMraidExpandedTest() {
-        mMraidExpand.setMraidExpanded(true);
-        assertTrue(mMraidExpand.isMraidExpanded());
+        mraidExpand.setMraidExpanded(true);
+        assertTrue(mraidExpand.isMraidExpanded());
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/mraid/methods/MraidResizeTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/mraid/methods/MraidResizeTest.java
@@ -54,31 +54,27 @@ import static org.mockito.Mockito.*;
 @Config(sdk = 19)
 public class MraidResizeTest {
 
-    private MraidResize mMraidResize;
+    private MraidResize mraidResize;
 
-    private Context mMockContext;
+    private Context mockContext;
 
-    private BaseJSInterface mSpyBaseJsInterface;
+    private BaseJSInterface spyBaseJsInterface;
 
-    @Mock
-    private WebViewBase mMockWebViewBase;
-    @Mock
-    private InterstitialManager mMockManager;
-    @Mock
-    private MraidVariableContainer mMockMraidVariableContainer;
-    @Mock
-    private JsExecutor mMockJsExecutor;
+    @Mock private WebViewBase mockWebViewBase;
+    @Mock private InterstitialManager mockManager;
+    @Mock private MraidVariableContainer mockMraidVariableContainer;
+    @Mock private JsExecutor mockJsExecutor;
 
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
         PrebidWebViewBase prebidWebViewBase = mock(PrebidWebViewBase.class);
-        mMockContext = Robolectric.buildActivity(Activity.class).create().get().getApplicationContext();
+        mockContext = Robolectric.buildActivity(Activity.class).create().get().getApplicationContext();
 
-        mSpyBaseJsInterface = spy(new BaseJSInterface(mMockContext, mMockWebViewBase, mMockJsExecutor));
-        when(mSpyBaseJsInterface.getMraidVariableContainer()).thenReturn(mMockMraidVariableContainer);
+        spyBaseJsInterface = spy(new BaseJSInterface(mockContext, mockWebViewBase, mockJsExecutor));
+        when(spyBaseJsInterface.getMraidVariableContainer()).thenReturn(mockMraidVariableContainer);
 
-        when(mMockWebViewBase.post(any(Runnable.class))).thenAnswer(invocation -> {
+        when(mockWebViewBase.post(any(Runnable.class))).thenAnswer(invocation -> {
             Runnable runnable = invocation.getArgument(0);
             runnable.run();
             return null;
@@ -87,92 +83,106 @@ public class MraidResizeTest {
             Handler handler = invocation.getArgument(0);
             Message message = new Message();
             Bundle data = new Bundle();
-            data.putString(JSInterface.JSON_VALUE, "{\"width\":320,\"height\":250,\"customClosePosition\":\"top-right\",\"offsetX\":0,\"offsetY\":0,\"allowOffscreen\":true}");
+            data.putString(
+                    JSInterface.JSON_VALUE,
+                    "{\"width\":320,\"height\":250,\"customClosePosition\":\"top-right\",\"offsetX\":0,\"offsetY\":0,\"allowOffscreen\":true}"
+            );
             message.setData(data);
             handler.handleMessage(message);
             return null;
-        }).when(mMockJsExecutor).executeGetResizeProperties(any(Handler.class));
+        }).when(mockJsExecutor).executeGetResizeProperties(any(Handler.class));
 
-        when(mMockWebViewBase.getParent()).thenReturn(prebidWebViewBase);
-        when(mSpyBaseJsInterface.getDefaultAdContainer()).thenReturn(prebidWebViewBase);
+        when(mockWebViewBase.getParent()).thenReturn(prebidWebViewBase);
+        when(spyBaseJsInterface.getDefaultAdContainer()).thenReturn(prebidWebViewBase);
 
-        mMraidResize = new MraidResize(mMockContext, mSpyBaseJsInterface, mMockWebViewBase, mMockManager);
+        mraidResize = new MraidResize(mockContext, spyBaseJsInterface, mockWebViewBase, mockManager);
     }
 
     @Test
     public void resizeWithDefaultState_executeGetResizeProperties() throws Exception {
-        when(mMockMraidVariableContainer.getCurrentState()).thenReturn(JSInterface.STATE_DEFAULT);
+        when(mockMraidVariableContainer.getCurrentState()).thenReturn(JSInterface.STATE_DEFAULT);
 
-        mMraidResize.resize();
+        mraidResize.resize();
 
-        verify(mMockJsExecutor).executeGetResizeProperties(Mockito.any(Handler.class));
+        verify(mockJsExecutor).executeGetResizeProperties(Mockito.any(Handler.class));
     }
 
     @Test
     public void resizeWithExpandedState_executeOnError() throws Exception {
-        when(mMockMraidVariableContainer.getCurrentState()).thenReturn(JSInterface.STATE_EXPANDED);
+        when(mockMraidVariableContainer.getCurrentState()).thenReturn(JSInterface.STATE_EXPANDED);
 
-        mMraidResize.resize();
+        mraidResize.resize();
 
-        verify(mSpyBaseJsInterface).onError("resize_when_expanded_error", JSInterface.ACTION_RESIZE);
+        verify(spyBaseJsInterface).onError("resize_when_expanded_error", JSInterface.ACTION_RESIZE);
     }
 
     @Test
     public void resizeWithInvalidState_DoNothing() throws Exception {
-        when(mMockMraidVariableContainer.getCurrentState()).thenReturn(JSInterface.STATE_LOADING);
+        when(mockMraidVariableContainer.getCurrentState()).thenReturn(JSInterface.STATE_LOADING);
 
-        mMraidResize.resize();
+        mraidResize.resize();
 
-        verify(mSpyBaseJsInterface, times(1)).getMraidVariableContainer();
-        verifyNoMoreInteractions(mSpyBaseJsInterface);
+        verify(spyBaseJsInterface, times(1)).getMraidVariableContainer();
+        verifyNoMoreInteractions(spyBaseJsInterface);
     }
 
     @Test
     public void showExpandDialogTest() throws InvocationTargetException, IllegalAccessException {
 
-        Method showExpandDialogMethod = WhiteBox.method(MraidResize.class, "showExpandDialog",
-                                                        int.class, int.class, int.class,
-                                                        int.class, boolean.class);
+        Method showExpandDialogMethod = WhiteBox.method(MraidResize.class,
+                "showExpandDialog",
+                int.class,
+                int.class,
+                int.class,
+                int.class,
+                boolean.class
+        );
 
-        Field secondaryAdContainerField = WhiteBox.field(MraidResize.class, "mSecondaryAdContainer");
-        secondaryAdContainerField.set(mMraidResize, mock(FrameLayout.class));
+        Field secondaryAdContainerField = WhiteBox.field(MraidResize.class, "secondaryAdContainer");
+        secondaryAdContainerField.set(mraidResize, mock(FrameLayout.class));
 
-        Field closeViewField = WhiteBox.field(MraidResize.class, "mCloseView");
+        Field closeViewField = WhiteBox.field(MraidResize.class, "closeView");
         View mockView = mock(View.class);
-        when(mockView.getLayoutParams()).thenReturn(new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
-        closeViewField.set(mMraidResize, mockView);
+        when(mockView.getLayoutParams()).thenReturn(new FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+        ));
+        closeViewField.set(mraidResize, mockView);
 
         MraidScreenMetrics mockMetrics = mock(MraidScreenMetrics.class);
         when(mockMetrics.getRootViewRect()).thenReturn(new Rect(0, 0, 100, 100));
         when(mockMetrics.getDefaultAdRect()).thenReturn(new Rect(0, 0, 0, 0));
         when(mockMetrics.getRootViewRectDips()).thenReturn(new Rect(0, 0, 0, 0));
-        when(mSpyBaseJsInterface.getScreenMetrics()).thenReturn(mockMetrics);
+        when(spyBaseJsInterface.getScreenMetrics()).thenReturn(mockMetrics);
 
         PrebidWebViewBase mockPrebidWebViewBase = mock(PrebidWebViewBase.class);
-        when(mMockWebViewBase.getParent()).thenReturn(mockPrebidWebViewBase);
-        when(mSpyBaseJsInterface.getDefaultAdContainer()).thenReturn(mockPrebidWebViewBase);
-        when(mSpyBaseJsInterface.getRootView()).thenReturn(mock(FrameLayout.class));
+        when(mockWebViewBase.getParent()).thenReturn(mockPrebidWebViewBase);
+        when(spyBaseJsInterface.getDefaultAdContainer()).thenReturn(mockPrebidWebViewBase);
+        when(spyBaseJsInterface.getRootView()).thenReturn(mock(FrameLayout.class));
 
-        showExpandDialogMethod.invoke(mMraidResize, 100, 100, 0, 0, true);
-        verify(mSpyBaseJsInterface).onStateChange(eq(JSInterface.STATE_RESIZED));
+        showExpandDialogMethod.invoke(mraidResize, 100, 100, 0, 0, true);
+        verify(spyBaseJsInterface).onStateChange(eq(JSInterface.STATE_RESIZED));
 
-        showExpandDialogMethod.invoke(mMraidResize, 1000, 1000, 0, 0, false);
-        verify(mSpyBaseJsInterface).onError("Resize properties specified a size & offset that does not allow the ad to appear within the max allowed size", JSInterface.ACTION_RESIZE);
+        showExpandDialogMethod.invoke(mraidResize, 1000, 1000, 0, 0, false);
+        verify(spyBaseJsInterface).onError(
+                "Resize properties specified a size & offset that does not allow the ad to appear within the max allowed size",
+                JSInterface.ACTION_RESIZE
+        );
 
-        showExpandDialogMethod.invoke(mMraidResize, 100, 100, 0, 0, false);
-        verify(mSpyBaseJsInterface, times(2)).onStateChange(eq(JSInterface.STATE_RESIZED));
+        showExpandDialogMethod.invoke(mraidResize, 100, 100, 0, 0, false);
+        verify(spyBaseJsInterface, times(2)).onStateChange(eq(JSInterface.STATE_RESIZED));
 
         WeakReference<Context> weakReference = new WeakReference<>(null);
-        WhiteBox.field(MraidResize.class, "mContextReference").set(mMraidResize, weakReference);
-        showExpandDialogMethod.invoke(mMraidResize, 100, 100, 0, 0, false);
-        verify(mSpyBaseJsInterface).onError("Unable to resize when mContext is null", JSInterface.ACTION_RESIZE);
+        WhiteBox.field(MraidResize.class, "contextReference").set(mraidResize, weakReference);
+        showExpandDialogMethod.invoke(mraidResize, 100, 100, 0, 0, false);
+        verify(spyBaseJsInterface).onError("Unable to resize when context is null", JSInterface.ACTION_RESIZE);
     }
 
     @Test
     public void closeViewTest() throws Exception {
         Method closeViewMethod = WhiteBox.method(MraidResize.class, "closeView");
 
-        closeViewMethod.invoke(mMraidResize);
-        verify(mMockManager).interstitialClosed(any(View.class));
+        closeViewMethod.invoke(mraidResize);
+        verify(mockManager).interstitialClosed(any(View.class));
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/mraid/methods/MraidScreenMetricsTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/mraid/methods/MraidScreenMetricsTest.java
@@ -32,92 +32,92 @@ import static org.junit.Assert.*;
 @Config(sdk = 19)
 public class MraidScreenMetricsTest {
 
-    private MraidScreenMetrics mMraidScreenMetrics;
+    private MraidScreenMetrics mraidScreenMetrics;
 
     @Before
     public void setUp() throws Exception {
         Context context = Robolectric.buildActivity(Activity.class).create().get();
-        mMraidScreenMetrics = new MraidScreenMetrics(context, 1f);
+        mraidScreenMetrics = new MraidScreenMetrics(context, 1f);
     }
 
     @Test
     public void getDensityTest() {
-        assertEquals(1f, mMraidScreenMetrics.getDensity(), 0);
+        assertEquals(1f, mraidScreenMetrics.getDensity(), 0);
     }
 
     @Test
     public void setScreenSizeTest() {
         Rect expected = new Rect(0, 0, 100, 200);
-        assertNotEquals(expected, mMraidScreenMetrics.getScreenRect());
+        assertNotEquals(expected, mraidScreenMetrics.getScreenRect());
 
-        mMraidScreenMetrics.setScreenSize(100, 200);
-        assertEquals(expected, mMraidScreenMetrics.getScreenRect());
+        mraidScreenMetrics.setScreenSize(100, 200);
+        assertEquals(expected, mraidScreenMetrics.getScreenRect());
     }
 
     @Test
     public void getScreenRectTest() {
-        assertNotNull(mMraidScreenMetrics.getScreenRect());
+        assertNotNull(mraidScreenMetrics.getScreenRect());
     }
 
     @Test
     public void getScreenRectDipsTest() {
-        assertNotNull(mMraidScreenMetrics.getScreenRectDips());
+        assertNotNull(mraidScreenMetrics.getScreenRectDips());
     }
 
     @Test
     public void setRootViewPositionTest() {
         Rect expected = new Rect(1, 2, 101, 202);
-        assertNotEquals(expected, mMraidScreenMetrics.getRootViewRect());
+        assertNotEquals(expected, mraidScreenMetrics.getRootViewRect());
 
-        mMraidScreenMetrics.setRootViewPosition(1, 2, 100, 200);
-        assertEquals(expected, mMraidScreenMetrics.getRootViewRect());
+        mraidScreenMetrics.setRootViewPosition(1, 2, 100, 200);
+        assertEquals(expected, mraidScreenMetrics.getRootViewRect());
     }
 
     @Test
     public void getRootViewRectTest() {
-        assertNotNull(mMraidScreenMetrics.getRootViewRect());
+        assertNotNull(mraidScreenMetrics.getRootViewRect());
     }
 
     @Test
     public void getRootViewRectDipsTest() {
-        assertNotNull(mMraidScreenMetrics.getRootViewRectDips());
+        assertNotNull(mraidScreenMetrics.getRootViewRectDips());
     }
 
     @Test
     public void setCurrentAdPositionTest() {
         Rect expected = new Rect(1, 2, 101, 202);
-        assertNotEquals(expected, mMraidScreenMetrics.getCurrentAdRect());
+        assertNotEquals(expected, mraidScreenMetrics.getCurrentAdRect());
 
-        mMraidScreenMetrics.setCurrentAdPosition(1, 2, 100, 200);
-        assertEquals(expected, mMraidScreenMetrics.getCurrentAdRect());
+        mraidScreenMetrics.setCurrentAdPosition(1, 2, 100, 200);
+        assertEquals(expected, mraidScreenMetrics.getCurrentAdRect());
     }
 
     @Test
     public void getCurrentAdRectTest() {
-        assertNotNull(mMraidScreenMetrics.getCurrentAdRect());
+        assertNotNull(mraidScreenMetrics.getCurrentAdRect());
     }
 
     @Test
     public void getCurrentAdRectDipsTest() {
-        assertNotNull(mMraidScreenMetrics.getCurrentAdRectDips());
+        assertNotNull(mraidScreenMetrics.getCurrentAdRectDips());
     }
 
     @Test
     public void setDefaultAdPositionTest() {
         Rect expected = new Rect(1, 2, 101, 202);
-        assertNotEquals(expected, mMraidScreenMetrics.getDefaultAdRect());
+        assertNotEquals(expected, mraidScreenMetrics.getDefaultAdRect());
 
-        mMraidScreenMetrics.setDefaultAdPosition(1, 2, 100, 200);
-        assertEquals(expected, mMraidScreenMetrics.getDefaultAdRect());
+        mraidScreenMetrics.setDefaultAdPosition(1, 2, 100, 200);
+        assertEquals(expected, mraidScreenMetrics.getDefaultAdRect());
     }
 
     @Test
     public void getDefaultAdRectTest() {
-        assertNotNull(mMraidScreenMetrics.getDefaultAdRect());
+        assertNotNull(mraidScreenMetrics.getDefaultAdRect());
     }
 
     @Test
     public void getDefaultAdRectDipsTest() {
-        assertNotNull(mMraidScreenMetrics.getDefaultAdRectDips());
+        assertNotNull(mraidScreenMetrics.getDefaultAdRectDips());
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/mraid/methods/MraidStorePictureTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/mraid/methods/MraidStorePictureTest.java
@@ -43,21 +43,21 @@ import static org.mockito.Mockito.*;
 @Config(sdk = 19)
 public class MraidStorePictureTest {
 
-    private MraidStorePicture mMraidStorePicture;
-    private Context mContext;
-    private WebViewBase mMockWebViewBase;
-    private BaseJSInterface mMockBaseJsInterface;
+    private MraidStorePicture mraidStorePicture;
+    private Context context;
+    private WebViewBase mockWebViewBase;
+    private BaseJSInterface mockBaseJsInterface;
 
-    private JsExecutor mMockJsExecutor;
+    private JsExecutor mockJsExecutor;
 
     @Before
     public void setup() {
-        mContext = spy(Robolectric.buildActivity(Activity.class).create().get());
-        ManagersResolver.getInstance().prepare(mContext);
-        mMockWebViewBase = Mockito.mock(WebViewBase.class);
-        mMockJsExecutor = mock(JsExecutor.class);
+        context = spy(Robolectric.buildActivity(Activity.class).create().get());
+        ManagersResolver.getInstance().prepare(context);
+        mockWebViewBase = Mockito.mock(WebViewBase.class);
+        mockJsExecutor = mock(JsExecutor.class);
 
-        when(mMockWebViewBase.post(any(Runnable.class))).thenAnswer(new Answer<Object>() {
+        when(mockWebViewBase.post(any(Runnable.class))).thenAnswer(new Answer<Object>() {
             @Override
             public Object answer(InvocationOnMock invocation) throws Throwable {
                 Runnable runnable = invocation.getArgument(0);
@@ -65,22 +65,22 @@ public class MraidStorePictureTest {
                 return null;
             }
         });
-        mMockBaseJsInterface = spy(new BaseJSInterface(mContext, mMockWebViewBase, mMockJsExecutor));
+        mockBaseJsInterface = spy(new BaseJSInterface(context, mockWebViewBase, mockJsExecutor));
 
-        mMraidStorePicture = new MraidStorePicture(mContext, mMockBaseJsInterface, mMockWebViewBase);
+        mraidStorePicture = new MraidStorePicture(context, mockBaseJsInterface, mockWebViewBase);
     }
 
     @Test
     public void storePictureTest() {
-        mMraidStorePicture.storePicture("test_url");
-        verify((Activity) mContext).isFinishing();
+        mraidStorePicture.storePicture("test_url");
+        verify((Activity) context).isFinishing();
     }
 
     @Test
     public void storePictureErrorPrivateTest() throws Exception {
         Method method = WhiteBox.method(MraidStorePicture.class, "storePicture");
 
-        method.invoke(mMraidStorePicture);
-        verify(mMockBaseJsInterface, timeout(5000)).onError("store_picture", JSInterface.ACTION_STORE_PICTURE);
+        method.invoke(mraidStorePicture);
+        verify(mockBaseJsInterface, timeout(5000)).onError("store_picture", JSInterface.ACTION_STORE_PICTURE);
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/mraid/methods/MraidUrlHandlerTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/mraid/methods/MraidUrlHandlerTest.java
@@ -41,23 +41,23 @@ import static org.mockito.Mockito.*;
 @Config(sdk = 19)
 public class MraidUrlHandlerTest {
 
-    private MraidUrlHandler mMraidUrlHandler;
+    private MraidUrlHandler mraidUrlHandler;
 
-    private BaseJSInterface mMockBaseJsInterface;
-    private Context mMockContext;
-    private WebViewBase mMockWebViewBase;
-    private UrlHandler mMockUrlHandler;
+    private BaseJSInterface mockBaseJsInterface;
+    private Context mockContext;
+    private WebViewBase mockWebViewBase;
+    private UrlHandler mockUrlHandler;
 
     @Before
     public void setup() {
-        mMockContext = mock(Context.class);
-        mMockBaseJsInterface = mock(BaseJSInterface.class);
-        mMockWebViewBase = mock(WebViewBase.class);
-        mMockUrlHandler = mock(UrlHandler.class);
+        mockContext = mock(Context.class);
+        mockBaseJsInterface = mock(BaseJSInterface.class);
+        mockWebViewBase = mock(WebViewBase.class);
+        mockUrlHandler = mock(UrlHandler.class);
 
-        mMraidUrlHandler = spy(new MraidUrlHandler(mMockContext, mMockBaseJsInterface));
+        mraidUrlHandler = spy(new MraidUrlHandler(mockContext, mockBaseJsInterface));
 
-        when(mMraidUrlHandler.createUrlHandler(anyInt())).thenReturn(mMockUrlHandler);
+        when(mraidUrlHandler.createUrlHandler(anyInt())).thenReturn(mockUrlHandler);
     }
 
     @Test
@@ -68,19 +68,22 @@ public class MraidUrlHandlerTest {
             listener.onSuccess(invocation.getArgument(0), "html");
 
             return null;
-        }).when(mMockBaseJsInterface).followToOriginalUrl(anyString(), any(RedirectUrlListener.class));
+        }).when(mockBaseJsInterface).followToOriginalUrl(anyString(), any(RedirectUrlListener.class));
         PackageManager mockPackageManager = mock(PackageManager.class);
-        when(mMockContext.getApplicationContext()).thenReturn(mMockContext);
-        when(mMockContext.getPackageManager()).thenReturn(mockPackageManager);
-        when(mockPackageManager.queryIntentActivities(any(Intent.class), eq(PackageManager.MATCH_DEFAULT_ONLY))).thenReturn(new ArrayList<>());
+        when(mockContext.getApplicationContext()).thenReturn(mockContext);
+        when(mockContext.getPackageManager()).thenReturn(mockPackageManager);
+        when(mockPackageManager.queryIntentActivities(
+                any(Intent.class),
+                eq(PackageManager.MATCH_DEFAULT_ONLY)
+        )).thenReturn(new ArrayList<>());
 
-        mMraidUrlHandler.open("http:", -1);
-        verify(mMockUrlHandler).handleUrl(mMockContext, "http:", null, true);
+        mraidUrlHandler.open("http:", -1);
+        verify(mockUrlHandler).handleUrl(mockContext, "http:", null, true);
     }
 
     @Test
     public void destroyTest() {
-        mMraidUrlHandler.destroy();
-        verify(mMockBaseJsInterface).destroy();
+        mraidUrlHandler.destroy();
+        verify(mockBaseJsInterface).destroy();
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/mraid/methods/network/GetOriginalUrlTaskTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/mraid/methods/network/GetOriginalUrlTaskTest.java
@@ -45,206 +45,206 @@ import static org.prebid.mobile.rendering.networking.BaseNetworkTask.REDIRECT_TA
 @Config(sdk = 25)
 public class GetOriginalUrlTaskTest {
 
-    private boolean mSuccess;
-    private GetUrlResult mResponse;
-    private MockWebServer mServer;
-    private String mMsg;
-    private BaseNetworkTask.GetUrlParams mParams;
-    private Exception mException;
+    private boolean success;
+    private GetUrlResult response;
+    private MockWebServer server;
+    private String msg;
+    private BaseNetworkTask.GetUrlParams params;
+    private Exception exception;
 
-    private ResponseHandler mBaseResponseHandler = new ResponseHandler() {
+    private ResponseHandler baseResponseHandler = new ResponseHandler() {
 
         @Override
         public void onResponse(GetUrlResult response) {
-            mSuccess = true;
-            mResponse = response;
+            success = true;
+            GetOriginalUrlTaskTest.this.response = response;
         }
 
         @Override
         public void onError(String msg, long responseTime) {
-            mSuccess = false;
-            mMsg = msg;
+            success = false;
+            GetOriginalUrlTaskTest.this.msg = msg;
         }
 
         @Override
         public void onErrorWithException(Exception e, long responseTime) {
-            mSuccess = false;
-            mException = e;
+            success = false;
+            exception = e;
         }
     };
 
     @Before
     public void setUp() throws Exception {
-        mServer = new MockWebServer();
-        mParams = new BaseNetworkTask.GetUrlParams();
-        mParams.name = "TESTFIRST";
-        mParams.userAgent = "user-agent";
-        HttpUrl baseUrl = mServer.url("/first");
-        mParams.url = baseUrl.url().toString();
-        mParams.requestType = "GET";
+        server = new MockWebServer();
+        params = new BaseNetworkTask.GetUrlParams();
+        params.name = "TESTFIRST";
+        params.userAgent = "user-agent";
+        HttpUrl baseUrl = server.url("/first");
+        params.url = baseUrl.url().toString();
+        params.requestType = "GET";
     }
 
     @After
     public void tearDown() throws Exception {
-        mServer.shutdown();
+        server.shutdown();
     }
 
     @Test
     public void testSuccessDoInBackground() throws IOException {
-        mServer.enqueue(new MockResponse().setResponseCode(200).setBody("This is google!"));
+        server.enqueue(new MockResponse().setResponseCode(200).setBody("This is google!"));
 
-        GetOriginalUrlTask baseNetworkTask = new GetOriginalUrlTask(mBaseResponseHandler);
+        GetOriginalUrlTask baseNetworkTask = new GetOriginalUrlTask(baseResponseHandler);
 
         try {
-            baseNetworkTask.execute(mParams);
+            baseNetworkTask.execute(params);
         } catch (Exception e) {
             e.printStackTrace();
         }
 
-        assertEquals(true, mSuccess);
+        assertEquals(true, success);
     }
 
     @Test
     public void test400ExceptionError() throws IOException {
-        mServer.enqueue(new MockResponse().setResponseCode(400).setBody("404 not found"));
+        server.enqueue(new MockResponse().setResponseCode(400).setBody("404 not found"));
 
-        GetOriginalUrlTask baseNetworkTask = new GetOriginalUrlTask(mBaseResponseHandler);
+        GetOriginalUrlTask baseNetworkTask = new GetOriginalUrlTask(baseResponseHandler);
 
         try {
-            baseNetworkTask.execute(mParams);
+            baseNetworkTask.execute(params);
         } catch (Exception e) {
             e.printStackTrace();
         }
 
-        assertTrue(mException.getLocalizedMessage().contains("Code 400"));
-        assertEquals(false, mSuccess);
+        assertTrue(exception.getLocalizedMessage().contains("Code 400"));
+        assertEquals(false, success);
     }
 
     @Test
     public void test401ExceptionError() throws IOException {
-        mServer.enqueue(new MockResponse().setResponseCode(401).setBody("404 not found"));
+        server.enqueue(new MockResponse().setResponseCode(401).setBody("404 not found"));
 
-        GetOriginalUrlTask baseNetworkTask = new GetOriginalUrlTask(mBaseResponseHandler);
+        GetOriginalUrlTask baseNetworkTask = new GetOriginalUrlTask(baseResponseHandler);
 
         try {
-            baseNetworkTask.execute(mParams);
+            baseNetworkTask.execute(params);
         } catch (Exception e) {
             e.printStackTrace();
         }
 
-        assertTrue(mException.getLocalizedMessage().contains("Code 401"));
-        assertEquals(false, mSuccess);
+        assertTrue(exception.getLocalizedMessage().contains("Code 401"));
+        assertEquals(false, success);
     }
 
     @Test
     public void test402ExceptionError() throws IOException {
-        mServer.enqueue(new MockResponse().setResponseCode(402).setBody("404 not found"));
+        server.enqueue(new MockResponse().setResponseCode(402).setBody("404 not found"));
 
-        GetOriginalUrlTask baseNetworkTask = new GetOriginalUrlTask(mBaseResponseHandler);
+        GetOriginalUrlTask baseNetworkTask = new GetOriginalUrlTask(baseResponseHandler);
 
         try {
-            baseNetworkTask.execute(mParams);
+            baseNetworkTask.execute(params);
         } catch (Exception e) {
             e.printStackTrace();
         }
 
-        assertTrue(mException.getLocalizedMessage().contains("Code 402"));
-        assertEquals(false, mSuccess);
+        assertTrue(exception.getLocalizedMessage().contains("Code 402"));
+        assertEquals(false, success);
     }
 
     @Test
     public void test403ExceptionError() throws IOException {
-        mServer.enqueue(new MockResponse().setResponseCode(403).setBody("404 not found"));
+        server.enqueue(new MockResponse().setResponseCode(403).setBody("404 not found"));
 
-        GetOriginalUrlTask baseNetworkTask = new GetOriginalUrlTask(mBaseResponseHandler);
+        GetOriginalUrlTask baseNetworkTask = new GetOriginalUrlTask(baseResponseHandler);
 
         try {
-            baseNetworkTask.execute(mParams);
+            baseNetworkTask.execute(params);
         } catch (Exception e) {
             e.printStackTrace();
         }
 
-        assertTrue(mException.getLocalizedMessage().contains("Code 403"));
-        assertEquals(false, mSuccess);
+        assertTrue(exception.getLocalizedMessage().contains("Code 403"));
+        assertEquals(false, success);
     }
 
     @Test
     public void test404ExceptionError() throws IOException {
-        mServer.enqueue(new MockResponse().setResponseCode(404).setBody("404 not found"));
+        server.enqueue(new MockResponse().setResponseCode(404).setBody("404 not found"));
 
-        GetOriginalUrlTask baseNetworkTask = new GetOriginalUrlTask(mBaseResponseHandler);
+        GetOriginalUrlTask baseNetworkTask = new GetOriginalUrlTask(baseResponseHandler);
 
         try {
-            baseNetworkTask.execute(mParams);
+            baseNetworkTask.execute(params);
         } catch (Exception e) {
             e.printStackTrace();
         }
 
-        assertTrue(mException.getLocalizedMessage().contains("Code 404"));
-        assertEquals(false, mSuccess);
+        assertTrue(exception.getLocalizedMessage().contains("Code 404"));
+        assertEquals(false, success);
     }
 
     @Test
     public void test405ExceptionError() throws IOException {
-        mServer.enqueue(new MockResponse().setResponseCode(405).setBody("404 not found"));
+        server.enqueue(new MockResponse().setResponseCode(405).setBody("404 not found"));
 
-        GetOriginalUrlTask baseNetworkTask = new GetOriginalUrlTask(mBaseResponseHandler);
+        GetOriginalUrlTask baseNetworkTask = new GetOriginalUrlTask(baseResponseHandler);
 
         try {
-            baseNetworkTask.execute(mParams);
+            baseNetworkTask.execute(params);
         } catch (Exception e) {
             e.printStackTrace();
         }
 
-        assertTrue(mException.getLocalizedMessage().contains("Code 405"));
-        assertEquals(false, mSuccess);
+        assertTrue(exception.getLocalizedMessage().contains("Code 405"));
+        assertEquals(false, success);
     }
 
     @Test
     public void testEmptyVast() throws IOException {
-        mServer.enqueue(new MockResponse().setResponseCode(200).setBody("<VAST version=\"2.0\"></VAST>"));
+        server.enqueue(new MockResponse().setResponseCode(200).setBody("<VAST version=\"2.0\"></VAST>"));
 
-        GetOriginalUrlTask baseNetworkTask = new GetOriginalUrlTask(mBaseResponseHandler);
+        GetOriginalUrlTask baseNetworkTask = new GetOriginalUrlTask(baseResponseHandler);
 
         try {
-            baseNetworkTask.execute(mParams);
+            baseNetworkTask.execute(params);
         } catch (Exception e) {
             e.printStackTrace();
         }
 
-        assertEquals("Invalid VAST Response: less than 100 characters.", mMsg);
-        assertEquals(false, mSuccess);
+        assertEquals("Invalid VAST Response: less than 100 characters.", msg);
+        assertEquals(false, success);
     }
 
     @Test
     public void test301Redirect() throws IOException {
-        mServer.enqueue(new MockResponse()
+        server.enqueue(new MockResponse()
                             .setResponseCode(301)
-                            .addHeader("Location: " + mServer.url("/new-path"))
+                            .addHeader("Location: " + server.url("/new-path"))
                             .setBody("This page has moved!"));
-        mServer.enqueue(new MockResponse().setBody("This is the new location!"));
+        server.enqueue(new MockResponse().setBody("This is the new location!"));
 
-        GetOriginalUrlTask baseNetworkTask = new GetOriginalUrlTask(mBaseResponseHandler);
+        GetOriginalUrlTask baseNetworkTask = new GetOriginalUrlTask(baseResponseHandler);
 
-        mParams.name = REDIRECT_TASK;
+        params.name = REDIRECT_TASK;
 
         try {
-            baseNetworkTask.execute(mParams);
+            baseNetworkTask.execute(params);
         } catch (Exception e) {
             e.printStackTrace();
         }
 
-        assertEquals(true, mSuccess);
+        assertEquals(true, success);
     }
 
     @Test
     public void testCustomParserWith200Code() throws IOException {
 
-        mServer.enqueue(new MockResponse().setResponseCode(200).setBody("this is a success response"));
+        server.enqueue(new MockResponse().setResponseCode(200).setBody("this is a success response"));
 
         GetOriginalUrlTask baseNetworkTask = new GetOriginalUrlTask(null);
 
-        HttpUrl baseUrl = mServer.url("/first");
+        HttpUrl baseUrl = server.url("/first");
         URL uUrl = new URL(baseUrl.url().toString());
         HttpURLConnection con = (HttpURLConnection) uUrl.openConnection();
 
@@ -284,9 +284,9 @@ public class GetOriginalUrlTaskTest {
 
     @Test
     public void testCustomParserWith301Code() throws IOException {
-        mServer.enqueue(new MockResponse().setResponseCode(301).setBody("this is a success response"));
+        server.enqueue(new MockResponse().setResponseCode(301).setBody("this is a success response"));
         GetOriginalUrlTask baseNetworkTask = new GetOriginalUrlTask(null);
-        HttpUrl baseUrl = mServer.url("/first");
+        HttpUrl baseUrl = server.url("/first");
         URL uUrl = new URL(baseUrl.url().toString());
         HttpURLConnection con = (HttpURLConnection) uUrl.openConnection();
         con.setInstanceFollowRedirects(false);
@@ -305,9 +305,9 @@ public class GetOriginalUrlTaskTest {
 
     @Test
     public void testCustomParserWith308Code() throws IOException {
-        mServer.enqueue(new MockResponse().setResponseCode(308).setBody("this is a success response"));
+        server.enqueue(new MockResponse().setResponseCode(308).setBody("this is a success response"));
         GetOriginalUrlTask baseNetworkTask = new GetOriginalUrlTask(null);
-        HttpUrl baseUrl = mServer.url("/first");
+        HttpUrl baseUrl = server.url("/first");
         URL uUrl = new URL(baseUrl.url().toString());
         HttpURLConnection con = (HttpURLConnection) uUrl.openConnection();
         con.setInstanceFollowRedirects(false);
@@ -327,11 +327,11 @@ public class GetOriginalUrlTaskTest {
     @Test
     public void getRedirectionUrlWithTypeWithNoUrlParamTest() throws Exception {
         GetOriginalUrlTask getOriginalUrlNetworkTask = new GetOriginalUrlTask(null);
-        mParams.url = "";
+        params.url = "";
         String[] redirectObject = (String[]) WhiteBox.method(GetOriginalUrlTask.class,
                                                              "getRedirectionUrlWithType",
                                                              BaseNetworkTask.GetUrlParams.class)
-                                                     .invoke(getOriginalUrlNetworkTask, mParams);
+                                                     .invoke(getOriginalUrlNetworkTask, params);
         Assert.assertEquals("A param object with empty url should return {'', null null}", redirectObject[0], "");
         Assert.assertEquals("A param object with empty url should return {'', null null}", redirectObject[1], null);
         Assert.assertEquals("A param object with empty url should return {'', null null}", redirectObject[2], null);
@@ -342,38 +342,38 @@ public class GetOriginalUrlTaskTest {
         Method methodGetRedirectionUrl = WhiteBox.method(GetOriginalUrlTask.class, "getRedirectionUrlWithType", BaseNetworkTask.GetUrlParams.class);
 
         GetOriginalUrlTask getOriginalUrlNetworkTask = new GetOriginalUrlTask(null);
-        mParams.url = "tel://123456789";
-        String[] redirectObject = (String[]) methodGetRedirectionUrl.invoke(getOriginalUrlNetworkTask, mParams);
+        params.url = "tel://123456789";
+        String[] redirectObject = (String[]) methodGetRedirectionUrl.invoke(getOriginalUrlNetworkTask, params);
         Assert.assertEquals("A url param object with tel: should return {'', null null}", redirectObject[0], "tel://123456789");
         Assert.assertEquals("A url param object with tel: url should return {'', null null}", redirectObject[1], null);
         Assert.assertEquals("A url param object with tel: url should return {'', null null}", redirectObject[2], null);
-        mParams.url = "voicemail://123456789";
-        redirectObject = (String[]) methodGetRedirectionUrl.invoke(getOriginalUrlNetworkTask, mParams);
+        params.url = "voicemail://123456789";
+        redirectObject = (String[]) methodGetRedirectionUrl.invoke(getOriginalUrlNetworkTask, params);
         Assert.assertEquals("A url param object with voicemail: should return {'', null null}", redirectObject[0], "voicemail://123456789");
         Assert.assertEquals( "A url param object with voicemail: url should return {'', null null}", redirectObject[1], null);
         Assert.assertEquals( "A url param object with voicemail: url should return {'', null null}", redirectObject[2], null);
-        mParams.url = "sms://123456789";
-        redirectObject = (String[]) methodGetRedirectionUrl.invoke(getOriginalUrlNetworkTask, mParams);
+        params.url = "sms://123456789";
+        redirectObject = (String[]) methodGetRedirectionUrl.invoke(getOriginalUrlNetworkTask, params);
         Assert.assertEquals("A url param object with sms: should return {'', null null}", redirectObject[0], "sms://123456789");
         Assert.assertEquals( "A url param object with sms: url should return {'', null null}", redirectObject[1], null);
         Assert.assertEquals( "A url param object with sms: url should return {'', null null}", redirectObject[2], null);
-        mParams.url = "mailto://123456789";
-        redirectObject = (String[]) methodGetRedirectionUrl.invoke(getOriginalUrlNetworkTask, mParams);
+        params.url = "mailto://123456789";
+        redirectObject = (String[]) methodGetRedirectionUrl.invoke(getOriginalUrlNetworkTask, params);
         Assert.assertEquals("A url param object with mailto: should return {'', null null}", redirectObject[0], "mailto://123456789");
         Assert.assertEquals( "A url param object with mailto: url should return {'', null null}", redirectObject[1], null);
         Assert.assertEquals( "A url param object with mailto: url should return {'', null null}", redirectObject[2], null);
-        mParams.url = "geo://123456789";
-        redirectObject = (String[]) methodGetRedirectionUrl.invoke(getOriginalUrlNetworkTask, mParams);
+        params.url = "geo://123456789";
+        redirectObject = (String[]) methodGetRedirectionUrl.invoke(getOriginalUrlNetworkTask, params);
         Assert.assertEquals("A url param object with tel: should return {'', null null}", redirectObject[0], "geo://123456789");
         Assert.assertEquals( "A url param object with tel: url should return {'', null null}", redirectObject[1], null);
         Assert.assertEquals( "A url param object with tel: url should return {'', null null}", redirectObject[2], null);
-        mParams.url = "google.streetview://123456789";
-        redirectObject = (String[]) methodGetRedirectionUrl.invoke(getOriginalUrlNetworkTask, mParams);
+        params.url = "google.streetview://123456789";
+        redirectObject = (String[]) methodGetRedirectionUrl.invoke(getOriginalUrlNetworkTask, params);
         Assert.assertEquals("A url param object with geo: should return {'', null null}", redirectObject[0], "google.streetview://123456789");
         Assert.assertEquals( "A url param object with geo: url should return {'', null null}", redirectObject[1], null);
         Assert.assertEquals( "A url param object with geo: url should return {'', null null}", redirectObject[2], null);
-        mParams.url = "market://123456789";
-        redirectObject = (String[]) methodGetRedirectionUrl.invoke(getOriginalUrlNetworkTask, mParams);
+        params.url = "market://123456789";
+        redirectObject = (String[]) methodGetRedirectionUrl.invoke(getOriginalUrlNetworkTask, params);
         Assert.assertEquals("A url param object with market: should return {'', null null}", redirectObject[0], "market://123456789");
         Assert.assertEquals( "A url param object with market: url should return {'', null null}", redirectObject[1], null);
         Assert.assertEquals( "A url param object with market: url should return {'', null null}", redirectObject[2], null);
@@ -381,130 +381,134 @@ public class GetOriginalUrlTaskTest {
 
     @Test
     public void getRedirectionUrlWithTypeWithRedirectUrlTest() {
-        mServer.enqueue(new MockResponse()
+        server.enqueue(new MockResponse()
                             .setResponseCode(301)
-                            .addHeader("Location: " + mServer.url("/new-path"))
+                            .addHeader("Location: " + server.url("/new-path"))
                             .setBody("This page has moved!"));
-        mServer.enqueue(new MockResponse().setResponseCode(200).setBody("This is the new location"));
-        GetOriginalUrlTask getOriginalUrlNetworkTask = new GetOriginalUrlTask(mBaseResponseHandler);
-        mParams.name = REDIRECT_TASK;
+        server.enqueue(new MockResponse().setResponseCode(200).setBody("This is the new location"));
+        GetOriginalUrlTask getOriginalUrlNetworkTask = new GetOriginalUrlTask(baseResponseHandler);
+        params.name = REDIRECT_TASK;
 
         try {
-            getOriginalUrlNetworkTask.execute(mParams);
+            getOriginalUrlNetworkTask.execute(params);
         }
         catch (Exception e) {
             e.printStackTrace();
         }
 
-        Assert.assertEquals(true, mSuccess);
+        Assert.assertEquals(true, success);
     }
 
     @Test
     public void getRedirectionUrlWithTypeWithNoRedirectUrlTest() throws Exception {
-        mServer.enqueue(new MockResponse().setResponseCode(200).setBody("this is a success response"));
+        server.enqueue(new MockResponse().setResponseCode(200).setBody("this is a success response"));
         GetOriginalUrlTask getOriginalUrlNetworkTask = new GetOriginalUrlTask(null);
-        HttpUrl baseUrl = mServer.url("/first");
-        mParams.url = baseUrl.url().toString();
+        HttpUrl baseUrl = server.url("/first");
+        params.url = baseUrl.url().toString();
         String[] redirectObject = (String[]) WhiteBox.method(GetOriginalUrlTask.class,
                                                              "getRedirectionUrlWithType",
                                                              BaseNetworkTask.GetUrlParams.class)
-                                                     .invoke(getOriginalUrlNetworkTask, mParams);
-        Assert.assertEquals("A param object with non-redirect url should return {non-redirect, application/json quit}", redirectObject[0], mServer.url("/first").toString());
+                                                     .invoke(getOriginalUrlNetworkTask, params);
+        Assert.assertEquals("A param object with non-redirect url should return {non-redirect, application/json quit}", redirectObject[0], server.url("/first").toString());
         Assert.assertEquals("A param object with non-redirect url should return {non-redirect, application/json quit}", redirectObject[1], "application/json");
         Assert.assertEquals("A param object with non-redirect url should return {non-redirect, application/json quit}", redirectObject[2], "quit");
     }
 
     @Test
     public void getUrlTest() throws Exception {
-        mServer.enqueue(new MockResponse().setResponseCode(200).setBody("this is a success response"));
+        server.enqueue(new MockResponse().setResponseCode(200).setBody("this is a success response"));
         GetOriginalUrlTask getOriginalUrlNetworkTask = new GetOriginalUrlTask(null);
-        HttpUrl baseUrl = mServer.url("/first");
-        mParams.url = baseUrl.url().toString();
-        BaseNetworkTask.GetUrlParams[] params = {mParams};
+        HttpUrl baseUrl = server.url("/first");
+        params.url = baseUrl.url().toString();
+        BaseNetworkTask.GetUrlParams[] params = {this.params};
         GetUrlResult result = (GetUrlResult) WhiteBox.method(GetOriginalUrlTask.class, "getUrl", BaseNetworkTask.GetUrlParams[].class)
-                                                     .invoke(getOriginalUrlNetworkTask, (Object) new BaseNetworkTask.GetUrlParams[]{
-                                                         mParams});
+                                                     .invoke(getOriginalUrlNetworkTask, (Object) new BaseNetworkTask.GetUrlParams[]{this.params});
         Assert.assertEquals("A successful response should yile a result object with status code 200", result.statusCode, 200);
     }
 
     @Test
     public void getUrlNullParamsTest() throws Exception {
         GetOriginalUrlTask getOriginalUrlNetworkTask = new GetOriginalUrlTask(null);
-        mParams = null;
-        GetUrlResult result = (GetUrlResult) WhiteBox.method(GetOriginalUrlTask.class, "getUrl", BaseNetworkTask.GetUrlParams.class).invoke(getOriginalUrlNetworkTask, mParams);
+        params = null;
+        GetUrlResult result = (GetUrlResult) WhiteBox.method(GetOriginalUrlTask.class, "getUrl", BaseNetworkTask.GetUrlParams.class).invoke(getOriginalUrlNetworkTask,
+                params
+        );
         assertNotNull("A null params object should generate a result object with Exception",result.getException());
     }
 
     @Test
     public void getUrlOriginalUrlShouldBeSetTest() throws Exception {
-        mServer.enqueue(new MockResponse()
+        server.enqueue(new MockResponse()
                             .setResponseCode(301)
-                            .addHeader("Location: " + mServer.url("/new-path"))
+                            .addHeader("Location: " + server.url("/new-path"))
                             .setBody("This page has moved!"));
-        mServer.enqueue(new MockResponse().setResponseCode(200).setBody("This is the new location"));
+        server.enqueue(new MockResponse().setResponseCode(200).setBody("This is the new location"));
         GetOriginalUrlTask getOriginalUrlNetworkTask = new GetOriginalUrlTask(null);
-        HttpUrl baseUrl = mServer.url("/first");
-        mParams.url = baseUrl.url().toString();
+        HttpUrl baseUrl = server.url("/first");
+        params.url = baseUrl.url().toString();
         GetUrlResult result = (GetUrlResult) WhiteBox.method(GetOriginalUrlTask.class, "getUrl", BaseNetworkTask.GetUrlParams[].class)
-                                                     .invoke(getOriginalUrlNetworkTask, (Object) new BaseNetworkTask.GetUrlParams[]{
-                                                         mParams});
+                                                     .invoke(getOriginalUrlNetworkTask, (Object) new BaseNetworkTask.GetUrlParams[]{params});
         Assert.assertNotNull("Original url should not be null", result.originalUrl);
     }
 
     @Test
     public void processRedirectsTest() {
-        mServer.enqueue(new MockResponse()
+        server.enqueue(new MockResponse()
                             .setResponseCode(301)
-                            .addHeader("Location: " + mServer.url("/second"))
+                            .addHeader("Location: " + server.url("/second"))
                             .setBody("This page has moved!"));
-        mServer.enqueue(new MockResponse()
+        server.enqueue(new MockResponse()
                             .setResponseCode(301)
-                            .addHeader("Location: " + mServer.url("/third"))
+                            .addHeader("Location: " + server.url("/third"))
                             .setBody("This page has moved!"));
-        mServer.enqueue(new MockResponse()
+        server.enqueue(new MockResponse()
                             .setResponseCode(301)
-                            .addHeader("Location: " + mServer.url("/fourth"))
+                            .addHeader("Location: " + server.url("/fourth"))
                             .setBody("This page has moved!"));
-        mServer.enqueue(new MockResponse().setResponseCode(200).setBody("This is the new location"));
-        GetOriginalUrlTask getOriginalUrlNetworkTask = new GetOriginalUrlTask(mBaseResponseHandler);
-        mParams.name = REDIRECT_TASK;
+        server.enqueue(new MockResponse().setResponseCode(200).setBody("This is the new location"));
+        GetOriginalUrlTask getOriginalUrlNetworkTask = new GetOriginalUrlTask(baseResponseHandler);
+        params.name = REDIRECT_TASK;
         try {
-            getOriginalUrlNetworkTask.execute(mParams);
+            getOriginalUrlNetworkTask.execute(params);
         }
         catch (Exception e) {
             e.printStackTrace();
         }
 
-        Assert.assertEquals("Should iterate through max of 3 redirects after the original landing on the '4th' url ", true, mSuccess);
+        Assert.assertEquals("Should iterate through max of 3 redirects after the original landing on the '4th' url ", true,
+                success
+        );
     }
 
     @Test
     public void processRedirectsMaxOf3RedirectsTest() throws Exception {
-        mServer.enqueue(new MockResponse()
+        server.enqueue(new MockResponse()
                             .setResponseCode(301)
-                            .addHeader("Location: " + mServer.url("/second"))
+                            .addHeader("Location: " + server.url("/second"))
                             .setBody("This page has moved!"));
-        mServer.enqueue(new MockResponse()
+        server.enqueue(new MockResponse()
                             .setResponseCode(301)
-                            .addHeader("Location: " + mServer.url("/third"))
+                            .addHeader("Location: " + server.url("/third"))
                             .setBody("This page has moved!"));
-        mServer.enqueue(new MockResponse()
+        server.enqueue(new MockResponse()
                             .setResponseCode(301)
-                            .addHeader("Location: " + mServer.url("/fourth"))
+                            .addHeader("Location: " + server.url("/fourth"))
                             .setBody("This page has moved!"));
-        mServer.enqueue(new MockResponse()
+        server.enqueue(new MockResponse()
                             .setResponseCode(301)
-                            .addHeader("Location: " + mServer.url("/fifth"))
+                            .addHeader("Location: " + server.url("/fifth"))
                             .setBody("This page has moved!"));
 
-        mServer.enqueue(new MockResponse().setResponseCode(200).setBody("This is the new location"));
+        server.enqueue(new MockResponse().setResponseCode(200).setBody("This is the new location"));
 
         GetOriginalUrlTask getOriginalUrlNetworkTask = new GetOriginalUrlTask(null);
-        HttpUrl baseUrl = mServer.url("/first");
-        mParams.url = baseUrl.url().toString();
-        mParams.name = REDIRECT_TASK;
-        WhiteBox.method(GetOriginalUrlTask.class, "processRedirects", BaseNetworkTask.GetUrlParams.class).invoke(getOriginalUrlNetworkTask, mParams);
-        GetUrlResult result = (GetUrlResult) WhiteBox.getInternalState(getOriginalUrlNetworkTask, "mResult");
+        HttpUrl baseUrl = server.url("/first");
+        params.url = baseUrl.url().toString();
+        params.name = REDIRECT_TASK;
+        WhiteBox.method(GetOriginalUrlTask.class, "processRedirects", BaseNetworkTask.GetUrlParams.class).invoke(getOriginalUrlNetworkTask,
+                params
+        );
+        GetUrlResult result = (GetUrlResult) WhiteBox.getInternalState(getOriginalUrlNetworkTask, "result");
         Assert.assertNull("Should not have a valid result.response if over max redirects ", result.responseString);
     }
 

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/networking/BaseNetworkTaskTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/networking/BaseNetworkTaskTest.java
@@ -37,48 +37,48 @@ import static org.prebid.mobile.rendering.networking.BaseNetworkTask.REDIRECT_TA
 @RunWith(RobolectricTestRunner.class)
 public class BaseNetworkTaskTest {
 
-    private MockWebServer mServer;
-    private boolean sSuccess;
-    private BaseNetworkTask.GetUrlResult mResponse;
-    private String mMsg;
-    private BaseNetworkTask.GetUrlParams mParams;
-    private Exception mException;
+    private MockWebServer server;
+    private boolean success;
+    private BaseNetworkTask.GetUrlResult response;
+    private String msg;
+    private BaseNetworkTask.GetUrlParams params;
+    private Exception exception;
 
     ResponseHandler baseResponseHandler = new ResponseHandler() {
 
         @Override
         public void onResponse(BaseNetworkTask.GetUrlResult response) {
-            sSuccess = true;
-            mResponse = response;
+            success = true;
+            BaseNetworkTaskTest.this.response = response;
         }
 
         @Override
         public void onError(String msg, long responseTime) {
-            sSuccess = false;
-            mMsg = msg;
+            success = false;
+            BaseNetworkTaskTest.this.msg = msg;
         }
 
         @Override
         public void onErrorWithException(Exception e, long responseTime) {
-            sSuccess = false;
-            mException = e;
+            success = false;
+            exception = e;
         }
     };
 
     @Before
     public void setUp() throws Exception {
-        mServer = new MockWebServer();
-        mParams = new BaseNetworkTask.GetUrlParams();
-        mParams.name = "TESTFIRST";
-        mParams.userAgent = "user-agent";
-        HttpUrl baseUrl = mServer.url("/first");
-        mParams.url = baseUrl.url().toString();
-        mParams.requestType = "GET";
+        server = new MockWebServer();
+        params = new BaseNetworkTask.GetUrlParams();
+        params.name = "TESTFIRST";
+        params.userAgent = "user-agent";
+        HttpUrl baseUrl = server.url("/first");
+        params.url = baseUrl.url().toString();
+        params.requestType = "GET";
     }
 
     @After
     public void tearDown() throws Exception {
-        mServer.shutdown();
+        server.shutdown();
     }
 
     @Suppress
@@ -98,180 +98,180 @@ public class BaseNetworkTaskTest {
 
     @Test
     public void testSuccessDoInBackground() throws IOException {
-        mServer.enqueue(new MockResponse().setResponseCode(200).setBody("This is google!"));
+        server.enqueue(new MockResponse().setResponseCode(200).setBody("This is google!"));
 
         BaseNetworkTask baseNetworkTask = new BaseNetworkTask(baseResponseHandler);
 
         try {
-            baseNetworkTask.execute(mParams);
+            baseNetworkTask.execute(params);
         }
         catch (Exception e) {
             e.printStackTrace();
         }
 
-        Assert.assertEquals("This is google!", mResponse.responseString);
-        Assert.assertEquals(true, sSuccess);
+        Assert.assertEquals("This is google!", response.responseString);
+        Assert.assertEquals(true, success);
     }
 
     @Test
     public void test400ExceptionError() throws IOException {
-        mServer.enqueue(new MockResponse().setResponseCode(400).setBody("404 not found"));
+        server.enqueue(new MockResponse().setResponseCode(400).setBody("404 not found"));
 
         BaseNetworkTask baseNetworkTask = new BaseNetworkTask(baseResponseHandler);
 
         try {
-            baseNetworkTask.execute(mParams);
+            baseNetworkTask.execute(params);
         }
         catch (Exception e) {
             e.printStackTrace();
         }
 
-        Assert.assertTrue(mException.getLocalizedMessage().contains("Code 400"));
-        Assert.assertEquals(false, sSuccess);
+        Assert.assertTrue(exception.getLocalizedMessage().contains("Code 400"));
+        Assert.assertEquals(false, success);
     }
 
     @Test
     public void test401ExceptionError() throws IOException {
-        mServer.enqueue(new MockResponse().setResponseCode(401).setBody("404 not found"));
+        server.enqueue(new MockResponse().setResponseCode(401).setBody("404 not found"));
 
         BaseNetworkTask baseNetworkTask = new BaseNetworkTask(baseResponseHandler);
 
         try {
-            baseNetworkTask.execute(mParams);
+            baseNetworkTask.execute(params);
         }
         catch (Exception e) {
             e.printStackTrace();
         }
 
-        Assert.assertTrue(mException.getLocalizedMessage().contains("Code 401"));
-        Assert.assertEquals(false, sSuccess);
+        Assert.assertTrue(exception.getLocalizedMessage().contains("Code 401"));
+        Assert.assertEquals(false, success);
     }
 
     @Test
     public void test402ExceptionError() throws IOException {
-        mServer.enqueue(new MockResponse().setResponseCode(402).setBody("404 not found"));
+        server.enqueue(new MockResponse().setResponseCode(402).setBody("404 not found"));
 
         BaseNetworkTask baseNetworkTask = new BaseNetworkTask(baseResponseHandler);
 
         try {
-            baseNetworkTask.execute(mParams);
+            baseNetworkTask.execute(params);
         }
         catch (Exception e) {
             e.printStackTrace();
         }
 
-        Assert.assertTrue(mException.getLocalizedMessage().contains("Code 402"));
-        Assert.assertEquals(false, sSuccess);
+        Assert.assertTrue(exception.getLocalizedMessage().contains("Code 402"));
+        Assert.assertEquals(false, success);
     }
 
     @Test
     public void test403ExceptionError() throws IOException {
-        mServer.enqueue(new MockResponse().setResponseCode(403).setBody("404 not found"));
+        server.enqueue(new MockResponse().setResponseCode(403).setBody("404 not found"));
 
         BaseNetworkTask baseNetworkTask = new BaseNetworkTask(baseResponseHandler);
 
         try {
-            baseNetworkTask.execute(mParams);
+            baseNetworkTask.execute(params);
         }
         catch (Exception e) {
             e.printStackTrace();
         }
 
-        Assert.assertTrue(mException.getLocalizedMessage().contains("Code 403"));
-        Assert.assertEquals(false, sSuccess);
+        Assert.assertTrue(exception.getLocalizedMessage().contains("Code 403"));
+        Assert.assertEquals(false, success);
     }
 
     @Test
     public void test404ExceptionError() throws IOException {
-        mServer.enqueue(new MockResponse().setResponseCode(404).setBody("404 not found"));
+        server.enqueue(new MockResponse().setResponseCode(404).setBody("404 not found"));
 
         BaseNetworkTask baseNetworkTask = new BaseNetworkTask(baseResponseHandler);
 
         try {
-            baseNetworkTask.execute(mParams);
+            baseNetworkTask.execute(params);
         }
         catch (Exception e) {
             e.printStackTrace();
         }
 
-        MatcherAssert.assertThat(mException.getLocalizedMessage(), containsString("404"));
-        Assert.assertFalse(sSuccess);
+        MatcherAssert.assertThat(exception.getLocalizedMessage(), containsString("404"));
+        Assert.assertFalse(success);
     }
 
     @Test
     public void test405ExceptionError() throws IOException {
-        mServer.enqueue(new MockResponse().setResponseCode(405).setBody("404 not found"));
+        server.enqueue(new MockResponse().setResponseCode(405).setBody("404 not found"));
 
         BaseNetworkTask baseNetworkTask = new BaseNetworkTask(baseResponseHandler);
 
         try {
-            baseNetworkTask.execute(mParams);
+            baseNetworkTask.execute(params);
         }
         catch (Exception e) {
             e.printStackTrace();
         }
 
-        Assert.assertTrue(mException.getLocalizedMessage().contains("Code 405"));
-        Assert.assertEquals(false, sSuccess);
+        Assert.assertTrue(exception.getLocalizedMessage().contains("Code 405"));
+        Assert.assertEquals(false, success);
     }
 
     @Test
     public void testEmptyVast() throws IOException {
-        mServer.enqueue(new MockResponse().setResponseCode(200).setBody("<VAST version=\"2.0\"></VAST>"));
+        server.enqueue(new MockResponse().setResponseCode(200).setBody("<VAST version=\"2.0\"></VAST>"));
 
         BaseNetworkTask baseNetworkTask = new BaseNetworkTask(baseResponseHandler);
 
         try {
-            baseNetworkTask.execute(mParams);
+            baseNetworkTask.execute(params);
         }
         catch (Exception e) {
             e.printStackTrace();
         }
 
-        Assert.assertEquals("Invalid VAST Response: less than 100 characters.", mMsg);
-        Assert.assertEquals(false, sSuccess);
+        Assert.assertEquals("Invalid VAST Response: less than 100 characters.", msg);
+        Assert.assertEquals(false, success);
     }
 
     @Test
     public void test301Redirect() throws IOException {
-        mServer.enqueue(new MockResponse()
+        server.enqueue(new MockResponse()
                             .setResponseCode(301)
-                            .addHeader("Location: " + mServer.url("/new-path"))
+                            .addHeader("Location: " + server.url("/new-path"))
                             .setBody("This page has moved!"));
-        mServer.enqueue(new MockResponse().setBody("This is the new location!"));
+        server.enqueue(new MockResponse().setBody("This is the new location!"));
 
         BaseNetworkTask baseNetworkTask = new BaseNetworkTask(baseResponseHandler);
 
-        mParams.name = REDIRECT_TASK;
+        params.name = REDIRECT_TASK;
 
         try {
-            baseNetworkTask.execute(mParams);
+            baseNetworkTask.execute(params);
         }
         catch (Exception e) {
             e.printStackTrace();
         }
 
-        Assert.assertEquals(true, sSuccess);
+        Assert.assertEquals(true, success);
     }
 
     @Test
     public void test302Redirect() {
-        mServer.enqueue(new MockResponse().setResponseCode(302)
-                                          .addHeader("Location: " + mServer.url("/new-path"))
-                                          .setBody("This page has moved"));
-        mServer.enqueue(new MockResponse().setResponseCode(200).setBody("This is the new location"));
+        server.enqueue(new MockResponse().setResponseCode(302)
+                                         .addHeader("Location: " + server.url("/new-path"))
+                                         .setBody("This page has moved"));
+        server.enqueue(new MockResponse().setResponseCode(200).setBody("This is the new location"));
 
         BaseNetworkTask baseNetworkTask = new BaseNetworkTask(baseResponseHandler);
 
-        mParams.name = REDIRECT_TASK;
+        params.name = REDIRECT_TASK;
 
         try {
-            baseNetworkTask.execute(mParams);
+            baseNetworkTask.execute(params);
         }
         catch (Exception e) {
             e.printStackTrace();
         }
 
-        Assert.assertEquals(true, sSuccess);
+        Assert.assertEquals(true, success);
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/networking/modelcontrollers/BidRequesterTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/networking/modelcontrollers/BidRequesterTest.java
@@ -41,42 +41,41 @@ import static org.mockito.Mockito.*;
 @Config(sdk = 19)
 public class BidRequesterTest {
 
-    private Context mContext;
-    private AdUnitConfiguration mAdConfiguration;
-    private AdRequestInput mAdRequestInput;
+    private Context context;
+    private AdUnitConfiguration adConfiguration;
+    private AdRequestInput adRequestInput;
 
-    @Mock
-    private ResponseHandler mMockResponseHandler;
+    @Mock private ResponseHandler mockResponseHandler;
 
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
-        mContext = Robolectric.buildActivity(Activity.class).create().get();
-        mAdConfiguration = new AdUnitConfiguration();
-        mAdRequestInput = new AdRequestInput();
-        ManagersResolver.getInstance().prepare(mContext);
+        context = Robolectric.buildActivity(Activity.class).create().get();
+        adConfiguration = new AdUnitConfiguration();
+        adRequestInput = new AdRequestInput();
+        ManagersResolver.getInstance().prepare(context);
     }
 
     @Test
     public void whenStartAdRequestAndContextNull_OnErrorWithExceptionCalled() {
-        mAdConfiguration.setConfigId("test");
-        BidRequester requester = new BidRequester(null, mAdConfiguration, mAdRequestInput, mMockResponseHandler);
+        adConfiguration.setConfigId("test");
+        BidRequester requester = new BidRequester(null, adConfiguration, adRequestInput, mockResponseHandler);
         requester.startAdRequest();
-        verify(mMockResponseHandler).onErrorWithException(any(AdException.class), anyLong());
+        verify(mockResponseHandler).onErrorWithException(any(AdException.class), anyLong());
     }
 
     @Test
     public void whenStartAdRequestAndNoConfigId_OnErrorCalled() {
-        mAdConfiguration.setConfigId(null);
-        BidRequester requester = new BidRequester(mContext, mAdConfiguration, mAdRequestInput, mMockResponseHandler);
+        adConfiguration.setConfigId(null);
+        BidRequester requester = new BidRequester(context, adConfiguration, adRequestInput, mockResponseHandler);
         requester.startAdRequest();
-        verify(mMockResponseHandler).onError(anyString(), anyLong());
+        verify(mockResponseHandler).onError(anyString(), anyLong());
     }
 
     @Test
     public void whenStartAdRequestAndInitValid_InitAdId() {
-        mAdConfiguration.setConfigId("test");
-        BidRequester requester = spy(new BidRequester(mContext, mAdConfiguration, mAdRequestInput, mMockResponseHandler));
+        adConfiguration.setConfigId("test");
+        BidRequester requester = spy(new BidRequester(context, adConfiguration, adRequestInput, mockResponseHandler));
         requester.startAdRequest();
         verify(requester).makeAdRequest();
     }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/networking/parameters/BasicParameterBuilderTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/networking/parameters/BasicParameterBuilderTest.java
@@ -71,15 +71,15 @@ public class BasicParameterBuilderTest {
     private static final String USER_GENDER = "M";
     private static final String USER_BUYER_ID = "bid";
 
-    private Context mContext;
+    private Context context;
 
-    private final boolean mBrowserActivityAvailable = true;
+    private final boolean browserActivityAvailable = true;
 
     @Before
     public void setUp() throws Exception {
-        mContext = Robolectric.buildActivity(Activity.class).create().get();
-        org.prebid.mobile.PrebidMobile.setApplicationContext(mContext);
-        ManagersResolver.getInstance().prepare(mContext);
+        context = Robolectric.buildActivity(Activity.class).create().get();
+        org.prebid.mobile.PrebidMobile.setApplicationContext(context);
+        ManagersResolver.getInstance().prepare(context);
     }
 
     @After
@@ -110,7 +110,10 @@ public class BasicParameterBuilderTest {
         PrebidMobile.addStoredBidResponse("bidderTest", "123456");
         PrebidMobile.setStoredAuctionResponse("storedResponse");
 
-        BasicParameterBuilder builder = new BasicParameterBuilder(adConfiguration, mContext.getResources(), mBrowserActivityAvailable);
+        BasicParameterBuilder builder = new BasicParameterBuilder(adConfiguration,
+                context.getResources(),
+                browserActivityAvailable
+        );
         AdRequestInput adRequestInput = new AdRequestInput();
         builder.appendBuilderParameters(adRequestInput);
 
@@ -133,7 +136,10 @@ public class BasicParameterBuilderTest {
         adConfiguration.setAdFormat(AdFormat.INTERSTITIAL);
         adConfiguration.setAdPosition(AdPosition.FULLSCREEN);
 
-        BasicParameterBuilder builder = new BasicParameterBuilder(adConfiguration, mContext.getResources(), mBrowserActivityAvailable);
+        BasicParameterBuilder builder = new BasicParameterBuilder(adConfiguration,
+                context.getResources(),
+                browserActivityAvailable
+        );
         AdRequestInput adRequestInput = new AdRequestInput();
         builder.appendBuilderParameters(adRequestInput);
 
@@ -157,7 +163,10 @@ public class BasicParameterBuilderTest {
         adConfiguration.setAdFormat(AdFormat.VAST);
         adConfiguration.setAdPosition(AdPosition.FULLSCREEN);
 
-        BasicParameterBuilder builder = new BasicParameterBuilder(adConfiguration, mContext.getResources(), mBrowserActivityAvailable);
+        BasicParameterBuilder builder = new BasicParameterBuilder(adConfiguration,
+                context.getResources(),
+                browserActivityAvailable
+        );
         AdRequestInput adRequestInput = new AdRequestInput();
         builder.appendBuilderParameters(adRequestInput);
 
@@ -184,7 +193,10 @@ public class BasicParameterBuilderTest {
         adConfiguration.setAdPosition(AdPosition.FULLSCREEN);
         adConfiguration.addSize(new AdSize(300, 250));
 
-        BasicParameterBuilder builder = new BasicParameterBuilder(adConfiguration, mContext.getResources(), mBrowserActivityAvailable);
+        BasicParameterBuilder builder = new BasicParameterBuilder(adConfiguration,
+                context.getResources(),
+                browserActivityAvailable
+        );
         AdRequestInput adRequestInput = new AdRequestInput();
         builder.appendBuilderParameters(adRequestInput);
 
@@ -210,7 +222,10 @@ public class BasicParameterBuilderTest {
 
         PrebidMobile.isCoppaEnabled = true;
 
-        BasicParameterBuilder builder = new BasicParameterBuilder(adConfiguration, mContext.getResources(), mBrowserActivityAvailable);
+        BasicParameterBuilder builder = new BasicParameterBuilder(adConfiguration,
+                context.getResources(),
+                browserActivityAvailable
+        );
         AdRequestInput adRequestInput = new AdRequestInput();
         builder.appendBuilderParameters(adRequestInput);
 
@@ -224,7 +239,10 @@ public class BasicParameterBuilderTest {
         adConfiguration.setAdFormat(AdFormat.BANNER);
         adConfiguration.addSize(new AdSize(320, 50));
 
-        BasicParameterBuilder builder = new BasicParameterBuilder(adConfiguration, mContext.getResources(), mBrowserActivityAvailable);
+        BasicParameterBuilder builder = new BasicParameterBuilder(adConfiguration,
+                context.getResources(),
+                browserActivityAvailable
+        );
         AdRequestInput adRequestInput = new AdRequestInput();
         builder.appendBuilderParameters(adRequestInput);
 
@@ -248,7 +266,10 @@ public class BasicParameterBuilderTest {
         TargetingParams.setUserExt(new Ext());
         TargetingParams.setUserLatLng(USER_LAT, USER_LON);
 
-        BasicParameterBuilder builder = new BasicParameterBuilder(adConfiguration, mContext.getResources(), mBrowserActivityAvailable);
+        BasicParameterBuilder builder = new BasicParameterBuilder(adConfiguration,
+                context.getResources(),
+                browserActivityAvailable
+        );
         AdRequestInput adRequestInput = new AdRequestInput();
         builder.appendBuilderParameters(adRequestInput);
 
@@ -265,7 +286,10 @@ public class BasicParameterBuilderTest {
 
         PrebidMobile.sendMraidSupportParams = false;
 
-        BasicParameterBuilder builder = new BasicParameterBuilder(adConfiguration, mContext.getResources(), mBrowserActivityAvailable);
+        BasicParameterBuilder builder = new BasicParameterBuilder(adConfiguration,
+                context.getResources(),
+                browserActivityAvailable
+        );
         AdRequestInput adRequestInput = new AdRequestInput();
         builder.appendBuilderParameters(adRequestInput);
 
@@ -281,7 +305,10 @@ public class BasicParameterBuilderTest {
 
         PrebidMobile.useExternalBrowser = false;
 
-        BasicParameterBuilder builder = new BasicParameterBuilder(adConfiguration, mContext.getResources(), mBrowserActivityAvailable);
+        BasicParameterBuilder builder = new BasicParameterBuilder(adConfiguration,
+                context.getResources(),
+                browserActivityAvailable
+        );
         AdRequestInput adRequestInput = new AdRequestInput();
         builder.appendBuilderParameters(adRequestInput);
 
@@ -297,7 +324,10 @@ public class BasicParameterBuilderTest {
 
         PrebidMobile.useExternalBrowser = true;
 
-        BasicParameterBuilder builder = new BasicParameterBuilder(adConfiguration, mContext.getResources(), mBrowserActivityAvailable);
+        BasicParameterBuilder builder = new BasicParameterBuilder(adConfiguration,
+                context.getResources(),
+                browserActivityAvailable
+        );
         AdRequestInput adRequestInput = new AdRequestInput();
         builder.appendBuilderParameters(adRequestInput);
 
@@ -313,7 +343,7 @@ public class BasicParameterBuilderTest {
 
         PrebidMobile.useExternalBrowser = false;
 
-        BasicParameterBuilder builder = new BasicParameterBuilder(adConfiguration, mContext.getResources(), false);
+        BasicParameterBuilder builder = new BasicParameterBuilder(adConfiguration, context.getResources(), false);
         AdRequestInput adRequestInput = new AdRequestInput();
         builder.appendBuilderParameters(adRequestInput);
 
@@ -328,7 +358,7 @@ public class BasicParameterBuilderTest {
 
         AdUnitConfiguration adConfiguration = new AdUnitConfiguration();
         adConfiguration.setConfigId("config");
-        BasicParameterBuilder builder = new BasicParameterBuilder(adConfiguration, mContext.getResources(), false);
+        BasicParameterBuilder builder = new BasicParameterBuilder(adConfiguration, context.getResources(), false);
         AdRequestInput adRequestInput = new AdRequestInput();
         builder.appendBuilderParameters(adRequestInput);
 
@@ -346,7 +376,7 @@ public class BasicParameterBuilderTest {
 
         AdUnitConfiguration adConfiguration = new AdUnitConfiguration();
         adConfiguration.setConfigId("config");
-        BasicParameterBuilder builder = new BasicParameterBuilder(adConfiguration, mContext.getResources(), false);
+        BasicParameterBuilder builder = new BasicParameterBuilder(adConfiguration, context.getResources(), false);
         AdRequestInput adRequestInput = new AdRequestInput();
         builder.appendBuilderParameters(adRequestInput);
 
@@ -366,7 +396,7 @@ public class BasicParameterBuilderTest {
         String testName = "testDataObject";
         dataObject.setName(testName);
         adConfiguration.addUserData(dataObject);
-        BasicParameterBuilder builder = new BasicParameterBuilder(adConfiguration, mContext.getResources(), false);
+        BasicParameterBuilder builder = new BasicParameterBuilder(adConfiguration, context.getResources(), false);
         AdRequestInput adRequestInput = new AdRequestInput();
         builder.appendBuilderParameters(adRequestInput);
 
@@ -386,7 +416,7 @@ public class BasicParameterBuilderTest {
     throws JSONException {
         AdUnitConfiguration adConfiguration = new AdUnitConfiguration();
         adConfiguration.addContextData("context", "contextData");
-        BasicParameterBuilder builder = new BasicParameterBuilder(adConfiguration, mContext.getResources(), false);
+        BasicParameterBuilder builder = new BasicParameterBuilder(adConfiguration, context.getResources(), false);
         AdRequestInput adRequestInput = new AdRequestInput();
         builder.appendBuilderParameters(adRequestInput);
 
@@ -479,7 +509,7 @@ public class BasicParameterBuilderTest {
         imp.instl = isInterstitial ? 1 : 0;
 
         // 0 == embedded, 1 == native
-        imp.clickBrowser = !PrebidMobile.useExternalBrowser && mBrowserActivityAvailable ? 0 : 1;
+        imp.clickBrowser = !PrebidMobile.useExternalBrowser && browserActivityAvailable ? 0 : 1;
         imp.id = uuid;
         imp.getExt().put("prebid", Prebid.getJsonObjectForImp(adConfiguration));
 
@@ -511,7 +541,7 @@ public class BasicParameterBuilderTest {
                 banner.addFormat(size.getWidth(), size.getHeight());
             }
         } else if (adConfiguration.isAdType(AdFormat.INTERSTITIAL)) {
-            Configuration deviceConfiguration = mContext.getResources().getConfiguration();
+            Configuration deviceConfiguration = context.getResources().getConfiguration();
             banner.addFormat(deviceConfiguration.screenWidthDp,
                     deviceConfiguration.screenHeightDp);
         }
@@ -536,7 +566,7 @@ public class BasicParameterBuilderTest {
 
         if (!adConfiguration.isPlacementTypeValid()) {
             video.placement = VIDEO_INTERSTITIAL_PLACEMENT;
-            Configuration deviceConfiguration = mContext.getResources().getConfiguration();
+            Configuration deviceConfiguration = context.getResources().getConfiguration();
             video.w = deviceConfiguration.screenWidthDp;
             video.h = deviceConfiguration.screenHeightDp;
         }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/networking/parameters/NetworkParameterBuilderTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/networking/parameters/NetworkParameterBuilderTest.java
@@ -43,19 +43,19 @@ public class NetworkParameterBuilderTest {
 
     private String NETWORK_CARRIER = "carrier";
 
-    private ShadowTelephonyManager mShadowTelephonyManager;
-    private ShadowConnectivityManager mShadowConnectivityManager;
+    private ShadowTelephonyManager shadowTelephonyManager;
+    private ShadowConnectivityManager shadowConnectivityManager;
 
     @Before
     public void setUp() throws Exception {
         Activity robolectricActivity = Robolectric.buildActivity(Activity.class).create().get();
         ShadowActivity shadowActivity = shadowOf(robolectricActivity);
         shadowActivity.grantPermissions("android.permission.ACCESS_NETWORK_STATE");
-        mShadowConnectivityManager = shadowOf((ConnectivityManager) robolectricActivity.getSystemService(Context.CONNECTIVITY_SERVICE));
-        mShadowTelephonyManager = shadowOf((TelephonyManager) robolectricActivity.getSystemService(Context.TELEPHONY_SERVICE));
+        shadowConnectivityManager = shadowOf((ConnectivityManager) robolectricActivity.getSystemService(Context.CONNECTIVITY_SERVICE));
+        shadowTelephonyManager = shadowOf((TelephonyManager) robolectricActivity.getSystemService(Context.TELEPHONY_SERVICE));
 
-        mShadowTelephonyManager.setNetworkOperatorName(NETWORK_CARRIER);
-        mShadowTelephonyManager.setNetworkOperator(NETWORK_CARRIER);
+        shadowTelephonyManager.setNetworkOperatorName(NETWORK_CARRIER);
+        shadowTelephonyManager.setNetworkOperator(NETWORK_CARRIER);
 
         ManagersResolver.getInstance().prepare(robolectricActivity);
     }
@@ -65,7 +65,7 @@ public class NetworkParameterBuilderTest {
         NetworkInfo mockInfo = mock(NetworkInfo.class);
         when(mockInfo.getType()).thenReturn(ConnectivityManager.TYPE_WIFI);
         when(mockInfo.isConnected()).thenReturn(true);
-        mShadowConnectivityManager.setActiveNetworkInfo(mockInfo);
+        shadowConnectivityManager.setActiveNetworkInfo(mockInfo);
 
         BidRequest expectedBidRequest = new BidRequest();
         expectedBidRequest.getDevice().mccmnc = "car-rier";
@@ -84,7 +84,7 @@ public class NetworkParameterBuilderTest {
         NetworkInfo mockInfo = mock(NetworkInfo.class);
         when(mockInfo.getType()).thenReturn(ConnectivityManager.TYPE_MOBILE);
         when(mockInfo.isConnected()).thenReturn(true);
-        mShadowConnectivityManager.setActiveNetworkInfo(mockInfo);
+        shadowConnectivityManager.setActiveNetworkInfo(mockInfo);
 
         BidRequest expectedBidRequest = new BidRequest();
         expectedBidRequest.getDevice().mccmnc = "car-rier";

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/networking/parameters/UserConsentParameterBuilderTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/networking/parameters/UserConsentParameterBuilderTest.java
@@ -33,8 +33,8 @@ import static org.junit.Assert.assertEquals;
 @RunWith(RobolectricTestRunner.class)
 public class UserConsentParameterBuilderTest {
 
-    private UserConsentParameterBuilder mBuilder;
-    private SharedPreferences mSharedPreferences;
+    private UserConsentParameterBuilder builder;
+    private SharedPreferences sharedPreferences;
 
     @Before
     public void setUp() throws Exception {
@@ -42,21 +42,21 @@ public class UserConsentParameterBuilderTest {
         ManagersResolver.getInstance().prepare(robolectricActivity);
 
         PrebidMobile.setPbsDebug(false);
-        mSharedPreferences = PreferenceManager.getDefaultSharedPreferences(robolectricActivity);
-        mSharedPreferences
+        sharedPreferences = PreferenceManager.getDefaultSharedPreferences(robolectricActivity);
+        sharedPreferences
                 .edit()
                 .putString("IABConsent_ConsentString", "foobar_consent_string")
                 .commit();
 
-        mBuilder = new UserConsentParameterBuilder(ManagersResolver.getInstance().getUserConsentManager());
+        builder = new UserConsentParameterBuilder(ManagersResolver.getInstance().getUserConsentManager());
     }
 
     @Test
     public void setAndGetUserConsentParamteterValuesWhenSubjectToGdgprIs1() throws JSONException {
-        mSharedPreferences.edit().putString("IABConsent_SubjectToGDPR", "1").commit();
+        sharedPreferences.edit().putString("IABConsent_SubjectToGDPR", "1").commit();
         AdRequestInput adRequestInput = new AdRequestInput();
 
-        mBuilder.appendBuilderParameters(adRequestInput);
+        builder.appendBuilderParameters(adRequestInput);
 
         String expectedJSON = "{\"regs\":{\"ext\":{\"gdpr\":1}},\"user\":{\"ext\":{\"consent\":\"foobar_consent_string\"}}}";
         assertEquals("Wrong values are set on pub Imp for the given adType", expectedJSON,
@@ -65,10 +65,10 @@ public class UserConsentParameterBuilderTest {
 
     @Test
     public void setAndGetUserConsentParamteterValuesWhenSubjectToGdprIs0() throws JSONException {
-        mSharedPreferences.edit().putString("IABConsent_SubjectToGDPR", "0").commit();
+        sharedPreferences.edit().putString("IABConsent_SubjectToGDPR", "0").commit();
         AdRequestInput adRequestInput = new AdRequestInput();
 
-        mBuilder.appendBuilderParameters(adRequestInput);
+        builder.appendBuilderParameters(adRequestInput);
 
         String expectedJSON = "{\"regs\":{\"ext\":{\"gdpr\":0}},\"user\":{\"ext\":{\"consent\":\"foobar_consent_string\"}}}";
         assertEquals("Wrong values are set on pub Imp for the given adType", expectedJSON,
@@ -77,10 +77,10 @@ public class UserConsentParameterBuilderTest {
 
     @Test
     public void WhenSubjectToGdprIsNullOrEmptyDontSendUserConsentValues() throws JSONException {
-        mSharedPreferences.edit().remove("IABConsent_SubjectToGDPR").commit();
+        sharedPreferences.edit().remove("IABConsent_SubjectToGDPR").commit();
         AdRequestInput adRequestInput = new AdRequestInput();
 
-        mBuilder.appendBuilderParameters(adRequestInput);
+        builder.appendBuilderParameters(adRequestInput);
 
         String expectedJSON = "{}";
         assertEquals("Wrong values are set on pub Imp for the given adType", expectedJSON,
@@ -89,10 +89,10 @@ public class UserConsentParameterBuilderTest {
 
     @Test
     public void usPrivacyStringIsEmpty_DontAppendToUserConsentValues() throws JSONException {
-        mSharedPreferences.edit().putString("IABUSPrivacy_String", "").commit();
+        sharedPreferences.edit().putString("IABUSPrivacy_String", "").commit();
         AdRequestInput adRequestInput = new AdRequestInput();
 
-        mBuilder.appendBuilderParameters(adRequestInput);
+        builder.appendBuilderParameters(adRequestInput);
 
         String expectedJSON = "{}";
         assertEquals(expectedJSON, adRequestInput.getBidRequest().getJsonObject().toString());
@@ -100,10 +100,10 @@ public class UserConsentParameterBuilderTest {
 
     @Test
     public void usPrivacyStringIsNull_DontAppendToUserConsentValues() throws JSONException {
-        mSharedPreferences.edit().remove("IABUSPrivacy_String").commit();
+        sharedPreferences.edit().remove("IABUSPrivacy_String").commit();
         AdRequestInput adRequestInput = new AdRequestInput();
 
-        mBuilder.appendBuilderParameters(adRequestInput);
+        builder.appendBuilderParameters(adRequestInput);
 
         String expectedJSON = "{}";
         assertEquals(expectedJSON, adRequestInput.getBidRequest().getJsonObject().toString());
@@ -111,10 +111,10 @@ public class UserConsentParameterBuilderTest {
 
     @Test
     public void usPrivacyStringIsNotEmpty_AppendToUserConsentValues() throws JSONException {
-        mSharedPreferences.edit().putString("IABUSPrivacy_String", "1YY").commit();
+        sharedPreferences.edit().putString("IABUSPrivacy_String", "1YY").commit();
         AdRequestInput adRequestInput = new AdRequestInput();
 
-        mBuilder.appendBuilderParameters(adRequestInput);
+        builder.appendBuilderParameters(adRequestInput);
 
         String expectedJSON = "{\"regs\":{\"ext\":{\"us_privacy\":\"1YY\"}}}";
         assertEquals(expectedJSON, adRequestInput.getBidRequest().getJsonObject().toString());
@@ -122,12 +122,12 @@ public class UserConsentParameterBuilderTest {
 
     @Test
     public void usPrivacAndGdprStringsNotEmtpy_AppendToUserConsentValues() throws JSONException {
-        mSharedPreferences.edit().putString("IABUSPrivacy_String", "1YY").commit();
-        mSharedPreferences.edit().putString("IABConsent_SubjectToGDPR", "0").commit();
+        sharedPreferences.edit().putString("IABUSPrivacy_String", "1YY").commit();
+        sharedPreferences.edit().putString("IABConsent_SubjectToGDPR", "0").commit();
 
         AdRequestInput adRequestInput = new AdRequestInput();
 
-        mBuilder.appendBuilderParameters(adRequestInput);
+        builder.appendBuilderParameters(adRequestInput);
 
         String expectedJSON = "{\"regs\":{\"ext\":{\"us_privacy\":\"1YY\",\"gdpr\":0}},\"user\":{\"ext\":{\"consent\":\"foobar_consent_string\"}}}";
         assertEquals("Wrong values are set on pub Imp for the given adType", expectedJSON,

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/networking/tracking/ImpressionUrlTaskTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/networking/tracking/ImpressionUrlTaskTest.java
@@ -30,25 +30,25 @@ import static junit.framework.Assert.assertNull;
 
 public class ImpressionUrlTaskTest {
 
-    private MockWebServer mServer;
+    private MockWebServer server;
 
     @Before
     public void setUp() throws Exception {
-        mServer = new MockWebServer();
+        server = new MockWebServer();
     }
 
     @After
     public void tearDown() throws Exception {
-        mServer.shutdown();
+        server.shutdown();
     }
 
     //@Ignore
     @Test
     public void redirectTest() throws Exception {
-        mServer.enqueue(new MockResponse().setResponseCode(302).addHeader("Location: " + mServer.url("/new-path"))
-                                          .setBody("This page has moved!"));
+        server.enqueue(new MockResponse().setResponseCode(302).addHeader("Location: " + server.url("/new-path"))
+                                         .setBody("This page has moved!"));
 
-        mServer.enqueue(new MockResponse().setResponseCode(200).setBody("This is the new location!"));
+        server.enqueue(new MockResponse().setResponseCode(200).setBody("This is the new location!"));
 
         ImpressionUrlTask impressionUrlTask = new ImpressionUrlTask(null);
 
@@ -56,7 +56,7 @@ public class ImpressionUrlTaskTest {
         params.requestType = "GET";
         params.userAgent = "user-agent";
         //get server url
-        HttpUrl baseUrl = mServer.url("/first");
+        HttpUrl baseUrl = server.url("/first");
         //give server url to SDK network class
         params.url = baseUrl.url().toString();
         params.name = BaseNetworkTask.REDIRECT_TASK;
@@ -66,19 +66,19 @@ public class ImpressionUrlTaskTest {
         //validate
         assertEquals("This is the new location!", result.responseString);
 
-        RecordedRequest first = mServer.takeRequest();
+        RecordedRequest first = server.takeRequest();
         assertEquals("GET /first HTTP/1.1", first.getRequestLine());
 
-        RecordedRequest redirect = mServer.takeRequest();
+        RecordedRequest redirect = server.takeRequest();
         assertEquals("GET /new-path HTTP/1.1", redirect.getRequestLine());
     }
 
     @Test
     public void redirectWithThrowExceptionTest() throws Exception {
-        mServer.enqueue(new MockResponse().setResponseCode(302).addHeader("Location: " + mServer.url("/new-path"))
-                                          .setBody("This page has moved!"));
+        server.enqueue(new MockResponse().setResponseCode(302).addHeader("Location: " + server.url("/new-path"))
+                                         .setBody("This page has moved!"));
 
-        mServer.enqueue(new MockResponse().setResponseCode(400).setBody("Bad server response. Should throw exception"));
+        server.enqueue(new MockResponse().setResponseCode(400).setBody("Bad server response. Should throw exception"));
 
         ImpressionUrlTask impressionUrlTask = new ImpressionUrlTask(null);
 
@@ -86,7 +86,7 @@ public class ImpressionUrlTaskTest {
         params.requestType = "GET";
         params.userAgent = "user-agent";
         //get server url
-        HttpUrl baseUrl = mServer.url("/first");
+        HttpUrl baseUrl = server.url("/first");
         //give server url to SDK network class
         params.url = baseUrl.url().toString();
         params.name = BaseNetworkTask.REDIRECT_TASK;
@@ -98,10 +98,10 @@ public class ImpressionUrlTaskTest {
         //There should be no exception set. We only log an error msg for an exception case
         assertNull(result.getException());
 
-        RecordedRequest first = mServer.takeRequest();
+        RecordedRequest first = server.takeRequest();
         assertEquals("GET /first HTTP/1.1", first.getRequestLine());
 
-        RecordedRequest redirect = mServer.takeRequest();
+        RecordedRequest redirect = server.takeRequest();
         assertEquals("GET /new-path HTTP/1.1", redirect.getRequestLine());
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/networking/urlBuilder/AutoDetectedOpenRtbTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/networking/urlBuilder/AutoDetectedOpenRtbTest.java
@@ -51,103 +51,103 @@ import static org.robolectric.Shadows.shadowOf;
 @Config(sdk = 19, qualifiers = "w1dp-h1dp")
 public class AutoDetectedOpenRtbTest {
 
-    private ArrayList<ParameterBuilder> mParamBuilderArray;
+    private ArrayList<ParameterBuilder> paramBuilderArray;
 
-    private Activity mActivity;
-    private AdRequestInput mOriginalAdRequestInput;
-    private BidRequest mOriginalOpenRtbParams;
+    private Activity activity;
+    private AdRequestInput originalAdRequestInput;
+    private BidRequest originalOpenRtbParams;
 
     @Before
     public void setup() {
-        mActivity = Robolectric.buildActivity(Activity.class).create().get();
-        ShadowActivity shadowActivity = shadowOf(mActivity);
+        activity = Robolectric.buildActivity(Activity.class).create().get();
+        ShadowActivity shadowActivity = shadowOf(activity);
         shadowActivity.grantPermissions("android.permission.ACCESS_FINE_LOCATION");
 
-        LocationManager locationManager = (LocationManager) mActivity.getSystemService(Context.LOCATION_SERVICE);
+        LocationManager locationManager = (LocationManager) activity.getSystemService(Context.LOCATION_SERVICE);
         ShadowLocationManager shadowLocationManager = shadowOf(locationManager);
         Location location = new Location("");
         location.setLatitude(1);
         location.setLongitude(1);
         shadowLocationManager.setLastKnownLocation("gps", location);
 
-        ShadowTelephonyManager shadowTelephonyManager = shadowOf((TelephonyManager) mActivity.getSystemService(Context.TELEPHONY_SERVICE));
+        ShadowTelephonyManager shadowTelephonyManager = shadowOf((TelephonyManager) activity.getSystemService(Context.TELEPHONY_SERVICE));
         shadowTelephonyManager.setNetworkOperatorName("carrier");
         shadowTelephonyManager.setNetworkOperator("carrier");
 
-        ManagersResolver.getInstance().prepare(mActivity);
+        ManagersResolver.getInstance().prepare(activity);
 
-        mParamBuilderArray = new ArrayList<>();
-        mOriginalAdRequestInput = new AdRequestInput();
-        mOriginalOpenRtbParams = new BidRequest();
+        paramBuilderArray = new ArrayList<>();
+        originalAdRequestInput = new AdRequestInput();
+        originalOpenRtbParams = new BidRequest();
     }
 
     @Test
     public void overwrittenGeoLocationParameterBuilderTest() {
-        mOriginalOpenRtbParams.getDevice().getGeo().lat = 0f;
-        mOriginalOpenRtbParams.getDevice().getGeo().lon = 0f;
-        mOriginalOpenRtbParams.getDevice().getGeo().type = 0;
-        mOriginalAdRequestInput.setBidRequest(mOriginalOpenRtbParams);
+        originalOpenRtbParams.getDevice().getGeo().lat = 0f;
+        originalOpenRtbParams.getDevice().getGeo().lon = 0f;
+        originalOpenRtbParams.getDevice().getGeo().type = 0;
+        originalAdRequestInput.setBidRequest(originalOpenRtbParams);
 
-        mParamBuilderArray.add(new GeoLocationParameterBuilder());
-        AdRequestInput newAdRequestInput = URLBuilder.buildParameters(mParamBuilderArray, mOriginalAdRequestInput);
+        paramBuilderArray.add(new GeoLocationParameterBuilder());
+        AdRequestInput newAdRequestInput = URLBuilder.buildParameters(paramBuilderArray, originalAdRequestInput);
         BidRequest newOpenRtbParams = newAdRequestInput.getBidRequest();
 
-        assertNotEquals(mOriginalOpenRtbParams.getDevice().getGeo().lat, newOpenRtbParams.getDevice().getGeo().lat);
-        assertNotEquals(mOriginalOpenRtbParams.getDevice().getGeo().lon, newOpenRtbParams.getDevice().getGeo().lon);
-        assertNotEquals(mOriginalOpenRtbParams.getDevice().getGeo().type, newOpenRtbParams.getDevice().getGeo().type);
+        assertNotEquals(originalOpenRtbParams.getDevice().getGeo().lat, newOpenRtbParams.getDevice().getGeo().lat);
+        assertNotEquals(originalOpenRtbParams.getDevice().getGeo().lon, newOpenRtbParams.getDevice().getGeo().lon);
+        assertNotEquals(originalOpenRtbParams.getDevice().getGeo().type, newOpenRtbParams.getDevice().getGeo().type);
     }
 
     @Test
     public void overwrittenAppInfoParameterBuilder() {
-        mOriginalOpenRtbParams.getApp().name = "foo";
-        mOriginalOpenRtbParams.getApp().bundle = "foo";
-        mOriginalOpenRtbParams.getDevice().ifa = "foo";
-        mOriginalOpenRtbParams.getDevice().lmt = 0;
+        originalOpenRtbParams.getApp().name = "foo";
+        originalOpenRtbParams.getApp().bundle = "foo";
+        originalOpenRtbParams.getDevice().ifa = "foo";
+        originalOpenRtbParams.getDevice().lmt = 0;
 
         AppInfoManager.setAppName("bar");
         AppInfoManager.setPackageName("bar");
         AdIdManager.setAdId("bar");
         AdIdManager.setLimitAdTrackingEnabled(true);
 
-        mParamBuilderArray.add(new AppInfoParameterBuilder(new AdUnitConfiguration()));
-        AdRequestInput newAdRequestInput = URLBuilder.buildParameters(mParamBuilderArray, mOriginalAdRequestInput);
+        paramBuilderArray.add(new AppInfoParameterBuilder(new AdUnitConfiguration()));
+        AdRequestInput newAdRequestInput = URLBuilder.buildParameters(paramBuilderArray, originalAdRequestInput);
         BidRequest newOpenRtbParams = newAdRequestInput.getBidRequest();
 
-        assertNotEquals(mOriginalOpenRtbParams.getApp().name, newOpenRtbParams.getApp().name);
-        assertNotEquals(mOriginalOpenRtbParams.getApp().bundle, newOpenRtbParams.getApp().bundle);
-        assertNotEquals(mOriginalOpenRtbParams.getDevice().ifa, newOpenRtbParams.getDevice().ifa);
-        assertNotEquals(mOriginalOpenRtbParams.getDevice().lmt, newOpenRtbParams.getDevice().lmt);
+        assertNotEquals(originalOpenRtbParams.getApp().name, newOpenRtbParams.getApp().name);
+        assertNotEquals(originalOpenRtbParams.getApp().bundle, newOpenRtbParams.getApp().bundle);
+        assertNotEquals(originalOpenRtbParams.getDevice().ifa, newOpenRtbParams.getDevice().ifa);
+        assertNotEquals(originalOpenRtbParams.getDevice().lmt, newOpenRtbParams.getDevice().lmt);
     }
 
     @Test
     public void overwrittenDeviceInfoParameterBuilder() {
-        mOriginalOpenRtbParams.getDevice().dpidmd5 = "foo";
-        mOriginalOpenRtbParams.getDevice().dpidsha1 = "foo";
-        mOriginalOpenRtbParams.getDevice().w = 0;
-        mOriginalOpenRtbParams.getDevice().h = 0;
+        originalOpenRtbParams.getDevice().dpidmd5 = "foo";
+        originalOpenRtbParams.getDevice().dpidsha1 = "foo";
+        originalOpenRtbParams.getDevice().w = 0;
+        originalOpenRtbParams.getDevice().h = 0;
 
-        mParamBuilderArray.add(new DeviceInfoParameterBuilder(new AdUnitConfiguration()));
-        AdRequestInput newAdRequestInput = URLBuilder.buildParameters(mParamBuilderArray, mOriginalAdRequestInput);
+        paramBuilderArray.add(new DeviceInfoParameterBuilder(new AdUnitConfiguration()));
+        AdRequestInput newAdRequestInput = URLBuilder.buildParameters(paramBuilderArray, originalAdRequestInput);
         BidRequest newOpenRtbParams = newAdRequestInput.getBidRequest();
 
-        assertNotEquals(mOriginalOpenRtbParams.getDevice().dpidmd5, newOpenRtbParams.getDevice().dpidmd5);
-        assertNotEquals(mOriginalOpenRtbParams.getDevice().dpidsha1, newOpenRtbParams.getDevice().dpidsha1);
-        assertNotEquals(mOriginalOpenRtbParams.getDevice().w, newOpenRtbParams.getDevice().w);
-        assertNotEquals(mOriginalOpenRtbParams.getDevice().h, newOpenRtbParams.getDevice().h);
+        assertNotEquals(originalOpenRtbParams.getDevice().dpidmd5, newOpenRtbParams.getDevice().dpidmd5);
+        assertNotEquals(originalOpenRtbParams.getDevice().dpidsha1, newOpenRtbParams.getDevice().dpidsha1);
+        assertNotEquals(originalOpenRtbParams.getDevice().w, newOpenRtbParams.getDevice().w);
+        assertNotEquals(originalOpenRtbParams.getDevice().h, newOpenRtbParams.getDevice().h);
     }
 
     @Test
     public void overwrittenNetworkParameterBuilder() {
-        mOriginalOpenRtbParams.getDevice().mccmnc = "foo";
-        mOriginalOpenRtbParams.getDevice().carrier = "foo";
-        mOriginalOpenRtbParams.getDevice().connectiontype = 0;
+        originalOpenRtbParams.getDevice().mccmnc = "foo";
+        originalOpenRtbParams.getDevice().carrier = "foo";
+        originalOpenRtbParams.getDevice().connectiontype = 0;
 
-        mParamBuilderArray.add(new NetworkParameterBuilder());
-        AdRequestInput newAdRequestInput = URLBuilder.buildParameters(mParamBuilderArray, mOriginalAdRequestInput);
+        paramBuilderArray.add(new NetworkParameterBuilder());
+        AdRequestInput newAdRequestInput = URLBuilder.buildParameters(paramBuilderArray, originalAdRequestInput);
         BidRequest newOpenRtbParams = newAdRequestInput.getBidRequest();
 
-        assertNotEquals(mOriginalOpenRtbParams.getDevice().mccmnc, newOpenRtbParams.getDevice().mccmnc);
-        assertNotEquals(mOriginalOpenRtbParams.getDevice().carrier, newOpenRtbParams.getDevice().carrier);
-        assertNotEquals(mOriginalOpenRtbParams.getDevice().connectiontype, newOpenRtbParams.getDevice().connectiontype);
+        assertNotEquals(originalOpenRtbParams.getDevice().mccmnc, newOpenRtbParams.getDevice().mccmnc);
+        assertNotEquals(originalOpenRtbParams.getDevice().carrier, newOpenRtbParams.getDevice().carrier);
+        assertNotEquals(originalOpenRtbParams.getDevice().connectiontype, newOpenRtbParams.getDevice().connectiontype);
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/networking/urlBuilder/URLBuilderTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/networking/urlBuilder/URLBuilderTest.java
@@ -38,14 +38,14 @@ import static org.mockito.Mockito.mock;
 @Config(sdk = 19)
 public class URLBuilderTest {
 
-    private AdUnitConfiguration mMockConfig;
-    private Context mContext;
-    private final boolean mBrowserActivityAvailable = true;
+    private AdUnitConfiguration mockConfig;
+    private Context context;
+    private final boolean browserActivityAvailable = true;
 
     @Before
     public void setUp() throws Exception {
-        mMockConfig = mock(AdUnitConfiguration.class);
-        mContext = Robolectric.buildActivity(Activity.class).create().get();
+        mockConfig = mock(AdUnitConfiguration.class);
+        context = Robolectric.buildActivity(Activity.class).create().get();
     }
 
     @Test

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/sdk/JSLibraryManagerTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/sdk/JSLibraryManagerTest.java
@@ -30,7 +30,7 @@ import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
 public class JSLibraryManagerTest {
-    private JSLibraryManager mManager;
+    private JSLibraryManager manager;
 
     @Before
     public void setup() throws Exception {
@@ -38,12 +38,12 @@ public class JSLibraryManagerTest {
         when(mock.getApplicationContext()).thenReturn(mock);
         when(mock.getResources()).thenReturn(mock(Resources.class));
 
-        mManager = Mockito.spy(JSLibraryManager.getInstance(mock));
+        manager = Mockito.spy(JSLibraryManager.getInstance(mock));
     }
 
     @Test
     public void testInitialStrings() {
-        Assert.assertEquals("", mManager.getMRAIDScript());
-        Assert.assertEquals("", mManager.getOMSDKScript());
+        Assert.assertEquals("", manager.getMRAIDScript());
+        Assert.assertEquals("", manager.getOMSDKScript());
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/sdk/calendar/CalendarGTE14Test.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/sdk/calendar/CalendarGTE14Test.java
@@ -50,11 +50,11 @@ public class CalendarGTE14Test {
     private static final String CALENDAR_RECURRENCE_YEARLY_DETAILED = "calendarRecurrenceYearlyDetailed.txt";
     private static final String CALENDAR_RECURRENCE_YEARLY_EMPTY_WEEK_IN_MONTH = "calendarRecurrenceYearlyEmptyWeekInMonth.txt";
 
-    private Activity mTestActivity;
+    private Activity testActivity;
 
     @Before
     public void setUp() throws Exception {
-        mTestActivity = Robolectric.buildActivity(Activity.class).create().get();
+        testActivity = Robolectric.buildActivity(Activity.class).create().get();
     }
 
     @Test
@@ -147,7 +147,7 @@ public class CalendarGTE14Test {
         JSONObject jsonObj = new JSONObject(json);
 
         CalendarEventWrapper event = new CalendarEventWrapper(jsonObj);
-        calendar.createCalendarEvent(mTestActivity, event);
+        calendar.createCalendarEvent(testActivity, event);
     }
 
     private String getNextStartedActivityExtraCalendarRule() {
@@ -155,7 +155,7 @@ public class CalendarGTE14Test {
     }
 
     private Intent getNextStartedActivityIntent() {
-        ShadowActivity shadowActivity = shadowOf(mTestActivity);
+        ShadowActivity shadowActivity = shadowOf(testActivity);
         return shadowActivity.getNextStartedActivity();
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/sdk/calendar/CalendarLT14Test.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/sdk/calendar/CalendarLT14Test.java
@@ -42,11 +42,11 @@ import static org.robolectric.Shadows.shadowOf;
 public class CalendarLT14Test {
 
     private final static String CALENDAR_FILE = "calendar.txt";
-    private Activity mTestActivity;
+    private Activity testActivity;
 
     @Before
     public void setUp() throws Exception {
-        mTestActivity = Robolectric.buildActivity(Activity.class).create().get();
+        testActivity = Robolectric.buildActivity(Activity.class).create().get();
     }
 
     @After
@@ -61,9 +61,9 @@ public class CalendarLT14Test {
 
         JSONObject jsonObj = new JSONObject(json);
         CalendarEventWrapper event = new CalendarEventWrapper(jsonObj);
-        calendar.createCalendarEvent(mTestActivity, event);
+        calendar.createCalendarEvent(testActivity, event);
 
-        ShadowActivity shadowActivity = shadowOf(mTestActivity);
+        ShadowActivity shadowActivity = shadowOf(testActivity);
         Intent startedIntent = shadowActivity.getNextStartedActivity();
 
         assertEquals("vnd.android.cursor.item/event", startedIntent.getType());

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/sdk/deviceData/managers/DeviceInfoImplTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/sdk/deviceData/managers/DeviceInfoImplTest.java
@@ -51,83 +51,83 @@ import static org.mockito.Mockito.*;
 @RunWith(RobolectricTestRunner.class)
 public class DeviceInfoImplTest {
 
-    private DeviceInfoImpl mDeviceInfoImpl;
+    private DeviceInfoImpl deviceInfoImpl;
     @Mock
-    private Context mMockContext;
+    private Context mockContext;
     @Mock
-    private TelephonyManager mMockTelephonyManger;
+    private TelephonyManager mockTelephonyManger;
     @Mock
-    private WindowManager mMockWindowManager;
+    private WindowManager mockWindowManager;
     @Mock
-    private PowerManager mMockPowerManager;
+    private PowerManager mockPowerManager;
     @Mock
-    private KeyguardManager mMockKeyguardManager;
+    private KeyguardManager mockKeyguardManager;
     @Mock
-    private PackageManager mMockPackageManager;
+    private PackageManager mockPackageManager;
 
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
-        mDeviceInfoImpl = new DeviceInfoImpl();
+        deviceInfoImpl = new DeviceInfoImpl();
 
-        when(mMockContext.getSystemService(Context.TELEPHONY_SERVICE)).thenReturn(mMockTelephonyManger);
-        when(mMockContext.getSystemService(Context.WINDOW_SERVICE)).thenReturn(mMockWindowManager);
-        when(mMockContext.getSystemService(Context.POWER_SERVICE)).thenReturn(mMockPowerManager);
-        when(mMockContext.getSystemService(Context.KEYGUARD_SERVICE)).thenReturn(mMockKeyguardManager);
-        when(mMockContext.getPackageManager()).thenReturn(mMockPackageManager);
+        when(mockContext.getSystemService(Context.TELEPHONY_SERVICE)).thenReturn(mockTelephonyManger);
+        when(mockContext.getSystemService(Context.WINDOW_SERVICE)).thenReturn(mockWindowManager);
+        when(mockContext.getSystemService(Context.POWER_SERVICE)).thenReturn(mockPowerManager);
+        when(mockContext.getSystemService(Context.KEYGUARD_SERVICE)).thenReturn(mockKeyguardManager);
+        when(mockContext.getPackageManager()).thenReturn(mockPackageManager);
 
-        mDeviceInfoImpl.init(mMockContext);
+        deviceInfoImpl.init(mockContext);
     }
 
     @Test
     public void hasTelephonyTest() throws IllegalAccessException {
-        when(mMockPackageManager.hasSystemFeature(anyString())).thenReturn(Boolean.TRUE);
-        assertTrue(mDeviceInfoImpl.hasTelephony());
+        when(mockPackageManager.hasSystemFeature(anyString())).thenReturn(Boolean.TRUE);
+        assertTrue(deviceInfoImpl.hasTelephony());
 
-        WhiteBox.field(DeviceInfoImpl.class, "mTelephonyManager").set(mDeviceInfoImpl, null);
-        assertFalse(mDeviceInfoImpl.hasTelephony());
+        WhiteBox.field(DeviceInfoImpl.class, "telephonyManager").set(deviceInfoImpl, null);
+        assertFalse(deviceInfoImpl.hasTelephony());
 
-        WhiteBox.field(DeviceInfoImpl.class, "mTelephonyManager").set(mDeviceInfoImpl, mMockTelephonyManger);
-        WhiteBox.field(DeviceInfoImpl.class, "mPackageManager").set(mDeviceInfoImpl, null);
-        assertFalse(mDeviceInfoImpl.hasTelephony());
+        WhiteBox.field(DeviceInfoImpl.class, "telephonyManager").set(deviceInfoImpl, mockTelephonyManger);
+        WhiteBox.field(DeviceInfoImpl.class, "packageManager").set(deviceInfoImpl, null);
+        assertFalse(deviceInfoImpl.hasTelephony());
     }
 
     @Test
     public void getMccMncTest() {
-        when(mMockTelephonyManger.getNetworkOperator()).thenReturn("0123456");
-        assertEquals("012-3456", mDeviceInfoImpl.getMccMnc());
+        when(mockTelephonyManger.getNetworkOperator()).thenReturn("0123456");
+        assertEquals("012-3456", deviceInfoImpl.getMccMnc());
 
-        when(mMockTelephonyManger.getNetworkOperator()).thenReturn("01");
-        assertNull(mDeviceInfoImpl.getMccMnc());
+        when(mockTelephonyManger.getNetworkOperator()).thenReturn("01");
+        assertNull(deviceInfoImpl.getMccMnc());
     }
 
     @Test
     public void getCarrierTest() {
-        when(mMockTelephonyManger.getNetworkOperatorName()).thenReturn("test");
-        assertEquals("test", mDeviceInfoImpl.getCarrier());
+        when(mockTelephonyManger.getNetworkOperatorName()).thenReturn("test");
+        assertEquals("test", deviceInfoImpl.getCarrier());
     }
 
     @Test
     public void isScreenOnTest() throws IllegalAccessException {
-        when(mMockPowerManager.isScreenOn()).thenReturn(true);
-        assertTrue(mDeviceInfoImpl.isScreenOn());
+        when(mockPowerManager.isScreenOn()).thenReturn(true);
+        assertTrue(deviceInfoImpl.isScreenOn());
 
-        WhiteBox.field(DeviceInfoImpl.class, "mPowerManager").set(mDeviceInfoImpl, null);
-        assertFalse(mDeviceInfoImpl.isScreenOn());
+        WhiteBox.field(DeviceInfoImpl.class, "powerManager").set(deviceInfoImpl, null);
+        assertFalse(deviceInfoImpl.isScreenOn());
     }
 
     @Test
     public void isScreenLockedTest() throws IllegalAccessException {
-        when(mMockKeyguardManager.inKeyguardRestrictedInputMode()).thenReturn(true);
-        assertTrue(mDeviceInfoImpl.isScreenLocked());
+        when(mockKeyguardManager.inKeyguardRestrictedInputMode()).thenReturn(true);
+        assertTrue(deviceInfoImpl.isScreenLocked());
 
-        WhiteBox.field(DeviceInfoImpl.class, "mKeyguardManager").set(mDeviceInfoImpl, null);
-        assertFalse(mDeviceInfoImpl.isScreenLocked());
+        WhiteBox.field(DeviceInfoImpl.class, "keyguardManager").set(deviceInfoImpl, null);
+        assertFalse(deviceInfoImpl.isScreenLocked());
     }
 
     @Test
     public void isActivityOrientationLockedWithApplicationContext_ReturnFalse() {
-        assertFalse(mDeviceInfoImpl.isActivityOrientationLocked(mMockContext));
+        assertFalse(deviceInfoImpl.isActivityOrientationLocked(mockContext));
     }
 
     @Test
@@ -135,7 +135,7 @@ public class DeviceInfoImplTest {
         Activity mockActivity = mock(Activity.class);
         when(mockActivity.getRequestedOrientation()).thenReturn(ActivityInfo.SCREEN_ORIENTATION_PORTRAIT);
 
-        assertTrue(mDeviceInfoImpl.isActivityOrientationLocked(mockActivity));
+        assertTrue(deviceInfoImpl.isActivityOrientationLocked(mockActivity));
     }
 
     @Test
@@ -143,13 +143,13 @@ public class DeviceInfoImplTest {
         Activity mockActivity = mock(Activity.class);
         when(mockActivity.getRequestedOrientation()).thenReturn(ActivityInfo.SCREEN_ORIENTATION_USER);
 
-        assertFalse(mDeviceInfoImpl.isActivityOrientationLocked(mockActivity));
+        assertFalse(deviceInfoImpl.isActivityOrientationLocked(mockActivity));
     }
 
     @Test
     public void playVideoTest() {
-        mDeviceInfoImpl.playVideo("test");
-        verify(mMockContext).startActivity(any(Intent.class));
+        deviceInfoImpl.playVideo("test");
+        verify(mockContext).startActivity(any(Intent.class));
     }
 
     @Test
@@ -158,29 +158,29 @@ public class DeviceInfoImplTest {
         DisplayMetrics mockMetrics = mock(DisplayMetrics.class);
         mockMetrics.density = 2.0f;
 
-        when(mMockContext.getResources()).thenReturn(mockResources);
+        when(mockContext.getResources()).thenReturn(mockResources);
         when(mockResources.getDisplayMetrics()).thenReturn(mockMetrics);
-        assertEquals(2.0f, mDeviceInfoImpl.getDeviceDensity(), 0);
+        assertEquals(2.0f, deviceInfoImpl.getDeviceDensity(), 0);
 
         WeakReference<Context> weakReference = new WeakReference<>(null);
-        WhiteBox.field(DeviceInfoImpl.class, "mContextReference").set(mDeviceInfoImpl, weakReference);
-        assertEquals(1.0f, mDeviceInfoImpl.getDeviceDensity(), 0);
+        WhiteBox.field(DeviceInfoImpl.class, "contextReference").set(deviceInfoImpl, weakReference);
+        assertEquals(1.0f, deviceInfoImpl.getDeviceDensity(), 0);
     }
 
     @Test
     public void isPermissionGrantedTest() {
-        when(mMockContext.checkCallingOrSelfPermission(anyString())).thenReturn(PackageManager.PERMISSION_GRANTED);
-        assertTrue(mDeviceInfoImpl.isPermissionGranted("test"));
+        when(mockContext.checkCallingOrSelfPermission(anyString())).thenReturn(PackageManager.PERMISSION_GRANTED);
+        assertTrue(deviceInfoImpl.isPermissionGranted("test"));
     }
 
     @Test
     public void canStorePictureTest() {
-        assertTrue(mDeviceInfoImpl.canStorePicture());
+        assertTrue(deviceInfoImpl.canStorePicture());
     }
 
     @Test
     public void storePictureOnQ_GetOutputStreamForQ() throws Exception {
-        DeviceInfoImpl spyDeviceImpl = spy(mDeviceInfoImpl);
+        DeviceInfoImpl spyDeviceImpl = spy(deviceInfoImpl);
         String url = "http://test.com/somefile.png";
 
         Field versionField = WhiteBox.field(Build.VERSION.class, "SDK_INT");
@@ -204,7 +204,7 @@ public class DeviceInfoImplTest {
 
     @Test
     public void storePicturePreQ_GetOutputStreamPreQ() throws Exception {
-        DeviceInfoImpl spyDeviceImpl = spy(mDeviceInfoImpl);
+        DeviceInfoImpl spyDeviceImpl = spy(deviceInfoImpl);
         String url = "http://test.com/somefile.png";
 
         ShadowEnvironment.setExternalStorageState(Environment.MEDIA_MOUNTED);
@@ -220,7 +220,7 @@ public class DeviceInfoImplTest {
     @Test
     public void storePictureWithFileExtension_AddFieExtensionToFileName()
     throws Exception {
-        DeviceInfoImpl spyDeviceImpl = spy(mDeviceInfoImpl);
+        DeviceInfoImpl spyDeviceImpl = spy(deviceInfoImpl);
         final String url = "http://test.com/somefile.png";
         final String extension = ".png";
 
@@ -237,7 +237,7 @@ public class DeviceInfoImplTest {
     @Test
     public void storePictureEmptyOrNullFileExtension_FileNameUnmodified() throws Exception {
         final String url = "http://test.com/somefile";
-        DeviceInfoImpl spyDeviceImpl = spy(mDeviceInfoImpl);
+        DeviceInfoImpl spyDeviceImpl = spy(deviceInfoImpl);
 
         ShadowEnvironment.setExternalStorageState(Environment.MEDIA_MOUNTED);
         doReturn(null).when(spyDeviceImpl).getOutputStreamPreQ(anyString());

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/sdk/deviceData/managers/LastKnownLocationInfoManagerTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/sdk/deviceData/managers/LastKnownLocationInfoManagerTest.java
@@ -33,17 +33,17 @@ import static org.mockito.Mockito.when;
 @Config(sdk = 19)
 public class LastKnownLocationInfoManagerTest {
 
-    private LastKnownLocationInfoManager mLocationImpl;
-    private Context mContext;
+    private LastKnownLocationInfoManager locationImpl;
+    private Context context;
 
     private final int TWO_MINUTES = 1000 * 60 * 2;
 
     @Before
     public void setUp() {
-        mContext = mock(Context.class);
+        context = mock(Context.class);
 
-        mLocationImpl = new LastKnownLocationInfoManager();
-        mLocationImpl.init(mContext);
+        locationImpl = new LastKnownLocationInfoManager();
+        locationImpl.init(context);
     }
 
     @Test
@@ -51,21 +51,21 @@ public class LastKnownLocationInfoManagerTest {
         Location location = mock(Location.class);
         Location currentLocation = mock(Location.class);
 
-        assertTrue(mLocationImpl.isBetterLocation(location, null));
+        assertTrue(locationImpl.isBetterLocation(location, null));
 
-        assertFalse(mLocationImpl.isBetterLocation(null, currentLocation));
+        assertFalse(locationImpl.isBetterLocation(null, currentLocation));
 
         when(location.getTime()).thenReturn((long) 100);
         when(currentLocation.getTime()).thenReturn((long) 200);
-        assertFalse(mLocationImpl.isBetterLocation(location, currentLocation));
+        assertFalse(locationImpl.isBetterLocation(location, currentLocation));
 
         when(location.getTime()).thenReturn((long) TWO_MINUTES + 1);
         when(currentLocation.getTime()).thenReturn((long) 0);
-        assertTrue(mLocationImpl.isBetterLocation(location, currentLocation));
+        assertTrue(locationImpl.isBetterLocation(location, currentLocation));
 
         when(location.getTime()).thenReturn((long) 0);
         when(currentLocation.getTime()).thenReturn((long) TWO_MINUTES + 1);
-        assertFalse(mLocationImpl.isBetterLocation(location, currentLocation));
+        assertFalse(locationImpl.isBetterLocation(location, currentLocation));
 
         when(location.getTime()).thenReturn((long) 2);
         when(currentLocation.getTime()).thenReturn((long) 0);
@@ -73,14 +73,14 @@ public class LastKnownLocationInfoManagerTest {
         when(currentLocation.getAccuracy()).thenReturn((float) 20);
         when(location.getProvider()).thenReturn("test");
         when(currentLocation.getProvider()).thenReturn("test");
-        assertTrue(mLocationImpl.isBetterLocation(location, currentLocation));
+        assertTrue(locationImpl.isBetterLocation(location, currentLocation));
 
         when(location.getAccuracy()).thenReturn((float) 20);
         when(currentLocation.getAccuracy()).thenReturn((float) 10);
-        assertTrue(mLocationImpl.isBetterLocation(location, currentLocation));
+        assertTrue(locationImpl.isBetterLocation(location, currentLocation));
 
         when(location.getAccuracy()).thenReturn((float) 0);
         when(currentLocation.getAccuracy()).thenReturn((float) 0);
-        assertTrue(mLocationImpl.isBetterLocation(location, currentLocation));
+        assertTrue(locationImpl.isBetterLocation(location, currentLocation));
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/sdk/deviceData/managers/NetworkConnectionInfoManagerTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/sdk/deviceData/managers/NetworkConnectionInfoManagerTest.java
@@ -36,30 +36,31 @@ import static org.mockito.Mockito.when;
 @Config(sdk = 19)
 public class NetworkConnectionInfoManagerTest {
 
-    private NetworkConnectionInfoManager mNetworkConnectionManager;
-    private Context mMockContext;
-    private ConnectivityManager mConnectivityManager;
+    private NetworkConnectionInfoManager networkConnectionManager;
+    private Context mockContext;
+    private ConnectivityManager connectivityManager;
 
     @Before
     public void setUp() throws Exception {
-        mNetworkConnectionManager = new NetworkConnectionInfoManager();
-        mMockContext = mock(Context.class);
-        mConnectivityManager = mock(ConnectivityManager.class);
-        when(mMockContext.getApplicationContext()).thenReturn(mMockContext);
-        when(mMockContext.getSystemService(Context.CONNECTIVITY_SERVICE)).thenReturn(mConnectivityManager);
+        networkConnectionManager = new NetworkConnectionInfoManager();
+        mockContext = mock(Context.class);
+        connectivityManager = mock(ConnectivityManager.class);
+        when(mockContext.getApplicationContext()).thenReturn(mockContext);
+        when(mockContext.getSystemService(Context.CONNECTIVITY_SERVICE)).thenReturn(connectivityManager);
 
-        mNetworkConnectionManager.init(mMockContext);
+        networkConnectionManager.init(mockContext);
     }
 
     @Test
     public void getConnectionTypeTest() {
         NetworkInfo mockInfo = mock(NetworkInfo.class);
 
-        when(mMockContext.checkCallingOrSelfPermission(Manifest.permission.ACCESS_NETWORK_STATE)).thenReturn(PackageManager.PERMISSION_GRANTED);
+        when(mockContext.checkCallingOrSelfPermission(Manifest.permission.ACCESS_NETWORK_STATE)).thenReturn(
+                PackageManager.PERMISSION_GRANTED);
         when(mockInfo.isConnected()).thenReturn(true);
         when(mockInfo.getType()).thenReturn(ConnectivityManager.TYPE_MOBILE);
-        when(mConnectivityManager.getActiveNetworkInfo()).thenReturn(mockInfo);
+        when(connectivityManager.getActiveNetworkInfo()).thenReturn(mockInfo);
 
-        assertEquals(UserParameters.ConnectionType.CELL, mNetworkConnectionManager.getConnectionType());
+        assertEquals(UserParameters.ConnectionType.CELL, networkConnectionManager.getConnectionType());
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/sdk/deviceData/managers/UserConsentManagerTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/sdk/deviceData/managers/UserConsentManagerTest.java
@@ -35,12 +35,12 @@ import static org.mockito.Mockito.*;
 @RunWith(RobolectricTestRunner.class)
 public class UserConsentManagerTest {
 
-    protected Context mContext = mock(Context.class);
-    protected SharedPreferences mSharedPreferences = mock(SharedPreferences.class);
-    private UserConsentManager mUserConsentManager;
-    private String mIsSubjectToGdpr = "";
-    private String mConsentString;
-    private String mPurposeConsent;
+    protected Context context = mock(Context.class);
+    protected SharedPreferences sharedPreferences = mock(SharedPreferences.class);
+    private UserConsentManager userConsentManager;
+    private String isSubjectToGdpr = "";
+    private String consentString;
+    private String purposeConsent;
 
     private static final String SUBJECT_TO_GDPR = "IABConsent_SubjectToGDPR";
     private static final String CONSENT_STRING = "IABConsent_ConsentString";
@@ -50,131 +50,131 @@ public class UserConsentManagerTest {
     public void setUp() throws Exception {
         Activity robolectricActivity = Robolectric.buildActivity(Activity.class).create().get();
 
-        mSharedPreferences = PreferenceManager.getDefaultSharedPreferences(robolectricActivity);
-        mSharedPreferences.edit().putString(SUBJECT_TO_GDPR, "1").commit();
-        mSharedPreferences.edit().putString(CONSENT_STRING, "consent_string").commit();
-        mSharedPreferences.edit().putString(PURPOSE_CONSENT, "01").commit();
+        sharedPreferences = PreferenceManager.getDefaultSharedPreferences(robolectricActivity);
+        sharedPreferences.edit().putString(SUBJECT_TO_GDPR, "1").commit();
+        sharedPreferences.edit().putString(CONSENT_STRING, "consent_string").commit();
+        sharedPreferences.edit().putString(PURPOSE_CONSENT, "01").commit();
 
-        mUserConsentManager = new UserConsentManager();
-        mUserConsentManager.init(robolectricActivity);
+        userConsentManager = new UserConsentManager();
+        userConsentManager.init(robolectricActivity);
     }
 
     @Test
     public void initConsentValuesAtStartTest() throws Exception {
-        mIsSubjectToGdpr = WhiteBox.getInternalState(mUserConsentManager, "mIsSubjectToGdpr");
-        assertEquals("1", mIsSubjectToGdpr);
+        isSubjectToGdpr = WhiteBox.getInternalState(userConsentManager, "isSubjectToGdpr");
+        assertEquals("1", isSubjectToGdpr);
 
-        mConsentString = WhiteBox.getInternalState(mUserConsentManager, "mConsentString");
-        assertEquals("consent_string", mConsentString);
+        consentString = WhiteBox.getInternalState(userConsentManager, "consentString");
+        assertEquals("consent_string", consentString);
 
-        mPurposeConsent = WhiteBox.getInternalState(mUserConsentManager, "mPurposeConsent");
-        assertEquals("01", mPurposeConsent);
+        purposeConsent = WhiteBox.getInternalState(userConsentManager, "purposeConsent");
+        assertEquals("01", purposeConsent);
     }
 
     @Test
     public void getConsentValuesTest() throws Exception {
         Method methodGetConsent = WhiteBox.method(UserConsentManager.class, "getConsentValues", SharedPreferences.class, String.class);
 
-        mConsentString = (String) methodGetConsent.invoke(mUserConsentManager, mSharedPreferences, CONSENT_STRING);
-        assertEquals("consent_string", mConsentString);
+        consentString = (String) methodGetConsent.invoke(userConsentManager, sharedPreferences, CONSENT_STRING);
+        assertEquals("consent_string", consentString);
 
-        mIsSubjectToGdpr = (String) methodGetConsent.invoke(mUserConsentManager, mSharedPreferences, SUBJECT_TO_GDPR);
-        assertEquals("1", mIsSubjectToGdpr);
+        isSubjectToGdpr = (String) methodGetConsent.invoke(userConsentManager, sharedPreferences, SUBJECT_TO_GDPR);
+        assertEquals("1", isSubjectToGdpr);
 
-        mPurposeConsent = (String) methodGetConsent.invoke(mUserConsentManager, mSharedPreferences, PURPOSE_CONSENT);
-        assertEquals("01", mPurposeConsent);
+        purposeConsent = (String) methodGetConsent.invoke(userConsentManager, sharedPreferences, PURPOSE_CONSENT);
+        assertEquals("01", purposeConsent);
     }
 
     @Test
     public void getSubjectToGdprTest() {
 
-        WhiteBox.setInternalState(mUserConsentManager, "mIsSubjectToGdpr", "1");
-        assertEquals(mUserConsentManager.getSubjectToGdpr(), "1");
+        WhiteBox.setInternalState(userConsentManager, "isSubjectToGdpr", "1");
+        assertEquals(userConsentManager.getSubjectToGdpr(), "1");
 
-        WhiteBox.setInternalState(mUserConsentManager, "mIsSubjectToGdpr", "0");
-        assertEquals(mUserConsentManager.getSubjectToGdpr(), "0");
+        WhiteBox.setInternalState(userConsentManager, "isSubjectToGdpr", "0");
+        assertEquals(userConsentManager.getSubjectToGdpr(), "0");
 
-        WhiteBox.setInternalState(mUserConsentManager, "mIsSubjectToGdpr", "");
-        assertEquals(mUserConsentManager.getSubjectToGdpr(), "");
+        WhiteBox.setInternalState(userConsentManager, "isSubjectToGdpr", "");
+        assertEquals(userConsentManager.getSubjectToGdpr(), "");
     }
 
     @Test
     public void getUserConsentStringTest() {
-        WhiteBox.setInternalState(mUserConsentManager, "mConsentString", "some_consent_string");
-        assertEquals(mUserConsentManager.getUserConsentString(), "some_consent_string");
+        WhiteBox.setInternalState(userConsentManager, "consentString", "some_consent_string");
+        assertEquals(userConsentManager.getUserConsentString(), "some_consent_string");
 
-        WhiteBox.setInternalState(mUserConsentManager, "mConsentString", "");
-        assertEquals(mUserConsentManager.getUserConsentString(), "");
+        WhiteBox.setInternalState(userConsentManager, "consentString", "");
+        assertEquals(userConsentManager.getUserConsentString(), "");
     }
 
     @Test
     public void shouldUseTcfV2WithValidCmpId_ReturnTrue() {
-        WhiteBox.setInternalState(mUserConsentManager, "mCmpSdkId", 1);
+        WhiteBox.setInternalState(userConsentManager, "cmpSdkId", 1);
 
-        assertTrue(mUserConsentManager.shouldUseTcfV2());
+        assertTrue(userConsentManager.shouldUseTcfV2());
     }
 
     @Test
     public void shouldUseTcfV2WithInValidCmpId_ReturnFalse() {
-        WhiteBox.setInternalState(mUserConsentManager, "mCmpSdkId", -2);
+        WhiteBox.setInternalState(userConsentManager, "cmpSdkId", -2);
 
-        assertFalse(mUserConsentManager.shouldUseTcfV2());
+        assertFalse(userConsentManager.shouldUseTcfV2());
     }
 
     @Test
     public void getTcfV2GdprAppliesWhenGdprValueIsNotAssigned_ReturnNull() {
-        WhiteBox.setInternalState(mUserConsentManager, "mTcfV2GdprApplies", -1);
+        WhiteBox.setInternalState(userConsentManager, "tcfV2GdprApplies", -1);
 
-        assertNull(mUserConsentManager.getTcfV2GdprApplies());
+        assertNull(userConsentManager.getTcfV2GdprApplies());
     }
 
     @Test
     public void getTcfV2GdprAppliesWhenGdprValueIsAssigned_ReturnStringValue() {
-        WhiteBox.setInternalState(mUserConsentManager, "mTcfV2GdprApplies", 1);
+        WhiteBox.setInternalState(userConsentManager, "tcfV2GdprApplies", 1);
 
-        assertEquals("1", mUserConsentManager.getTcfV2GdprApplies());
+        assertEquals("1", userConsentManager.getTcfV2GdprApplies());
     }
 
     @Test
     public void getSubjectToGdprShouldUseTcfV2True_ReturnTcfV2GdprApplies() {
-        UserConsentManager spyConsentManager = spy(mUserConsentManager);
+        UserConsentManager spyConsentManager = spy(userConsentManager);
         when(spyConsentManager.shouldUseTcfV2()).thenReturn(true);
 
-        WhiteBox.setInternalState(spyConsentManager, "mTcfV2GdprApplies", 1);
-        WhiteBox.setInternalState(spyConsentManager, "mIsSubjectToGdpr", "0");
+        WhiteBox.setInternalState(spyConsentManager, "tcfV2GdprApplies", 1);
+        WhiteBox.setInternalState(spyConsentManager, "isSubjectToGdpr", "0");
 
         assertEquals("1", spyConsentManager.getSubjectToGdpr());
     }
 
     @Test
     public void getSubjectToGdprShouldUseTcfV2False_ReturnTcfV1IsSubjectToGdpr() {
-        UserConsentManager spyConsentManager = spy(mUserConsentManager);
+        UserConsentManager spyConsentManager = spy(userConsentManager);
         when(spyConsentManager.shouldUseTcfV2()).thenReturn(false);
 
-        WhiteBox.setInternalState(spyConsentManager, "mTcfV2GdprApplies", 1);
-        WhiteBox.setInternalState(spyConsentManager, "mIsSubjectToGdpr", "0");
+        WhiteBox.setInternalState(spyConsentManager, "tcfV2GdprApplies", 1);
+        WhiteBox.setInternalState(spyConsentManager, "isSubjectToGdpr", "0");
 
         assertEquals("0", spyConsentManager.getSubjectToGdpr());
     }
 
     @Test
     public void getUserConsentStringShouldUseTcfV2True_ReturnTcfV2ConsentString() {
-        UserConsentManager spyConsentManager = spy(mUserConsentManager);
+        UserConsentManager spyConsentManager = spy(userConsentManager);
         when(spyConsentManager.shouldUseTcfV2()).thenReturn(true);
 
-        WhiteBox.setInternalState(spyConsentManager, "mTcfV2ConsentString", "tcf_v2_consent");
-        WhiteBox.setInternalState(spyConsentManager, "mConsentString", "tcf_v1_consent");
+        WhiteBox.setInternalState(spyConsentManager, "tcfV2ConsentString", "tcf_v2_consent");
+        WhiteBox.setInternalState(spyConsentManager, "consentString", "tcf_v1_consent");
 
         assertEquals("tcf_v2_consent", spyConsentManager.getUserConsentString());
     }
 
     @Test
     public void getUserConsentStringShouldUseTcfV2False_ReturnTcfV1ConsentString() {
-        UserConsentManager spyConsentManager = spy(mUserConsentManager);
+        UserConsentManager spyConsentManager = spy(userConsentManager);
         when(spyConsentManager.shouldUseTcfV2()).thenReturn(false);
 
-        WhiteBox.setInternalState(spyConsentManager, "mTcfV2ConsentString", "tcf_v2_consent");
-        WhiteBox.setInternalState(spyConsentManager, "mConsentString", "tcf_v1_consent");
+        WhiteBox.setInternalState(spyConsentManager, "tcfV2ConsentString", "tcf_v2_consent");
+        WhiteBox.setInternalState(spyConsentManager, "consentString", "tcf_v1_consent");
 
         assertEquals("tcf_v1_consent", spyConsentManager.getUserConsentString());
     }
@@ -190,66 +190,66 @@ public class UserConsentManagerTest {
     */
     @Test
     public void canAccessDeviceData_SubjectToGdprFalse() {
-        UserConsentManager spyConsentManager = spy(mUserConsentManager);
+        UserConsentManager spyConsentManager = spy(userConsentManager);
         when(spyConsentManager.shouldUseTcfV2()).thenReturn(true);
         when(spyConsentManager.getSubjectToGdpr()).thenReturn("0"); // false
 
-        WhiteBox.setInternalState(spyConsentManager, "mPurposeConsent", "10"); // true
+        WhiteBox.setInternalState(spyConsentManager, "purposeConsent", "10"); // true
         assertTrue(spyConsentManager.canAccessDeviceData());
 
-        WhiteBox.setInternalState(spyConsentManager, "mPurposeConsent", "00"); // false
+        WhiteBox.setInternalState(spyConsentManager, "purposeConsent", "00"); // false
         assertFalse(spyConsentManager.canAccessDeviceData());
 
-        WhiteBox.setInternalState(spyConsentManager, "mPurposeConsent", null); // undefined
+        WhiteBox.setInternalState(spyConsentManager, "purposeConsent", null); // undefined
         assertTrue(spyConsentManager.canAccessDeviceData());
     }
 
     @Test
     public void canAccessDeviceData_SubjectToGdprTrue() {
-        UserConsentManager spyConsentManager = spy(mUserConsentManager);
+        UserConsentManager spyConsentManager = spy(userConsentManager);
         when(spyConsentManager.shouldUseTcfV2()).thenReturn(true);
         when(spyConsentManager.getSubjectToGdpr()).thenReturn("1"); // true
 
-        WhiteBox.setInternalState(spyConsentManager, "mPurposeConsent", "10"); // true
+        WhiteBox.setInternalState(spyConsentManager, "purposeConsent", "10"); // true
         assertTrue(spyConsentManager.canAccessDeviceData());
 
-        WhiteBox.setInternalState(spyConsentManager, "mPurposeConsent", "00"); // false
+        WhiteBox.setInternalState(spyConsentManager, "purposeConsent", "00"); // false
         assertFalse(spyConsentManager.canAccessDeviceData());
 
-        WhiteBox.setInternalState(spyConsentManager, "mPurposeConsent", null); // undefined
+        WhiteBox.setInternalState(spyConsentManager, "purposeConsent", null); // undefined
         assertFalse(spyConsentManager.canAccessDeviceData());
     }
 
     @Test
     public void canAccessDeviceData_SubjectToGdprUndefined() {
-        UserConsentManager spyConsentManager = spy(mUserConsentManager);
+        UserConsentManager spyConsentManager = spy(userConsentManager);
         when(spyConsentManager.shouldUseTcfV2()).thenReturn(true);
         when(spyConsentManager.getSubjectToGdpr()).thenReturn(""); // undefined
 
-        WhiteBox.setInternalState(spyConsentManager, "mPurposeConsent", "10"); // true
+        WhiteBox.setInternalState(spyConsentManager, "purposeConsent", "10"); // true
         assertTrue(spyConsentManager.canAccessDeviceData());
 
-        WhiteBox.setInternalState(spyConsentManager, "mPurposeConsent", "00"); // false
+        WhiteBox.setInternalState(spyConsentManager, "purposeConsent", "00"); // false
         assertFalse(spyConsentManager.canAccessDeviceData());
 
-        WhiteBox.setInternalState(spyConsentManager, "mPurposeConsent", null); // undefined
+        WhiteBox.setInternalState(spyConsentManager, "purposeConsent", null); // undefined
         assertTrue(spyConsentManager.canAccessDeviceData());
     }
 
     @Test
     public void getPurposeConsent_validString_ReturnValueAtIndexAsBoolean() {
-        WhiteBox.setInternalState(mUserConsentManager, "mPurposeConsent", "01019");
+        WhiteBox.setInternalState(userConsentManager, "purposeConsent", "01019");
 
-        assertTrue(mUserConsentManager.getPurposeConsent(1));
-        assertFalse(mUserConsentManager.getPurposeConsent(2));
-        assertFalse(mUserConsentManager.getPurposeConsent(4));
+        assertTrue(userConsentManager.getPurposeConsent(1));
+        assertFalse(userConsentManager.getPurposeConsent(2));
+        assertFalse(userConsentManager.getPurposeConsent(4));
     }
 
     @Test
     public void getPurposeConsent_nullString_ReturnNull() {
-        WhiteBox.setInternalState(mUserConsentManager, "mPurposeConsent", null);
+        WhiteBox.setInternalState(userConsentManager, "purposeConsent", null);
 
-        assertNull(mUserConsentManager.getPurposeConsent(1));
-        assertNull(mUserConsentManager.getPurposeConsent(0));
+        assertNull(userConsentManager.getPurposeConsent(1));
+        assertNull(userConsentManager.getPurposeConsent(0));
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/session/manager/OmAdSessionManagerTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/session/manager/OmAdSessionManagerTest.java
@@ -27,24 +27,24 @@ public class OmAdSessionManagerTest {
     // TODO: 03.12.2020 How to test without Powermock static mock
     @Test
     public void test() {}
-    // private OmAdSessionManager mOmAdSessionManager;
+    // private OmAdSessionManager omAdSessionManager;
     // @Mock
-    // AdSession mMockAdSession;
+    // AdSession mockAdSession;
     // @Mock
-    // JSLibraryManager mMockJsLibraryManager;
+    // JSLibraryManager mockJsLibraryManager;
     //
     // @Before
     // public void setUp() throws IllegalAccessException {
     //     MockitoAnnotations.initMocks(this);
     //
-    //     mOmAdSessionManager = OmAdSessionManager.createNewInstance(mMockJsLibraryManager);
-    //     WhiteBox.field(OmAdSessionManager.class, "mAdSession").set(mOmAdSessionManager, mMockAdSession);
+    //     omAdSessionManager = OmAdSessionManager.createNewInstance(mockJsLibraryManager);
+    //     WhiteBox.field(OmAdSessionManager.class, "adSession").set(omAdSessionManager, mockAdSession);
     // }
     //
     // @Test
     // public void createInstanceOmNotActive_ReturnNull() {
     //     when(Omid.isActive()).thenReturn(false);
-    //     OmAdSessionManager omAdSessionManager = OmAdSessionManager.createNewInstance(mMockJsLibraryManager);
+    //     OmAdSessionManager omAdSessionManager = OmAdSessionManager.createNewInstance(mockJsLibraryManager);
     //
     //     assertNull(omAdSessionManager);
     // }
@@ -52,7 +52,7 @@ public class OmAdSessionManagerTest {
     // @Test
     // public void createInstanceOmActive_ReturnInstance() {
     //     when(Omid.isActive()).thenReturn(true);
-    //     OmAdSessionManager omAdSessionManager = OmAdSessionManager.createNewInstance(mMockJsLibraryManager);
+    //     OmAdSessionManager omAdSessionManager = OmAdSessionManager.createNewInstance(mockJsLibraryManager);
     //
     //     assertNotNull(omAdSessionManager);
     // }
@@ -70,61 +70,61 @@ public class OmAdSessionManagerTest {
     //     InternalFriendlyObstruction friendlyObstruction = new InternalFriendlyObstruction(null,
     //                                                                                       InternalFriendlyObstruction.Purpose.VIDEO_CONTROLS,
     //                                                                                       "content");
-    //     mOmAdSessionManager.addObstruction(friendlyObstruction);
-    //     verify(mMockAdSession).addFriendlyObstruction(null, FriendlyObstructionPurpose.VIDEO_CONTROLS, "content");
+    //     omAdSessionManager.addObstruction(friendlyObstruction);
+    //     verify(mockAdSession).addFriendlyObstruction(null, FriendlyObstructionPurpose.VIDEO_CONTROLS, "content");
     // }
     //
     // @Test
     // public void trackVideoAdEventsTest() throws Exception {
     //
     //     MediaEvents mockVideoAdEvent = mock(MediaEvents.class);
-    //     WhiteBox.field(OmAdSessionManager.class, "mMediaEvents")
-    //                   .set(mOmAdSessionManager, mockVideoAdEvent);
+    //     WhiteBox.field(OmAdSessionManager.class, "mediaEvents")
+    //                   .set(omAdSessionManager, mockVideoAdEvent);
     //
-    //     mOmAdSessionManager.trackAdVideoEvent(VideoAdEvent.Event.AD_PAUSE);
+    //     omAdSessionManager.trackAdVideoEvent(VideoAdEvent.Event.AD_PAUSE);
     //     verify(mockVideoAdEvent).pause();
     //
-    //     mOmAdSessionManager.trackAdVideoEvent(VideoAdEvent.Event.AD_RESUME);
+    //     omAdSessionManager.trackAdVideoEvent(VideoAdEvent.Event.AD_RESUME);
     //     verify(mockVideoAdEvent).resume();
     //
-    //     mOmAdSessionManager.trackAdVideoEvent(VideoAdEvent.Event.AD_SKIP);
+    //     omAdSessionManager.trackAdVideoEvent(VideoAdEvent.Event.AD_SKIP);
     //     verify(mockVideoAdEvent).skipped();
     //
-    //     mOmAdSessionManager.trackAdVideoEvent(VideoAdEvent.Event.AD_COMPLETE);
+    //     omAdSessionManager.trackAdVideoEvent(VideoAdEvent.Event.AD_COMPLETE);
     //     verify(mockVideoAdEvent).complete();
     //
-    //     mOmAdSessionManager.trackAdVideoEvent(VideoAdEvent.Event.AD_FIRSTQUARTILE);
+    //     omAdSessionManager.trackAdVideoEvent(VideoAdEvent.Event.AD_FIRSTQUARTILE);
     //     verify(mockVideoAdEvent).firstQuartile();
     //
-    //     mOmAdSessionManager.trackAdVideoEvent(VideoAdEvent.Event.AD_MIDPOINT);
+    //     omAdSessionManager.trackAdVideoEvent(VideoAdEvent.Event.AD_MIDPOINT);
     //     verify(mockVideoAdEvent).midpoint();
     //
-    //     mOmAdSessionManager.trackAdVideoEvent(VideoAdEvent.Event.AD_THIRDQUARTILE);
+    //     omAdSessionManager.trackAdVideoEvent(VideoAdEvent.Event.AD_THIRDQUARTILE);
     //     verify(mockVideoAdEvent).thirdQuartile();
     //
-    //     mOmAdSessionManager.trackAdVideoEvent(VideoAdEvent.Event.AD_FULLSCREEN);
+    //     omAdSessionManager.trackAdVideoEvent(VideoAdEvent.Event.AD_FULLSCREEN);
     //     verify(mockVideoAdEvent).playerStateChange(PlayerState.FULLSCREEN);
     //
-    //     mOmAdSessionManager.trackAdVideoEvent(VideoAdEvent.Event.AD_EXITFULLSCREEN);
+    //     omAdSessionManager.trackAdVideoEvent(VideoAdEvent.Event.AD_EXITFULLSCREEN);
     //     verify(mockVideoAdEvent).playerStateChange(PlayerState.NORMAL);
     //
-    //     mOmAdSessionManager.trackAdVideoEvent(VideoAdEvent.Event.AD_CLICK);
+    //     omAdSessionManager.trackAdVideoEvent(VideoAdEvent.Event.AD_CLICK);
     //     verify(mockVideoAdEvent).adUserInteraction(InteractionType.CLICK);
     //
-    //     mOmAdSessionManager.videoAdStarted(0, 0);
+    //     omAdSessionManager.videoAdStarted(0, 0);
     //     verify(mockVideoAdEvent).start(0, 0);
     //
-    //     mOmAdSessionManager.trackVolumeChange(1);
+    //     omAdSessionManager.trackVolumeChange(1);
     //     verify(mockVideoAdEvent).volumeChange(1);
     // }
     //
     // @Test
     // public void nonSkippableVideoAdLoadedTest() throws IllegalAccessException {
     //     AdEvents mockAdEvents = PowerMockito.mock(AdEvents.class);
-    //     WhiteBox.field(OmAdSessionManager.class, "mAdEvents")
-    //                   .set(mOmAdSessionManager, mockAdEvents);
+    //     WhiteBox.field(OmAdSessionManager.class, "adEvents")
+    //                   .set(omAdSessionManager, mockAdEvents);
     //
-    //     mOmAdSessionManager.nonSkippableStandaloneVideoAdLoaded(false);
+    //     omAdSessionManager.nonSkippableStandaloneVideoAdLoaded(false);
     //     VastProperties vastProperties = VastProperties.createVastPropertiesForNonSkippableMedia(false, Position.STANDALONE);
     //     mockAdEvents.loaded(vastProperties);
     // }
@@ -132,19 +132,19 @@ public class OmAdSessionManagerTest {
     // @Test
     // public void registerAdViewTest() {
     //     View adView = any(View.class);
-    //     mOmAdSessionManager.registerAdView(adView);
-    //     verify(mMockAdSession).registerAdView(adView);
+    //     omAdSessionManager.registerAdView(adView);
+    //     verify(mockAdSession).registerAdView(adView);
     // }
     //
     // @Test
     // public void stopAdSessionTest() {
-    //     mOmAdSessionManager.stopAdSession();
-    //     verify(mMockAdSession).finish();
+    //     omAdSessionManager.stopAdSession();
+    //     verify(mockAdSession).finish();
     // }
     //
     // @Test
     // public void startAdSessionTest() throws IllegalAccessException {
-    //     mOmAdSessionManager.startAdSession();
-    //     verify(mMockAdSession).start();
+    //     omAdSessionManager.startAdSession();
+    //     verify(mockAdSession).start();
     // }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/utils/device/DeviceVolumeObserverTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/utils/device/DeviceVolumeObserverTest.java
@@ -36,96 +36,96 @@ public class DeviceVolumeObserverTest {
     private static final boolean IRRELEVANT_SELF_CHANGE = true;
 
     @Mock
-    Handler mMockHandler;
+    Handler mockHandler;
     @Mock
-    Context mMockContext;
+    Context mockContext;
     @Mock
-    ContentResolver mMockContentResolver;
+    ContentResolver mockContentResolver;
     @Mock
-    DeviceVolumeObserver.DeviceVolumeListener mMockDeviceVolumeListener;
+    DeviceVolumeObserver.DeviceVolumeListener mockDeviceVolumeListener;
     @Mock
-    AudioManager mMockAudioManager;
+    AudioManager mockAudioManager;
 
-    private DeviceVolumeObserver mSpyDeviceVolumeObserver;
+    private DeviceVolumeObserver spyDeviceVolumeObserver;
 
     @Before
     public void setupMocks() {
         MockitoAnnotations.initMocks(this);
 
-        when(mMockContext.getSystemService(Context.AUDIO_SERVICE)).thenReturn(mMockAudioManager);
-        when(mMockContext.getContentResolver()).thenReturn(mMockContentResolver);
+        when(mockContext.getSystemService(Context.AUDIO_SERVICE)).thenReturn(mockAudioManager);
+        when(mockContext.getContentResolver()).thenReturn(mockContentResolver);
 
-        mSpyDeviceVolumeObserver = spy(new DeviceVolumeObserver(mMockContext, mMockHandler, mMockDeviceVolumeListener));
+        spyDeviceVolumeObserver = spy(new DeviceVolumeObserver(mockContext, mockHandler, mockDeviceVolumeListener));
     }
 
     @Test
     public void start_NotifyListenerWithCurrentDeviceVolume() {
-        when(mMockContext.getContentResolver()).thenReturn(mMockContentResolver);
-        when(mMockAudioManager.getStreamVolume(STREAM_MUSIC)).thenReturn(100);
-        when(mMockAudioManager.getStreamMaxVolume(STREAM_MUSIC)).thenReturn(100);
-        when(mSpyDeviceVolumeObserver.convertDeviceVolume(100, 100)).thenReturn(1f);
+        when(mockContext.getContentResolver()).thenReturn(mockContentResolver);
+        when(mockAudioManager.getStreamVolume(STREAM_MUSIC)).thenReturn(100);
+        when(mockAudioManager.getStreamMaxVolume(STREAM_MUSIC)).thenReturn(100);
+        when(spyDeviceVolumeObserver.convertDeviceVolume(100, 100)).thenReturn(1f);
 
-        mSpyDeviceVolumeObserver.start();
+        spyDeviceVolumeObserver.start();
 
-        verify(mMockAudioManager, times(1)).getStreamVolume(STREAM_MUSIC);
-        verify(mMockAudioManager, times(1)).getStreamMaxVolume(STREAM_MUSIC);
-        verify(mSpyDeviceVolumeObserver, times(1)).convertDeviceVolume(100, 100);
-        verify(mMockDeviceVolumeListener, times(1)).onDeviceVolumeChanged(1f);
+        verify(mockAudioManager, times(1)).getStreamVolume(STREAM_MUSIC);
+        verify(mockAudioManager, times(1)).getStreamMaxVolume(STREAM_MUSIC);
+        verify(spyDeviceVolumeObserver, times(1)).convertDeviceVolume(100, 100);
+        verify(mockDeviceVolumeListener, times(1)).onDeviceVolumeChanged(1f);
     }
 
     @Test
     public void start_RegisterContentObserver() {
-        when(mMockContext.getContentResolver()).thenReturn(mMockContentResolver);
-        when(mMockAudioManager.getStreamVolume(STREAM_MUSIC)).thenReturn(100);
-        when(mMockAudioManager.getStreamMaxVolume(STREAM_MUSIC)).thenReturn(100);
-        when(mSpyDeviceVolumeObserver.convertDeviceVolume(100, 100)).thenReturn(1f);
+        when(mockContext.getContentResolver()).thenReturn(mockContentResolver);
+        when(mockAudioManager.getStreamVolume(STREAM_MUSIC)).thenReturn(100);
+        when(mockAudioManager.getStreamMaxVolume(STREAM_MUSIC)).thenReturn(100);
+        when(spyDeviceVolumeObserver.convertDeviceVolume(100, 100)).thenReturn(1f);
 
-        mSpyDeviceVolumeObserver.start();
+        spyDeviceVolumeObserver.start();
 
-        verify(mMockContext, times(1)).getContentResolver();
+        verify(mockContext, times(1)).getContentResolver();
     }
 
     @Test
     public void stop_UnregisterContentObserver() {
-        when(mMockAudioManager.getStreamVolume(STREAM_MUSIC)).thenReturn(100);
-        when(mMockAudioManager.getStreamMaxVolume(STREAM_MUSIC)).thenReturn(100);
-        when(mSpyDeviceVolumeObserver.convertDeviceVolume(100, 100)).thenReturn(1f);
+        when(mockAudioManager.getStreamVolume(STREAM_MUSIC)).thenReturn(100);
+        when(mockAudioManager.getStreamMaxVolume(STREAM_MUSIC)).thenReturn(100);
+        when(spyDeviceVolumeObserver.convertDeviceVolume(100, 100)).thenReturn(1f);
 
-        mSpyDeviceVolumeObserver.stop();
+        spyDeviceVolumeObserver.stop();
 
-        verify(mMockContext, times(1)).getContentResolver();
+        verify(mockContext, times(1)).getContentResolver();
     }
 
     @Test
     public void onChangeWithDeviceVolumeChanged_NotifyListener() {
-        when(mMockAudioManager.getStreamVolume(STREAM_MUSIC)).thenReturn(100, 50);
-        when(mMockAudioManager.getStreamMaxVolume(STREAM_MUSIC)).thenReturn(100, 100);
-        when(mSpyDeviceVolumeObserver.convertDeviceVolume(100, 100)).thenReturn(1f);
-        when(mSpyDeviceVolumeObserver.convertDeviceVolume(50, 100)).thenReturn(0.5f);
+        when(mockAudioManager.getStreamVolume(STREAM_MUSIC)).thenReturn(100, 50);
+        when(mockAudioManager.getStreamMaxVolume(STREAM_MUSIC)).thenReturn(100, 100);
+        when(spyDeviceVolumeObserver.convertDeviceVolume(100, 100)).thenReturn(1f);
+        when(spyDeviceVolumeObserver.convertDeviceVolume(50, 100)).thenReturn(0.5f);
 
-        mSpyDeviceVolumeObserver.onChange(IRRELEVANT_SELF_CHANGE);
-        mSpyDeviceVolumeObserver.onChange(IRRELEVANT_SELF_CHANGE);
+        spyDeviceVolumeObserver.onChange(IRRELEVANT_SELF_CHANGE);
+        spyDeviceVolumeObserver.onChange(IRRELEVANT_SELF_CHANGE);
 
-        verify(mMockAudioManager, times(2)).getStreamVolume(STREAM_MUSIC);
-        verify(mMockAudioManager, times(2)).getStreamMaxVolume(STREAM_MUSIC);
-        verify(mSpyDeviceVolumeObserver, times(1)).convertDeviceVolume(100, 100);
-        verify(mMockDeviceVolumeListener, times(1)).onDeviceVolumeChanged(1f);
-        verify(mSpyDeviceVolumeObserver, times(1)).convertDeviceVolume(50, 100);
-        verify(mMockDeviceVolumeListener, times(1)).onDeviceVolumeChanged(0.5f);
+        verify(mockAudioManager, times(2)).getStreamVolume(STREAM_MUSIC);
+        verify(mockAudioManager, times(2)).getStreamMaxVolume(STREAM_MUSIC);
+        verify(spyDeviceVolumeObserver, times(1)).convertDeviceVolume(100, 100);
+        verify(mockDeviceVolumeListener, times(1)).onDeviceVolumeChanged(1f);
+        verify(spyDeviceVolumeObserver, times(1)).convertDeviceVolume(50, 100);
+        verify(mockDeviceVolumeListener, times(1)).onDeviceVolumeChanged(0.5f);
     }
 
     @Test
     public void onChangeWithDeviceVolumeNotChanged_NoNotifyListener() {
-        when(mMockAudioManager.getStreamVolume(STREAM_MUSIC)).thenReturn(100);
-        when(mMockAudioManager.getStreamMaxVolume(STREAM_MUSIC)).thenReturn(100);
-        when(mSpyDeviceVolumeObserver.convertDeviceVolume(100, 100)).thenReturn(1f);
+        when(mockAudioManager.getStreamVolume(STREAM_MUSIC)).thenReturn(100);
+        when(mockAudioManager.getStreamMaxVolume(STREAM_MUSIC)).thenReturn(100);
+        when(spyDeviceVolumeObserver.convertDeviceVolume(100, 100)).thenReturn(1f);
 
-        mSpyDeviceVolumeObserver.onChange(IRRELEVANT_SELF_CHANGE);
-        mSpyDeviceVolumeObserver.onChange(IRRELEVANT_SELF_CHANGE);
+        spyDeviceVolumeObserver.onChange(IRRELEVANT_SELF_CHANGE);
+        spyDeviceVolumeObserver.onChange(IRRELEVANT_SELF_CHANGE);
 
-        verify(mMockAudioManager, times(2)).getStreamVolume(STREAM_MUSIC);
-        verify(mMockAudioManager, times(2)).getStreamMaxVolume(STREAM_MUSIC);
-        verify(mSpyDeviceVolumeObserver, times(2)).convertDeviceVolume(100, 100);
-        verify(mMockDeviceVolumeListener, times(1)).onDeviceVolumeChanged(1f);
+        verify(mockAudioManager, times(2)).getStreamVolume(STREAM_MUSIC);
+        verify(mockAudioManager, times(2)).getStreamMaxVolume(STREAM_MUSIC);
+        verify(spyDeviceVolumeObserver, times(2)).convertDeviceVolume(100, 100);
+        verify(mockDeviceVolumeListener, times(1)).onDeviceVolumeChanged(1f);
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/utils/exposure/ViewExposureCheckerTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/utils/exposure/ViewExposureCheckerTest.java
@@ -43,32 +43,35 @@ import static org.mockito.Mockito.when;
 @Config(sdk = 23, qualifiers = "w800dp-h800dp-xhdpi")
 public class ViewExposureCheckerTest {
 
-    private Activity mActivity;
-    private FrameLayout mContainer;
-    private ViewExposureChecker mViewExposureChecker;
+    private Activity activity;
+    private FrameLayout container;
+    private ViewExposureChecker viewExposureChecker;
 
     @Before
     public void setup() {
-        mActivity = Robolectric.buildActivity(Activity.class)
-                               .setup()
-                               .create()
-                               .visible()
-                               .resume()
-                               .windowFocusChanged(true)
-                               .get();
-        mContainer = new FrameLayout(mActivity);
-        mContainer.setLayoutParams(new FrameLayout.LayoutParams(ViewGroup.LayoutParams.MATCH_PARENT, ViewGroup.LayoutParams.MATCH_PARENT));
-        mActivity.setContentView(mContainer);
-        mViewExposureChecker = new ViewExposureChecker();
+        activity = Robolectric.buildActivity(Activity.class)
+                              .setup()
+                              .create()
+                              .visible()
+                              .resume()
+                              .windowFocusChanged(true)
+                              .get();
+        container = new FrameLayout(activity);
+        container.setLayoutParams(new FrameLayout.LayoutParams(
+                ViewGroup.LayoutParams.MATCH_PARENT,
+                ViewGroup.LayoutParams.MATCH_PARENT
+        ));
+        activity.setContentView(container);
+        viewExposureChecker = new ViewExposureChecker();
     }
 
     @Test
     public void whenNoObstruction_FullyVisible() {
-        FrameLayout grandParent = new FrameLayout(mActivity);
-        FrameLayout parent = new FrameLayout(mActivity);
-        View view = new View(mActivity);
+        FrameLayout grandParent = new FrameLayout(activity);
+        FrameLayout parent = new FrameLayout(activity);
+        View view = new View(activity);
 
-        mContainer.addView(grandParent);
+        container.addView(grandParent);
         grandParent.addView(parent);
         parent.addView(view);
 
@@ -76,7 +79,7 @@ public class ViewExposureCheckerTest {
         parent.layout(20, 20, 320, 720);
         view.layout(20, 20, 220, 220);
 
-        ViewExposure resultExposure = mViewExposureChecker.exposure(view);
+        ViewExposure resultExposure = viewExposureChecker.exposure(view);
         assertEquals(new ViewExposure(1, new Rect(0, 0, 200, 200), new ArrayList<>()), resultExposure);
     }
 
@@ -151,11 +154,11 @@ public class ViewExposureCheckerTest {
 
     @Test
     public void whenSingleObstruction_DetectObstruction() {
-        FrameLayout root = new FrameLayout(mActivity);
-        FrameLayout grandParent = new FrameLayout(mActivity);
-        FrameLayout parent = new FrameLayout(mActivity);
-        View view = new View(mActivity);
-        View obstruction = new View(mActivity);
+        FrameLayout root = new FrameLayout(activity);
+        FrameLayout grandParent = new FrameLayout(activity);
+        FrameLayout parent = new FrameLayout(activity);
+        View view = new View(activity);
+        View obstruction = new View(activity);
 
         final ColorDrawable background = mock(ColorDrawable.class);
         when(background.getAlpha()).thenReturn(255);
@@ -163,11 +166,11 @@ public class ViewExposureCheckerTest {
         grandParent.setBackground(background);
         root.setBackground(background);
 
-        mContainer.addView(root);
+        container.addView(root);
         root.addView(grandParent);
         grandParent.addView(parent);
         parent.addView(view);
-        mContainer.addView(obstruction);
+        container.addView(obstruction);
 
         root.layout(10, 10, 250, 410);
         grandParent.layout(80, 40, 540, 180);
@@ -228,7 +231,7 @@ public class ViewExposureCheckerTest {
         ///table 4
         parent.setClipChildren(false);
         Views.removeFromParent(obstruction);
-        mContainer.addView(obstruction, 0);
+        container.addView(obstruction, 0);
         root.layout(10, 10, 250, 410);
         grandParent.layout(80, 40, 540, 180);
         parent.layout(240, 40, 380, 320);
@@ -284,29 +287,29 @@ public class ViewExposureCheckerTest {
 
     @Test
     public void whenMultipleObstructions_DetectObstructions() {
-        FrameLayout parent = new FrameLayout(mActivity);
-        View adView = new View(mActivity);
-        View brother = new View(mActivity);
-        View xBtn = new View(mActivity);
-        View uncle = new View(mActivity);
-        FrameLayout aunt = new FrameLayout(mActivity);
-        View cousin = new View(mActivity);
+        FrameLayout parent = new FrameLayout(activity);
+        View adView = new View(activity);
+        View brother = new View(activity);
+        View xBtn = new View(activity);
+        View uncle = new View(activity);
+        FrameLayout aunt = new FrameLayout(activity);
+        View cousin = new View(activity);
 
         final ColorDrawable background = mock(ColorDrawable.class);
         when(background.getAlpha()).thenReturn(255);
         parent.setBackground(background);
         aunt.setBackground(background);
 
-        mContainer.setClipChildren(false);
+        container.setClipChildren(false);
         parent.setClipChildren(false);
         aunt.setClipChildren(false);
 
-        mContainer.addView(parent);
+        container.addView(parent);
         parent.addView(adView);
         parent.addView(brother);
         parent.addView(xBtn);
-        mContainer.addView(uncle);
-        mContainer.addView(aunt);
+        container.addView(uncle);
+        container.addView(aunt);
         aunt.addView(cousin);
 
         parent.layout(10, 10, 610, 410);
@@ -364,7 +367,7 @@ public class ViewExposureCheckerTest {
 
     @Test
     public void whenShouldCollectObstructionWithTransparentBgAndNonTransparentFg_ReturnTrue() {
-        FrameLayout child = new FrameLayout(mActivity);
+        FrameLayout child = new FrameLayout(activity);
         final ColorDrawable foreground = mock(ColorDrawable.class);
         final ColorDrawable background = mock(ColorDrawable.class);
         when(foreground.getAlpha()).thenReturn(255);
@@ -372,12 +375,12 @@ public class ViewExposureCheckerTest {
 
         child.setForeground(foreground);
         child.setBackground(background);
-        assertTrue(mViewExposureChecker.shouldCollectObstruction(child));
+        assertTrue(viewExposureChecker.shouldCollectObstruction(child));
     }
 
     @Test
     public void whenShouldCollectObstructionWithTransparentFgAndNonTransparentBg_ReturnTrue() {
-        FrameLayout child = new FrameLayout(mActivity);
+        FrameLayout child = new FrameLayout(activity);
         final ColorDrawable foreground = mock(ColorDrawable.class);
         final ColorDrawable background = mock(ColorDrawable.class);
         when(foreground.getAlpha()).thenReturn(0);
@@ -385,18 +388,18 @@ public class ViewExposureCheckerTest {
 
         child.setForeground(foreground);
         child.setBackground(background);
-        assertTrue(mViewExposureChecker.shouldCollectObstruction(child));
+        assertTrue(viewExposureChecker.shouldCollectObstruction(child));
     }
 
     @Test
     public void whenShouldCollectObstructionWithNonViewGroup_ReturnTrue() {
-        View child = new View(mActivity);
-        assertTrue(mViewExposureChecker.shouldCollectObstruction(child));
+        View child = new View(activity);
+        assertTrue(viewExposureChecker.shouldCollectObstruction(child));
     }
 
     @Test
     public void whenShouldCollectObstructionWithTransparentBgAndTransparentFg_ReturnFalse() {
-        FrameLayout child = new FrameLayout(mActivity);
+        FrameLayout child = new FrameLayout(activity);
         final ColorDrawable foreground = mock(ColorDrawable.class);
         final ColorDrawable background = mock(ColorDrawable.class);
         when(foreground.getAlpha()).thenReturn(0);
@@ -404,10 +407,10 @@ public class ViewExposureCheckerTest {
 
         child.setForeground(foreground);
         child.setBackground(background);
-        assertFalse(mViewExposureChecker.shouldCollectObstruction(child));
+        assertFalse(viewExposureChecker.shouldCollectObstruction(child));
     }
 
     private ViewExposure getViewExposure(View view) {
-        return mViewExposureChecker.exposure(view);
+        return viewExposureChecker.exposure(view);
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/utils/helpers/ExternalViewerUtilsTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/utils/helpers/ExternalViewerUtilsTest.java
@@ -47,9 +47,9 @@ import static org.mockito.Mockito.*;
 public class ExternalViewerUtilsTest {
 
     @Mock
-    private Context mMockContext;
+    private Context mockContext;
     @Mock
-    private OnBrowserActionResultListener mMockResultListener;
+    private OnBrowserActionResultListener mockResultListener;
 
     @Before
     public void setUp() throws Exception {
@@ -64,7 +64,7 @@ public class ExternalViewerUtilsTest {
     @Test
     public void whenIsActivityCallableAndContextOrIntentNull_ReturnFalse() {
         assertFalse(ExternalViewerUtils.isActivityCallable(null, null));
-        assertFalse(ExternalViewerUtils.isActivityCallable(mMockContext, null));
+        assertFalse(ExternalViewerUtils.isActivityCallable(mockContext, null));
         assertFalse(ExternalViewerUtils.isActivityCallable(null, mock(Intent.class)));
     }
 
@@ -72,8 +72,8 @@ public class ExternalViewerUtilsTest {
     public void whenIsActivityCallableAndQueryIntentActivitiesEmpty_ReturnFalse() {
         PackageManager mockManager = mock(PackageManager.class);
         when(mockManager.queryIntentActivities(any(Intent.class), anyInt())).thenReturn(Collections.emptyList());
-        when(mMockContext.getPackageManager()).thenReturn(mockManager);
-        assertFalse(ExternalViewerUtils.isActivityCallable(mMockContext, mock(Intent.class)));
+        when(mockContext.getPackageManager()).thenReturn(mockManager);
+        assertFalse(ExternalViewerUtils.isActivityCallable(mockContext, mock(Intent.class)));
     }
 
     @Test
@@ -81,20 +81,20 @@ public class ExternalViewerUtilsTest {
         PackageManager mockManager = mock(PackageManager.class);
         List<ResolveInfo> mockList = Collections.singletonList(mock(ResolveInfo.class));
         when(mockManager.queryIntentActivities(any(Intent.class), anyInt())).thenReturn(mockList);
-        when(mMockContext.getPackageManager()).thenReturn(mockManager);
-        assertTrue(ExternalViewerUtils.isActivityCallable(mMockContext, mock(Intent.class)));
+        when(mockContext.getPackageManager()).thenReturn(mockManager);
+        assertTrue(ExternalViewerUtils.isActivityCallable(mockContext, mock(Intent.class)));
     }
 
     @Test
     public void whenStartExternalVideoPlayerAndUrlNull_DoNothing() {
-        ExternalViewerUtils.startExternalVideoPlayer(mMockContext, null);
-        verifyZeroInteractions(mMockContext);
+        ExternalViewerUtils.startExternalVideoPlayer(mockContext, null);
+        verifyZeroInteractions(mockContext);
     }
 
     @Test
     public void whenStartExternalVideoPlayerAndUrlNotNull_StartActivity() {
-        ExternalViewerUtils.startExternalVideoPlayer(mMockContext, "https://url");
-        verify(mMockContext).startActivity(any(Intent.class));
+        ExternalViewerUtils.startExternalVideoPlayer(mockContext, "https://url");
+        verify(mockContext).startActivity(any(Intent.class));
     }
 
     @Test
@@ -102,9 +102,9 @@ public class ExternalViewerUtilsTest {
         PackageManager mockManager = mock(PackageManager.class);
         List<ResolveInfo> mockList = Collections.singletonList(mock(ResolveInfo.class));
         when(mockManager.queryIntentActivities(any(Intent.class), anyInt())).thenReturn(mockList);
-        when(mMockContext.getPackageManager()).thenReturn(mockManager);
-        ExternalViewerUtils.launchApplicationUrl(mMockContext, Uri.parse("test"));
-        verify(mMockContext).startActivity(any(Intent.class));
+        when(mockContext.getPackageManager()).thenReturn(mockManager);
+        ExternalViewerUtils.launchApplicationUrl(mockContext, Uri.parse("test"));
+        verify(mockContext).startActivity(any(Intent.class));
     }
 
     @Test
@@ -113,11 +113,11 @@ public class ExternalViewerUtilsTest {
         PackageManager mockManager = mock(PackageManager.class);
         List<ResolveInfo> mockList = Collections.singletonList(mock(ResolveInfo.class));
         when(mockManager.queryIntentActivities(any(Intent.class), anyInt())).thenReturn(mockList);
-        when(mMockContext.getPackageManager()).thenReturn(mockManager);
+        when(mockContext.getPackageManager()).thenReturn(mockManager);
 
-        ExternalViewerUtils.startBrowser(mMockContext, "url", true, mMockResultListener);
-        verify(mMockContext).startActivity(any(Intent.class));
-        verify(mMockResultListener).onSuccess(OnBrowserActionResultListener.BrowserActionResult.INTERNAL_BROWSER);
+        ExternalViewerUtils.startBrowser(mockContext, "url", true, mockResultListener);
+        verify(mockContext).startActivity(any(Intent.class));
+        verify(mockResultListener).onSuccess(OnBrowserActionResultListener.BrowserActionResult.INTERNAL_BROWSER);
     }
 
     @Test
@@ -126,19 +126,19 @@ public class ExternalViewerUtilsTest {
         PackageManager mockManager = mock(PackageManager.class);
         List<ResolveInfo> mockList = Collections.singletonList(mock(ResolveInfo.class));
         when(mockManager.queryIntentActivities(any(Intent.class), anyInt())).thenReturn(mockList);
-        when(mMockContext.getPackageManager()).thenReturn(mockManager);
+        when(mockContext.getPackageManager()).thenReturn(mockManager);
 
-        ExternalViewerUtils.startBrowser(mMockContext, "url", true, mMockResultListener);
-        verify(mMockContext).startActivity(any(Intent.class));
-        verify(mMockResultListener).onSuccess(OnBrowserActionResultListener.BrowserActionResult.INTERNAL_BROWSER);
+        ExternalViewerUtils.startBrowser(mockContext, "url", true, mockResultListener);
+        verify(mockContext).startActivity(any(Intent.class));
+        verify(mockResultListener).onSuccess(OnBrowserActionResultListener.BrowserActionResult.INTERNAL_BROWSER);
     }
 
     @Test
     public void whenStartBrowserAndUseExternalBrowserTrue_NotifyExternalBrowserSuccess() {
         PrebidMobile.useExternalBrowser = true;
 
-        ExternalViewerUtils.startBrowser(mMockContext, "https://url.com", true, mMockResultListener);
-        verify(mMockContext).startActivity(any(Intent.class));
-        verify(mMockResultListener).onSuccess(OnBrowserActionResultListener.BrowserActionResult.EXTERNAL_BROWSER);
+        ExternalViewerUtils.startBrowser(mockContext, "https://url.com", true, mockResultListener);
+        verify(mockContext).startActivity(any(Intent.class));
+        verify(mockResultListener).onSuccess(OnBrowserActionResultListener.BrowserActionResult.EXTERNAL_BROWSER);
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/utils/helpers/OrientationBroadcastReceiverTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/utils/helpers/OrientationBroadcastReceiverTest.java
@@ -40,53 +40,53 @@ import static org.mockito.Mockito.*;
 @Config(sdk = 19)
 public class OrientationBroadcastReceiverTest {
 
-    private OrientationBroadcastReceiver mOrientationReceiver;
-    private Context mMockContext;
+    private OrientationBroadcastReceiver orientationReceiver;
+    private Context mockContext;
 
     @Before
     public void setup() {
-        mOrientationReceiver = Mockito.spy(new OrientationBroadcastReceiver());
-        mMockContext = Robolectric.buildActivity(Activity.class).create().get();
+        orientationReceiver = Mockito.spy(new OrientationBroadcastReceiver());
+        mockContext = Robolectric.buildActivity(Activity.class).create().get();
     }
 
     @Test
     public void onReceiveTest() throws IllegalAccessException {
         Intent intent = new Intent();
-        Field contextField = WhiteBox.field(OrientationBroadcastReceiver.class, "mApplicationContext");
+        Field contextField = WhiteBox.field(OrientationBroadcastReceiver.class, "applicationContext");
 
-        contextField.set(mOrientationReceiver, mMockContext.getApplicationContext());
+        contextField.set(orientationReceiver, mockContext.getApplicationContext());
         intent.setAction(Intent.ACTION_SCREEN_ON);
-        mOrientationReceiver.onReceive(null, intent);
-        verify(mOrientationReceiver, times(0)).setOrientationChanged(anyBoolean());
+        orientationReceiver.onReceive(null, intent);
+        verify(orientationReceiver, times(0)).setOrientationChanged(anyBoolean());
 
         intent.setAction(Intent.ACTION_CONFIGURATION_CHANGED);
-        mOrientationReceiver.onReceive(null, intent);
-        verify(mOrientationReceiver, times(1)).setOrientationChanged(eq(true));
-        verify(mOrientationReceiver, times(1)).handleOrientationChange(anyInt());
+        orientationReceiver.onReceive(null, intent);
+        verify(orientationReceiver, times(1)).setOrientationChanged(eq(true));
+        verify(orientationReceiver, times(1)).handleOrientationChange(anyInt());
 
-        mOrientationReceiver.onReceive(null, intent);
-        verify(mOrientationReceiver, times(1)).setOrientationChanged(eq(false));
+        orientationReceiver.onReceive(null, intent);
+        verify(orientationReceiver, times(1)).setOrientationChanged(eq(false));
     }
 
     @Test
     public void registerTest() {
-        mMockContext = spy(mMockContext);
+        mockContext = spy(mockContext);
         Context mockContext = mock(Context.class);
-        when(mockContext.getApplicationContext()).thenReturn(mMockContext);
+        when(mockContext.getApplicationContext()).thenReturn(this.mockContext);
 
-        mOrientationReceiver.register(mockContext);
-        verify(mMockContext).registerReceiver(any(BroadcastReceiver.class), any(IntentFilter.class));
+        orientationReceiver.register(mockContext);
+        verify(this.mockContext).registerReceiver(any(BroadcastReceiver.class), any(IntentFilter.class));
     }
 
     @Test
     public void unregisterTest() throws IllegalAccessException {
-        mMockContext = spy(mMockContext);
-        doNothing().when(mMockContext).unregisterReceiver(any(BroadcastReceiver.class));
-        Field contextField = WhiteBox.field(OrientationBroadcastReceiver.class, "mApplicationContext");
-        contextField.set(mOrientationReceiver, mMockContext);
+        mockContext = spy(mockContext);
+        doNothing().when(mockContext).unregisterReceiver(any(BroadcastReceiver.class));
+        Field contextField = WhiteBox.field(OrientationBroadcastReceiver.class, "applicationContext");
+        contextField.set(orientationReceiver, mockContext);
 
-        mOrientationReceiver.unregister();
-        verify(mMockContext).unregisterReceiver(any(BroadcastReceiver.class));
-        Assert.assertNull(contextField.get(mOrientationReceiver));
+        orientationReceiver.unregister();
+        verify(mockContext).unregisterReceiver(any(BroadcastReceiver.class));
+        Assert.assertNull(contextField.get(orientationReceiver));
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/utils/helpers/RefreshTimerTaskTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/utils/helpers/RefreshTimerTaskTest.java
@@ -34,26 +34,26 @@ import static junit.framework.Assert.assertTrue;
 @Config(sdk = 19)
 public class RefreshTimerTaskTest {
 
-    private RefreshTimerTask mRefreshTimerTask;
+    private RefreshTimerTask refreshTimerTask;
 
-    private boolean mRefreshTriggered;
+    private boolean refreshTriggered;
 
     @Before
     public void setup() {
         Activity testActivity = Robolectric.buildActivity(Activity.class).create().get();
         ManagersResolver.getInstance().prepare(testActivity);
 
-        mRefreshTimerTask = new RefreshTimerTask(null);
+        refreshTimerTask = new RefreshTimerTask(null);
     }
 
     @Test
     public void testIfRefreshTimerTriggeredAfterIntervalNoCallback() throws Exception {
-        mRefreshTimerTask.scheduleRefreshTask(2000);
+        refreshTimerTask.scheduleRefreshTask(2000);
         //inject a delay to finish up post of message to the timertask.
         Thread.sleep(4000);
 
         //Because of NPE, this should return false
-        assertFalse(mRefreshTimerTask.isRefreshExecuted());
+        assertFalse(refreshTimerTask.isRefreshExecuted());
     }
 
     @Test
@@ -62,7 +62,7 @@ public class RefreshTimerTaskTest {
         RefreshTimerTask refreshParams = new RefreshTimerTask(new RefreshTriggered() {
             @Override
             public void handleRefresh() {
-                mRefreshTriggered = true;
+                refreshTriggered = true;
             }
         });
         refreshParams.scheduleRefreshTask(2000);
@@ -71,35 +71,35 @@ public class RefreshTimerTaskTest {
         ShadowLooper.runUiThreadTasksIncludingDelayedTasks();
 
         assertTrue(refreshParams.isRefreshExecuted());
-        assertTrue(mRefreshTriggered);
+        assertTrue(refreshTriggered);
     }
 
     @Ignore
     public void testIfRefreshTimerWorkedWhenIntervalNotExpired() {
-        mRefreshTimerTask.scheduleRefreshTask(2000);
+        refreshTimerTask.scheduleRefreshTask(2000);
         //do not inject a delay to finish up post of message to the timertask.
 
-        assertFalse(mRefreshTimerTask.isRefreshExecuted());
+        assertFalse(refreshTimerTask.isRefreshExecuted());
     }
 
     @Test
     public void testDestroyWhenNoTimerWasScheduled() {
         //refresh is not called as it was not scheduled at all.
-        assertFalse(mRefreshTimerTask.isRefreshExecuted());
+        assertFalse(refreshTimerTask.isRefreshExecuted());
 
-        mRefreshTimerTask.destroy();
+        refreshTimerTask.destroy();
 
         //refresh is set to false on destroy.
-        assertFalse(mRefreshTimerTask.isRefreshExecuted());
+        assertFalse(refreshTimerTask.isRefreshExecuted());
     }
 
     @Test
     public void testDestroyWhenTimerWasScheduled() {
-        mRefreshTimerTask.scheduleRefreshTask(1000);
+        refreshTimerTask.scheduleRefreshTask(1000);
 
-        mRefreshTimerTask.destroy();
+        refreshTimerTask.destroy();
 
         //refresh is set to false on destroy.
-        assertFalse(mRefreshTimerTask.isRefreshExecuted());
+        assertFalse(refreshTimerTask.isRefreshExecuted());
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/utils/helpers/ScreenStateReceiverTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/utils/helpers/ScreenStateReceiverTest.java
@@ -31,48 +31,46 @@ import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.*;
 
 public class ScreenStateReceiverTest {
-    private ScreenStateReceiver mScreenStateReceiver;
+    private ScreenStateReceiver screenStateReceiver;
 
-    @Mock
-    private Context mMockContext;
-    @Mock
-    private Intent mMockIntent;
+    @Mock private Context mockContext;
+    @Mock private Intent mockIntent;
 
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
 
-        mScreenStateReceiver = new ScreenStateReceiver();
+        screenStateReceiver = new ScreenStateReceiver();
     }
 
     @Test
     public void onReceiveActionUserPresent_ScreenOnIsTrue() {
-        when(mMockIntent.getAction()).thenReturn(Intent.ACTION_USER_PRESENT);
+        when(mockIntent.getAction()).thenReturn(Intent.ACTION_USER_PRESENT);
 
-        mScreenStateReceiver.onReceive(mMockContext, mMockIntent);
+        screenStateReceiver.onReceive(mockContext, mockIntent);
 
-        assertTrue(mScreenStateReceiver.isScreenOn());
+        assertTrue(screenStateReceiver.isScreenOn());
     }
 
     @Test
     public void onReceiveActionScreenOff_ScreenOnIsFalse() {
-        when(mMockIntent.getAction()).thenReturn(Intent.ACTION_SCREEN_OFF);
+        when(mockIntent.getAction()).thenReturn(Intent.ACTION_SCREEN_OFF);
 
-        mScreenStateReceiver.onReceive(mMockContext, mMockIntent);
+        screenStateReceiver.onReceive(mockContext, mockIntent);
 
-        assertFalse(mScreenStateReceiver.isScreenOn());
+        assertFalse(screenStateReceiver.isScreenOn());
     }
 
     @Test
     public void whenRegisterAndUnregisterReceiver_PerformActionOnContext() {
-        when(mMockContext.getApplicationContext()).thenReturn(mMockContext);
+        when(mockContext.getApplicationContext()).thenReturn(mockContext);
 
-        mScreenStateReceiver.register(mMockContext);
+        screenStateReceiver.register(mockContext);
 
-        verify(mMockContext, times(1)).getApplicationContext();
-        verify(mMockContext, times(1)).registerReceiver(eq(mScreenStateReceiver), any());
+        verify(mockContext, times(1)).getApplicationContext();
+        verify(mockContext, times(1)).registerReceiver(eq(screenStateReceiver), any());
 
-        mScreenStateReceiver.unregister();
-        verify(mMockContext, times(1)).unregisterReceiver(eq(mScreenStateReceiver));
+        screenStateReceiver.unregister();
+        verify(mockContext, times(1)).unregisterReceiver(eq(screenStateReceiver));
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/utils/url/UrlHandlerTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/utils/url/UrlHandlerTest.java
@@ -46,23 +46,23 @@ public class UrlHandlerTest {
     private static final String VALID_URL = "http://prebid.com";
 
     @Mock
-    Context mMockContext;
+    Context mockContext;
     @Mock
-    TrackingManager mMockTrackingManager;
+    TrackingManager mockTrackingManager;
     @Mock
-    UrlResolutionTask.UrlResolutionListener mMockUrlResolutionListener;
+    UrlResolutionTask.UrlResolutionListener mockUrlResolutionListener;
     @Mock
-    UrlHandler.UrlHandlerResultListener mMockUrlHandlerResultListener;
+    UrlHandler.UrlHandlerResultListener mockUrlHandlerResultListener;
     @Mock
-    DeepLinkAction mMockDeepLinkAction;
+    DeepLinkAction mockDeepLinkAction;
 
-    private UrlHandler mUrlHandler;
+    private UrlHandler urlHandler;
 
     @Before
     public void setup() throws Exception {
         MockitoAnnotations.initMocks(this);
-        mUrlHandler = createUrlHandler(mMockDeepLinkAction);
-        WhiteBox.field(TrackingManager.class, "sInstance").set(null, mMockTrackingManager);
+        urlHandler = createUrlHandler(mockDeepLinkAction);
+        WhiteBox.field(TrackingManager.class, "sInstance").set(null, mockTrackingManager);
     }
 
     @After
@@ -73,18 +73,18 @@ public class UrlHandlerTest {
     @Test
     public void whenHandleResolvedUrlWithEmptyString_NotifyFailure() {
         boolean result = createUrlHandler(null)
-            .handleResolvedUrl(mMockContext, " ", null, true);
+            .handleResolvedUrl(mockContext, " ", null, true);
 
-        verify(mMockUrlHandlerResultListener, times(1)).onFailure(" ");
+        verify(mockUrlHandlerResultListener, times(1)).onFailure(" ");
         assertFalse(result);
     }
 
     @Test
     public void whenHandleResolvedUrlWithEmptyActions_NotifyFailure() {
         boolean result = createUrlHandler(null)
-            .handleResolvedUrl(mMockContext, VALID_URL, null, true);
+            .handleResolvedUrl(mockContext, VALID_URL, null, true);
 
-        verify(mMockUrlHandlerResultListener, times(1)).onFailure(VALID_URL);
+        verify(mockUrlHandlerResultListener, times(1)).onFailure(VALID_URL);
         assertFalse(result);
     }
 
@@ -96,61 +96,61 @@ public class UrlHandlerTest {
         List<String> trackingUrlList = new ArrayList<>();
         trackingUrlList.add("http://exampleTrackingUrl");
 
-        when(mMockDeepLinkAction.shouldBeTriggeredByUserAction()).thenReturn(true);
-        when(mMockDeepLinkAction.shouldOverrideUrlLoading(destinationUri)).thenReturn(true);
+        when(mockDeepLinkAction.shouldBeTriggeredByUserAction()).thenReturn(true);
+        when(mockDeepLinkAction.shouldOverrideUrlLoading(destinationUri)).thenReturn(true);
 
-        boolean result = mUrlHandler.handleResolvedUrl(mMockContext, url, trackingUrlList, true);
+        boolean result = urlHandler.handleResolvedUrl(mockContext, url, trackingUrlList, true);
 
-        verify(mMockDeepLinkAction, times(1)).performAction(mMockContext, mUrlHandler, destinationUri);
-        verify(mMockTrackingManager, times(1)).fireEventTrackingURLs(trackingUrlList);
-        verify(mMockUrlHandlerResultListener, times(1)).onSuccess(url, mMockDeepLinkAction);
+        verify(mockDeepLinkAction, times(1)).performAction(mockContext, urlHandler, destinationUri);
+        verify(mockTrackingManager, times(1)).fireEventTrackingURLs(trackingUrlList);
+        verify(mockUrlHandlerResultListener, times(1)).onSuccess(url, mockDeepLinkAction);
         assertTrue(result);
     }
 
     @Test
     public void whenHandleResolvedUrlWithInvalidExpectedInteractionCondition_NotifySuccess() {
-        when(mMockDeepLinkAction.shouldBeTriggeredByUserAction()).thenReturn(true);
-        when(mMockDeepLinkAction.shouldOverrideUrlLoading(any())).thenReturn(true);
+        when(mockDeepLinkAction.shouldBeTriggeredByUserAction()).thenReturn(true);
+        when(mockDeepLinkAction.shouldOverrideUrlLoading(any())).thenReturn(true);
 
-        boolean result = mUrlHandler.handleResolvedUrl(mMockContext, VALID_URL, null, false);
+        boolean result = urlHandler.handleResolvedUrl(mockContext, VALID_URL, null, false);
 
         assertFalse(result);
-        verify(mMockUrlHandlerResultListener, times(1)).onFailure(VALID_URL);
+        verify(mockUrlHandlerResultListener, times(1)).onFailure(VALID_URL);
     }
 
     @Test(expected = ActionNotResolvedException.class)
     public void whenHandleActionWithInvalidInteractionCondition_ThrowException()
     throws ActionNotResolvedException {
         Uri destinationUri = Uri.parse(VALID_URL);
-        when(mMockDeepLinkAction.shouldBeTriggeredByUserAction()).thenReturn(true);
+        when(mockDeepLinkAction.shouldBeTriggeredByUserAction()).thenReturn(true);
 
-        mUrlHandler.handleAction(mMockContext, destinationUri, mMockDeepLinkAction, false);
+        urlHandler.handleAction(mockContext, destinationUri, mockDeepLinkAction, false);
     }
 
     @Test
     public void whenHandleActionWithValidInteractionCondition_PerformAction()
     throws ActionNotResolvedException {
         Uri destinationUri = Uri.parse(VALID_URL);
-        when(mMockDeepLinkAction.shouldBeTriggeredByUserAction()).thenReturn(true);
+        when(mockDeepLinkAction.shouldBeTriggeredByUserAction()).thenReturn(true);
 
-        mUrlHandler.handleAction(mMockContext, destinationUri, mMockDeepLinkAction, true);
+        urlHandler.handleAction(mockContext, destinationUri, mockDeepLinkAction, true);
 
-        verify(mMockDeepLinkAction, times(1)).performAction(mMockContext, mUrlHandler, destinationUri);
+        verify(mockDeepLinkAction, times(1)).performAction(mockContext, urlHandler, destinationUri);
     }
 
     @Test
     public void whenHandleUrlWithEmptyString_NotifyFailure() {
         String url = "  ";
 
-        mUrlHandler.handleUrl(mMockContext, url, null, false);
+        urlHandler.handleUrl(mockContext, url, null, false);
 
-        verify(mMockUrlHandlerResultListener, times(1)).onFailure(url);
+        verify(mockUrlHandlerResultListener, times(1)).onFailure(url);
     }
 
     @Test
     public void whenHandleUrlWithValidString_PerformUrlResolutionRequest() {
-        UrlHandler spyUrlHandler = spy(createUrlHandler(mMockDeepLinkAction));
-        spyUrlHandler.handleUrl(mMockContext, VALID_URL, null, false);
+        UrlHandler spyUrlHandler = spy(createUrlHandler(mockDeepLinkAction));
+        spyUrlHandler.handleUrl(mockContext, VALID_URL, null, false);
 
         verify(spyUrlHandler, times(1)).performUrlResolutionRequest(eq(VALID_URL), any(UrlResolutionTask.UrlResolutionListener.class));
     }
@@ -162,7 +162,7 @@ public class UrlHandlerTest {
             builder.withDeepLinkAction(deepLinkAction);
         }
 
-        builder.withResultListener(mMockUrlHandlerResultListener);
+        builder.withResultListener(mockUrlHandlerResultListener);
         return builder.build();
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/utils/url/action/DeepLinkActionTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/utils/url/action/DeepLinkActionTest.java
@@ -30,13 +30,13 @@ import static org.junit.Assert.assertFalse;
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 19)
 public class DeepLinkActionTest {
-    private DeepLinkAction mDeepLinkAction;
+    private DeepLinkAction deepLinkAction;
 
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(DeepLinkActionTest.class);
 
-        mDeepLinkAction = new DeepLinkAction();
+        deepLinkAction = new DeepLinkAction();
     }
 
     @Test
@@ -44,19 +44,19 @@ public class DeepLinkActionTest {
         Uri httpUri = Uri.parse("http://prebid.com");
         Uri httpsUri = Uri.parse("https://prebid.com");
 
-        assertFalse(mDeepLinkAction.shouldOverrideUrlLoading(httpUri));
-        assertFalse(mDeepLinkAction.shouldOverrideUrlLoading(httpsUri));
+        assertFalse(deepLinkAction.shouldOverrideUrlLoading(httpUri));
+        assertFalse(deepLinkAction.shouldOverrideUrlLoading(httpsUri));
     }
 
     @Test
     public void whenShouldOverrideUrlLoadingCustomScheme_ReturnTrue() {
         Uri customSchemeUri = Uri.parse("prebid://open");
 
-        assertTrue(mDeepLinkAction.shouldOverrideUrlLoading(customSchemeUri));
+        assertTrue(deepLinkAction.shouldOverrideUrlLoading(customSchemeUri));
     }
 
     @Test
     public void whenShouldBeTriggeredByUserAction_ReturnTrue() {
-        assertTrue(mDeepLinkAction.shouldBeTriggeredByUserAction());
+        assertTrue(deepLinkAction.shouldBeTriggeredByUserAction());
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/utils/url/action/DeepLinkPlusActionTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/utils/url/action/DeepLinkPlusActionTest.java
@@ -61,26 +61,26 @@ public class DeepLinkPlusActionTest {
                                                                           + "&primaryTrackingUrl=http%3A%2F%2Fmopub.com%2Fclicktracking&primaryTrackingUrl=http%3A%2F%2Fmopub.com%2Fmopubtracking"
                                                                           + "&fallbackUrl=deeplink%2B://Fmobile.twitter.com&fallbackTrackingUrl=http%3A%2F%2Fmopub.com%2Fmopubtrackingfallback";
 
-    private DeepLinkPlusAction mDeepLinkPlusAction;
+    private DeepLinkPlusAction deepLinkPlusAction;
 
     @Mock
-    Context mMockContext;
+    Context mockContext;
     @Mock
-    UrlHandler mMockUrlHandler;
+    UrlHandler mockUrlHandler;
     @Mock
-    TrackingManager mMockTrackingManager;
+    TrackingManager mockTrackingManager;
     @Mock
-    PackageManager mMockPackageManager;
+    PackageManager mockPackageManager;
 
     @Before
     public void setup() throws IllegalAccessException {
         MockitoAnnotations.initMocks(this);
-        mDeepLinkPlusAction = new DeepLinkPlusAction();
+        deepLinkPlusAction = new DeepLinkPlusAction();
 
-        WhiteBox.field(TrackingManager.class, "sInstance").set(null, mMockTrackingManager);
+        WhiteBox.field(TrackingManager.class, "sInstance").set(null, mockTrackingManager);
 
-        when(mMockPackageManager.queryIntentActivities(any(Intent.class), anyInt())).thenReturn(new ArrayList<>());
-        when(mMockContext.getPackageManager()).thenReturn(mMockPackageManager);
+        when(mockPackageManager.queryIntentActivities(any(Intent.class), anyInt())).thenReturn(new ArrayList<>());
+        when(mockContext.getPackageManager()).thenReturn(mockPackageManager);
     }
 
     @After
@@ -94,14 +94,14 @@ public class DeepLinkPlusActionTest {
         Uri httpsUri = Uri.parse("https://prebid.com");
         Uri customScheme = Uri.parse("prebid://open");
 
-        assertFalse(mDeepLinkPlusAction.shouldOverrideUrlLoading(httpUri));
-        assertFalse(mDeepLinkPlusAction.shouldOverrideUrlLoading(httpsUri));
-        assertFalse(mDeepLinkPlusAction.shouldOverrideUrlLoading(customScheme));
+        assertFalse(deepLinkPlusAction.shouldOverrideUrlLoading(httpUri));
+        assertFalse(deepLinkPlusAction.shouldOverrideUrlLoading(httpsUri));
+        assertFalse(deepLinkPlusAction.shouldOverrideUrlLoading(customScheme));
     }
 
     @Test
     public void shouldOverrideUrlLoadingDeepLinkPlusScheme_ReturnTrue() {
-        assertTrue(mDeepLinkPlusAction.shouldOverrideUrlLoading(Uri.parse(INVALID_DEEPLINK_EXAMPLE)));
+        assertTrue(deepLinkPlusAction.shouldOverrideUrlLoading(Uri.parse(INVALID_DEEPLINK_EXAMPLE)));
     }
 
     @Test
@@ -110,7 +110,7 @@ public class DeepLinkPlusActionTest {
         String actualMessage = "";
 
         try {
-            mDeepLinkPlusAction.performAction(mMockContext, mMockUrlHandler, Uri.parse("example.com/holiday/prebid/"));
+            deepLinkPlusAction.performAction(mockContext, mockUrlHandler, Uri.parse("example.com/holiday/prebid/"));
         }
         catch (ActionNotResolvedException e) {
             actualMessage = e.getMessage();
@@ -124,7 +124,7 @@ public class DeepLinkPlusActionTest {
         String actualMessage = "";
 
         try {
-            mDeepLinkPlusAction.performAction(mMockContext, mMockUrlHandler, Uri.parse("deeplink+://navigate?"));
+            deepLinkPlusAction.performAction(mockContext, mockUrlHandler, Uri.parse("deeplink+://navigate?"));
         }
         catch (ActionNotResolvedException e) {
             actualMessage = e.getMessage();
@@ -138,7 +138,7 @@ public class DeepLinkPlusActionTest {
         String actualMessage = "";
 
         try {
-            mDeepLinkPlusAction.performAction(mMockContext, mMockUrlHandler, Uri.parse(INVALID_NESTED_DEEPLINK_IN_PRIMARY_URL));
+            deepLinkPlusAction.performAction(mockContext, mockUrlHandler, Uri.parse(INVALID_NESTED_DEEPLINK_IN_PRIMARY_URL));
         }
         catch (ActionNotResolvedException e) {
             actualMessage = e.getMessage();
@@ -151,14 +151,14 @@ public class DeepLinkPlusActionTest {
     throws ActionNotResolvedException {
         ArrayList<ResolveInfo> resolveInfos = new ArrayList<>();
         resolveInfos.add(mock(ResolveInfo.class));
-        when(mMockPackageManager.queryIntentActivities(any(Intent.class), anyInt())).thenReturn(resolveInfos);
+        when(mockPackageManager.queryIntentActivities(any(Intent.class), anyInt())).thenReturn(resolveInfos);
 
         Uri validDeepLinkPlusUri = Uri.parse(FULL_DEEPLINK_EXAMPLE);
         List<String> primaryTrackingUrl = validDeepLinkPlusUri.getQueryParameters(QUERY_PRIMARY_TRACKING_URL);
 
-        mDeepLinkPlusAction.performAction(mMockContext, mMockUrlHandler, validDeepLinkPlusUri);
+        deepLinkPlusAction.performAction(mockContext, mockUrlHandler, validDeepLinkPlusUri);
 
-        verify(mMockTrackingManager, times(1)).fireEventTrackingURLs(primaryTrackingUrl);
+        verify(mockTrackingManager, times(1)).fireEventTrackingURLs(primaryTrackingUrl);
     }
 
     @Test
@@ -166,13 +166,13 @@ public class DeepLinkPlusActionTest {
     throws ActionNotResolvedException {
         ArrayList<ResolveInfo> resolveInfos = new ArrayList<>();
         resolveInfos.add(mock(ResolveInfo.class));
-        when(mMockPackageManager.queryIntentActivities(any(Intent.class), anyInt())).thenReturn(resolveInfos);
+        when(mockPackageManager.queryIntentActivities(any(Intent.class), anyInt())).thenReturn(resolveInfos);
 
         Uri validDeepLinkPlusUri = Uri.parse(FULL_DEEPLINK_EXAMPLE);
         List<String> primaryTrackingUrl = validDeepLinkPlusUri.getQueryParameters(QUERY_PRIMARY_TRACKING_URL);
 
-        mDeepLinkPlusAction.performAction(mMockContext, mMockUrlHandler, validDeepLinkPlusUri);
-        verify(mMockTrackingManager, times(1)).fireEventTrackingURLs(primaryTrackingUrl);
+        deepLinkPlusAction.performAction(mockContext, mockUrlHandler, validDeepLinkPlusUri);
+        verify(mockTrackingManager, times(1)).fireEventTrackingURLs(primaryTrackingUrl);
     }
 
     @Test
@@ -183,7 +183,7 @@ public class DeepLinkPlusActionTest {
         String actualMessage = "";
 
         try {
-            mDeepLinkPlusAction.performAction(mMockContext, mMockUrlHandler, emptyFallbackDeepLink);
+            deepLinkPlusAction.performAction(mockContext, mockUrlHandler, emptyFallbackDeepLink);
         }
         catch (ActionNotResolvedException e) {
             actualMessage = e.getMessage();
@@ -199,7 +199,7 @@ public class DeepLinkPlusActionTest {
         String actualMessage = "";
 
         try {
-            mDeepLinkPlusAction.performAction(mMockContext, mMockUrlHandler, invalidFallbackDeepLink);
+            deepLinkPlusAction.performAction(mockContext, mockUrlHandler, invalidFallbackDeepLink);
         }
         catch (ActionNotResolvedException e) {
             actualMessage = e.getMessage();
@@ -214,13 +214,13 @@ public class DeepLinkPlusActionTest {
         String fallbackUrl = validFallbackDeepLinkUri.getQueryParameter(QUERY_FALLBACK_URL);
         List<String> fallbackTrackingUrls = validFallbackDeepLinkUri.getQueryParameters(QUERY_FALLBACK_TRACKING_URL);
 
-        mDeepLinkPlusAction.performAction(mMockContext, mMockUrlHandler, validFallbackDeepLinkUri);
+        deepLinkPlusAction.performAction(mockContext, mockUrlHandler, validFallbackDeepLinkUri);
 
-        verify(mMockUrlHandler).handleUrl(mMockContext, fallbackUrl, fallbackTrackingUrls, true);
+        verify(mockUrlHandler).handleUrl(mockContext, fallbackUrl, fallbackTrackingUrls, true);
     }
 
     @Test
     public void shouldBeTriggeredByUser_ReturnTrue() {
-        assertTrue(mDeepLinkPlusAction.shouldBeTriggeredByUserAction());
+        assertTrue(deepLinkPlusAction.shouldBeTriggeredByUserAction());
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/utils/url/action/MraidInternalBrowserActionTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/utils/url/action/MraidInternalBrowserActionTest.java
@@ -53,22 +53,22 @@ public class MraidInternalBrowserActionTest {
     private static final Uri VALID_URI = Uri.parse("http://prebid.com");
     private static final String VALID_URL = VALID_URI.toString();
 
-    private MraidInternalBrowserAction mMraidInternalBrowserAction;
+    private MraidInternalBrowserAction mraidInternalBrowserAction;
 
-    @Mock BaseJSInterface mMockBaseJsInterface;
-    @Mock Context mMockContext;
-    @Mock UrlHandler mMockUrlHandler;
+    @Mock BaseJSInterface mockBaseJsInterface;
+    @Mock Context mockContext;
+    @Mock UrlHandler mockUrlHandler;
     @Mock
-    MraidVariableContainer mMockMraidVariableContainer;
-    private Context mContext;
+    MraidVariableContainer mockMraidVariableContainer;
+    private Context context;
 
 
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        mContext = Robolectric.buildActivity(Activity.class).create().get();
-        mMraidInternalBrowserAction = new MraidInternalBrowserAction(mMockBaseJsInterface, -1);
-        when(mMockBaseJsInterface.getMraidVariableContainer()).thenReturn(mMockMraidVariableContainer);
+        context = Robolectric.buildActivity(Activity.class).create().get();
+        mraidInternalBrowserAction = new MraidInternalBrowserAction(mockBaseJsInterface, -1);
+        when(mockBaseJsInterface.getMraidVariableContainer()).thenReturn(mockMraidVariableContainer);
     }
 
     @Test
@@ -76,8 +76,8 @@ public class MraidInternalBrowserActionTest {
         Uri httpUri = Uri.parse("http://prebid.com");
         Uri httpsUri = Uri.parse("https://prebid.com");
 
-        assertTrue(mMraidInternalBrowserAction.shouldOverrideUrlLoading(httpUri));
-        assertTrue(mMraidInternalBrowserAction.shouldOverrideUrlLoading(httpsUri));
+        assertTrue(mraidInternalBrowserAction.shouldOverrideUrlLoading(httpUri));
+        assertTrue(mraidInternalBrowserAction.shouldOverrideUrlLoading(httpsUri));
     }
 
     @Test
@@ -85,8 +85,8 @@ public class MraidInternalBrowserActionTest {
         Uri customUri = Uri.parse("prebid://open");
         Uri deepLinkPlusUri = Uri.parse("deeplink+://open");
 
-        assertFalse(mMraidInternalBrowserAction.shouldOverrideUrlLoading(customUri));
-        assertFalse(mMraidInternalBrowserAction.shouldOverrideUrlLoading(deepLinkPlusUri));
+        assertFalse(mraidInternalBrowserAction.shouldOverrideUrlLoading(customUri));
+        assertFalse(mraidInternalBrowserAction.shouldOverrideUrlLoading(deepLinkPlusUri));
     }
 
     @Test
@@ -97,7 +97,7 @@ public class MraidInternalBrowserActionTest {
         String actualMessage = "";
 
         try {
-            mraidInternalBrowserAction.performAction(mMockContext, mMockUrlHandler, VALID_URI);
+            mraidInternalBrowserAction.performAction(mockContext, mockUrlHandler, VALID_URI);
         }
         catch (ActionNotResolvedException e) {
             actualMessage = e.getMessage();
@@ -110,27 +110,27 @@ public class MraidInternalBrowserActionTest {
     throws ActionNotResolvedException {
         String url = VALID_URI.toString();
 
-        mMraidInternalBrowserAction.performAction(mMockContext, mMockUrlHandler, VALID_URI);
+        mraidInternalBrowserAction.performAction(mockContext, mockUrlHandler, VALID_URI);
 
-        verify(mMockBaseJsInterface).followToOriginalUrl(eq(url), any(RedirectUrlListener.class));
+        verify(mockBaseJsInterface).followToOriginalUrl(eq(url), any(RedirectUrlListener.class));
     }
 
     @Test
     public void handleInternalBrowserActionFollowUrlSuccessAndIsMraid_StartActionViewActivity() {
-        when(mMockContext.getApplicationContext()).thenReturn(mMockContext);
+        when(mockContext.getApplicationContext()).thenReturn(mockContext);
 
         ArgumentCaptor<RedirectUrlListener> callbackCapture = ArgumentCaptor.forClass(RedirectUrlListener.class);
         ArgumentCaptor<Intent> intentArgumentCaptor = ArgumentCaptor.forClass(Intent.class);
         String url = Uri.parse("tel://222").toString();
 
-        mMraidInternalBrowserAction.handleInternalBrowserAction(mMockContext, mMockBaseJsInterface, url);
+        mraidInternalBrowserAction.handleInternalBrowserAction(mockContext, mockBaseJsInterface, url);
 
-        verify(mMockBaseJsInterface).followToOriginalUrl(eq(url), callbackCapture.capture());
+        verify(mockBaseJsInterface).followToOriginalUrl(eq(url), callbackCapture.capture());
 
         callbackCapture.getValue().onSuccess(url, null);
 
-        verify(mMockContext, times(1)).getApplicationContext();
-        verify(mMockContext, times(1)).startActivity(intentArgumentCaptor.capture());
+        verify(mockContext, times(1)).getApplicationContext();
+        verify(mockContext, times(1)).startActivity(intentArgumentCaptor.capture());
 
         Intent intentArgument = intentArgumentCaptor.getValue();
 
@@ -141,16 +141,16 @@ public class MraidInternalBrowserActionTest {
     @Test
     public void handleInternalBrowserActionFollowUrlSuccessAndNotMraidAndNotVideoContent_LaunchBrowserActivity() {
         String url = VALID_URI.toString();
-        MraidInternalBrowserAction spyMraidInternalBrowserAction = spy(mMraidInternalBrowserAction);
+        MraidInternalBrowserAction spyMraidInternalBrowserAction = spy(mraidInternalBrowserAction);
         ArgumentCaptor<RedirectUrlListener> callbackCapture = ArgumentCaptor.forClass(RedirectUrlListener.class);
 
-        spyMraidInternalBrowserAction.handleInternalBrowserAction(mContext, mMockBaseJsInterface, url);
+        spyMraidInternalBrowserAction.handleInternalBrowserAction(context, mockBaseJsInterface, url);
 
-        verify(mMockBaseJsInterface).followToOriginalUrl(eq(url), callbackCapture.capture());
+        verify(mockBaseJsInterface).followToOriginalUrl(eq(url), callbackCapture.capture());
 
         callbackCapture.getValue().onSuccess(url, null);
 
-        verify(spyMraidInternalBrowserAction).launchBrowserActivity(any(Activity.class), eq(mMockBaseJsInterface), eq(url));
+        verify(spyMraidInternalBrowserAction).launchBrowserActivity(any(Activity.class), eq(mockBaseJsInterface), eq(url));
     }
 
     @Test
@@ -161,18 +161,18 @@ public class MraidInternalBrowserActionTest {
         shadowOf(MimeTypeMap.getSingleton()).addExtensionMimeTypMapping("mp4", extension);
 
         ArgumentCaptor<RedirectUrlListener> callbackCapture = ArgumentCaptor.forClass(RedirectUrlListener.class);
-        mMraidInternalBrowserAction.handleInternalBrowserAction(mContext, mMockBaseJsInterface, url);
+        mraidInternalBrowserAction.handleInternalBrowserAction(context, mockBaseJsInterface, url);
 
-        verify(mMockBaseJsInterface).followToOriginalUrl(eq(url), callbackCapture.capture());
+        verify(mockBaseJsInterface).followToOriginalUrl(eq(url), callbackCapture.capture());
 
         callbackCapture.getValue().onSuccess(url, extension);
 
-        verify(mMockBaseJsInterface).playVideo(url);
+        verify(mockBaseJsInterface).playVideo(url);
     }
 
     @Test
     public void shouldBeTriggeredByUser_ReturnTrue() {
-        assertTrue(mMraidInternalBrowserAction.shouldBeTriggeredByUserAction());
+        assertTrue(mraidInternalBrowserAction.shouldBeTriggeredByUserAction());
     }
 
     @Test
@@ -181,18 +181,18 @@ public class MraidInternalBrowserActionTest {
         resolveInfoArrayList.add(null);
         prepareContextAndInterfaceMocks(false, null, resolveInfoArrayList);
 
-        mMraidInternalBrowserAction.launchBrowserActivity(mMockContext, mMockBaseJsInterface, null);
+        mraidInternalBrowserAction.launchBrowserActivity(mockContext, mockBaseJsInterface, null);
 
-        verify(mMockContext).startActivity(any(Intent.class));
+        verify(mockContext).startActivity(any(Intent.class));
     }
 
     @Test
     public void launchBrowserActivityWithNullUrlAndEmptyResolveInfoList_NeverStartBrowserActivity() {
         prepareContextAndInterfaceMocks(false, null, new ArrayList<>());
 
-        mMraidInternalBrowserAction.launchBrowserActivity(mMockContext, mMockBaseJsInterface, null);
+        mraidInternalBrowserAction.launchBrowserActivity(mockContext, mockBaseJsInterface, null);
 
-        verify(mMockContext, never()).startActivity(any(Intent.class));
+        verify(mockContext, never()).startActivity(any(Intent.class));
     }
 
     @Test
@@ -202,10 +202,10 @@ public class MraidInternalBrowserActionTest {
         resolveInfos.add(null);
         prepareContextAndInterfaceMocks(true, url, resolveInfos);
 
-        mMraidInternalBrowserAction.launchBrowserActivity(mMockContext, mMockBaseJsInterface, url);
+        mraidInternalBrowserAction.launchBrowserActivity(mockContext, mockBaseJsInterface, url);
 
-        verify(mMockMraidVariableContainer).setUrlForLaunching(url);
-        verify(mMockContext).startActivity(any(Intent.class));
+        verify(mockMraidVariableContainer).setUrlForLaunching(url);
+        verify(mockContext).startActivity(any(Intent.class));
     }
 
     @Test
@@ -213,17 +213,17 @@ public class MraidInternalBrowserActionTest {
         String demo = VALID_URI.toString();
         prepareContextAndInterfaceMocks(true, demo, new ArrayList<>());
 
-        mMraidInternalBrowserAction.launchBrowserActivity(mMockContext, mMockBaseJsInterface, demo);
+        mraidInternalBrowserAction.launchBrowserActivity(mockContext, mockBaseJsInterface, demo);
 
-        verify(mMockMraidVariableContainer).setUrlForLaunching(demo);
-        verify(mMockContext).startActivity(any(Intent.class));
+        verify(mockMraidVariableContainer).setUrlForLaunching(demo);
+        verify(mockContext).startActivity(any(Intent.class));
     }
 
     private void prepareContextAndInterfaceMocks(boolean isLaunchingWithUrl, String url, List<ResolveInfo> resolveInfoList) {
         PackageManager mockPackageManager = mock(PackageManager.class);
-        when(mMockContext.getPackageManager()).thenReturn(mockPackageManager);
+        when(mockContext.getPackageManager()).thenReturn(mockPackageManager);
         when(mockPackageManager.queryIntentActivities(any(Intent.class), eq(PackageManager.MATCH_DEFAULT_ONLY))).thenReturn(resolveInfoList);
-        when(mMockMraidVariableContainer.isLaunchedWithUrl()).thenReturn(isLaunchingWithUrl);
-        when(mMockMraidVariableContainer.getUrlForLaunching()).thenReturn(url);
+        when(mockMraidVariableContainer.isLaunchedWithUrl()).thenReturn(isLaunchingWithUrl);
+        when(mockMraidVariableContainer.getUrlForLaunching()).thenReturn(url);
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/video/AdViewProgressUpdateTaskTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/video/AdViewProgressUpdateTaskTest.java
@@ -34,121 +34,121 @@ import static org.mockito.Mockito.*;
 @Config(sdk = 19)
 public class AdViewProgressUpdateTaskTest {
 
-    private AdViewProgressUpdateTask mAdViewProgressTask;
-    private VideoCreative mMockVideoCreative;
-    private View mMockCreativeView;
-    private final int mDuration = 50;
+    private AdViewProgressUpdateTask adViewProgressTask;
+    private VideoCreative mockVideoCreative;
+    private View mockCreativeView;
+    private final int duration = 50;
 
     @Before
     public void setup() throws AdException {
-        mMockVideoCreative = mock(VideoCreative.class);
-        mMockCreativeView = mock(VideoCreativeView.class);
+        mockVideoCreative = mock(VideoCreative.class);
+        mockCreativeView = mock(VideoCreativeView.class);
 
-        when(mMockVideoCreative.getCreativeView()).thenReturn(mMockCreativeView);
+        when(mockVideoCreative.getCreativeView()).thenReturn(mockCreativeView);
 
-        mAdViewProgressTask = spy(new AdViewProgressUpdateTask(mMockVideoCreative, mDuration));
+        adViewProgressTask = spy(new AdViewProgressUpdateTask(mockVideoCreative, duration));
     }
 
     @Test
     public void onPostExecuteTest() {
-        mAdViewProgressTask.onPostExecute(null);
-        verify(mAdViewProgressTask).cancel(true);
+        adViewProgressTask.onPostExecute(null);
+        verify(adViewProgressTask).cancel(true);
     }
 
     @Test
     public void onProgressUpdateTest() {
-        assertFalse(mAdViewProgressTask.getFirstQuartile());
-        mAdViewProgressTask.onProgressUpdate((long) 25);
-        verify(mMockVideoCreative).onEvent(VideoAdEvent.Event.AD_FIRSTQUARTILE);
-        assertTrue(mAdViewProgressTask.getFirstQuartile());
+        assertFalse(adViewProgressTask.getFirstQuartile());
+        adViewProgressTask.onProgressUpdate((long) 25);
+        verify(mockVideoCreative).onEvent(VideoAdEvent.Event.AD_FIRSTQUARTILE);
+        assertTrue(adViewProgressTask.getFirstQuartile());
 
-        reset(mMockVideoCreative);
-        assertFalse(mAdViewProgressTask.getMidpoint());
-        mAdViewProgressTask.onProgressUpdate((long) 50);
-        verify(mMockVideoCreative).onEvent(VideoAdEvent.Event.AD_MIDPOINT);
-        assertTrue(mAdViewProgressTask.getMidpoint());
+        reset(mockVideoCreative);
+        assertFalse(adViewProgressTask.getMidpoint());
+        adViewProgressTask.onProgressUpdate((long) 50);
+        verify(mockVideoCreative).onEvent(VideoAdEvent.Event.AD_MIDPOINT);
+        assertTrue(adViewProgressTask.getMidpoint());
 
-        reset(mMockVideoCreative);
-        assertFalse(mAdViewProgressTask.getThirdQuartile());
-        mAdViewProgressTask.onProgressUpdate((long) 75);
-        verify(mMockVideoCreative).onEvent(VideoAdEvent.Event.AD_THIRDQUARTILE);
-        assertTrue(mAdViewProgressTask.getThirdQuartile());
+        reset(mockVideoCreative);
+        assertFalse(adViewProgressTask.getThirdQuartile());
+        adViewProgressTask.onProgressUpdate((long) 75);
+        verify(mockVideoCreative).onEvent(VideoAdEvent.Event.AD_THIRDQUARTILE);
+        assertTrue(adViewProgressTask.getThirdQuartile());
     }
 
     @Test
     public void getCurrentPositionTest() {
-        assertEquals(0, mAdViewProgressTask.getCurrentPosition());
+        assertEquals(0, adViewProgressTask.getCurrentPosition());
     }
 
     @Test
     public void setVastVideoDurationTest() throws IllegalAccessException, NoSuchFieldException {
-        Field vastDurationField = WhiteBox.field(AdViewProgressUpdateTask.class, "mVastVideoDuration");
-        assertEquals((long) -1, vastDurationField.get(mAdViewProgressTask));
+        Field vastDurationField = WhiteBox.field(AdViewProgressUpdateTask.class, "vastVideoDuration");
+        assertEquals((long) -1, vastDurationField.get(adViewProgressTask));
 
-        mAdViewProgressTask.setVastVideoDuration(10);
-        assertEquals((long) 10, vastDurationField.get(mAdViewProgressTask));
+        adViewProgressTask.setVastVideoDuration(10);
+        assertEquals((long) 10, vastDurationField.get(adViewProgressTask));
     }
 
     @Test
     public void whenNoQuartilePassed_NoEventsTracked() {
-        assertFalse(mAdViewProgressTask.getFirstQuartile());
-        assertFalse(mAdViewProgressTask.getMidpoint());
-        assertFalse(mAdViewProgressTask.getThirdQuartile());
-        mAdViewProgressTask.onProgressUpdate((long) 24);
+        assertFalse(adViewProgressTask.getFirstQuartile());
+        assertFalse(adViewProgressTask.getMidpoint());
+        assertFalse(adViewProgressTask.getThirdQuartile());
+        adViewProgressTask.onProgressUpdate((long) 24);
 
-        assertFalse(mAdViewProgressTask.getFirstQuartile());
-        assertFalse(mAdViewProgressTask.getMidpoint());
-        assertFalse(mAdViewProgressTask.getThirdQuartile());
-        verify(mMockVideoCreative, never()).onEvent(VideoAdEvent.Event.AD_FIRSTQUARTILE);
-        verify(mMockVideoCreative, never()).onEvent(VideoAdEvent.Event.AD_MIDPOINT);
-        verify(mMockVideoCreative, never()).onEvent(VideoAdEvent.Event.AD_THIRDQUARTILE);
+        assertFalse(adViewProgressTask.getFirstQuartile());
+        assertFalse(adViewProgressTask.getMidpoint());
+        assertFalse(adViewProgressTask.getThirdQuartile());
+        verify(mockVideoCreative, never()).onEvent(VideoAdEvent.Event.AD_FIRSTQUARTILE);
+        verify(mockVideoCreative, never()).onEvent(VideoAdEvent.Event.AD_MIDPOINT);
+        verify(mockVideoCreative, never()).onEvent(VideoAdEvent.Event.AD_THIRDQUARTILE);
     }
 
     @Test
     public void whenFirstQuartilePassedAndNoEventsTracked_TrackOnlyFirstQuartile() {
-        assertFalse(mAdViewProgressTask.getFirstQuartile());
-        assertFalse(mAdViewProgressTask.getMidpoint());
-        assertFalse(mAdViewProgressTask.getThirdQuartile());
+        assertFalse(adViewProgressTask.getFirstQuartile());
+        assertFalse(adViewProgressTask.getMidpoint());
+        assertFalse(adViewProgressTask.getThirdQuartile());
 
-        mAdViewProgressTask.onProgressUpdate((long) 49);
+        adViewProgressTask.onProgressUpdate((long) 49);
 
-        assertTrue(mAdViewProgressTask.getFirstQuartile());
-        assertFalse(mAdViewProgressTask.getMidpoint());
-        assertFalse(mAdViewProgressTask.getThirdQuartile());
-        verify(mMockVideoCreative).onEvent(VideoAdEvent.Event.AD_FIRSTQUARTILE);
-        verify(mMockVideoCreative, never()).onEvent(VideoAdEvent.Event.AD_MIDPOINT);
-        verify(mMockVideoCreative, never()).onEvent(VideoAdEvent.Event.AD_THIRDQUARTILE);
+        assertTrue(adViewProgressTask.getFirstQuartile());
+        assertFalse(adViewProgressTask.getMidpoint());
+        assertFalse(adViewProgressTask.getThirdQuartile());
+        verify(mockVideoCreative).onEvent(VideoAdEvent.Event.AD_FIRSTQUARTILE);
+        verify(mockVideoCreative, never()).onEvent(VideoAdEvent.Event.AD_MIDPOINT);
+        verify(mockVideoCreative, never()).onEvent(VideoAdEvent.Event.AD_THIRDQUARTILE);
     }
 
     @Test
     public void whenMidpointPassedAndNoEventsTracked_TrackFirstQuartileAndMidpoint() {
-        assertFalse(mAdViewProgressTask.getFirstQuartile());
-        assertFalse(mAdViewProgressTask.getMidpoint());
-        assertFalse(mAdViewProgressTask.getThirdQuartile());
+        assertFalse(adViewProgressTask.getFirstQuartile());
+        assertFalse(adViewProgressTask.getMidpoint());
+        assertFalse(adViewProgressTask.getThirdQuartile());
 
-        mAdViewProgressTask.onProgressUpdate((long) 74);
+        adViewProgressTask.onProgressUpdate((long) 74);
 
-        assertTrue(mAdViewProgressTask.getFirstQuartile());
-        assertTrue(mAdViewProgressTask.getMidpoint());
-        assertFalse(mAdViewProgressTask.getThirdQuartile());
-        verify(mMockVideoCreative).onEvent(VideoAdEvent.Event.AD_FIRSTQUARTILE);
-        verify(mMockVideoCreative).onEvent(VideoAdEvent.Event.AD_MIDPOINT);
-        verify(mMockVideoCreative, never()).onEvent(VideoAdEvent.Event.AD_THIRDQUARTILE);
+        assertTrue(adViewProgressTask.getFirstQuartile());
+        assertTrue(adViewProgressTask.getMidpoint());
+        assertFalse(adViewProgressTask.getThirdQuartile());
+        verify(mockVideoCreative).onEvent(VideoAdEvent.Event.AD_FIRSTQUARTILE);
+        verify(mockVideoCreative).onEvent(VideoAdEvent.Event.AD_MIDPOINT);
+        verify(mockVideoCreative, never()).onEvent(VideoAdEvent.Event.AD_THIRDQUARTILE);
     }
 
     @Test
     public void whenThirdQuartilePassedAndNoEventsTracked_TrackAllEvents() {
-        assertFalse(mAdViewProgressTask.getFirstQuartile());
-        assertFalse(mAdViewProgressTask.getMidpoint());
-        assertFalse(mAdViewProgressTask.getThirdQuartile());
+        assertFalse(adViewProgressTask.getFirstQuartile());
+        assertFalse(adViewProgressTask.getMidpoint());
+        assertFalse(adViewProgressTask.getThirdQuartile());
 
-        mAdViewProgressTask.onProgressUpdate((long) 99);
+        adViewProgressTask.onProgressUpdate((long) 99);
 
-        assertTrue(mAdViewProgressTask.getFirstQuartile());
-        assertTrue(mAdViewProgressTask.getMidpoint());
-        assertTrue(mAdViewProgressTask.getThirdQuartile());
-        verify(mMockVideoCreative).onEvent(VideoAdEvent.Event.AD_FIRSTQUARTILE);
-        verify(mMockVideoCreative).onEvent(VideoAdEvent.Event.AD_MIDPOINT);
-        verify(mMockVideoCreative).onEvent(VideoAdEvent.Event.AD_THIRDQUARTILE);
+        assertTrue(adViewProgressTask.getFirstQuartile());
+        assertTrue(adViewProgressTask.getMidpoint());
+        assertTrue(adViewProgressTask.getThirdQuartile());
+        verify(mockVideoCreative).onEvent(VideoAdEvent.Event.AD_FIRSTQUARTILE);
+        verify(mockVideoCreative).onEvent(VideoAdEvent.Event.AD_MIDPOINT);
+        verify(mockVideoCreative).onEvent(VideoAdEvent.Event.AD_THIRDQUARTILE);
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/video/ExoPlayerViewTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/video/ExoPlayerViewTest.java
@@ -39,12 +39,12 @@ import static org.mockito.Mockito.*;
 
 @RunWith(RobolectricTestRunner.class)
 public class ExoPlayerViewTest {
-    private ExoPlayerView mExoPlayerView;
+    private ExoPlayerView exoPlayerView;
 
     @Mock
-    VideoCreative mMockVideoCreative;
+    VideoCreative mockVideoCreative;
     @Mock
-    SimpleExoPlayer mMockSimpleExoPlayer;
+    SimpleExoPlayer mockSimpleExoPlayer;
 
     @Before
     public void setUp() throws Exception {
@@ -52,146 +52,146 @@ public class ExoPlayerViewTest {
 
         Context context = Robolectric.buildActivity(Activity.class).create().get();
 
-        mExoPlayerView = spy(new ExoPlayerView(context, mMockVideoCreative));
-        WhiteBox.field(ExoPlayerView.class, "mPlayer").set(mExoPlayerView, mMockSimpleExoPlayer);
+        exoPlayerView = spy(new ExoPlayerView(context, mockVideoCreative));
+        WhiteBox.field(ExoPlayerView.class, "player").set(exoPlayerView, mockSimpleExoPlayer);
 
-        reset(mMockVideoCreative, mMockSimpleExoPlayer);
+        reset(mockVideoCreative, mockSimpleExoPlayer);
     }
 
     @Test
     public void setValidVolume_TrackEventAndChangePlayerVolume() {
-        mExoPlayerView.setVolume(1);
+        exoPlayerView.setVolume(1);
 
-        verify(mMockSimpleExoPlayer, times(1)).setVolume(1);
-        verify(mMockVideoCreative, times(1)).onVolumeChanged(1);
+        verify(mockSimpleExoPlayer, times(1)).setVolume(1);
+        verify(mockVideoCreative, times(1)).onVolumeChanged(1);
     }
 
     @Test
     public void setInvalidVolume_NoEventAndNoVolumeChange() {
-        mExoPlayerView.setVolume(-1);
+        exoPlayerView.setVolume(-1);
 
-        verifyNoMoreInteractions(mMockSimpleExoPlayer);
-        verifyNoMoreInteractions(mMockVideoCreative);
+        verifyNoMoreInteractions(mockSimpleExoPlayer);
+        verifyNoMoreInteractions(mockVideoCreative);
     }
 
     @Test
     public void mute() {
-        mExoPlayerView.mute();
-        verify(mExoPlayerView, times(1)).setVolume(0);
+        exoPlayerView.mute();
+        verify(exoPlayerView, times(1)).setVolume(0);
     }
 
     @Test
     public void isPlaying() {
-        mExoPlayerView.isPlaying();
-        verify(mMockSimpleExoPlayer).getPlayWhenReady();
-        when(mExoPlayerView.isPlaying()).thenReturn(false);
-        boolean playing = mExoPlayerView.isPlaying();
+        exoPlayerView.isPlaying();
+        verify(mockSimpleExoPlayer).getPlayWhenReady();
+        when(exoPlayerView.isPlaying()).thenReturn(false);
+        boolean playing = exoPlayerView.isPlaying();
         assertFalse(playing);
-        doNothing().when(mExoPlayerView).start(anyInt());
-        mExoPlayerView.start(anyInt());
-        when(mExoPlayerView.isPlaying()).thenReturn(true);
-        assertTrue(mExoPlayerView.isPlaying());
+        doNothing().when(exoPlayerView).start(anyInt());
+        exoPlayerView.start(anyInt());
+        when(exoPlayerView.isPlaying()).thenReturn(true);
+        assertTrue(exoPlayerView.isPlaying());
     }
 
     @Test
     public void unMute() {
-        mExoPlayerView.unMute();
-        verify(mExoPlayerView, times(1)).setVolume(1);
+        exoPlayerView.unMute();
+        verify(exoPlayerView, times(1)).setVolume(1);
     }
 
     @Test
     public void startWithNullUri_NoPlayerInteractions() {
-        mExoPlayerView.setVideoUri(null);
-        mExoPlayerView.start(anyInt());
+        exoPlayerView.setVideoUri(null);
+        exoPlayerView.start(anyInt());
 
-        verifyZeroInteractions(mMockSimpleExoPlayer);
-        verifyZeroInteractions(mMockVideoCreative);
+        verifyZeroInteractions(mockSimpleExoPlayer);
+        verifyZeroInteractions(mockVideoCreative);
     }
 
     @Test
     public void startWithValidUri_TrackEventPrepareAndVideoPlayer() {
-        mExoPlayerView.setVideoUri(Uri.EMPTY);
-        mExoPlayerView.start(anyInt());
+        exoPlayerView.setVideoUri(Uri.EMPTY);
+        exoPlayerView.start(anyInt());
 
-        verify(mMockVideoCreative).onEvent(VideoAdEvent.Event.AD_CREATIVEVIEW);
-        verify(mMockVideoCreative).onEvent(VideoAdEvent.Event.AD_START);
-        verify(mMockSimpleExoPlayer).prepare(any(MediaSource.class), anyBoolean(), anyBoolean());
+        verify(mockVideoCreative).onEvent(VideoAdEvent.Event.AD_CREATIVEVIEW);
+        verify(mockVideoCreative).onEvent(VideoAdEvent.Event.AD_START);
+        verify(mockSimpleExoPlayer).prepare(any(MediaSource.class), anyBoolean(), anyBoolean());
     }
 
     @Test
     public void setVastVideoDuration() {
-        mExoPlayerView.setVastVideoDuration(1000l);
-        verify(mExoPlayerView).setVastVideoDuration(1000l);
+        exoPlayerView.setVastVideoDuration(1000l);
+        verify(exoPlayerView).setVastVideoDuration(1000l);
     }
 
     @Test
     public void getCurrentPosition() {
-        mExoPlayerView.getCurrentPosition();
-        verify(mMockSimpleExoPlayer).getContentPosition();
+        exoPlayerView.getCurrentPosition();
+        verify(mockSimpleExoPlayer).getContentPosition();
     }
 
     @Test
     public void setVideoURI() {
-        mExoPlayerView.setVideoUri(mock(Uri.class));
-        verify(mExoPlayerView).setVideoUri(any(Uri.class));
+        exoPlayerView.setVideoUri(mock(Uri.class));
+        verify(exoPlayerView).setVideoUri(any(Uri.class));
     }
 
     @Test
     public void getDuration() {
-        mExoPlayerView.getDuration();
-        verify(mMockSimpleExoPlayer).getDuration();
+        exoPlayerView.getDuration();
+        verify(mockSimpleExoPlayer).getDuration();
     }
 
     @Test
     public void getVolume() {
-        when(mExoPlayerView.getVolume()).thenReturn(1.0f);
-        float volume = mExoPlayerView.getVolume();
+        when(exoPlayerView.getVolume()).thenReturn(1.0f);
+        float volume = exoPlayerView.getVolume();
         assertEquals(1.0f, volume, 0.0f);
-        mExoPlayerView.setVolume(0.5f);
-        verify(mExoPlayerView).setVolume(0.5f);
-        when(mExoPlayerView.getVolume()).thenReturn(0.5f);
-        assertEquals(0.5f, mExoPlayerView.getVolume(), 0f);
+        exoPlayerView.setVolume(0.5f);
+        verify(exoPlayerView).setVolume(0.5f);
+        when(exoPlayerView.getVolume()).thenReturn(0.5f);
+        assertEquals(0.5f, exoPlayerView.getVolume(), 0f);
     }
 
     @Test
     public void pause() {
-        mExoPlayerView.pause();
-        verify(mMockSimpleExoPlayer).stop();
+        exoPlayerView.pause();
+        verify(mockSimpleExoPlayer).stop();
     }
 
     @Test
     public void destroy() throws IllegalAccessException {
         AdViewProgressUpdateTask mockAdViewProgressUpdateTask = mock(AdViewProgressUpdateTask.class);
-        WhiteBox.field(ExoPlayerView.class, "mAdViewProgressUpdateTask").set(mExoPlayerView, mockAdViewProgressUpdateTask);
-        mExoPlayerView.destroy();
+        WhiteBox.field(ExoPlayerView.class, "adViewProgressUpdateTask").set(exoPlayerView, mockAdViewProgressUpdateTask);
+        exoPlayerView.destroy();
         verify(mockAdViewProgressUpdateTask).cancel(true);
-        verify(mExoPlayerView, times(1)).destroy();
-        verify(mMockSimpleExoPlayer).removeListener(any(Player.EventListener.class));
-        verify(mExoPlayerView).setPlayer(null);
-        verify(mMockSimpleExoPlayer).release();
+        verify(exoPlayerView, times(1)).destroy();
+        verify(mockSimpleExoPlayer).removeListener(any(Player.EventListener.class));
+        verify(exoPlayerView).setPlayer(null);
+        verify(mockSimpleExoPlayer).release();
     }
 
     @Test
     public void forceStop() {
-        mExoPlayerView.forceStop();
-        verify(mMockSimpleExoPlayer).stop();
-        verify(mExoPlayerView, times(1)).destroy();
-        verify(mMockVideoCreative).onDisplayCompleted();
+        exoPlayerView.forceStop();
+        verify(mockSimpleExoPlayer).stop();
+        verify(exoPlayerView, times(1)).destroy();
+        verify(mockVideoCreative).onDisplayCompleted();
     }
 
     @Test
     public void resumeWithValidUri_PreparePlayer() {
-        mExoPlayerView.setVideoUri(Uri.EMPTY);
-        mExoPlayerView.resume();
+        exoPlayerView.setVideoUri(Uri.EMPTY);
+        exoPlayerView.resume();
 
-        verify(mMockSimpleExoPlayer).prepare(any(MediaSource.class), anyBoolean(), anyBoolean());
+        verify(mockSimpleExoPlayer).prepare(any(MediaSource.class), anyBoolean(), anyBoolean());
     }
 
     @Test
     public void resumeWithInvalidUri_DoNothing() {
-        mExoPlayerView.setVideoUri(null);
-        mExoPlayerView.resume();
+        exoPlayerView.setVideoUri(null);
+        exoPlayerView.resume();
 
-        verifyZeroInteractions(mMockSimpleExoPlayer);
+        verifyZeroInteractions(mockSimpleExoPlayer);
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/video/LruControllerTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/video/LruControllerTest.java
@@ -27,10 +27,10 @@ import static org.junit.Assert.assertEquals;
 @Config(sdk = 19)
 public class LruControllerTest {
 
-    private String mUrl = "http://path/to/video/Vast_Video.mp4";
+    private String url = "http://path/to/video/Vast_Video.mp4";
 
     @Test
     public void whenNoAdUnits_UseVideoNameOnly() {
-        assertEquals("/Vast_Video", LruController.getShortenedPath(mUrl));
+        assertEquals("/Vast_Video", LruController.getShortenedPath(url));
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/video/OmEventTrackerTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/video/OmEventTrackerTest.java
@@ -31,48 +31,48 @@ import static org.mockito.Mockito.*;
 @RunWith(JUnit4.class)
 @Config(sdk = 19)
 public class OmEventTrackerTest {
-    private OmEventTracker mOmEventTracker;
+    private OmEventTracker omEventTracker;
 
-    private OmAdSessionManager mMockOmAdSessionManager;
+    private OmAdSessionManager mockOmAdSessionManager;
 
     @Before
     public void setup() {
-        mMockOmAdSessionManager = mock(OmAdSessionManager.class);
-        mOmEventTracker = new OmEventTracker();
-        mOmEventTracker.registerActiveAdSession(mMockOmAdSessionManager);
+        mockOmAdSessionManager = mock(OmAdSessionManager.class);
+        omEventTracker = new OmEventTracker();
+        omEventTracker.registerActiveAdSession(mockOmAdSessionManager);
     }
 
     @Test
     public void trackOmVideoAdEventTest() {
         VideoAdEvent.Event anyVideoEvent = any(VideoAdEvent.Event.class);
-        mOmEventTracker.trackOmVideoAdEvent(anyVideoEvent);
-        verify(mMockOmAdSessionManager, times(1)).trackAdVideoEvent(anyVideoEvent);
+        omEventTracker.trackOmVideoAdEvent(anyVideoEvent);
+        verify(mockOmAdSessionManager, times(1)).trackAdVideoEvent(anyVideoEvent);
     }
 
     @Test
     public void trackOmHtmlAdEventTest() {
-        mOmEventTracker.trackOmHtmlAdEvent(TrackingEvent.Events.IMPRESSION);
-        mOmEventTracker.trackOmHtmlAdEvent(TrackingEvent.Events.CLICK);
+        omEventTracker.trackOmHtmlAdEvent(TrackingEvent.Events.IMPRESSION);
+        omEventTracker.trackOmHtmlAdEvent(TrackingEvent.Events.CLICK);
 
-        verify(mMockOmAdSessionManager, times(1)).trackDisplayAdEvent(TrackingEvent.Events.IMPRESSION);
-        verify(mMockOmAdSessionManager, times(1)).trackDisplayAdEvent(TrackingEvent.Events.CLICK);
+        verify(mockOmAdSessionManager, times(1)).trackDisplayAdEvent(TrackingEvent.Events.IMPRESSION);
+        verify(mockOmAdSessionManager, times(1)).trackDisplayAdEvent(TrackingEvent.Events.CLICK);
     }
 
     @Test
     public void trackOmPlayerStateChangeTest() {
-        mOmEventTracker.trackOmPlayerStateChange(InternalPlayerState.NORMAL);
-        verify(mMockOmAdSessionManager, times(1)).trackPlayerStateChangeEvent(InternalPlayerState.NORMAL);
+        omEventTracker.trackOmPlayerStateChange(InternalPlayerState.NORMAL);
+        verify(mockOmAdSessionManager, times(1)).trackPlayerStateChangeEvent(InternalPlayerState.NORMAL);
     }
 
     @Test
     public void trackVideoAdStartedTest() {
-        mOmEventTracker.trackVideoAdStarted(0, 0);
-        verify(mMockOmAdSessionManager).videoAdStarted(0, 0);
+        omEventTracker.trackVideoAdStarted(0, 0);
+        verify(mockOmAdSessionManager).videoAdStarted(0, 0);
     }
 
     @Test
     public void trackNonSkippableVideoLoadedTest() {
-        mOmEventTracker.trackNonSkippableStandaloneVideoLoaded(false);
-        verify(mMockOmAdSessionManager).nonSkippableStandaloneVideoAdLoaded(false);
+        omEventTracker.trackNonSkippableStandaloneVideoLoaded(false);
+        verify(mockOmAdSessionManager).nonSkippableStandaloneVideoAdLoaded(false);
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/video/VideoCreativeModelTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/video/VideoCreativeModelTest.java
@@ -36,45 +36,43 @@ import static org.mockito.Mockito.verify;
 @Config(sdk = 19)
 public class VideoCreativeModelTest {
 
-    private VideoCreativeModel mVideoCreativeModel;
+    private VideoCreativeModel videoCreativeModel;
 
-    private OmEventTracker mMockOmEventTracker;
-    private TrackingManager mMockTrackingManager;
+    private OmEventTracker mockOmEventTracker;
+    private TrackingManager mockTrackingManager;
 
     @Before
     public void setup() {
         AdUnitConfiguration adConfiguration = mock(AdUnitConfiguration.class);
-        mMockOmEventTracker = mock(OmEventTracker.class);
+        mockOmEventTracker = mock(OmEventTracker.class);
 
-        mMockTrackingManager = mock(TrackingManager.class);
+        mockTrackingManager = mock(TrackingManager.class);
 
-        mVideoCreativeModel = new VideoCreativeModel(mMockTrackingManager,
-                                                     mMockOmEventTracker,
-                                                     adConfiguration);
+        videoCreativeModel = new VideoCreativeModel(mockTrackingManager, mockOmEventTracker, adConfiguration);
     }
 
     @Test
     public void trackVideoEventTest() {
-        mVideoCreativeModel.getVideoEventUrls().put(VideoAdEvent.Event.AD_COLLAPSE, new ArrayList<String>());
+        videoCreativeModel.getVideoEventUrls().put(VideoAdEvent.Event.AD_COLLAPSE, new ArrayList<String>());
 
-        mVideoCreativeModel.trackVideoEvent(VideoAdEvent.Event.AD_COLLAPSE);
-        verify(mMockTrackingManager).fireEventTrackingURLs(any(ArrayList.class));
-        verify(mMockOmEventTracker).trackOmVideoAdEvent(VideoAdEvent.Event.AD_COLLAPSE);
+        videoCreativeModel.trackVideoEvent(VideoAdEvent.Event.AD_COLLAPSE);
+        verify(mockTrackingManager).fireEventTrackingURLs(any(ArrayList.class));
+        verify(mockOmEventTracker).trackOmVideoAdEvent(VideoAdEvent.Event.AD_COLLAPSE);
 
-        mVideoCreativeModel.trackNonSkippableStandaloneVideoLoaded(false);
-        verify(mMockOmEventTracker).trackNonSkippableStandaloneVideoLoaded(false);
+        videoCreativeModel.trackNonSkippableStandaloneVideoLoaded(false);
+        verify(mockOmEventTracker).trackNonSkippableStandaloneVideoLoaded(false);
 
-        mVideoCreativeModel.trackPlayerStateChange(InternalPlayerState.FULLSCREEN);
-        verify(mMockOmEventTracker).trackOmPlayerStateChange(InternalPlayerState.FULLSCREEN);
+        videoCreativeModel.trackPlayerStateChange(InternalPlayerState.FULLSCREEN);
+        verify(mockOmEventTracker).trackOmPlayerStateChange(InternalPlayerState.FULLSCREEN);
 
-        mVideoCreativeModel.trackVideoAdStarted(0, 0);
-        verify(mMockOmEventTracker).trackVideoAdStarted(0, 0);
+        videoCreativeModel.trackVideoAdStarted(0, 0);
+        verify(mockOmEventTracker).trackVideoAdStarted(0, 0);
     }
 
     @Test
     public void registerVideoEventTest() {
-        assertEquals(0, mVideoCreativeModel.getVideoEventUrls().size());
-        mVideoCreativeModel.registerVideoEvent(VideoAdEvent.Event.AD_COLLAPSE, new ArrayList<String>());
-        assertEquals(1, mVideoCreativeModel.getVideoEventUrls().size());
+        assertEquals(0, videoCreativeModel.getVideoEventUrls().size());
+        videoCreativeModel.registerVideoEvent(VideoAdEvent.Event.AD_COLLAPSE, new ArrayList<String>());
+        assertEquals(1, videoCreativeModel.getVideoEventUrls().size());
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/video/VideoCreativeTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/video/VideoCreativeTest.java
@@ -48,124 +48,120 @@ import static org.mockito.Mockito.*;
 @Config(sdk = 19)
 public class VideoCreativeTest {
 
-    private Context mContext;
-    @Mock
-    private VideoCreativeModel mMockModel;
-    @Mock
-    private OmAdSessionManager mMockOmAdSessionManager;
-    @Mock
-    private InterstitialManager mMockInterstitialManager;
-    @Mock
-    private VideoCreativeView mMockVideoCreativeView;
+    private Context context;
+    @Mock private VideoCreativeModel mockModel;
+    @Mock private OmAdSessionManager mockOmAdSessionManager;
+    @Mock private InterstitialManager mockInterstitialManager;
+    @Mock private VideoCreativeView mockVideoCreativeView;
 
-    private VideoCreative mVideoCreative;
+    private VideoCreative videoCreative;
 
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
-        mContext = Robolectric.buildActivity(Activity.class).create().get();
+        context = Robolectric.buildActivity(Activity.class).create().get();
 
         AdUnitConfiguration mockConfig = mock(AdUnitConfiguration.class);
-        when(mMockModel.getAdConfiguration()).thenReturn(mockConfig);
+        when(mockModel.getAdConfiguration()).thenReturn(mockConfig);
 
-        mVideoCreative = new VideoCreative(mContext, mMockModel, mMockOmAdSessionManager, mMockInterstitialManager);
-        mVideoCreative.mVideoCreativeView = mMockVideoCreativeView;
+        videoCreative = new VideoCreative(context, mockModel, mockOmAdSessionManager, mockInterstitialManager);
+        videoCreative.videoCreativeView = mockVideoCreativeView;
     }
 
     @After
     public void tearDown() throws Exception {
-        mVideoCreative.destroy();
+        videoCreative.destroy();
     }
 
     @Test
     public void displayTest() throws Exception {
-        VideoCreative spyVideoCreative = spy(mVideoCreative);
+        VideoCreative spyVideoCreative = spy(videoCreative);
 
         spyVideoCreative.display();
 
-        verify(mVideoCreative.mVideoCreativeView).start(anyFloat());
+        verify(videoCreative.videoCreativeView).start(anyFloat());
     }
 
     @Test
     public void initNativeAdSessionManagerSuccessTest() throws Exception {
-        mVideoCreative.mVideoCreativeView = new VideoCreativeView(mContext, mVideoCreative);
-        VideoCreative spyVideoCreative = spy(mVideoCreative);
+        videoCreative.videoCreativeView = new VideoCreativeView(context, videoCreative);
+        VideoCreative spyVideoCreative = spy(videoCreative);
 
         spyVideoCreative.createOmAdSession();
 
-        verify(mMockOmAdSessionManager).initVideoAdSession(any(), any());
+        verify(mockOmAdSessionManager).initVideoAdSession(any(), any());
     }
 
     @Test
     public void initNativeAdSessionManagerFailureTest() {
-        mVideoCreative.mVideoCreativeView = null;
-        VideoCreative spyVideoCreative = Mockito.spy(mVideoCreative);
+        videoCreative.videoCreativeView = null;
+        VideoCreative spyVideoCreative = Mockito.spy(videoCreative);
 
         spyVideoCreative.createOmAdSession();
 
-        verify(mMockOmAdSessionManager, never()).registerAdView(any());
-        verify(mMockOmAdSessionManager, never()).startAdSession();
+        verify(mockOmAdSessionManager, never()).registerAdView(any());
+        verify(mockOmAdSessionManager, never()).startAdSession();
     }
 
     @Test
     public void trackAdVideoEventTest() throws Exception {
         CreativeViewListener mockCreativeViewListener = mock(CreativeViewListener.class);
         VideoPlayerView mockView = mock(VideoPlayerView.class);
-        mVideoCreative.setCreativeViewListener(mockCreativeViewListener);
+        videoCreative.setCreativeViewListener(mockCreativeViewListener);
         when(mockView.getDuration()).thenReturn(0);
         when(mockView.getVolume()).thenReturn(0f);
-        when(mMockVideoCreativeView.hasVideoStarted()).thenReturn(true);
-        when(mMockVideoCreativeView.isPlaying()).thenReturn(true);
-        when(mMockVideoCreativeView.getVideoPlayerView()).thenReturn(mockView);
+        when(mockVideoCreativeView.hasVideoStarted()).thenReturn(true);
+        when(mockVideoCreativeView.isPlaying()).thenReturn(true);
+        when(mockVideoCreativeView.getVideoPlayerView()).thenReturn(mockView);
 
-        mVideoCreative.complete();
-        verify(mMockModel).trackVideoEvent(VideoAdEvent.Event.AD_COMPLETE);
-        mockCreativeViewListener.creativeDidComplete(mVideoCreative);
+        videoCreative.complete();
+        verify(mockModel).trackVideoEvent(VideoAdEvent.Event.AD_COMPLETE);
+        mockCreativeViewListener.creativeDidComplete(videoCreative);
 
-        mVideoCreative.onVolumeChanged(1);
-        verify(mMockOmAdSessionManager).trackVolumeChange(1);
+        videoCreative.onVolumeChanged(1);
+        verify(mockOmAdSessionManager).trackVolumeChange(1);
 
-        mVideoCreative.onPlayerStateChanged(InternalPlayerState.NORMAL);
-        verify(mMockModel).trackPlayerStateChange(InternalPlayerState.NORMAL);
+        videoCreative.onPlayerStateChanged(InternalPlayerState.NORMAL);
+        verify(mockModel).trackPlayerStateChange(InternalPlayerState.NORMAL);
 
-        mVideoCreative.skip();
-        verify(mMockModel).trackVideoEvent(VideoAdEvent.Event.AD_SKIP);
-        mockCreativeViewListener.creativeDidComplete(mVideoCreative);
+        videoCreative.skip();
+        verify(mockModel).trackVideoEvent(VideoAdEvent.Event.AD_SKIP);
+        mockCreativeViewListener.creativeDidComplete(videoCreative);
 
-        mVideoCreative.onEvent(VideoAdEvent.Event.AD_RESUME);
-        verify(mMockModel).trackVideoEvent(VideoAdEvent.Event.AD_RESUME);
+        videoCreative.onEvent(VideoAdEvent.Event.AD_RESUME);
+        verify(mockModel).trackVideoEvent(VideoAdEvent.Event.AD_RESUME);
 
-        mVideoCreative.onEvent(VideoAdEvent.Event.AD_PAUSE);
-        verify(mMockModel).trackVideoEvent(VideoAdEvent.Event.AD_PAUSE);
+        videoCreative.onEvent(VideoAdEvent.Event.AD_PAUSE);
+        verify(mockModel).trackVideoEvent(VideoAdEvent.Event.AD_PAUSE);
 
-        mVideoCreative.onEvent(VideoAdEvent.Event.AD_UNMUTE);
-        verify(mMockModel).trackVideoEvent(VideoAdEvent.Event.AD_UNMUTE);
+        videoCreative.onEvent(VideoAdEvent.Event.AD_UNMUTE);
+        verify(mockModel).trackVideoEvent(VideoAdEvent.Event.AD_UNMUTE);
 
-        mVideoCreative.onEvent(VideoAdEvent.Event.AD_MUTE);
-        verify(mMockModel).trackVideoEvent(VideoAdEvent.Event.AD_MUTE);
+        videoCreative.onEvent(VideoAdEvent.Event.AD_MUTE);
+        verify(mockModel).trackVideoEvent(VideoAdEvent.Event.AD_MUTE);
 
-        mVideoCreative.onEvent(VideoAdEvent.Event.AD_FULLSCREEN);
-        verify(mMockModel).trackVideoEvent(VideoAdEvent.Event.AD_FULLSCREEN);
+        videoCreative.onEvent(VideoAdEvent.Event.AD_FULLSCREEN);
+        verify(mockModel).trackVideoEvent(VideoAdEvent.Event.AD_FULLSCREEN);
 
-        mVideoCreative.onEvent(VideoAdEvent.Event.AD_EXITFULLSCREEN);
-        verify(mMockModel).trackVideoEvent(VideoAdEvent.Event.AD_EXITFULLSCREEN);
+        videoCreative.onEvent(VideoAdEvent.Event.AD_EXITFULLSCREEN);
+        verify(mockModel).trackVideoEvent(VideoAdEvent.Event.AD_EXITFULLSCREEN);
 
-        mVideoCreative.onEvent(VideoAdEvent.Event.AD_START);
-        verify(mMockModel).trackVideoEvent(VideoAdEvent.Event.AD_START);
+        videoCreative.onEvent(VideoAdEvent.Event.AD_START);
+        verify(mockModel).trackVideoEvent(VideoAdEvent.Event.AD_START);
 
-        mVideoCreative.mVideoCreativeView = null;
-        mVideoCreative.onEvent(VideoAdEvent.Event.AD_START);
-        verify(mMockModel, atLeastOnce()).trackVideoEvent(VideoAdEvent.Event.AD_START);
+        videoCreative.videoCreativeView = null;
+        videoCreative.onEvent(VideoAdEvent.Event.AD_START);
+        verify(mockModel, atLeastOnce()).trackVideoEvent(VideoAdEvent.Event.AD_START);
     }
 
     @Test
     public void destroyTest() throws Exception {
         VideoDownloadTask mockVideoDownloadTask = mock(VideoDownloadTask.class);
-        WhiteBox.field(VideoCreative.class, "mVideoDownloadTask").set(mVideoCreative, mockVideoDownloadTask);
+        WhiteBox.field(VideoCreative.class, "videoDownloadTask").set(videoCreative, mockVideoDownloadTask);
 
-        mVideoCreative.destroy();
+        videoCreative.destroy();
 
-        verify(mMockVideoCreativeView).destroy();
+        verify(mockVideoCreativeView).destroy();
         verify(mockVideoDownloadTask).cancel(true);
     }
 
@@ -175,73 +171,73 @@ public class VideoCreativeTest {
         when(mockModel.getMediaUrl()).thenReturn("/video.mp4");
         AdUnitConfiguration mockAdConfig = mock(AdUnitConfiguration.class);
         when(mockModel.getAdConfiguration()).thenReturn(mockAdConfig);
-        WhiteBox.field(VideoCreative.class, "mModel").set(mVideoCreative, mockModel);
+        WhiteBox.field(VideoCreative.class, "model").set(videoCreative, mockModel);
 
-        mVideoCreative.load();
-        assertNotNull(WhiteBox.getInternalState(mVideoCreative, "mVideoDownloadTask"));
+        videoCreative.load();
+        assertNotNull(WhiteBox.getInternalState(videoCreative, "videoDownloadTask"));
     }
 
     @Test
     public void getVideoDurationTest() {
         long duration = 15 * 1000;
-        when(mMockModel.getMediaDuration()).thenReturn(duration);
-        assertEquals(15000, mVideoCreative.getMediaDuration());
+        when(mockModel.getMediaDuration()).thenReturn(duration);
+        assertEquals(15000, videoCreative.getMediaDuration());
     }
 
     @Test
     public void mute_volumeZero_DoNothing() {
-        when(mMockVideoCreativeView.getVolume()).thenReturn(0f);
+        when(mockVideoCreativeView.getVolume()).thenReturn(0f);
 
-        mVideoCreative.mute();
+        videoCreative.mute();
 
-        verify(mMockVideoCreativeView, never()).mute();
+        verify(mockVideoCreativeView, never()).mute();
     }
 
     @Test
     public void mute_volumeNotZero_MuteVideoCreativeView() {
-        when(mMockVideoCreativeView.getVolume()).thenReturn(1f);
+        when(mockVideoCreativeView.getVolume()).thenReturn(1f);
 
-        mVideoCreative.mute();
+        videoCreative.mute();
 
-        verify(mMockVideoCreativeView).mute();
+        verify(mockVideoCreativeView).mute();
     }
 
     @Test
     public void unmute_volumeZero_UnMuteVideoCreativeView() {
-        when(mMockVideoCreativeView.getVolume()).thenReturn(0f);
+        when(mockVideoCreativeView.getVolume()).thenReturn(0f);
 
-        mVideoCreative.unmute();
+        videoCreative.unmute();
 
-        verify(mMockVideoCreativeView).unMute();
+        verify(mockVideoCreativeView).unMute();
     }
 
     @Test
     public void unmute_volumeNotZero_DoNothing() {
-        when(mMockVideoCreativeView.getVolume()).thenReturn(1f);
+        when(mockVideoCreativeView.getVolume()).thenReturn(1f);
 
-        mVideoCreative.unmute();
+        videoCreative.unmute();
 
-        verify(mMockVideoCreativeView, never()).unMute();
+        verify(mockVideoCreativeView, never()).unMute();
     }
 
     @Test
     public void getCreativeModelTest() {
-        assertEquals(mMockModel, mVideoCreative.getCreativeModel());
+        assertEquals(mockModel, videoCreative.getCreativeModel());
     }
 
     @Test
     public void videoAdLoaded_TrackEvent() {
-        mVideoCreative.trackAdLoaded();
-        verify(mMockModel).trackNonSkippableStandaloneVideoLoaded(false);
+        videoCreative.trackAdLoaded();
+        verify(mockModel).trackNonSkippableStandaloneVideoLoaded(false);
     }
 
     @Test
     public void whenOnCallToAction_CreativeViewListenerCreativeWasClicked() {
         CreativeViewListener mockListener = mock(CreativeViewListener.class);
-        when(mMockVideoCreativeView.getCallToActionUrl()).thenReturn("url");
-        mVideoCreative.setCreativeViewListener(mockListener);
+        when(mockVideoCreativeView.getCallToActionUrl()).thenReturn("url");
+        videoCreative.setCreativeViewListener(mockListener);
 
-        mVideoCreative.onEvent(VideoAdEvent.Event.AD_CLICK);
+        videoCreative.onEvent(VideoAdEvent.Event.AD_CLICK);
 
         verify(mockListener).creativeWasClicked(any(AbstractCreative.class), eq("url"));
     }
@@ -250,26 +246,26 @@ public class VideoCreativeTest {
     public void whenOnVideoInterstitialClosed_DestroyCreativeViewAndCallCreativeDidComplete() {
         CreativeViewListener mockListener = mock(CreativeViewListener.class);
 
-        mVideoCreative.setCreativeViewListener(mockListener);
+        videoCreative.setCreativeViewListener(mockListener);
 
-        mVideoCreative.onVideoInterstitialClosed();
-        verify(mMockVideoCreativeView).destroy();
+        videoCreative.onVideoInterstitialClosed();
+        verify(mockVideoCreativeView).destroy();
         verify(mockListener).creativeDidComplete(any(AbstractCreative.class));
     }
 
     @Test
     public void whenAdConfigurationMuted_MuteCreative() throws AdException {
         VideoCreativeModel mockModel = mock(VideoCreativeModel.class);
-        VideoCreative videoCreative = spy(new VideoCreative(mContext,
+        VideoCreative videoCreative = spy(new VideoCreative(context,
                 mockModel,
-                mMockOmAdSessionManager,
-                mMockInterstitialManager
+                mockOmAdSessionManager,
+                mockInterstitialManager
         ));
         AdUnitConfiguration configuration = new AdUnitConfiguration();
         configuration.setIsMuted(true);
 
         when(mockModel.getAdConfiguration()).thenReturn(configuration);
-        Reflection.setVariableTo(videoCreative, "mVideoCreativeView", mock(VideoCreativeView.class));
+        Reflection.setVariableTo(videoCreative, "videoCreativeView", mock(VideoCreativeView.class));
 
         videoCreative.display();
 
@@ -280,16 +276,16 @@ public class VideoCreativeTest {
     @Test
     public void whenAdConfigurationUnMuted_UnMuteCreative() throws AdException {
         VideoCreativeModel mockModel = mock(VideoCreativeModel.class);
-        VideoCreative videoCreative = spy(new VideoCreative(mContext,
+        VideoCreative videoCreative = spy(new VideoCreative(context,
                 mockModel,
-                mMockOmAdSessionManager,
-                mMockInterstitialManager
+                mockOmAdSessionManager,
+                mockInterstitialManager
         ));
         AdUnitConfiguration configuration = new AdUnitConfiguration();
         configuration.setIsMuted(false);
 
         when(mockModel.getAdConfiguration()).thenReturn(configuration);
-        Reflection.setVariableTo(videoCreative, "mVideoCreativeView", mock(VideoCreativeView.class));
+        Reflection.setVariableTo(videoCreative, "videoCreativeView", mock(VideoCreativeView.class));
 
         videoCreative.display();
 

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/video/VideoCreativeViewTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/video/VideoCreativeViewTest.java
@@ -38,23 +38,23 @@ import static org.mockito.Mockito.verify;
 @Config(sdk = 19)
 public class VideoCreativeViewTest {
 
-    private VideoCreativeView mVideoCreativeView;
-    private VideoCreative mMockCreative;
+    private VideoCreativeView videoCreativeView;
+    private VideoCreative mockCreative;
 
     @Before
     public void setUp() throws AdException {
         Context context = Robolectric.buildActivity(Activity.class).create().get();
-        mMockCreative = Mockito.mock(VideoCreative.class);
+        mockCreative = Mockito.mock(VideoCreative.class);
 
-        mVideoCreativeView = new VideoCreativeView(context, mMockCreative);
+        videoCreativeView = new VideoCreativeView(context, mockCreative);
     }
 
     @Test
     public void startTest() throws IllegalAccessException {
         VideoPlayerView mockPlugPlayView = mock(ExoPlayerView.class);
-        WhiteBox.field(VideoCreativeView.class, "mExoPlayerView").set(mVideoCreativeView, mockPlugPlayView);
+        WhiteBox.field(VideoCreativeView.class, "exoPlayerView").set(videoCreativeView, mockPlugPlayView);
 
-        mVideoCreativeView.start(anyInt());
+        videoCreativeView.start(anyInt());
         verify(mockPlugPlayView).start(anyFloat());
     }
 
@@ -62,10 +62,10 @@ public class VideoCreativeViewTest {
     public void destroyTest() throws IllegalAccessException {
         VideoPlayerView mockPlugPlayView = mock(ExoPlayerView.class);
         View mockLytCallToActionOverlay = mock(View.class);
-        WhiteBox.field(VideoCreativeView.class, "mExoPlayerView").set(mVideoCreativeView, mockPlugPlayView);
-        mVideoCreativeView.addView(mockLytCallToActionOverlay);
+        WhiteBox.field(VideoCreativeView.class, "exoPlayerView").set(videoCreativeView, mockPlugPlayView);
+        videoCreativeView.addView(mockLytCallToActionOverlay);
 
-        mVideoCreativeView.destroy();
+        videoCreativeView.destroy();
         verify(mockPlugPlayView).destroy();
     }
 

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/views/AdViewManagerTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/views/AdViewManagerTest.java
@@ -28,9 +28,10 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.mockito.invocation.InvocationOnMock;
 import org.mockito.stubbing.Answer;
+import org.prebid.mobile.api.exceptions.AdException;
 import org.prebid.mobile.api.rendering.InterstitialView;
 import org.prebid.mobile.api.rendering.VideoView;
-import org.prebid.mobile.api.exceptions.AdException;
+import org.prebid.mobile.configuration.AdUnitConfiguration;
 import org.prebid.mobile.rendering.loading.CreativeFactory;
 import org.prebid.mobile.rendering.loading.Transaction;
 import org.prebid.mobile.rendering.loading.TransactionManager;
@@ -41,7 +42,6 @@ import org.prebid.mobile.rendering.networking.tracking.TrackingManager;
 import org.prebid.mobile.rendering.video.*;
 import org.prebid.mobile.rendering.views.interstitial.InterstitialManager;
 import org.prebid.mobile.test.utils.WhiteBox;
-import org.prebid.mobile.configuration.AdUnitConfiguration;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
@@ -57,25 +57,25 @@ import static org.mockito.Mockito.*;
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 19)
 public class AdViewManagerTest {
-    private Context mContext;
-    private AdViewManager mAdViewManager;
+    private Context context;
+    private AdViewManager adViewManager;
 
     @Mock
-    private AdViewManagerListener mMockAdViewListener;
+    private AdViewManagerListener mockAdViewListener;
     @Mock
     private InterstitialView mockAdView;
     @Mock
-    private VideoCreative mMockVideoCreative;
+    private VideoCreative mockVideoCreative;
     @Mock
-    private VideoCreativeView mMockVideoCreativeView;
+    private VideoCreativeView mockVideoCreativeView;
     @Mock
-    InterstitialManager mMockInterstitialManager;
+    InterstitialManager mockInterstitialManager;
 
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
-        mContext = Robolectric.buildActivity(Activity.class).create().get().getApplicationContext();
-        mAdViewManager = new AdViewManager(mContext, mMockAdViewListener, mockAdView, mMockInterstitialManager);
+        context = Robolectric.buildActivity(Activity.class).create().get().getApplicationContext();
+        adViewManager = new AdViewManager(context, mockAdViewListener, mockAdView, mockInterstitialManager);
     }
 
     @Test
@@ -83,7 +83,9 @@ public class AdViewManagerTest {
         AdViewManagerListener mockAdViewListener = mock(AdViewManagerListener.class);
         InterstitialView mockAdView = mock(InterstitialView.class);
 
-        AdViewManager adViewManager = new AdViewManager(mContext, mockAdViewListener, mockAdView, mMockInterstitialManager);
+        AdViewManager adViewManager = new AdViewManager(context, mockAdViewListener, mockAdView,
+                mockInterstitialManager
+        );
         assertNotNull(adViewManager);
     }
 
@@ -93,7 +95,7 @@ public class AdViewManagerTest {
         AdViewManager adViewManager = null;
         AdException err = null;
         try {
-            adViewManager = new AdViewManager(mContext, null, mockAdView, mMockInterstitialManager);
+            adViewManager = new AdViewManager(context, null, mockAdView, mockInterstitialManager);
         }
         catch (AdException e) {
             err = e;
@@ -109,7 +111,7 @@ public class AdViewManagerTest {
         AdViewManager adViewManager = null;
         AdException err = null;
         try {
-            adViewManager = new AdViewManager(mContext, null, mockAdView, mMockInterstitialManager);
+            adViewManager = new AdViewManager(context, null, mockAdView, mockInterstitialManager);
         }
         catch (Exception e) {
             err = new AdException(AdException.INTERNAL_ERROR, e.getMessage());
@@ -125,31 +127,31 @@ public class AdViewManagerTest {
 
         TransactionManager mockTransactionManager = mock(TransactionManager.class);
         when(mockTransactionManager.getCurrentCreative()).thenReturn(mock);
-        WhiteBox.field(AdViewManager.class, "mTransactionManager").set(mAdViewManager, mockTransactionManager);
+        WhiteBox.field(AdViewManager.class, "transactionManager").set(adViewManager, mockTransactionManager);
 
-        mAdViewManager.show();
-        verify(mMockAdViewListener).viewReadyForImmediateDisplay(any(View.class));
+        adViewManager.show();
+        verify(mockAdViewListener).viewReadyForImmediateDisplay(any(View.class));
     }
 
     @Test
     public void whenBannerHtmlNotResolved_Return() throws IllegalAccessException, AdException {
         ViewGroup mockBanner = mock(ViewGroup.class);
-        mAdViewManager = new AdViewManager(mContext, mMockAdViewListener, mockBanner, mock(InterstitialManager.class));
+        adViewManager = new AdViewManager(context, mockAdViewListener, mockBanner, mock(InterstitialManager.class));
 
         AbstractCreative mockCreative = mock(AbstractCreative.class);
         when(mockCreative.isDisplay()).thenReturn(true);
         when(mockCreative.isResolved()).thenReturn(false);
-        WhiteBox.field(AdViewManager.class, "mCurrentCreative").set(mAdViewManager, mockCreative);
+        WhiteBox.field(AdViewManager.class, "currentCreative").set(adViewManager, mockCreative);
 
         TransactionManager mockTransactionManager = mock(TransactionManager.class);
         when(mockTransactionManager.getCurrentCreative()).thenReturn(mockCreative);
-        WhiteBox.field(AdViewManager.class, "mTransactionManager").set(mAdViewManager, mockTransactionManager);
+        WhiteBox.field(AdViewManager.class, "transactionManager").set(adViewManager, mockTransactionManager);
 
         ArgumentCaptor exceptionCaptor = ArgumentCaptor.forClass(AdException.class);
 
-        mAdViewManager.show();
-        verify(mMockAdViewListener, never()).viewReadyForImmediateDisplay(any(View.class));
-        verify(mMockAdViewListener).failedToLoad((AdException) exceptionCaptor.capture());
+        adViewManager.show();
+        verify(mockAdViewListener, never()).viewReadyForImmediateDisplay(any(View.class));
+        verify(mockAdViewListener).failedToLoad((AdException) exceptionCaptor.capture());
         assertEquals("SDK internal error: Creative has not been resolved yet", ((AdException) exceptionCaptor.getValue()).getMessage());
     }
 
@@ -159,17 +161,17 @@ public class AdViewManagerTest {
         AbstractCreative mockCreative = mock(AbstractCreative.class);
         when(mockCreative.isDisplay()).thenReturn(true);
         when(mockCreative.isResolved()).thenReturn(false);
-        WhiteBox.field(AdViewManager.class, "mCurrentCreative").set(mAdViewManager, mockCreative);
+        WhiteBox.field(AdViewManager.class, "currentCreative").set(adViewManager, mockCreative);
 
         TransactionManager mockTransactionManager = mock(TransactionManager.class);
         when(mockTransactionManager.getCurrentCreative()).thenReturn(mockCreative);
-        WhiteBox.field(AdViewManager.class, "mTransactionManager").set(mAdViewManager, mockTransactionManager);
+        WhiteBox.field(AdViewManager.class, "transactionManager").set(adViewManager, mockTransactionManager);
 
         ArgumentCaptor exceptionCaptor = ArgumentCaptor.forClass(AdException.class);
 
-        mAdViewManager.show();
-        verify(mMockAdViewListener, never()).viewReadyForImmediateDisplay(any(View.class));
-        verify(mMockAdViewListener).failedToLoad((AdException) exceptionCaptor.capture());
+        adViewManager.show();
+        verify(mockAdViewListener, never()).viewReadyForImmediateDisplay(any(View.class));
+        verify(mockAdViewListener).failedToLoad((AdException) exceptionCaptor.capture());
         assertEquals("SDK internal error: Creative has not been resolved yet", ((AdException) exceptionCaptor.getValue()).getMessage());
     }
 
@@ -180,39 +182,39 @@ public class AdViewManagerTest {
         when(mockCreative.isDisplay()).thenReturn(false);
         when(mockCreative.isVideo()).thenReturn(true);
         when(mockCreative.isResolved()).thenReturn(false);
-        WhiteBox.field(AdViewManager.class, "mCurrentCreative").set(mAdViewManager, mockCreative);
+        WhiteBox.field(AdViewManager.class, "currentCreative").set(adViewManager, mockCreative);
 
         TransactionManager mockTransactionManager = mock(TransactionManager.class);
         when(mockTransactionManager.getCurrentCreative()).thenReturn(mockCreative);
-        WhiteBox.field(AdViewManager.class, "mTransactionManager").set(mAdViewManager, mockTransactionManager);
+        WhiteBox.field(AdViewManager.class, "transactionManager").set(adViewManager, mockTransactionManager);
 
         ArgumentCaptor exceptionCaptor = ArgumentCaptor.forClass(AdException.class);
 
-        mAdViewManager.show();
-        verify(mMockAdViewListener, never()).viewReadyForImmediateDisplay(any(View.class));
-        verify(mMockAdViewListener).failedToLoad((AdException) exceptionCaptor.capture());
+        adViewManager.show();
+        verify(mockAdViewListener, never()).viewReadyForImmediateDisplay(any(View.class));
+        verify(mockAdViewListener).failedToLoad((AdException) exceptionCaptor.capture());
         assertEquals("SDK internal error: Creative has not been resolved yet", ((AdException) exceptionCaptor.getValue()).getMessage());
     }
 
     @Test
     public void whenVideoNotResolved_Return() throws AdException, IllegalAccessException {
         VideoView mockVideoView = mock(VideoView.class);
-        mAdViewManager = new AdViewManager(mContext, mMockAdViewListener, mockVideoView, mock(InterstitialManager.class));
+        adViewManager = new AdViewManager(context, mockAdViewListener, mockVideoView, mock(InterstitialManager.class));
 
         AbstractCreative mockCreative = mock(AbstractCreative.class);
         when(mockCreative.isVideo()).thenReturn(true);
         when(mockCreative.isResolved()).thenReturn(false);
-        WhiteBox.field(AdViewManager.class, "mCurrentCreative").set(mAdViewManager, mockCreative);
+        WhiteBox.field(AdViewManager.class, "currentCreative").set(adViewManager, mockCreative);
 
         TransactionManager mockTransactionManager = mock(TransactionManager.class);
         when(mockTransactionManager.getCurrentCreative()).thenReturn(mockCreative);
-        WhiteBox.field(AdViewManager.class, "mTransactionManager").set(mAdViewManager, mockTransactionManager);
+        WhiteBox.field(AdViewManager.class, "transactionManager").set(adViewManager, mockTransactionManager);
 
         ArgumentCaptor exceptionCaptor = ArgumentCaptor.forClass(AdException.class);
 
-        mAdViewManager.show();
-        verify(mMockAdViewListener, never()).viewReadyForImmediateDisplay(any(View.class));
-        verify(mMockAdViewListener).failedToLoad((AdException) exceptionCaptor.capture());
+        adViewManager.show();
+        verify(mockAdViewListener, never()).viewReadyForImmediateDisplay(any(View.class));
+        verify(mockAdViewListener).failedToLoad((AdException) exceptionCaptor.capture());
         assertEquals("SDK internal error: Creative has not been resolved yet", ((AdException) exceptionCaptor.getValue()).getMessage());
     }
 
@@ -229,23 +231,23 @@ public class AdViewManagerTest {
         when(mockTransactionManager.getCurrentTransaction()).thenReturn(mockTransaction);
         when(mockTransaction.getCreativeFactories()).thenReturn(creativeFactories);
 
-        WhiteBox.field(AdViewManager.class, "mTransactionManager").set(mAdViewManager, mockTransactionManager);
-        WhiteBox.field(AdViewManager.class, "mAdView").set(mAdViewManager, mockAdView);
+        WhiteBox.field(AdViewManager.class, "transactionManager").set(adViewManager, mockTransactionManager);
+        WhiteBox.field(AdViewManager.class, "adView").set(adViewManager, mockAdView);
 
-        mAdViewManager.creativeDidComplete(mockVideoCreative);
+        adViewManager.creativeDidComplete(mockVideoCreative);
         verify(mockAdView).closeInterstitialVideo();
-        verify(mMockAdViewListener, times(1)).adCompleted();
+        verify(mockAdViewListener, times(1)).adCompleted();
 
-        mAdViewManager.creativeDidComplete(mockVideoCreative);
-        verify(mMockAdViewListener, times(2)).adCompleted();
+        adViewManager.creativeDidComplete(mockVideoCreative);
+        verify(mockAdViewListener, times(2)).adCompleted();
     }
 
     @Test
     public void creativeWasClickedTest() {
         AbstractCreative mockCreative = mock(AbstractCreative.class);
 
-        mAdViewManager.creativeWasClicked(mockCreative, "test");
-        verify(mMockAdViewListener).creativeClicked(eq("test"));
+        adViewManager.creativeWasClicked(mockCreative, "test");
+        verify(mockAdViewListener).creativeClicked(eq("test"));
     }
 
     @Test
@@ -254,100 +256,100 @@ public class AdViewManagerTest {
         TransactionManager mock = mock(TransactionManager.class);
         Transaction transaction = mock(Transaction.class);
         when(mock.getCurrentTransaction()).thenReturn(transaction);
-        WhiteBox.field(AdViewManager.class, "mTransactionManager").set(mAdViewManager, mock);
+        WhiteBox.field(AdViewManager.class, "transactionManager").set(adViewManager, mock);
 
-        mAdViewManager.creativeInterstitialDidClose(mockCreative);
-        verify(mMockAdViewListener).creativeInterstitialClosed();
+        adViewManager.creativeInterstitialDidClose(mockCreative);
+        verify(mockAdViewListener).creativeInterstitialClosed();
     }
 
     @Test
     public void creativeDidExpandTest() {
         AbstractCreative mockCreative = mock(AbstractCreative.class);
 
-        mAdViewManager.creativeDidExpand(mockCreative);
-        verify(mMockAdViewListener).creativeExpanded();
+        adViewManager.creativeDidExpand(mockCreative);
+        verify(mockAdViewListener).creativeExpanded();
     }
 
     @Test
     public void creativeDidCollapseTest() {
         AbstractCreative mockCreative = mock(AbstractCreative.class);
 
-        mAdViewManager.creativeDidCollapse(mockCreative);
-        verify(mMockAdViewListener).creativeCollapsed();
+        adViewManager.creativeDidCollapse(mockCreative);
+        verify(mockAdViewListener).creativeCollapsed();
     }
 
     @Test
     public void creativeVolumeStateChanged_NotifyListener() {
-        mAdViewManager.creativeMuted(mMockVideoCreative);
-        verify(mMockAdViewListener).creativeMuted();
+        adViewManager.creativeMuted(mockVideoCreative);
+        verify(mockAdViewListener).creativeMuted();
 
-        mAdViewManager.creativeUnMuted(mMockVideoCreative);
-        verify(mMockAdViewListener).creativeMuted();
+        adViewManager.creativeUnMuted(mockVideoCreative);
+        verify(mockAdViewListener).creativeMuted();
     }
 
     @Test
     public void creativePlaybackStateChanged_NotifyListener() {
-        mAdViewManager.creativePaused(mMockVideoCreative);
-        verify(mMockAdViewListener).creativePaused();
+        adViewManager.creativePaused(mockVideoCreative);
+        verify(mockAdViewListener).creativePaused();
 
-        mAdViewManager.creativeResumed(mMockVideoCreative);
-        verify(mMockAdViewListener).creativeResumed();
+        adViewManager.creativeResumed(mockVideoCreative);
+        verify(mockAdViewListener).creativeResumed();
     }
 
     @Test
     public void changeVolumeState_InvokeCreative() throws IllegalAccessException {
         setupCreative();
 
-        mAdViewManager.mute();
-        verify(mMockVideoCreative).mute();
+        adViewManager.mute();
+        verify(mockVideoCreative).mute();
 
-        mAdViewManager.unmute();
-        verify(mMockVideoCreative).unmute();
+        adViewManager.unmute();
+        verify(mockVideoCreative).unmute();
     }
 
     @Test
     public void isNotShowingEndCard_withEndCard_ReturnFalse() throws IllegalAccessException {
         setupCreative();
-        when(mMockVideoCreative.isDisplay()).thenReturn(true);
-        when(mMockVideoCreative.isEndCard()).thenReturn(true);
+        when(mockVideoCreative.isDisplay()).thenReturn(true);
+        when(mockVideoCreative.isEndCard()).thenReturn(true);
 
-        assertFalse(mAdViewManager.isNotShowingEndCard());
+        assertFalse(adViewManager.isNotShowingEndCard());
     }
 
     @Test
     public void isNotShowingEndCard_noEndCard_ReturnTrue() throws IllegalAccessException {
         setupCreative();
-        when(mMockVideoCreative.isDisplay()).thenReturn(false);
-        when(mMockVideoCreative.isEndCard()).thenReturn(true);
+        when(mockVideoCreative.isDisplay()).thenReturn(false);
+        when(mockVideoCreative.isEndCard()).thenReturn(true);
 
-        assertTrue(mAdViewManager.isNotShowingEndCard());
+        assertTrue(adViewManager.isNotShowingEndCard());
     }
 
     @Test
     public void hasEndCard_withEndCard_ReturnTrue() throws IllegalAccessException {
         setupCreative();
-        when(mMockVideoCreative.isDisplay()).thenReturn(true);
+        when(mockVideoCreative.isDisplay()).thenReturn(true);
 
-        assertTrue(mAdViewManager.hasEndCard());
+        assertTrue(adViewManager.hasEndCard());
     }
 
     @Test
     public void hasEndCard_noEndCard_ReturnFalse() throws IllegalAccessException {
         setupCreative();
-        when(mMockVideoCreative.isDisplay()).thenReturn(false);
-        when(mMockVideoCreative.isEndCard()).thenReturn(true);
+        when(mockVideoCreative.isDisplay()).thenReturn(false);
+        when(mockVideoCreative.isEndCard()).thenReturn(true);
 
-        assertFalse(mAdViewManager.hasEndCard());
+        assertFalse(adViewManager.hasEndCard());
     }
 
     @Test
     public void hideTest() throws IllegalAccessException {
         AbstractCreative mockCreative = mock(AbstractCreative.class);
 
-        mAdViewManager.hide();
+        adViewManager.hide();
         verify(mockAdView, never()).removeView(any(View.class));
-        WhiteBox.field(AdViewManager.class, "mCurrentCreative").set(mAdViewManager, mockCreative);
-        mAdViewManager.hide();
+        WhiteBox.field(AdViewManager.class, "currentCreative").set(adViewManager, mockCreative);
+        adViewManager.hide();
         verify(mockAdView).removeView(any());
     }
 
@@ -355,49 +357,49 @@ public class AdViewManagerTest {
     public void destroy_Cleanup() throws IllegalAccessException {
         setupCreative();
         TransactionManager mockTransactionManager = mock(TransactionManager.class);
-        WhiteBox.field(AdViewManager.class, "mTransactionManager").set(mAdViewManager, mockTransactionManager);
+        WhiteBox.field(AdViewManager.class, "transactionManager").set(adViewManager, mockTransactionManager);
 
-        mAdViewManager.destroy();
+        adViewManager.destroy();
         verify(mockTransactionManager).destroy();
-        verify(mMockVideoCreative).destroy();
+        verify(mockVideoCreative).destroy();
     }
 
     @Test
     public void setAdVisibilityTest() throws IllegalAccessException {
         AbstractCreative mockCreative = mock(AbstractCreative.class);
-        WhiteBox.field(AdViewManager.class, "mCurrentCreative").set(mAdViewManager, mockCreative);
+        WhiteBox.field(AdViewManager.class, "currentCreative").set(adViewManager, mockCreative);
 
-        mAdViewManager.setAdVisibility(View.INVISIBLE);
+        adViewManager.setAdVisibility(View.INVISIBLE);
         verify(mockCreative).handleAdWindowNoFocus();
 
-        mAdViewManager.setAdVisibility(View.VISIBLE);
+        adViewManager.setAdVisibility(View.VISIBLE);
         verify(mockCreative).handleAdWindowFocus();
     }
 
     @Test
     public void testGetMediaDuration() throws IllegalAccessException {
-        long mediaDuration = mAdViewManager.getMediaDuration();
+        long mediaDuration = adViewManager.getMediaDuration();
         assertEquals(0, mediaDuration);
         VideoCreative videoCreative = mock(VideoCreative.class);
         long expectedValue = 15 * 1000;
         when(videoCreative.getMediaDuration()).thenReturn(expectedValue);
-        WhiteBox.field(AdViewManager.class, "mCurrentCreative").set(mAdViewManager, videoCreative);
-        assertEquals(expectedValue, mAdViewManager.getMediaDuration());
+        WhiteBox.field(AdViewManager.class, "currentCreative").set(adViewManager, videoCreative);
+        assertEquals(expectedValue, adViewManager.getMediaDuration());
     }
 
     @Test
     public void testInterstitialClosed() throws IllegalAccessException {
-        assertFalse(mAdViewManager.isInterstitialClosed());
+        assertFalse(adViewManager.isInterstitialClosed());
 
         VideoCreative videoCreative = mock(VideoCreative.class);
         final VideoCreativeModel videoCreativeModel = mock(VideoCreativeModel.class);
 
         when(videoCreative.getCreativeModel()).thenReturn(videoCreativeModel);
         when(videoCreative.isInterstitialClosed()).thenReturn(true);
-        WhiteBox.field(AdViewManager.class, "mCurrentCreative").set(mAdViewManager, videoCreative);
-        assertTrue(mAdViewManager.isInterstitialClosed());
+        WhiteBox.field(AdViewManager.class, "currentCreative").set(adViewManager, videoCreative);
+        assertTrue(adViewManager.isInterstitialClosed());
         when(videoCreativeModel.hasEndCard()).thenReturn(false);
-        WhiteBox.field(VideoCreative.class, "mModel").set(videoCreative, videoCreativeModel);
+        WhiteBox.field(VideoCreative.class, "model").set(videoCreative, videoCreativeModel);
         when(videoCreative.isInterstitialClosed()).then(new Answer<Object>() {
             @Override
             public Object answer(InvocationOnMock invocation) throws Throwable {
@@ -405,24 +407,24 @@ public class AdViewManagerTest {
                 return null;
             }
         });
-        mAdViewManager.isInterstitialClosed();
+        adViewManager.isInterstitialClosed();
         verify(videoCreativeModel).trackVideoEvent(VideoAdEvent.Event.AD_CLOSE);
     }
 
     @Test
     public void testIsPlaying() throws IllegalAccessException {
-        assertFalse(mAdViewManager.isPlaying());
+        assertFalse(adViewManager.isPlaying());
 
         setupCreative();
 
-        assertTrue(mAdViewManager.isPlaying());
+        assertTrue(adViewManager.isPlaying());
     }
 
     private void setupCreative() throws IllegalAccessException {
-        when(mMockVideoCreative.isBuiltInVideo()).thenReturn(true);
-        when(mMockVideoCreative.isPlaying()).thenReturn(true);
-        when(mMockVideoCreative.getCreativeView()).thenReturn(mMockVideoCreativeView);
-        WhiteBox.field(AdViewManager.class, "mCurrentCreative").set(mAdViewManager, mMockVideoCreative);
+        when(mockVideoCreative.isBuiltInVideo()).thenReturn(true);
+        when(mockVideoCreative.isPlaying()).thenReturn(true);
+        when(mockVideoCreative.getCreativeView()).thenReturn(mockVideoCreativeView);
+        WhiteBox.field(AdViewManager.class, "currentCreative").set(adViewManager, mockVideoCreative);
     }
 
     @Test
@@ -431,74 +433,74 @@ public class AdViewManagerTest {
 
         setupCreative();
 
-        when(mMockVideoCreative.isVideo()).thenReturn(true);
-        mAdViewManager.returnFromVideo(mockCallView);
-        verify(mMockVideoCreativeView).hideCallToAction();
-        verify(mMockVideoCreative).updateAdView(mockCallView);
-        verify(mMockVideoCreativeView).mute();
-        verify(mMockVideoCreative).onPlayerStateChanged(InternalPlayerState.NORMAL);
+        when(mockVideoCreative.isVideo()).thenReturn(true);
+        adViewManager.returnFromVideo(mockCallView);
+        verify(mockVideoCreativeView).hideCallToAction();
+        verify(mockVideoCreative).updateAdView(mockCallView);
+        verify(mockVideoCreativeView).mute();
+        verify(mockVideoCreative).onPlayerStateChanged(InternalPlayerState.NORMAL);
     }
 
     @Test
     public void testCanShowFullScreen() throws IllegalAccessException {
-        assertFalse(mAdViewManager.canShowFullScreen());
+        assertFalse(adViewManager.canShowFullScreen());
         setupCreative();
-        assertTrue(mAdViewManager.canShowFullScreen());
+        assertTrue(adViewManager.canShowFullScreen());
     }
 
     @Test
     public void testTrackVideoStateChange() throws IllegalAccessException {
-        WhiteBox.field(AdViewManager.class, "mCurrentCreative").set(mAdViewManager, mMockVideoCreative);
-        when(mMockVideoCreative.isVideo()).thenReturn(true);
+        WhiteBox.field(AdViewManager.class, "currentCreative").set(adViewManager, mockVideoCreative);
+        when(mockVideoCreative.isVideo()).thenReturn(true);
 
-        mAdViewManager.trackVideoStateChange(InternalPlayerState.NORMAL);
+        adViewManager.trackVideoStateChange(InternalPlayerState.NORMAL);
 
-        verify(mMockVideoCreative).trackVideoStateChange(eq(InternalPlayerState.NORMAL));
+        verify(mockVideoCreative).trackVideoStateChange(eq(InternalPlayerState.NORMAL));
     }
 
     @Test
     public void testUpdateAdView() throws IllegalAccessException {
         setupCreative();
         View mock = mock(View.class);
-        mAdViewManager.updateAdView(mock);
-        verify(mMockVideoCreative).updateAdView(mock);
+        adViewManager.updateAdView(mock);
+        verify(mockVideoCreative).updateAdView(mock);
     }
 
     @Test
     public void whenConditionNotMet_ResumeNotCalled() {
-        mAdViewManager.resume();
-        verify(mMockVideoCreative, never()).resume();
+        adViewManager.resume();
+        verify(mockVideoCreative, never()).resume();
     }
 
     @Test
     public void whenConditionNotMet_PauseNotCalled() {
-        mAdViewManager.pause();
-        verify(mMockVideoCreative, never()).pause();
+        adViewManager.pause();
+        verify(mockVideoCreative, never()).pause();
     }
 
     @Test
     public void whenResumeCalled_CreativeResumeCalled() throws IllegalAccessException {
-        WhiteBox.field(AdViewManager.class, "mCurrentCreative").set(mAdViewManager, mMockVideoCreative);
-        when(mMockVideoCreative.isVideo()).thenReturn(true);
-        mAdViewManager.resume();
-        verify(mMockVideoCreative).resume();
+        WhiteBox.field(AdViewManager.class, "currentCreative").set(adViewManager, mockVideoCreative);
+        when(mockVideoCreative.isVideo()).thenReturn(true);
+        adViewManager.resume();
+        verify(mockVideoCreative).resume();
     }
 
     @Test
     public void whenResumeCalled_CreativePauseCalled() throws IllegalAccessException {
-        WhiteBox.field(AdViewManager.class, "mCurrentCreative").set(mAdViewManager, mMockVideoCreative);
-        when(mMockVideoCreative.isVideo()).thenReturn(true);
-        mAdViewManager.pause();
-        verify(mMockVideoCreative).pause();
+        WhiteBox.field(AdViewManager.class, "currentCreative").set(adViewManager, mockVideoCreative);
+        when(mockVideoCreative.isVideo()).thenReturn(true);
+        adViewManager.pause();
+        verify(mockVideoCreative).pause();
     }
 
     @Test
     public void whenFetchedWithException_callFailedToLoad() {
         AdException adException = new AdException(AdException.INTERNAL_ERROR, "Error message");
-        mAdViewManager.onFetchingFailed(adException);
+        adViewManager.onFetchingFailed(adException);
 
         ArgumentCaptor exceptionCaptor = ArgumentCaptor.forClass(AdException.class);
-        verify(mMockAdViewListener).failedToLoad((AdException) exceptionCaptor.capture());
+        verify(mockAdViewListener).failedToLoad((AdException) exceptionCaptor.capture());
         assertEquals("SDK internal error: Error message", ((AdException) exceptionCaptor.getValue()).getMessage());
     }
 
@@ -514,8 +516,8 @@ public class AdViewManagerTest {
         when(mockTransaction.getTransactionState()).thenReturn("state");
         when(mockTransaction.getCreativeFactories()).thenReturn(creativeFactories);
 
-        mAdViewManager.onFetchingCompleted(mockTransaction);
+        adViewManager.onFetchingCompleted(mockTransaction);
         verify(mockCreative).createOmAdSession();
-        verify(mMockAdViewListener).adLoaded(any(AdDetails.class));
+        verify(mockAdViewListener).adLoaded(any(AdDetails.class));
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/views/base/BaseAdViewTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/views/base/BaseAdViewTest.java
@@ -41,44 +41,44 @@ import static org.mockito.Mockito.*;
 @Config(sdk = 19)
 public class BaseAdViewTest {
 
-    private BaseAdView mBaseAdView;
-    private Context mMockContext;
-    private AdViewManager mMockAdViewManager;
+    private BaseAdView baseAdView;
+    private Context mockContext;
+    private AdViewManager mockAdViewManager;
 
     @Before
     public void setUp() throws Exception {
-        mMockContext = spy(Robolectric.buildActivity(Activity.class).create().get());
+        mockContext = spy(Robolectric.buildActivity(Activity.class).create().get());
 
-        mBaseAdView = new BaseAdView(mMockContext) {
+        baseAdView = new BaseAdView(mockContext) {
             @Override
             protected void notifyErrorListeners(AdException adException) {
 
             }
         };
-        mMockAdViewManager = Mockito.mock(AdViewManager.class);
-        when(mMockAdViewManager.getAdConfiguration()).thenReturn(new AdUnitConfiguration());
-        Field field = WhiteBox.field(BaseAdView.class, "mAdViewManager");
-        field.set(mBaseAdView, mMockAdViewManager);
+        mockAdViewManager = Mockito.mock(AdViewManager.class);
+        when(mockAdViewManager.getAdConfiguration()).thenReturn(new AdUnitConfiguration());
+        Field field = WhiteBox.field(BaseAdView.class, "adViewManager");
+        field.set(baseAdView, mockAdViewManager);
     }
 
     @Test
     public void getMediaDurationTest() {
-        when(mMockAdViewManager.getMediaDuration()).thenReturn(0L);
-        assertEquals(0, mBaseAdView.getMediaDuration());
+        when(mockAdViewManager.getMediaDuration()).thenReturn(0L);
+        assertEquals(0, baseAdView.getMediaDuration());
     }
 
     @Test
     public void whenGetMediaOffsetEmpty_ReturnDefault() {
-        when(mMockAdViewManager.getSkipOffset()).thenReturn(0L);
-        assertEquals(0, mBaseAdView.getMediaOffset());
+        when(mockAdViewManager.getSkipOffset()).thenReturn(0L);
+        assertEquals(0, baseAdView.getMediaOffset());
     }
 
     @Test
     public void onWindowFocusChangedTest() throws IllegalAccessException {
-        WhiteBox.field(BaseAdView.class, "mScreenVisibility").set(mBaseAdView, -1);
+        WhiteBox.field(BaseAdView.class, "screenVisibility").set(baseAdView, -1);
 
-        mBaseAdView.onWindowFocusChanged(true);
-        verify(mMockAdViewManager).setAdVisibility(eq(View.VISIBLE));
+        baseAdView.onWindowFocusChanged(true);
+        verify(mockAdViewManager).setAdVisibility(eq(View.VISIBLE));
     }
 
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/views/browser/AdBrowserActivityTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/views/browser/AdBrowserActivityTest.java
@@ -37,64 +37,65 @@ import static org.prebid.mobile.rendering.views.browser.AdBrowserActivity.EXTRA_
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 19)
 public class AdBrowserActivityTest {
-    private AdBrowserActivity mAdBrowserActivity;
-    private Intent mIntent;
+
+    private AdBrowserActivity adBrowserActivity;
+    private Intent intent;
 
     @Before
     public void setUp() throws Exception {
-        mIntent = new Intent();
-        mIntent.putExtra(AdBrowserActivity.EXTRA_IS_VIDEO, false);
-        mIntent.putExtra(EXTRA_URL, "tel:123123");
-        mAdBrowserActivity = Robolectric.buildActivity(AdBrowserActivity.class, mIntent).create().get();
+        intent = new Intent();
+        intent.putExtra(AdBrowserActivity.EXTRA_IS_VIDEO, false);
+        intent.putExtra(EXTRA_URL, "tel:123123");
+        adBrowserActivity = Robolectric.buildActivity(AdBrowserActivity.class, intent).create().get();
     }
 
     @Test
     public void initTest() {
         //verify that activity creates without an Exception
-        mAdBrowserActivity = Robolectric.buildActivity(AdBrowserActivity.class, mIntent).create().get();
+        adBrowserActivity = Robolectric.buildActivity(AdBrowserActivity.class, intent).create().get();
 
-        mIntent.putExtra(AdBrowserActivity.EXTRA_IS_VIDEO, true);
-        mAdBrowserActivity = Robolectric.buildActivity(AdBrowserActivity.class, mIntent).create().get();
+        intent.putExtra(AdBrowserActivity.EXTRA_IS_VIDEO, true);
+        adBrowserActivity = Robolectric.buildActivity(AdBrowserActivity.class, intent).create().get();
     }
 
     @Test
     public void onKeyDownTest() throws IllegalAccessException {
         WebView mockWebView = mock(WebView.class);
-        WhiteBox.field(AdBrowserActivity.class, "mWebView").set(mAdBrowserActivity, mockWebView);
+        WhiteBox.field(AdBrowserActivity.class, "webView").set(adBrowserActivity, mockWebView);
 
-        mAdBrowserActivity.onKeyDown(KeyEvent.KEYCODE_BACK, new KeyEvent(0, 0));
+        adBrowserActivity.onKeyDown(KeyEvent.KEYCODE_BACK, new KeyEvent(0, 0));
         verify(mockWebView).goBack();
     }
 
     @Test
     public void onPauseTest() throws IllegalAccessException {
         VideoView mockView = mock(VideoView.class);
-        WhiteBox.field(AdBrowserActivity.class, "mVideoView").set(mAdBrowserActivity, mockView);
+        WhiteBox.field(AdBrowserActivity.class, "videoView").set(adBrowserActivity, mockView);
 
-        mAdBrowserActivity.onPause();
+        adBrowserActivity.onPause();
         verify(mockView).suspend();
     }
 
     @Test
     public void onResumeTest() throws IllegalAccessException {
         VideoView mockView = mock(VideoView.class);
-        WhiteBox.field(AdBrowserActivity.class, "mVideoView").set(mAdBrowserActivity, mockView);
+        WhiteBox.field(AdBrowserActivity.class, "videoView").set(adBrowserActivity, mockView);
 
-        mAdBrowserActivity.onResume();
+        adBrowserActivity.onResume();
         verify(mockView).resume();
     }
 
     @Test
     public void onDestroyTest() throws IllegalAccessException {
-        mIntent.putExtra(AdBrowserActivity.EXTRA_IS_VIDEO, true);
-        mAdBrowserActivity = Robolectric.buildActivity(AdBrowserActivity.class, mIntent).create().get();
+        intent.putExtra(AdBrowserActivity.EXTRA_IS_VIDEO, true);
+        adBrowserActivity = Robolectric.buildActivity(AdBrowserActivity.class, intent).create().get();
 
         WebView mockWebView = mock(WebView.class);
         VideoView mockVideoView = mock(VideoView.class);
-        WhiteBox.field(AdBrowserActivity.class, "mWebView").set(mAdBrowserActivity, mockWebView);
-        WhiteBox.field(AdBrowserActivity.class, "mVideoView").set(mAdBrowserActivity, mockVideoView);
+        WhiteBox.field(AdBrowserActivity.class, "webView").set(adBrowserActivity, mockWebView);
+        WhiteBox.field(AdBrowserActivity.class, "videoView").set(adBrowserActivity, mockVideoView);
 
-        mAdBrowserActivity.onDestroy();
+        adBrowserActivity.onDestroy();
         verify(mockWebView).destroy();
         verify(mockVideoView).suspend();
     }
@@ -109,9 +110,12 @@ public class AdBrowserActivityTest {
         InterstitialManager mockManager = mock(InterstitialManager.class);
         when(mockManager.getInterstitialDisplayDelegate()).thenReturn(null);
 
-        WhiteBox.field(AdBrowserActivity.class, "mShouldFireEvents").set(mAdBrowserActivity, true);
-        WhiteBox.field(AdBrowserActivity.class, "mWebView").set(mAdBrowserActivity, mockWebView);
-        BrowserControlsEventsListener eventsListener = ((BrowserControls) WhiteBox.field(AdBrowserActivity.class, "mBrowserControls").get(mAdBrowserActivity)).getBrowserControlsEventsListener();
+        WhiteBox.field(AdBrowserActivity.class, "shouldFireEvents").set(adBrowserActivity, true);
+        WhiteBox.field(AdBrowserActivity.class, "webView").set(adBrowserActivity, mockWebView);
+        BrowserControlsEventsListener eventsListener = ((BrowserControls) WhiteBox.field(
+                AdBrowserActivity.class,
+                "browserControls"
+        ).get(adBrowserActivity)).getBrowserControlsEventsListener();
 
         eventsListener.onRelaod();
         verify(mockWebView).reload();

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/views/browser/BrowserControlsTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/views/browser/BrowserControlsTest.java
@@ -42,83 +42,84 @@ import static org.mockito.Mockito.*;
 @Config(sdk = 19)
 public class BrowserControlsTest {
 
-    private BrowserControls mBrowserControls;
-    private Context mContext;
-    private BrowserControlsEventsListener mMockListener;
+    private BrowserControls browserControls;
+    private Context context;
+    private BrowserControlsEventsListener mockListener;
 
     @Before
     public void setUp() throws Exception {
-        mContext = spy(Robolectric.buildActivity(Activity.class).create().get());
-        mMockListener = mock(BrowserControlsEventsListener.class);
+        context = spy(Robolectric.buildActivity(Activity.class).create().get());
+        mockListener = mock(BrowserControlsEventsListener.class);
 
-        mBrowserControls = new BrowserControls(mContext, mMockListener);
+        browserControls = new BrowserControls(context, mockListener);
     }
 
     @Test
     public void updateNavigationButtonsStateTest() throws IllegalAccessException {
-        Field backBtnField = WhiteBox.field(BrowserControls.class, "mBackBtn");
-        Field forthBtnField = WhiteBox.field(BrowserControls.class, "mForthBtn");
-        Button backBtn = spy((Button) backBtnField.get(mBrowserControls));
-        Button forthBtn = spy((Button) forthBtnField.get(mBrowserControls));
-        backBtnField.set(mBrowserControls, backBtn);
-        forthBtnField.set(mBrowserControls, forthBtn);
+        Field backBtnField = WhiteBox.field(BrowserControls.class, "backBtn");
+        Field forthBtnField = WhiteBox.field(BrowserControls.class, "forthBtn");
+        Button backBtn = spy((Button) backBtnField.get(browserControls));
+        Button forthBtn = spy((Button) forthBtnField.get(browserControls));
+        backBtnField.set(browserControls, backBtn);
+        forthBtnField.set(browserControls, forthBtn);
 
-        mBrowserControls.updateNavigationButtonsState();
+        browserControls.updateNavigationButtonsState();
         verify(backBtn).setBackgroundResource(eq(R.drawable.prebid_ic_back_inactive));
         verify(forthBtn).setBackgroundResource(eq(R.drawable.prebid_ic_forth_inactive));
 
-        when(mMockListener.canGoBack()).thenReturn(true);
-        when(mMockListener.canGoForward()).thenReturn(true);
-        mBrowserControls.updateNavigationButtonsState();
+        when(mockListener.canGoBack()).thenReturn(true);
+        when(mockListener.canGoForward()).thenReturn(true);
+        browserControls.updateNavigationButtonsState();
         verify(backBtn).setBackgroundResource(eq(R.drawable.prebid_ic_back_active));
         verify(forthBtn).setBackgroundResource(eq(R.drawable.prebid_ic_forth_active));
     }
 
     @Test
     public void openURLInExternalBrowserTest() {
-        mBrowserControls.openURLInExternalBrowser("tel:");
-        verify(mContext).startActivity(any(Intent.class));
+        browserControls.openURLInExternalBrowser("tel:");
+        verify(context).startActivity(any(Intent.class));
     }
 
     @Test
     public void showHideNavigationControlsTest() throws IllegalAccessException {
-        Field leftPartField = WhiteBox.field(BrowserControls.class, "mLeftPart");
+        Field leftPartField = WhiteBox.field(BrowserControls.class, "leftPart");
 
-        mBrowserControls.showNavigationControls();
-        Assert.assertEquals(View.VISIBLE, ((LinearLayout) leftPartField.get(mBrowserControls)).getVisibility());
+        browserControls.showNavigationControls();
+        Assert.assertEquals(View.VISIBLE, ((LinearLayout) leftPartField.get(browserControls)).getVisibility());
 
-        mBrowserControls.hideNavigationControls();
-        Assert.assertEquals(View.GONE, ((LinearLayout) leftPartField.get(mBrowserControls)).getVisibility());
+        browserControls.hideNavigationControls();
+        Assert.assertEquals(View.GONE, ((LinearLayout) leftPartField.get(browserControls)).getVisibility());
     }
 
     @Test
     public void clickListenersTest() throws IllegalAccessException {
-        Button closeBtn = (Button) WhiteBox.field(BrowserControls.class, "mCloseBtn").get(mBrowserControls);
-        Button backBtn = (Button) WhiteBox.field(BrowserControls.class, "mBackBtn").get(mBrowserControls);
-        Button forthBtn = (Button) WhiteBox.field(BrowserControls.class, "mForthBtn").get(mBrowserControls);
-        Button refreshBtn = (Button) WhiteBox.field(BrowserControls.class, "mRefreshBtn").get(mBrowserControls);
-        Button openInExternalBtn = (Button) WhiteBox.field(BrowserControls.class, "mOpenInExternalBrowserBtn").get(mBrowserControls);
+        Button closeBtn = (Button) WhiteBox.field(BrowserControls.class, "closeBtn").get(browserControls);
+        Button backBtn = (Button) WhiteBox.field(BrowserControls.class, "backBtn").get(browserControls);
+        Button forthBtn = (Button) WhiteBox.field(BrowserControls.class, "forthBtn").get(browserControls);
+        Button refreshBtn = (Button) WhiteBox.field(BrowserControls.class, "refreshBtn").get(browserControls);
+        Button openInExternalBtn = (Button) WhiteBox.field(BrowserControls.class, "openInExternalBrowserBtn")
+                                                    .get(browserControls);
 
         closeBtn.callOnClick();
-        verify(mMockListener).closeBrowser();
+        verify(mockListener).closeBrowser();
 
         backBtn.callOnClick();
-        verify(mMockListener).onGoBack();
+        verify(mockListener).onGoBack();
 
         forthBtn.callOnClick();
-        verify(mMockListener).onGoForward();
+        verify(mockListener).onGoForward();
 
         refreshBtn.callOnClick();
-        verify(mMockListener).onRelaod();
+        verify(mockListener).onRelaod();
 
         openInExternalBtn.callOnClick();
-        verify(mMockListener).getCurrentURL();
-        verify(mContext, times(0)).startActivity(any(Intent.class));
+        verify(mockListener).getCurrentURL();
+        verify(context, times(0)).startActivity(any(Intent.class));
 
-        reset(mMockListener);
-        when(mMockListener.getCurrentURL()).thenReturn("url");
+        reset(mockListener);
+        when(mockListener.getCurrentURL()).thenReturn("url");
         openInExternalBtn.callOnClick();
-        verify(mMockListener).getCurrentURL();
-        verify(mContext).startActivity(any(Intent.class));
+        verify(mockListener).getCurrentURL();
+        verify(context).startActivity(any(Intent.class));
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/views/interstitial/InterstitialManagerTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/views/interstitial/InterstitialManagerTest.java
@@ -59,25 +59,25 @@ import static org.mockito.Mockito.*;
 @Config(sdk = 19)
 public class InterstitialManagerTest {
 
-    private Context mContext;
-    private InterstitialManager mSpyInterstitialManager;
+    private Context context;
+    private InterstitialManager spyInterstitialManager;
 
     @Mock
-    InterstitialManagerDisplayDelegate mMockInterstitialManagerDisplayDelegate;
+    InterstitialManagerDisplayDelegate mockInterstitialManagerDisplayDelegate;
     @Mock
-    private AdViewManager.AdViewManagerInterstitialDelegate mMockAdViewDelegate;
+    private AdViewManager.AdViewManagerInterstitialDelegate mockAdViewDelegate;
     @Mock
-    private InterstitialManagerMraidDelegate mMockMraidDelegate;
+    private InterstitialManagerMraidDelegate mockMraidDelegate;
 
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
 
-        mContext = Robolectric.buildActivity(Activity.class).create().get();
-        mSpyInterstitialManager = spy(InterstitialManager.class);
-        mSpyInterstitialManager.setInterstitialDisplayDelegate(mMockInterstitialManagerDisplayDelegate);
-        mSpyInterstitialManager.setAdViewManagerInterstitialDelegate(mMockAdViewDelegate);
-        mSpyInterstitialManager.setMraidDelegate(mMockMraidDelegate);
+        context = Robolectric.buildActivity(Activity.class).create().get();
+        spyInterstitialManager = spy(InterstitialManager.class);
+        spyInterstitialManager.setInterstitialDisplayDelegate(mockInterstitialManagerDisplayDelegate);
+        spyInterstitialManager.setAdViewManagerInterstitialDelegate(mockAdViewDelegate);
+        spyInterstitialManager.setMraidDelegate(mockMraidDelegate);
     }
 
     @Test
@@ -87,9 +87,9 @@ public class InterstitialManagerTest {
 
         when(mockWebView.getMRAIDInterface()).thenReturn(mockInterface);
 
-        mSpyInterstitialManager.interstitialClosed(mockWebView);
+        spyInterstitialManager.interstitialClosed(mockWebView);
 
-        verify(mMockInterstitialManagerDisplayDelegate, times(1)).interstitialAdClosed();
+        verify(mockInterstitialManagerDisplayDelegate, times(1)).interstitialAdClosed();
     }
 
     @Test
@@ -98,14 +98,14 @@ public class InterstitialManagerTest {
         HTMLCreative mockHtmlCreative = mock(HTMLCreative.class);
         AdInterstitialDialog mockAdInterstitialDialog = mock(AdInterstitialDialog.class);
 
-        WhiteBox.field(InterstitialManager.class, "mInterstitialDialog")
-                .set(mSpyInterstitialManager, mockAdInterstitialDialog);
+        WhiteBox.field(InterstitialManager.class, "interstitialDialog")
+                .set(spyInterstitialManager, mockAdInterstitialDialog);
 
-        mSpyInterstitialManager.setInterstitialDisplayDelegate(mockHtmlCreative);
+        spyInterstitialManager.setInterstitialDisplayDelegate(mockHtmlCreative);
 
-        when(mMockMraidDelegate.collapseMraid()).thenReturn(true);
+        when(mockMraidDelegate.collapseMraid()).thenReturn(true);
 
-        mSpyInterstitialManager.interstitialClosed(null);
+        spyInterstitialManager.interstitialClosed(null);
 
         verify(mockAdInterstitialDialog, never()).nullifyDialog();
     }
@@ -114,24 +114,24 @@ public class InterstitialManagerTest {
     public void interstitialClosedNullMraidExpand_NullifyDialog() throws IllegalAccessException {
         AdInterstitialDialog mockAdInterstitialDialog = mock(AdInterstitialDialog.class);
 
-        WhiteBox.field(InterstitialManager.class, "mInterstitialDialog")
-                .set(mSpyInterstitialManager, mockAdInterstitialDialog);
-        when(mMockMraidDelegate.collapseMraid()).thenReturn(false);
-        mSpyInterstitialManager.interstitialClosed(null);
+        WhiteBox.field(InterstitialManager.class, "interstitialDialog")
+                .set(spyInterstitialManager, mockAdInterstitialDialog);
+        when(mockMraidDelegate.collapseMraid()).thenReturn(false);
+        spyInterstitialManager.interstitialClosed(null);
 
         verify(mockAdInterstitialDialog, times(1)).nullifyDialog();
     }
 
     @Test
     public void whenDestroy_ResetInterstitialPropertiesAndDestroyExpand() {
-        mSpyInterstitialManager.destroy();
+        spyInterstitialManager.destroy();
 
-        InterstitialDisplayPropertiesInternal interstitialDisplayProperties = mSpyInterstitialManager.getInterstitialDisplayProperties();
+        InterstitialDisplayPropertiesInternal interstitialDisplayProperties = spyInterstitialManager.getInterstitialDisplayProperties();
 
         assertEquals(0, interstitialDisplayProperties.expandHeight);
         assertEquals(0, interstitialDisplayProperties.expandWidth);
 
-        verify(mMockMraidDelegate).destroyMraidExpand();
+        verify(mockMraidDelegate).destroyMraidExpand();
     }
 
     @Test
@@ -152,9 +152,9 @@ public class InterstitialManagerTest {
         InterstitialView mockInterstitialView = mock(InterstitialView.class);
         when(mockInterstitialView.getCreativeView()).thenReturn(mockPrebidWebViewInterstitial);
 
-        mSpyInterstitialManager.displayAdViewInInterstitial(mContext, mockInterstitialView);
+        spyInterstitialManager.displayAdViewInInterstitial(context, mockInterstitialView);
 
-        verify(mMockAdViewDelegate).showInterstitial();
+        verify(mockAdViewDelegate).showInterstitial();
     }
 
     @Test
@@ -167,19 +167,19 @@ public class InterstitialManagerTest {
         mockEvent.mraidActionHelper = "test";
         when(mockWebView.getMraidEvent()).thenReturn(mockEvent);
 
-        mSpyInterstitialManager.displayPrebidWebViewForMraid(mockWebView, true);
+        spyInterstitialManager.displayPrebidWebViewForMraid(mockWebView, true);
 
-        verify(mMockMraidDelegate).displayPrebidWebViewForMraid(mockWebView, true, mockEvent);
+        verify(mockMraidDelegate).displayPrebidWebViewForMraid(mockWebView, true, mockEvent);
     }
 
     @Test
     public void addOldViewToBackStackIntControllerNull_ZeroViewStackInteractions() throws IllegalAccessException {
         WebViewBase mockWebViewBase = mock(WebViewBase.class);
         Stack<View> mockViewStack = spy(new Stack<>());
-        WhiteBox.field(InterstitialManager.class, "mViewStack")
-                .set(mSpyInterstitialManager, mockViewStack);
+        WhiteBox.field(InterstitialManager.class, "viewStack")
+                .set(spyInterstitialManager, mockViewStack);
 
-        mSpyInterstitialManager.addOldViewToBackStack(mockWebViewBase, null, null);
+        spyInterstitialManager.addOldViewToBackStack(mockWebViewBase, null, null);
 
         verifyZeroInteractions(mockViewStack);
     }
@@ -190,12 +190,12 @@ public class InterstitialManagerTest {
         Stack<View> mockViewStack = spy(new Stack<>());
         AdBaseDialog mockInterstitialViewController = mock(AdBaseDialog.class);
         View mockDisplayView = mock(View.class);
-        WhiteBox.field(InterstitialManager.class, "mViewStack")
-                .set(mSpyInterstitialManager, mockViewStack);
+        WhiteBox.field(InterstitialManager.class, "viewStack")
+                .set(spyInterstitialManager, mockViewStack);
 
         when(mockInterstitialViewController.getDisplayView()).thenReturn(mockDisplayView);
 
-        mSpyInterstitialManager.addOldViewToBackStack(mockWebViewBase, "test", mockInterstitialViewController);
+        spyInterstitialManager.addOldViewToBackStack(mockWebViewBase, "test", mockInterstitialViewController);
 
         verify(mockViewStack).push(mockDisplayView);
     }
@@ -204,31 +204,31 @@ public class InterstitialManagerTest {
     public void displayVideoAdViewInInterstitial_ExecuteVideoAdViewShow() {
         VideoView mockVideoAdView = mock(VideoView.class);
 
-        mSpyInterstitialManager.displayVideoAdViewInInterstitial(mContext, mockVideoAdView);
+        spyInterstitialManager.displayVideoAdViewInInterstitial(context, mockVideoAdView);
 
-        verify(mMockAdViewDelegate).showInterstitial();
+        verify(mockAdViewDelegate).showInterstitial();
     }
 
     @Test
     public void interstitialAdClosed_NotifyInterstitialDelegate() {
-        mSpyInterstitialManager.interstitialAdClosed();
+        spyInterstitialManager.interstitialAdClosed();
 
-        verify(mMockInterstitialManagerDisplayDelegate).interstitialAdClosed();
+        verify(mockInterstitialManagerDisplayDelegate).interstitialAdClosed();
     }
 
     @Test
     public void interstitialAdClosed_NotifyVideoDelegate() {
         InterstitialManagerVideoDelegate mockDelegate = mock(InterstitialManagerVideoDelegate.class);
-        mSpyInterstitialManager.setInterstitialVideoDelegate(mockDelegate);
-        mSpyInterstitialManager.interstitialAdClosed();
+        spyInterstitialManager.setInterstitialVideoDelegate(mockDelegate);
+        spyInterstitialManager.interstitialAdClosed();
 
         verify(mockDelegate).onVideoInterstitialClosed();
     }
 
     @Test
     public void interstitialDialogShown_NotifyInterstitialDelegate() {
-        mSpyInterstitialManager.interstitialDialogShown(mock(ViewGroup.class));
+        spyInterstitialManager.interstitialDialogShown(mock(ViewGroup.class));
 
-        verify(mMockInterstitialManagerDisplayDelegate).interstitialDialogShown(any(ViewGroup.class));
+        verify(mockInterstitialManagerDisplayDelegate).interstitialDialogShown(any(ViewGroup.class));
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/views/video/VideoDialogTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/views/video/VideoDialogTest.java
@@ -42,37 +42,37 @@ import static org.mockito.Mockito.*;
 public class VideoDialogTest {
 
     @Mock
-    InterstitialManager mMockInterstitialManager;
+    InterstitialManager mockInterstitialManager;
 
-    private VideoDialog mVideoDialog;
+    private VideoDialog videoDialog;
 
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
 
         Context context = Robolectric.buildActivity(Activity.class).create().get();
-        mVideoDialog = spy(new VideoDialog(context, mock(VideoCreativeView.class), mock(AdViewManager.class),
-                                           mMockInterstitialManager, mock(FrameLayout.class)));
+        videoDialog = spy(new VideoDialog(context, mock(VideoCreativeView.class), mock(AdViewManager.class),
+                mockInterstitialManager, mock(FrameLayout.class)));
     }
 
     @Test
     public void handleCloseClick_DismissDialog() {
-        mVideoDialog.handleCloseClick();
-        verify(mVideoDialog).dismiss();
+        videoDialog.handleCloseClick();
+        verify(videoDialog).dismiss();
     }
 
     // @Test
     // public void whenClose_NotifyVideoAdManager() {
-    //     mVideoDialog.close();
-    //     verify(mMockInterstitialManager).videoAdViewInterstitialAdClosed();
+    //     videoDialog.close();
+    //     verify(mockInterstitialManager).videoAdViewInterstitialAdClosed();
     // }
 
     @Test
     public void showBannerCreative_NullAdView() throws IllegalAccessException {
         InterstitialDisplayPropertiesInternal propertiesInternal = new InterstitialDisplayPropertiesInternal();
-        when(mMockInterstitialManager.getInterstitialDisplayProperties()).thenReturn(propertiesInternal);
-        mVideoDialog.showBannerCreative(mock(View.class));
-        Object adView = WhiteBox.field(VideoDialog.class, "mAdView").get(mVideoDialog);
+        when(mockInterstitialManager.getInterstitialDisplayProperties()).thenReturn(propertiesInternal);
+        videoDialog.showBannerCreative(mock(View.class));
+        Object adView = WhiteBox.field(VideoDialog.class, "adView").get(videoDialog);
         Assert.assertNull(adView);
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/views/webview/AdWebViewClientTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/views/webview/AdWebViewClientTest.java
@@ -33,34 +33,34 @@ public class AdWebViewClientTest {
 
     public static final String TEST_URL = "test";
 
-    private AdWebViewClient mAdWebViewClient;
-    private AdWebViewClient.AdAssetsLoadedListener mAdAssetLoadListener;
+    private AdWebViewClient adWebViewClient;
+    private AdWebViewClient.AdAssetsLoadedListener adAssetLoadListener;
 
     @Before
     public void setup() {
-        mAdAssetLoadListener = mock(AdWebViewClient.AdAssetsLoadedListener.class);
+        adAssetLoadListener = mock(AdWebViewClient.AdAssetsLoadedListener.class);
 
-        mAdWebViewClient = new AdWebViewClient(mAdAssetLoadListener);
+        adWebViewClient = new AdWebViewClient(adAssetLoadListener);
     }
 
     @Test
     public void onPageStartedLoadingTest() {
         WebView mockWebView = mock(WebView.class);
 
-        mAdWebViewClient.onPageStarted(mockWebView, TEST_URL, null);
+        adWebViewClient.onPageStarted(mockWebView, TEST_URL, null);
 
-        verify(mAdAssetLoadListener).startLoadingAssets();
-        assertEquals(false, mAdWebViewClient.isLoadingFinished());
+        verify(adAssetLoadListener).startLoadingAssets();
+        assertEquals(false, adWebViewClient.isLoadingFinished());
     }
 
     @Test
     public void onPageFinishedTest() {
         WebView mockWebView = mock(WebView.class);
 
-        mAdWebViewClient.onPageFinished(mockWebView, TEST_URL);
+        adWebViewClient.onPageFinished(mockWebView, TEST_URL);
 
-        verify(mAdAssetLoadListener).adAssetsLoaded();
-        assertEquals(true, mAdWebViewClient.isLoadingFinished());
+        verify(adAssetLoadListener).adAssetsLoaded();
+        assertEquals(true, adWebViewClient.isLoadingFinished());
     }
 
     @Test
@@ -73,7 +73,7 @@ public class AdWebViewClientTest {
         when(mockWebView.getHitTestResult()).thenReturn(mockHitTestResult);
         when(mockHitTestResult.getType()).thenReturn(WebView.HitTestResult.SRC_ANCHOR_TYPE);
 
-        mAdWebViewClient.onLoadResource(mockWebView, TEST_URL);
+        adWebViewClient.onLoadResource(mockWebView, TEST_URL);
 
         verify(mockWebView).stopLoading();
         verify(mockWebView).loadUrl(TEST_URL);
@@ -84,7 +84,7 @@ public class AdWebViewClientTest {
         WebViewBase mockWebView = mock(WebViewBase.class);
         when(mockWebView.isClicked()).thenReturn(false);
 
-        boolean returnValue = mAdWebViewClient.shouldOverrideUrlLoading(mockWebView, TEST_URL);
+        boolean returnValue = adWebViewClient.shouldOverrideUrlLoading(mockWebView, TEST_URL);
 
         // Get the rendered HTML
         verify(mockWebView).loadUrl("javascript:window.HtmlViewer.showHTML" + "('<html>'+document.getElementsByTagName('html')[0].innerHTML+'</html>');");
@@ -92,12 +92,12 @@ public class AdWebViewClientTest {
         assertEquals(true, returnValue);
 
         MraidEventsManager.MraidListener mockListener = mock(MraidEventsManager.MraidListener.class);
-        mockWebView.mMraidListener = mockListener;
+        mockWebView.mraidListener = mockListener;
         when(mockWebView.getMRAIDInterface()).thenReturn(mock(BaseJSInterface.class));
         when(mockWebView.getPreloadedListener()).thenReturn(mock(PreloadManager.PreloadedListener.class));
         when(mockWebView.canHandleClick()).thenReturn(true);
         when(mockWebView.isClicked()).thenReturn(true);
-        returnValue = mAdWebViewClient.shouldOverrideUrlLoading(mockWebView, TEST_URL);
+        returnValue = adWebViewClient.shouldOverrideUrlLoading(mockWebView, TEST_URL);
         // Get the rendered HTML
         verify(mockListener).openExternalLink(TEST_URL);
         assertEquals(true, returnValue);

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/views/webview/PrebidWebViewBannerTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/views/webview/PrebidWebViewBannerTest.java
@@ -56,30 +56,30 @@ import static org.mockito.Mockito.*;
 @Config(sdk = 19)
 public class PrebidWebViewBannerTest {
 
-    private PrebidWebViewBanner mBanner;
-    private WebViewBanner mMockWebViewBanner;
-    private BaseJSInterface mMockBaseJSInterface;
+    private PrebidWebViewBanner banner;
+    private WebViewBanner mockWebViewBanner;
+    private BaseJSInterface mockBaseJSInterface;
 
-    private Context mContext;
-    private String mAdHTML;
-    private JsExecutor mMockJsExecutor;
+    private Context context;
+    private String adHTML;
+    private JsExecutor mockJsExecutor;
 
     @Before
     public void setUp() throws Exception {
-        mContext = Robolectric.buildActivity(Activity.class).create().get();
-        ManagersResolver.getInstance().prepare(mContext);
+        context = Robolectric.buildActivity(Activity.class).create().get();
+        ManagersResolver.getInstance().prepare(context);
 
-        mAdHTML = ResourceUtils.convertResourceToString("ad_not_mraid_html.txt");
-        mMockWebViewBanner = mock(WebViewBanner.class);
-        mMockBaseJSInterface = mock(BaseJSInterface.class);
-        mMockJsExecutor = mock(JsExecutor.class);
+        adHTML = ResourceUtils.convertResourceToString("ad_not_mraid_html.txt");
+        mockWebViewBanner = mock(WebViewBanner.class);
+        mockBaseJSInterface = mock(BaseJSInterface.class);
+        mockJsExecutor = mock(JsExecutor.class);
 
-        when(mMockBaseJSInterface.getJsExecutor()).thenReturn(mMockJsExecutor);
+        when(mockBaseJSInterface.getJsExecutor()).thenReturn(mockJsExecutor);
 
-        when(mMockWebViewBanner.getMRAIDInterface()).thenReturn(mMockBaseJSInterface);
-        mBanner = new PrebidWebViewBanner(mContext, mock(InterstitialManager.class));
+        when(mockWebViewBanner.getMRAIDInterface()).thenReturn(mockBaseJSInterface);
+        banner = new PrebidWebViewBanner(context, mock(InterstitialManager.class));
 
-        mBanner.mMraidWebView = mMockWebViewBanner;
+        banner.mraidWebView = mockWebViewBanner;
     }
 
     @Test
@@ -96,12 +96,12 @@ public class PrebidWebViewBannerTest {
             message.setData(data);
             handler.handleMessage(message);
             return null;
-        }).when(mMockJsExecutor).executeGetExpandProperties(any(Handler.class));
+        }).when(mockJsExecutor).executeGetExpandProperties(any(Handler.class));
 
         FetchPropertiesHandler.FetchPropertyCallback mockCallback = mock(FetchPropertiesHandler.FetchPropertyCallback.class);
-        WhiteBox.field(PrebidWebViewBanner.class, "mExpandPropertiesCallback").set(mBanner, mockCallback);
+        WhiteBox.field(PrebidWebViewBanner.class, "expandPropertiesCallback").set(banner, mockCallback);
 
-        mBanner.loadMraidExpandProperties();
+        banner.loadMraidExpandProperties();
 
         verify(mockCallback).onResult(eq(jsonAnswer));
     }
@@ -110,41 +110,41 @@ public class PrebidWebViewBannerTest {
     public void preloadedTest() {
         WebViewDelegate mockDelegate = mock(WebViewDelegate.class);
         InterstitialManager mockManager = mock(InterstitialManager.class);
-        mBanner.mWebViewDelegate = mockDelegate;
-        mBanner.mInterstitialManager = mockManager;
+        banner.webViewDelegate = mockDelegate;
+        banner.interstitialManager = mockManager;
         MraidEvent mockEvent = mock(MraidEvent.class);
-        when(mMockWebViewBanner.getMraidEvent()).thenReturn(mockEvent);
+        when(mockWebViewBanner.getMraidEvent()).thenReturn(mockEvent);
 
-        mBanner.preloaded(null);
+        banner.preloaded(null);
         verify(mockDelegate).webViewFailedToLoad(any(AdException.class));
 
-        mMockWebViewBanner.mMRAIDBridgeName = "twopart";
-        mBanner.preloaded(mMockWebViewBanner);
-        verify(mockManager).displayPrebidWebViewForMraid(eq(mMockWebViewBanner), eq(true));
+        mockWebViewBanner.MRAIDBridgeName = "twopart";
+        banner.preloaded(mockWebViewBanner);
+        verify(mockManager).displayPrebidWebViewForMraid(eq(mockWebViewBanner), eq(true));
 
-        mMockWebViewBanner.mMRAIDBridgeName = "else";
-        mBanner.preloaded(mMockWebViewBanner);
+        mockWebViewBanner.MRAIDBridgeName = "else";
+        banner.preloaded(mockWebViewBanner);
         //verify render
-        verify(mMockWebViewBanner).setAdWidth(anyInt());
+        verify(mockWebViewBanner).setAdWidth(anyInt());
 
-        when(mMockWebViewBanner.getParent()).thenReturn(mock(ViewGroup.class));
-        mBanner.preloaded(mMockWebViewBanner);
-        verify(mMockWebViewBanner).bringToFront();
+        when(mockWebViewBanner.getParent()).thenReturn(mock(ViewGroup.class));
+        banner.preloaded(mockWebViewBanner);
+        verify(mockWebViewBanner).bringToFront();
 
         verify(mockDelegate, times(3)).webViewReadyToDisplay();
     }
 
     @Test
     public void initTwoPartAndLoadTest() throws IOException {
-        mBanner.mCreative = mock(HTMLCreative.class);
+        banner.creative = mock(HTMLCreative.class);
         CreativeModel mockModel = mock(CreativeModel.class);
         when(mockModel.getHtml()).thenReturn(ResourceUtils.convertResourceToString("ad_contains_iframe"));
-        when(mBanner.mCreative.getCreativeModel()).thenReturn(mockModel);
+        when(banner.creative.getCreativeModel()).thenReturn(mockModel);
 
-        mBanner.initTwoPartAndLoad(mAdHTML);
+        banner.initTwoPartAndLoad(adHTML);
 
-        assertNotNull(mBanner.mMraidWebView);
-        assertEquals("twopart", mBanner.mMraidWebView.mMRAIDBridgeName);
+        assertNotNull(banner.mraidWebView);
+        assertEquals("twopart", banner.mraidWebView.MRAIDBridgeName);
     }
 
     @Test
@@ -154,12 +154,12 @@ public class PrebidWebViewBannerTest {
         when(mockCreative.getCreativeModel()).thenReturn(mockCreativeModel);
         when(mockCreativeModel.getHtml()).thenReturn(ResourceUtils.convertResourceToString("ad_contains_iframe"));
         when(mockCreativeModel.getAdConfiguration()).thenReturn(new AdUnitConfiguration());
-        mBanner.mCreative = mockCreative;
+        banner.creative = mockCreative;
 
-        mBanner.loadHTML(mAdHTML, 100 ,200);
+        banner.loadHTML(adHTML, 100 ,200);
 
-        assertNotNull(mBanner.mWebView);
-        assertEquals("1part", mBanner.mWebView.mMRAIDBridgeName);
+        assertNotNull(banner.webView);
+        assertEquals("1part", banner.webView.MRAIDBridgeName);
     }
 
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/views/webview/PrebidWebViewBaseTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/views/webview/PrebidWebViewBaseTest.java
@@ -44,86 +44,86 @@ import static org.mockito.Mockito.*;
 @Config(sdk = 19)
 public class PrebidWebViewBaseTest {
 
-    private PrebidWebViewBase mPrebidWebViewBase;
-    private WebViewBanner mMockWebViewBanner;
-    private BaseJSInterface mMockBaseJSInterface;
-    private JsExecutor mMockJsExecutor;
+    private PrebidWebViewBase prebidWebViewBase;
+    private WebViewBanner mockWebViewBanner;
+    private BaseJSInterface mockBaseJSInterface;
+    private JsExecutor mockJsExecutor;
 
     @Before
     public void setUp() throws Exception {
         Context context = Robolectric.buildActivity(Activity.class).create().get();
-        mPrebidWebViewBase = new PrebidWebViewBase(context, mock(InterstitialManager.class));
-        mMockWebViewBanner = mock(WebViewBanner.class);
-        mMockBaseJSInterface = mock(BaseJSInterface.class);
-        mMockJsExecutor = mock(JsExecutor.class);
+        prebidWebViewBase = new PrebidWebViewBase(context, mock(InterstitialManager.class));
+        mockWebViewBanner = mock(WebViewBanner.class);
+        mockBaseJSInterface = mock(BaseJSInterface.class);
+        mockJsExecutor = mock(JsExecutor.class);
 
-        when(mMockWebViewBanner.getMRAIDInterface()).thenReturn(mMockBaseJSInterface);
-        when(mMockBaseJSInterface.getJsExecutor()).thenReturn(mMockJsExecutor);
+        when(mockWebViewBanner.getMRAIDInterface()).thenReturn(mockBaseJSInterface);
+        when(mockBaseJSInterface.getJsExecutor()).thenReturn(mockJsExecutor);
 
-        mPrebidWebViewBase.mMraidWebView = mMockWebViewBanner;
+        prebidWebViewBase.mraidWebView = mockWebViewBanner;
     }
 
     @Test
-    public void initMRAIDExpandedTest(){
+    public void initMRAIDExpandedTest() {
 
-        mPrebidWebViewBase.initMraidExpanded();
-        verify(mMockBaseJSInterface, timeout(100)).onReadyExpanded();
+        prebidWebViewBase.initMraidExpanded();
+        verify(mockBaseJSInterface, timeout(100)).onReadyExpanded();
     }
 
     @Test
     public void handleOpenTest() {
         WebViewBase mockWebView = mock(WebViewBase.class);
-        when(mockWebView.getMRAIDInterface()).thenReturn(mMockBaseJSInterface);
-        mPrebidWebViewBase.mCurrentWebViewBase = mockWebView;
+        when(mockWebView.getMRAIDInterface()).thenReturn(mockBaseJSInterface);
+        prebidWebViewBase.currentWebViewBase = mockWebView;
 
-        mPrebidWebViewBase.handleOpen("test");
-        verify(mMockBaseJSInterface).open(eq("test"));
+        prebidWebViewBase.handleOpen("test");
+        verify(mockBaseJSInterface).open(eq("test"));
     }
 
     @Test
     public void openExternalLinkTest() {
         WebViewDelegate mockDelegate = mock(WebViewDelegate.class);
-        mPrebidWebViewBase.mWebViewDelegate = mockDelegate;
+        prebidWebViewBase.webViewDelegate = mockDelegate;
 
-        mPrebidWebViewBase.openExternalLink("test");
+        prebidWebViewBase.openExternalLink("test");
         verify(mockDelegate).webViewShouldOpenExternalLink(eq("test"));
     }
 
     @Test
     public void openMRAIDExternalLinkTest() {
         WebViewDelegate mockDelegate = mock(WebViewDelegate.class);
-        mPrebidWebViewBase.mWebViewDelegate = mockDelegate;
+        prebidWebViewBase.webViewDelegate = mockDelegate;
 
-        mPrebidWebViewBase.openMraidExternalLink("test");
+        prebidWebViewBase.openMraidExternalLink("test");
         verify(mockDelegate).webViewShouldOpenMRAIDLink(eq("test"));
     }
 
     @Test
     public void renderAdViewTest() {
-        when(mMockWebViewBanner.isMRAID()).thenReturn(true);
+        when(mockWebViewBanner.isMRAID()).thenReturn(true);
 
-        mPrebidWebViewBase.renderAdView(null);
-        verify(mMockWebViewBanner, times(0)).setVisibility(eq(View.VISIBLE));
+        prebidWebViewBase.renderAdView(null);
+        verify(mockWebViewBanner, times(0)).setVisibility(eq(View.VISIBLE));
 
-        mPrebidWebViewBase.renderAdView(mMockWebViewBanner);
-        verify(mMockWebViewBanner).setVisibility(eq(View.VISIBLE));
+        prebidWebViewBase.renderAdView(mockWebViewBanner);
+        verify(mockWebViewBanner).setVisibility(eq(View.VISIBLE));
     }
 
     @Test
     public void displayAdViewPlacement() {
-        when(mMockWebViewBanner.getAdHeight()).thenReturn(1);
-        when(mMockWebViewBanner.getAdWidth()).thenReturn(1);
+        when(mockWebViewBanner.getAdHeight()).thenReturn(1);
+        when(mockWebViewBanner.getAdWidth()).thenReturn(1);
 
-        mPrebidWebViewBase.setLayoutParams(mock(FrameLayout.LayoutParams.class));
-        mPrebidWebViewBase.displayAdViewPlacement(mMockWebViewBanner);
-        verify(mMockWebViewBanner, times(2)).getAdHeight();
-        verify(mMockWebViewBanner, times(2)).getAdWidth();
+        prebidWebViewBase.setLayoutParams(mock(FrameLayout.LayoutParams.class));
+        prebidWebViewBase.displayAdViewPlacement(mockWebViewBanner);
+        verify(mockWebViewBanner, times(2)).getAdHeight();
+        verify(mockWebViewBanner, times(2)).getAdWidth();
     }
 
     @Test
     public void destroyTest() throws IllegalAccessException {
         Handler mockHandler = mock(Handler.class);
-        WhiteBox.field(PrebidWebViewBase.class, "mHandler").set(mPrebidWebViewBase, mockHandler);
+        WhiteBox.field(PrebidWebViewBase.class, "handler").set(prebidWebViewBase, mockHandler);
         when(mockHandler.postDelayed(any(Runnable.class), anyLong())).thenAnswer(new Answer() {
             @Override
             public Object answer(InvocationOnMock invocation) {
@@ -133,16 +133,16 @@ public class PrebidWebViewBaseTest {
             }
         });
 
-        mPrebidWebViewBase.destroy();
-        verify(mMockWebViewBanner).destroy();
+        prebidWebViewBase.destroy();
+        verify(mockWebViewBanner).destroy();
     }
 
     @Test
     public void onWindowFocusChangedTest() throws IllegalAccessException {
-        mPrebidWebViewBase.mCurrentWebViewBase = mMockWebViewBanner;
-        WhiteBox.field(PrebidWebViewBase.class, "mScreenVisibility").set(mPrebidWebViewBase, -1);
+        prebidWebViewBase.currentWebViewBase = mockWebViewBanner;
+        WhiteBox.field(PrebidWebViewBase.class, "screenVisibility").set(prebidWebViewBase, -1);
 
-        mPrebidWebViewBase.onWindowFocusChanged(true);
-        verify(mMockBaseJSInterface).handleScreenViewabilityChange(eq(true));
+        prebidWebViewBase.onWindowFocusChanged(true);
+        verify(mockBaseJSInterface).handleScreenViewabilityChange(eq(true));
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/views/webview/PrebidWebViewInterstitialTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/views/webview/PrebidWebViewInterstitialTest.java
@@ -21,13 +21,13 @@ import android.content.Context;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.prebid.mobile.configuration.AdUnitConfiguration;
 import org.prebid.mobile.rendering.listeners.WebViewDelegate;
 import org.prebid.mobile.rendering.models.CreativeModel;
 import org.prebid.mobile.rendering.models.HTMLCreative;
 import org.prebid.mobile.rendering.sdk.ManagersResolver;
 import org.prebid.mobile.rendering.views.interstitial.InterstitialManager;
 import org.prebid.mobile.test.utils.ResourceUtils;
-import org.prebid.mobile.configuration.AdUnitConfiguration;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
@@ -42,42 +42,42 @@ import static org.mockito.Mockito.*;
 @Config(sdk = 19)
 public class PrebidWebViewInterstitialTest {
 
-    private PrebidWebViewInterstitial mPrebidWebViewInterstitial;
-    private Context mContext;
-    private String mAdHTML;
+    private PrebidWebViewInterstitial prebidWebViewInterstitial;
+    private Context context;
+    private String adHTML;
 
     @Before
     public void setUp() throws Exception {
-        mContext = Robolectric.buildActivity(Activity.class).create().get();
-        ManagersResolver.getInstance().prepare(mContext);
+        context = Robolectric.buildActivity(Activity.class).create().get();
+        ManagersResolver.getInstance().prepare(context);
 
-        mAdHTML = ResourceUtils.convertResourceToString("ad_not_mraid_html.txt");
+        adHTML = ResourceUtils.convertResourceToString("ad_not_mraid_html.txt");
 
-        mPrebidWebViewInterstitial = new PrebidWebViewInterstitial(mContext, mock(InterstitialManager.class));
+        prebidWebViewInterstitial = new PrebidWebViewInterstitial(context, mock(InterstitialManager.class));
     }
 
     @Test
     public void loadHTMLTest() throws IOException {
-        mPrebidWebViewInterstitial.mCreative = mock(HTMLCreative.class);
+        prebidWebViewInterstitial.creative = mock(HTMLCreative.class);
         CreativeModel mockModel = mock(CreativeModel.class);
-        when(mPrebidWebViewInterstitial.mCreative.getCreativeModel()).thenReturn(mockModel);
+        when(prebidWebViewInterstitial.creative.getCreativeModel()).thenReturn(mockModel);
         when(mockModel.getHtml()).thenReturn(ResourceUtils.convertResourceToString("ad_contains_iframe"));
         when(mockModel.getAdConfiguration()).thenReturn(new AdUnitConfiguration());
-        mPrebidWebViewInterstitial.loadHTML(mAdHTML, 100, 200);
+        prebidWebViewInterstitial.loadHTML(adHTML, 100, 200);
 
-        assertNotNull(mPrebidWebViewInterstitial.mWebView);
-        assertEquals("WebViewInterstitial", mPrebidWebViewInterstitial.mWebView.mMRAIDBridgeName);
+        assertNotNull(prebidWebViewInterstitial.webView);
+        assertEquals("WebViewInterstitial", prebidWebViewInterstitial.webView.MRAIDBridgeName);
     }
 
     @Test
     public void preloadedTest() {
         WebViewBase mockWebView = mock(WebViewBase.class);
-        mPrebidWebViewInterstitial.mWebViewDelegate = mock(WebViewDelegate.class);
+        prebidWebViewInterstitial.webViewDelegate = mock(WebViewDelegate.class);
 
-        mPrebidWebViewInterstitial.preloaded(null);
-        verify(mPrebidWebViewInterstitial.mWebViewDelegate, never()).webViewReadyToDisplay();
+        prebidWebViewInterstitial.preloaded(null);
+        verify(prebidWebViewInterstitial.webViewDelegate, never()).webViewReadyToDisplay();
 
-        mPrebidWebViewInterstitial.preloaded(mockWebView);
-        verify(mPrebidWebViewInterstitial.mWebViewDelegate).webViewReadyToDisplay();
+        prebidWebViewInterstitial.preloaded(mockWebView);
+        verify(prebidWebViewInterstitial.webViewDelegate).webViewReadyToDisplay();
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/views/webview/WebViewBannerTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/views/webview/WebViewBannerTest.java
@@ -36,29 +36,35 @@ import static org.mockito.Mockito.mock;
 @Config(sdk = 19)
 public class WebViewBannerTest {
 
-    private Context mContext;
-    private PreloadManager.PreloadedListener mMockPreloadListener;
-    private MraidEventsManager.MraidListener mMockMraidListener;
-    private String mAdHTML;
+    private Context context;
+    private PreloadManager.PreloadedListener mockPreloadListener;
+    private MraidEventsManager.MraidListener mockMraidListener;
+    private String adHTML;
 
     @Before
     public void setup() throws IOException {
-        mContext = Robolectric.buildActivity(Activity.class).create().get();
-        ManagersResolver.getInstance().prepare(mContext);
+        context = Robolectric.buildActivity(Activity.class).create().get();
+        ManagersResolver.getInstance().prepare(context);
 
-        mMockPreloadListener = mock(PreloadManager.PreloadedListener.class);
+        mockPreloadListener = mock(PreloadManager.PreloadedListener.class);
 
-        mMockMraidListener = mock(MraidEventsManager.MraidListener.class);
+        mockMraidListener = mock(MraidEventsManager.MraidListener.class);
 
-        mAdHTML = ResourceUtils.convertResourceToString("ad_not_mraid_html.txt");
+        adHTML = ResourceUtils.convertResourceToString("ad_not_mraid_html.txt");
     }
 
     @Test
-    public void initTest(){
-        WebViewBanner webViewBanner = new WebViewBanner(mContext, mAdHTML, 100, 200,  mMockPreloadListener, mMockMraidListener);
+    public void initTest() {
+        WebViewBanner webViewBanner = new WebViewBanner(context,
+                adHTML,
+                100,
+                200,
+                mockPreloadListener,
+                mockMraidListener
+        );
         assertNotNull(webViewBanner.getMRAIDInterface());
 
-        webViewBanner = new WebViewBanner(mContext, mock(PrebidWebViewBase.class), mMockMraidListener);
+        webViewBanner = new WebViewBanner(context, mock(PrebidWebViewBase.class), mockMraidListener);
         assertNotNull(webViewBanner.getMRAIDInterface());
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/views/webview/WebViewBaseTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/views/webview/WebViewBaseTest.java
@@ -45,115 +45,115 @@ import static org.mockito.Mockito.*;
 @Config(sdk = 19)
 public class WebViewBaseTest {
 
-    private WebViewBase mWebViewBase;
-    private Context mContext;
-    private PreloadManager.PreloadedListener mMockPreloadListener;
-    private MraidEventsManager.MraidListener mMockMraidListener;
-    private String mAdHTML;
+    private WebViewBase webViewBase;
+    private Context context;
+    private PreloadManager.PreloadedListener mockPreloadListener;
+    private MraidEventsManager.MraidListener mockMraidListener;
+    private String adHTML;
 
     @Before
     public void setup() throws IOException {
-        mContext = Robolectric.buildActivity(Activity.class).create().get();
-        ManagersResolver.getInstance().prepare(mContext);
+        context = Robolectric.buildActivity(Activity.class).create().get();
+        ManagersResolver.getInstance().prepare(context);
 
-        mMockPreloadListener = mock(PreloadManager.PreloadedListener.class);
+        mockPreloadListener = mock(PreloadManager.PreloadedListener.class);
 
-        mMockMraidListener = mock(MraidEventsManager.MraidListener.class);
+        mockMraidListener = mock(MraidEventsManager.MraidListener.class);
 
-        mAdHTML = ResourceUtils.convertResourceToString("ad_not_mraid_html.txt");
-        mWebViewBase = new WebViewBase(mContext, mAdHTML, 100, 200, mMockPreloadListener, mMockMraidListener);
+        adHTML = ResourceUtils.convertResourceToString("ad_not_mraid_html.txt");
+        webViewBase = new WebViewBase(context, adHTML, 100, 200, mockPreloadListener, mockMraidListener);
     }
 
     @Test
     public void testCheckIFrameHtmlTagContainsIFrame() throws IOException {
-        mWebViewBase.initContainsIFrame(ResourceUtils.convertResourceToString("ad_contains_iframe"));
+        webViewBase.initContainsIFrame(ResourceUtils.convertResourceToString("ad_contains_iframe"));
 
-        Assert.assertTrue(mWebViewBase.containsIFrame());
+        Assert.assertTrue(webViewBase.containsIFrame());
     }
 
     @Test
     public void testCheckIFrameHtmlTagNotContainsIFrame() throws IOException {
-        mWebViewBase.initContainsIFrame(ResourceUtils.convertResourceToString("ad_no_iframe"));
+        webViewBase.initContainsIFrame(ResourceUtils.convertResourceToString("ad_no_iframe"));
 
-        assertFalse(mWebViewBase.containsIFrame());
+        assertFalse(webViewBase.containsIFrame());
     }
 
     @Test
     public void setJSNameTest() {
-        mWebViewBase.setJSName("test");
-        assertEquals("test", mWebViewBase.mMRAIDBridgeName);
+        webViewBase.setJSName("test");
+        assertEquals("test", webViewBase.MRAIDBridgeName);
     }
 
     @Test
     public void isClickedTest() throws IllegalAccessException {
-        Field field = WhiteBox.field(WebViewBase.class, "mIsClicked");
-        field.set(mWebViewBase, true);
-        assertEquals(field.get(mWebViewBase), mWebViewBase.isClicked());
+        Field field = WhiteBox.field(WebViewBase.class, "isClicked");
+        field.set(webViewBase, true);
+        assertEquals(field.get(webViewBase), webViewBase.isClicked());
     }
 
     @Test
     public void setIsClickedTest() throws IllegalAccessException {
-        Field field = WhiteBox.field(WebViewBase.class, "mIsClicked");
-        assertFalse((Boolean) field.get(mWebViewBase));
-        mWebViewBase.setIsClicked(true);
-        assertTrue((Boolean) field.get(mWebViewBase));
+        Field field = WhiteBox.field(WebViewBase.class, "isClicked");
+        assertFalse((Boolean) field.get(webViewBase));
+        webViewBase.setIsClicked(true);
+        assertTrue((Boolean) field.get(webViewBase));
     }
 
     @Test
     public void initLoadTest() throws IllegalAccessException, IOException {
-        mWebViewBase.initLoad();
-        String newAdHtml = (String) WhiteBox.field(WebViewBase.class, "mAdHTML").get(mWebViewBase);
-        assertNotEquals(mAdHTML, newAdHtml);
+        webViewBase.initLoad();
+        String newAdHtml = (String) WhiteBox.field(WebViewBase.class, "adHTML").get(webViewBase);
+        assertNotEquals(adHTML, newAdHtml);
 
-        mAdHTML = ResourceUtils.convertResourceToString("ad_mraid_html.txt");
-        mWebViewBase = new WebViewBase(mContext, mAdHTML, 100, 200, mMockPreloadListener, mMockMraidListener);
-        mWebViewBase.initLoad();
-        newAdHtml = (String) WhiteBox.field(WebViewBase.class, "mAdHTML").get(mWebViewBase);
-        assertNotEquals(mAdHTML, newAdHtml);
+        adHTML = ResourceUtils.convertResourceToString("ad_mraid_html.txt");
+        webViewBase = new WebViewBase(context, adHTML, 100, 200, mockPreloadListener, mockMraidListener);
+        webViewBase.initLoad();
+        newAdHtml = (String) WhiteBox.field(WebViewBase.class, "adHTML").get(webViewBase);
+        assertNotEquals(adHTML, newAdHtml);
     }
 
     @Test
     public void setGetAdHeightTest() {
-        assertEquals(200, mWebViewBase.getAdHeight());
-        mWebViewBase.setAdHeight(100);
-        assertEquals(100, mWebViewBase.getAdHeight());
+        assertEquals(200, webViewBase.getAdHeight());
+        webViewBase.setAdHeight(100);
+        assertEquals(100, webViewBase.getAdHeight());
     }
 
     @Test
     public void setGetAdWidthTest() {
-        assertEquals(100, mWebViewBase.getAdWidth());
-        mWebViewBase.setAdWidth(200);
-        assertEquals(200, mWebViewBase.getAdWidth());
+        assertEquals(100, webViewBase.getAdWidth());
+        webViewBase.setAdWidth(200);
+        assertEquals(200, webViewBase.getAdWidth());
     }
 
     @Test
     public void getPreloadedListenerTest() {
-        assertEquals(mMockPreloadListener, mWebViewBase.getPreloadedListener());
+        assertEquals(mockPreloadListener, webViewBase.getPreloadedListener());
     }
 
     @Test
     public void adAssetsLoadedTest() {
         BaseJSInterface mockBaseJsInterface = mock(BaseJSInterface.class);
-        mWebViewBase.setBaseJSInterface(mockBaseJsInterface);
+        webViewBase.setBaseJSInterface(mockBaseJsInterface);
 
-        mWebViewBase.mIsMRAID = false;
-        mWebViewBase.adAssetsLoaded();
+        webViewBase.isMRAID = false;
+        webViewBase.adAssetsLoaded();
         verify(mockBaseJsInterface, times(0)).prepareAndSendReady();
-        verify(mMockPreloadListener, times(1)).preloaded(eq(mWebViewBase));
+        verify(mockPreloadListener, times(1)).preloaded(eq(webViewBase));
 
-        mWebViewBase.mIsMRAID = true;
-        mWebViewBase.adAssetsLoaded();
+        webViewBase.isMRAID = true;
+        webViewBase.adAssetsLoaded();
         verify(mockBaseJsInterface, times(1)).prepareAndSendReady();
-        verify(mMockPreloadListener, times(2)).preloaded(eq(mWebViewBase));
+        verify(mockPreloadListener, times(2)).preloaded(eq(webViewBase));
     }
 
     @Test
     public void setGetDialogTest() {
         AdBaseDialog mockDialog = mock(AdBaseDialog.class);
-        assertNull(mWebViewBase.getDialog());
+        assertNull(webViewBase.getDialog());
 
-        mWebViewBase.setDialog(mockDialog);
-        assertEquals(mockDialog, mWebViewBase.getDialog());
+        webViewBase.setDialog(mockDialog);
+        assertEquals(mockDialog, webViewBase.getDialog());
     }
 
     @Test
@@ -173,61 +173,61 @@ public class WebViewBaseTest {
             metaState
         );
 
-        mWebViewBase.loadAd();
-        assertTrue(mWebViewBase.dispatchTouchEvent(motionEvent));
-        assertTrue(mWebViewBase.isClicked());
+        webViewBase.loadAd();
+        assertTrue(webViewBase.dispatchTouchEvent(motionEvent));
+        assertTrue(webViewBase.isClicked());
     }
 
     @Test
     public void getParentContainerTest(){
-        FrameLayout parentLayout = new FrameLayout(mContext);
-        parentLayout.addView(mWebViewBase);
-        assertEquals(parentLayout, mWebViewBase.getParentContainer());
+        FrameLayout parentLayout = new FrameLayout(context);
+        parentLayout.addView(webViewBase);
+        assertEquals(parentLayout, webViewBase.getParentContainer());
     }
 
     @Test
     public void detatchFromParentTest(){
-        FrameLayout parentLayout = new FrameLayout(mContext);
-        parentLayout.addView(mWebViewBase);
-        mWebViewBase.detachFromParent();
-        assertNull(mWebViewBase.getParentContainer());
+        FrameLayout parentLayout = new FrameLayout(context);
+        parentLayout.addView(webViewBase);
+        webViewBase.detachFromParent();
+        assertNull(webViewBase.getParentContainer());
     }
 
     @Test
     public void isMRAIDTest() throws IllegalAccessException {
-        assertFalse(mWebViewBase.isMRAID());
-        WhiteBox.field(WebViewBase.class, "mIsMRAID").set(mWebViewBase, true);
-        assertTrue(mWebViewBase.isMRAID());
+        assertFalse(webViewBase.isMRAID());
+        WhiteBox.field(WebViewBase.class, "isMRAID").set(webViewBase, true);
+        assertTrue(webViewBase.isMRAID());
     }
 
     @Test
     public void sendClickCallbackTest(){
-        mWebViewBase.sendClickCallBack("test");
-        verify(mMockMraidListener).openMraidExternalLink("test");
+        webViewBase.sendClickCallBack("test");
+        verify(mockMraidListener).openMraidExternalLink("test");
     }
 
     @Test
     public void startLoadingAssetsTest() throws IllegalAccessException {
         BaseJSInterface mockInterface = mock(BaseJSInterface.class);
-        WhiteBox.field(WebViewBase.class, "mMraidInterface").set(mWebViewBase, mockInterface);
-        mWebViewBase.startLoadingAssets();
+        WhiteBox.field(WebViewBase.class, "mraidInterface").set(webViewBase, mockInterface);
+        webViewBase.startLoadingAssets();
         verify(mockInterface).loading();
     }
 
     @Test
     public void onWindowFocusChanged_NotifyMRaidListener() {
-        mWebViewBase.onWindowFocusChanged(false);
-        verify(mMockMraidListener).onAdWebViewWindowFocusChanged(false);
+        webViewBase.onWindowFocusChanged(false);
+        verify(mockMraidListener).onAdWebViewWindowFocusChanged(false);
 
-        mWebViewBase.onWindowFocusChanged(true);
-        verify(mMockMraidListener).onAdWebViewWindowFocusChanged(true);
+        webViewBase.onWindowFocusChanged(true);
+        verify(mockMraidListener).onAdWebViewWindowFocusChanged(true);
     }
 
     @Test
     public void destroyTest() throws IllegalAccessException {
         BaseJSInterface mockInterface = mock(BaseJSInterface.class);
-        WhiteBox.field(WebViewBase.class, "mMraidInterface").set(mWebViewBase, mockInterface);
-        mWebViewBase.destroy();
+        WhiteBox.field(WebViewBase.class, "mraidInterface").set(webViewBase, mockInterface);
+        webViewBase.destroy();
         verify(mockInterface).destroy();
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/views/webview/WebViewInterstitialTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/views/webview/WebViewInterstitialTest.java
@@ -39,36 +39,40 @@ import static org.mockito.Mockito.when;
 @Config(sdk = 19)
 public class WebViewInterstitialTest {
 
-    private Context mContext;
-    private PreloadManager.PreloadedListener mMockPreloadListener;
-    private MraidEventsManager.MraidListener mMockMraidListener;
-    private String mAdHTML;
+    private Context context;
+    private PreloadManager.PreloadedListener mockPreloadListener;
+    private MraidEventsManager.MraidListener mockMraidListener;
+    private String adHTML;
 
     @Before
     public void setup() throws IOException {
         ManagersResolver mockResolver = mock(ManagersResolver.class);
         when(mockResolver.getDeviceManager()).thenReturn(mock(DeviceInfoManager.class));
 
-        mContext = Robolectric.buildActivity(Activity.class).create().get();
-        ManagersResolver.getInstance().prepare(mContext);
+        context = Robolectric.buildActivity(Activity.class).create().get();
+        ManagersResolver.getInstance().prepare(context);
 
-        mMockPreloadListener = mock(PreloadManager.PreloadedListener.class);
+        mockPreloadListener = mock(PreloadManager.PreloadedListener.class);
 
-        mMockMraidListener = mock(MraidEventsManager.MraidListener.class);
+        mockMraidListener = mock(MraidEventsManager.MraidListener.class);
 
-        mAdHTML = ResourceUtils.convertResourceToString("ad_not_mraid_html.txt");
+        adHTML = ResourceUtils.convertResourceToString("ad_not_mraid_html.txt");
     }
 
     @Test
     public void initTest() {
-        WebViewInterstitial webViewInterstitial = new WebViewInterstitial(mContext, mAdHTML, 100, 200, mMockPreloadListener, mMockMraidListener);
+        WebViewInterstitial webViewInterstitial = new WebViewInterstitial(context, adHTML, 100, 200,
+                mockPreloadListener, mockMraidListener
+        );
         assertNotNull(webViewInterstitial.getMRAIDInterface());
     }
 
     @Test
     public void setJSNameTest(){
-        WebViewInterstitial webViewInterstitial = new WebViewInterstitial(mContext, mAdHTML, 100, 200, mMockPreloadListener, mMockMraidListener);
+        WebViewInterstitial webViewInterstitial = new WebViewInterstitial(context, adHTML, 100, 200,
+                mockPreloadListener, mockMraidListener
+        );
         webViewInterstitial.setJSName("test");
-        assertEquals("test", webViewInterstitial.mMRAIDBridgeName);
+        assertEquals("test", webViewInterstitial.MRAIDBridgeName);
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/views/webview/mraid/BaseJSInterfaceTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/views/webview/mraid/BaseJSInterfaceTest.java
@@ -70,34 +70,34 @@ import static org.robolectric.Shadows.shadowOf;
 @Config(sdk = 19)
 public class BaseJSInterfaceTest {
 
-    private Activity mTestActivity;
-    private Context mMockContext;
-    private BaseJSInterface mSpyBaseJSInterface;
-    private HTMLCreative mMockCreative;
+    private Activity testActivity;
+    private Context mockContext;
+    private BaseJSInterface spyBaseJSInterface;
+    private HTMLCreative mockCreative;
 
-    @Mock private WebViewBase mMockWebViewBase;
-    @Mock private PrebidWebViewBase mMockPrebidWebViewBase;
-    @Mock private JsExecutor mMockJsExecutor;
-    @Mock private MraidController mMockMraidController;
-    @Mock private DeviceVolumeObserver mMockDeviceVolumeObserver;
+    @Mock private WebViewBase mockWebViewBase;
+    @Mock private PrebidWebViewBase mockPrebidWebViewBase;
+    @Mock private JsExecutor mockJsExecutor;
+    @Mock private MraidController mockMraidController;
+    @Mock private DeviceVolumeObserver mockDeviceVolumeObserver;
 
     @Before
     public void setUp() throws Exception {
         MockitoAnnotations.initMocks(this);
-        mTestActivity = Robolectric.buildActivity(Activity.class).create().get();
-        mMockContext = mTestActivity.getApplicationContext();
+        testActivity = Robolectric.buildActivity(Activity.class).create().get();
+        mockContext = testActivity.getApplicationContext();
 
-        mMockCreative = Mockito.spy(new HTMLCreative(mMockContext, mock(CreativeModel.class), mock(OmAdSessionManager.class), mock(InterstitialManager.class)));
-        WhiteBox.setInternalState(mMockCreative, "mMraidController", mMockMraidController);
+        mockCreative = Mockito.spy(new HTMLCreative(mockContext, mock(CreativeModel.class), mock(OmAdSessionManager.class), mock(InterstitialManager.class)));
+        WhiteBox.setInternalState(mockCreative, "mraidController", mockMraidController);
 
-        when(mMockPrebidWebViewBase.getCreative()).thenReturn(mMockCreative);
+        when(mockPrebidWebViewBase.getCreative()).thenReturn(mockCreative);
 
-        mSpyBaseJSInterface = Mockito.spy(new BaseJSInterface(mTestActivity, mMockWebViewBase, mMockJsExecutor));
-        WhiteBox.setInternalState(mSpyBaseJSInterface, "mDeviceVolumeObserver", mMockDeviceVolumeObserver);
+        spyBaseJSInterface = Mockito.spy(new BaseJSInterface(testActivity, mockWebViewBase, mockJsExecutor));
+        WhiteBox.setInternalState(spyBaseJSInterface, "deviceVolumeObserver", mockDeviceVolumeObserver);
 
-        when(mMockWebViewBase.getPreloadedListener()).thenReturn(mMockPrebidWebViewBase);
+        when(mockWebViewBase.getPreloadedListener()).thenReturn(mockPrebidWebViewBase);
 
-        Mockito.when(mMockWebViewBase.post(Mockito.any(Runnable.class))).thenAnswer(
+        Mockito.when(mockWebViewBase.post(Mockito.any(Runnable.class))).thenAnswer(
             invocation -> {
                 Runnable runnable = invocation.getArgument(0);
                 if (runnable != null) {
@@ -115,181 +115,181 @@ public class BaseJSInterfaceTest {
 
     @Test
     public void getMaxSizeTest() {
-        assertEquals("{}", mSpyBaseJSInterface.getMaxSize());
-        final MraidScreenMetrics screenMetrics = mSpyBaseJSInterface.getScreenMetrics();
+        assertEquals("{}", spyBaseJSInterface.getMaxSize());
+        final MraidScreenMetrics screenMetrics = spyBaseJSInterface.getScreenMetrics();
 
         Rect rect = new Rect(0, 0, 100, 100);
         screenMetrics.setCurrentMaxSizeRect(rect);
-        assertEquals("{\"width\":100,\"height\":100}", mSpyBaseJSInterface.getMaxSize());
+        assertEquals("{\"width\":100,\"height\":100}", spyBaseJSInterface.getMaxSize());
     }
 
     @Test
     public void setMaxSizeTest() {
-        assertEquals("{}", mSpyBaseJSInterface.getMaxSize());
+        assertEquals("{}", spyBaseJSInterface.getMaxSize());
 
         Rect rect = new Rect(0, 0, 0, 0);
-        final MraidScreenMetrics screenMetrics = mSpyBaseJSInterface.getScreenMetrics();
+        final MraidScreenMetrics screenMetrics = spyBaseJSInterface.getScreenMetrics();
         screenMetrics.setCurrentMaxSizeRect(rect);
-        assertEquals("{\"width\":0,\"height\":0}", mSpyBaseJSInterface.getMaxSize());
+        assertEquals("{\"width\":0,\"height\":0}", spyBaseJSInterface.getMaxSize());
 
         rect = new Rect(100, 100, 0, 0);
         screenMetrics.setCurrentMaxSizeRect(rect);
-        assertEquals("{\"width\":-100,\"height\":-100}", mSpyBaseJSInterface.getMaxSize());
+        assertEquals("{\"width\":-100,\"height\":-100}", spyBaseJSInterface.getMaxSize());
 
         rect = new Rect(100, 0, 0, 0);
         screenMetrics.setCurrentMaxSizeRect(rect);
-        assertEquals("{\"width\":-100,\"height\":0}", mSpyBaseJSInterface.getMaxSize());
+        assertEquals("{\"width\":-100,\"height\":0}", spyBaseJSInterface.getMaxSize());
 
         rect = new Rect(0, 100, 0, 0);
         screenMetrics.setCurrentMaxSizeRect(rect);
-        assertEquals("{\"width\":0,\"height\":-100}", mSpyBaseJSInterface.getMaxSize());
+        assertEquals("{\"width\":0,\"height\":-100}", spyBaseJSInterface.getMaxSize());
 
         rect = new Rect(0, 0, 100, 0);
         screenMetrics.setCurrentMaxSizeRect(rect);
-        assertEquals("{\"width\":100,\"height\":0}", mSpyBaseJSInterface.getMaxSize());
+        assertEquals("{\"width\":100,\"height\":0}", spyBaseJSInterface.getMaxSize());
 
         rect = new Rect(0, 0, 0, 100);
         screenMetrics.setCurrentMaxSizeRect(rect);
-        assertEquals("{\"width\":0,\"height\":100}", mSpyBaseJSInterface.getMaxSize());
+        assertEquals("{\"width\":0,\"height\":100}", spyBaseJSInterface.getMaxSize());
 
         rect = new Rect(0, 0, 100, 100);
         screenMetrics.setCurrentMaxSizeRect(rect);
-        assertEquals("{\"width\":100,\"height\":100}", mSpyBaseJSInterface.getMaxSize());
+        assertEquals("{\"width\":100,\"height\":100}", spyBaseJSInterface.getMaxSize());
     }
 
     @Test
     public void getDefaultPositionTest() {
-        assertEquals("{}", mSpyBaseJSInterface.getDefaultPosition());
+        assertEquals("{}", spyBaseJSInterface.getDefaultPosition());
 
-        final MraidScreenMetrics screenMetrics = mSpyBaseJSInterface.getScreenMetrics();
+        final MraidScreenMetrics screenMetrics = spyBaseJSInterface.getScreenMetrics();
         screenMetrics.setDefaultPosition(new Rect(0, 0, 0, 0));
 
-        assertEquals("{\"x\":0,\"width\":0,\"y\":0,\"height\":0}", mSpyBaseJSInterface.getDefaultPosition());
+        assertEquals("{\"x\":0,\"width\":0,\"y\":0,\"height\":0}", spyBaseJSInterface.getDefaultPosition());
     }
 
     @Test
     public void onOrientationPropertiesChangedTest() throws Exception {
-        Field field = WhiteBox.field(BaseJSInterface.class, "mMraidEvent");
+        Field field = WhiteBox.field(BaseJSInterface.class, "mraidEvent");
 
-        mSpyBaseJSInterface.onOrientationPropertiesChanged("test");
-        MraidEvent event = (MraidEvent) field.get(mSpyBaseJSInterface);
+        spyBaseJSInterface.onOrientationPropertiesChanged("test");
+        MraidEvent event = (MraidEvent) field.get(spyBaseJSInterface);
 
         assertEquals(JSInterface.ACTION_ORIENTATION_CHANGE, event.mraidAction);
         assertEquals("test", event.mraidActionHelper);
 
-        verify(mMockMraidController).handleMraidEvent(eq(event), eq(mMockCreative), any(WebViewBase.class), any());
+        verify(mockMraidController).handleMraidEvent(eq(event), eq(mockCreative), any(WebViewBase.class), any());
     }
 
     @Test
     public void closeTest() throws Exception {
-        Field field = WhiteBox.field(BaseJSInterface.class, "mMraidEvent");
+        Field field = WhiteBox.field(BaseJSInterface.class, "mraidEvent");
 
-        mSpyBaseJSInterface.close();
-        MraidEvent event = (MraidEvent) field.get(mSpyBaseJSInterface);
+        spyBaseJSInterface.close();
+        MraidEvent event = (MraidEvent) field.get(spyBaseJSInterface);
 
         assertEquals(JSInterface.ACTION_CLOSE, event.mraidAction);
 
-        verify(mMockMraidController).handleMraidEvent(eq(event), eq(mMockCreative), any(WebViewBase.class), any());
+        verify(mockMraidController).handleMraidEvent(eq(event), eq(mockCreative), any(WebViewBase.class), any());
     }
 
     @Test
     public void resizeTest() throws Exception {
-        Field field = WhiteBox.field(BaseJSInterface.class, "mMraidEvent");
+        Field field = WhiteBox.field(BaseJSInterface.class, "mraidEvent");
 
-        mSpyBaseJSInterface.resize();
-        MraidEvent event = (MraidEvent) field.get(mSpyBaseJSInterface);
+        spyBaseJSInterface.resize();
+        MraidEvent event = (MraidEvent) field.get(spyBaseJSInterface);
 
         assertEquals(JSInterface.ACTION_RESIZE, event.mraidAction);
 
-        verify(mMockMraidController).handleMraidEvent(eq(event), eq(mMockCreative), any(WebViewBase.class), any());
+        verify(mockMraidController).handleMraidEvent(eq(event), eq(mockCreative), any(WebViewBase.class), any());
     }
 
     @Test
     public void expandNoUrlTest() throws Exception {
-        Field field = WhiteBox.field(BaseJSInterface.class, "mMraidEvent");
+        Field field = WhiteBox.field(BaseJSInterface.class, "mraidEvent");
 
-        mSpyBaseJSInterface.expand();
-        MraidEvent event = (MraidEvent) field.get(mSpyBaseJSInterface);
+        spyBaseJSInterface.expand();
+        MraidEvent event = (MraidEvent) field.get(spyBaseJSInterface);
 
         assertEquals(JSInterface.ACTION_EXPAND, event.mraidAction);
         assertNull(event.mraidActionHelper);
 
-        verify(mMockMraidController).handleMraidEvent(eq(event), eq(mMockCreative), any(WebViewBase.class), any());
+        verify(mockMraidController).handleMraidEvent(eq(event), eq(mockCreative), any(WebViewBase.class), any());
     }
 
     @Test
     public void expandWithUrlTest() throws Exception {
-        Field field = WhiteBox.field(BaseJSInterface.class, "mMraidEvent");
+        Field field = WhiteBox.field(BaseJSInterface.class, "mraidEvent");
 
-        mSpyBaseJSInterface.expand(null);
-        MraidEvent event = (MraidEvent) field.get(mSpyBaseJSInterface);
+        spyBaseJSInterface.expand(null);
+        MraidEvent event = (MraidEvent) field.get(spyBaseJSInterface);
 
         assertEquals(JSInterface.ACTION_EXPAND, event.mraidAction);
 
-        verify(mMockMraidController).handleMraidEvent(eq(event), eq(mMockCreative), any(WebViewBase.class), any());
+        verify(mockMraidController).handleMraidEvent(eq(event), eq(mockCreative), any(WebViewBase.class), any());
     }
 
     @Test
     public void openTest() throws Exception {
-        Field field = WhiteBox.field(BaseJSInterface.class, "mMraidEvent");
+        Field field = WhiteBox.field(BaseJSInterface.class, "mraidEvent");
 
-        mSpyBaseJSInterface.open("test");
-        MraidEvent event = (MraidEvent) field.get(mSpyBaseJSInterface);
+        spyBaseJSInterface.open("test");
+        MraidEvent event = (MraidEvent) field.get(spyBaseJSInterface);
 
-        verify(mMockWebViewBase, times(1)).sendClickCallBack(anyString());
+        verify(mockWebViewBase, times(1)).sendClickCallBack(anyString());
         assertEquals(JSInterface.ACTION_OPEN, event.mraidAction);
         assertEquals("test", event.mraidActionHelper);
 
-        verify(mMockMraidController).handleMraidEvent(eq(event), eq(mMockCreative), any(WebViewBase.class), any());
+        verify(mockMraidController).handleMraidEvent(eq(event), eq(mockCreative), any(WebViewBase.class), any());
     }
 
     @Test
     public void createCalendarEventTest() throws Exception {
-        Field field = WhiteBox.field(BaseJSInterface.class, "mMraidEvent");
+        Field field = WhiteBox.field(BaseJSInterface.class, "mraidEvent");
 
-        mSpyBaseJSInterface.createCalendarEvent("test");
-        MraidEvent event = (MraidEvent) field.get(mSpyBaseJSInterface);
+        spyBaseJSInterface.createCalendarEvent("test");
+        MraidEvent event = (MraidEvent) field.get(spyBaseJSInterface);
 
         assertEquals(JSInterface.ACTION_CREATE_CALENDAR_EVENT, event.mraidAction);
         assertEquals("test", event.mraidActionHelper);
 
-        verify(mMockMraidController).handleMraidEvent(eq(event), eq(mMockCreative), any(WebViewBase.class), any());
+        verify(mockMraidController).handleMraidEvent(eq(event), eq(mockCreative), any(WebViewBase.class), any());
     }
 
     @Test
     public void storePictureTest() throws Exception {
-        Field field = WhiteBox.field(BaseJSInterface.class, "mMraidEvent");
+        Field field = WhiteBox.field(BaseJSInterface.class, "mraidEvent");
 
-        mSpyBaseJSInterface.storePicture("test");
-        MraidEvent event = (MraidEvent) field.get(mSpyBaseJSInterface);
+        spyBaseJSInterface.storePicture("test");
+        MraidEvent event = (MraidEvent) field.get(spyBaseJSInterface);
 
         assertEquals(JSInterface.ACTION_STORE_PICTURE, event.mraidAction);
         assertEquals("test", event.mraidActionHelper);
 
-        verify(mMockMraidController).handleMraidEvent(eq(event), eq(mMockCreative), any(WebViewBase.class), any());
+        verify(mockMraidController).handleMraidEvent(eq(event), eq(mockCreative), any(WebViewBase.class), any());
     }
 
     @Test
     public void playVideoTest() throws Exception {
-        Field field = WhiteBox.field(BaseJSInterface.class, "mMraidEvent");
+        Field field = WhiteBox.field(BaseJSInterface.class, "mraidEvent");
 
-        mSpyBaseJSInterface.playVideo("test");
-        MraidEvent event = (MraidEvent) field.get(mSpyBaseJSInterface);
+        spyBaseJSInterface.playVideo("test");
+        MraidEvent event = (MraidEvent) field.get(spyBaseJSInterface);
 
         assertEquals(JSInterface.ACTION_PLAY_VIDEO, event.mraidAction);
         assertEquals("test", event.mraidActionHelper);
 
-        verify(mMockMraidController).handleMraidEvent(eq(event), eq(mMockCreative), any(WebViewBase.class), any());
+        verify(mockMraidController).handleMraidEvent(eq(event), eq(mockCreative), any(WebViewBase.class), any());
     }
 
     @Test
     public void getPlacementTypeTest() {
-        assertNull(mSpyBaseJSInterface.getPlacementType());
+        assertNull(spyBaseJSInterface.getPlacementType());
     }
 
     @Test
     public void setOrientationPropertiesTest() throws IllegalAccessException {
-        final MraidVariableContainer mraidVariableContainer = mSpyBaseJSInterface.getMraidVariableContainer();
+        final MraidVariableContainer mraidVariableContainer = spyBaseJSInterface.getMraidVariableContainer();
 
         assertNull(mraidVariableContainer.getOrientationProperties());
 
@@ -302,31 +302,31 @@ public class BaseJSInterfaceTest {
     @Test
     @LooperMode(LooperMode.Mode.PAUSED)
     public void onStateChangeTest() {
-        mSpyBaseJSInterface.onStateChange(null);
-        verify(mSpyBaseJSInterface, never()).updateScreenMetricsAsync(any());
+        spyBaseJSInterface.onStateChange(null);
+        verify(spyBaseJSInterface, never()).updateScreenMetricsAsync(any());
 
-        mSpyBaseJSInterface.onStateChange("test");
-        verify(mSpyBaseJSInterface, times(1)).updateScreenMetricsAsync(any());
+        spyBaseJSInterface.onStateChange("test");
+        verify(spyBaseJSInterface, times(1)).updateScreenMetricsAsync(any());
     }
 
     @Test
     public void getScreenSizeTest() {
-        String size = mSpyBaseJSInterface.getScreenSize();
+        String size = spyBaseJSInterface.getScreenSize();
         assertEquals("{\"width\":0,\"height\":0}", size);
 
-        ManagersResolver.getInstance().prepare(mTestActivity);
+        ManagersResolver.getInstance().prepare(testActivity);
 
-        size = mSpyBaseJSInterface.getScreenSize();
+        size = spyBaseJSInterface.getScreenSize();
 
         assertNotEquals("{}", size);
     }
 
     @Test
     public void getCurrentPositionTest() {
-        String currentPosition = mSpyBaseJSInterface.getCurrentPosition();
+        String currentPosition = spyBaseJSInterface.getCurrentPosition();
         assertEquals("{\"x\":0,\"width\":0,\"y\":0,\"height\":0}", currentPosition);
 
-        when(mMockWebViewBase.getGlobalVisibleRect(any(Rect.class))).then(invocation -> {
+        when(mockWebViewBase.getGlobalVisibleRect(any(Rect.class))).then(invocation -> {
             Rect argumentRect = invocation.getArgument(0);
             argumentRect.left = 1;
             argumentRect.top = 2;
@@ -335,39 +335,39 @@ public class BaseJSInterfaceTest {
             return null;
         });
 
-        currentPosition = mSpyBaseJSInterface.getCurrentPosition();
+        currentPosition = spyBaseJSInterface.getCurrentPosition();
         assertNotEquals("{\"x\":0,\"width\":0,\"y\":0,\"height\":0}", currentPosition);
     }
 
     @Test
     @LooperMode(LooperMode.Mode.PAUSED)
     public void prepareAndSendReadyTest() {
-        when(mMockWebViewBase.getHeight()).thenReturn(1);
-        when(mMockPrebidWebViewBase.getHeight()).thenReturn(1);
+        when(mockWebViewBase.getHeight()).thenReturn(1);
+        when(mockPrebidWebViewBase.getHeight()).thenReturn(1);
 
-        mSpyBaseJSInterface.prepareAndSendReady();
+        spyBaseJSInterface.prepareAndSendReady();
         Shadows.shadowOf(Looper.getMainLooper()).idle();
 
-        verify(mMockJsExecutor).executeOnReady();
+        verify(mockJsExecutor).executeOnReady();
     }
 
     @Test
     @LooperMode(LooperMode.Mode.PAUSED)
     public void onReadyExpandedTest() {
-        when(mMockWebViewBase.getHeight()).thenReturn(1);
-        when(mMockPrebidWebViewBase.getHeight()).thenReturn(1);
+        when(mockWebViewBase.getHeight()).thenReturn(1);
+        when(mockPrebidWebViewBase.getHeight()).thenReturn(1);
 
-        mSpyBaseJSInterface.onReadyExpanded();
+        spyBaseJSInterface.onReadyExpanded();
         Shadows.shadowOf(Looper.getMainLooper()).idle();
 
-        verify(mSpyBaseJSInterface, timeout(100)).updateScreenMetricsAsync(any(Runnable.class));
-        verify(mSpyBaseJSInterface).supports(any());
-        verify(mMockJsExecutor).executeOnReadyExpanded();
+        verify(spyBaseJSInterface, timeout(100)).updateScreenMetricsAsync(any(Runnable.class));
+        verify(spyBaseJSInterface).supports(any());
+        verify(mockJsExecutor).executeOnReadyExpanded();
     }
 
     @Test
     public void setExpandPropertiesTest() {
-        final MraidVariableContainer mraidVariableContainer = mSpyBaseJSInterface.getMraidVariableContainer();
+        final MraidVariableContainer mraidVariableContainer = spyBaseJSInterface.getMraidVariableContainer();
         String expandProperties = mraidVariableContainer.getExpandProperties();
 
         assertNull(expandProperties);
@@ -378,7 +378,7 @@ public class BaseJSInterfaceTest {
 
     @Test
     public void setURLForLaunchingTest() throws IllegalAccessException {
-        final MraidVariableContainer mraidVariableContainer = mSpyBaseJSInterface.getMraidVariableContainer();
+        final MraidVariableContainer mraidVariableContainer = spyBaseJSInterface.getMraidVariableContainer();
 
         assertEquals("", mraidVariableContainer.getUrlForLaunching());
 
@@ -388,7 +388,7 @@ public class BaseJSInterfaceTest {
 
     @Test
     public void getURLForLaunchingTest() throws IllegalAccessException {
-        final MraidVariableContainer mraidVariableContainer = mSpyBaseJSInterface.getMraidVariableContainer();
+        final MraidVariableContainer mraidVariableContainer = spyBaseJSInterface.getMraidVariableContainer();
 
         assertEquals("", mraidVariableContainer.getUrlForLaunching());
         mraidVariableContainer.setUrlForLaunching("test");
@@ -398,10 +398,10 @@ public class BaseJSInterfaceTest {
     @Test
     public void getOriginalURLCallBackTest() throws IllegalAccessException {
         RedirectUrlListener mockListener = mock(RedirectUrlListener.class);
-        mSpyBaseJSInterface.followToOriginalUrl("test", mockListener);
+        spyBaseJSInterface.followToOriginalUrl("test", mockListener);
 
-        GetOriginalUrlTask redirectedUrlAsyncTask = WhiteBox.getInternalState(mSpyBaseJSInterface, "mRedirectedUrlAsyncTask");
-        ResponseHandler getOriginalURLCallBack = WhiteBox.getInternalState(redirectedUrlAsyncTask, "mResponseHandler");
+        GetOriginalUrlTask redirectedUrlAsyncTask = WhiteBox.getInternalState(spyBaseJSInterface, "redirectedUrlAsyncTask");
+        ResponseHandler getOriginalURLCallBack = WhiteBox.getInternalState(redirectedUrlAsyncTask, "responseHandler");
 
         getOriginalURLCallBack.onResponse(mock(BaseNetworkTask.GetUrlResult.class));
         verify(mockListener).onSuccess(any(), any());
@@ -420,10 +420,10 @@ public class BaseJSInterfaceTest {
 
     @Test
     public void whenGetLocationAndLocationAvailable_ReturnLocationJson() throws JSONException {
-        ShadowActivity shadowActivity = shadowOf(mTestActivity);
+        ShadowActivity shadowActivity = shadowOf(testActivity);
         shadowActivity.grantPermissions("android.permission.ACCESS_FINE_LOCATION");
 
-        LocationManager locationManager = (LocationManager) mTestActivity.getSystemService(Context.LOCATION_SERVICE);
+        LocationManager locationManager = (LocationManager) testActivity.getSystemService(Context.LOCATION_SERVICE);
         ShadowLocationManager shadowLocationManager = shadowOf(locationManager);
         Location location = new Location("");
         location.setLatitude(1.0);
@@ -432,7 +432,7 @@ public class BaseJSInterfaceTest {
         location.setTime(System.currentTimeMillis() - 4000);
         shadowLocationManager.setLastKnownLocation("gps", location);
         ManagersResolver.getInstance().dispose();
-        ManagersResolver.getInstance().prepare(mTestActivity);
+        ManagersResolver.getInstance().prepare(testActivity);
 
         JSONObject locationJson = new JSONObject();
         locationJson.put(LOCATION_LAT, 1.0);
@@ -441,79 +441,79 @@ public class BaseJSInterfaceTest {
         locationJson.put(LOCATION_ACCURACY, 3F);
         locationJson.put(LOCATION_LASTFIX, (long) 4);
 
-        assertEquals(locationJson.toString(), mSpyBaseJSInterface.getLocation());
+        assertEquals(locationJson.toString(), spyBaseJSInterface.getLocation());
     }
 
     @Test
     public void whenGetLocationAndLocationNotAvailable_ReturnError() {
-        ManagersResolver.getInstance().prepare(mTestActivity);
+        ManagersResolver.getInstance().prepare(testActivity);
 
-        assertEquals(LOCATION_ERROR, mSpyBaseJSInterface.getLocation());
+        assertEquals(LOCATION_ERROR, spyBaseJSInterface.getLocation());
     }
 
     @Test
     @Config(qualifiers = "land")
     public void whenGetAppOrientation_ReturnAppOrientation() throws JSONException {
-        mTestActivity.setRequestedOrientation(1);
-        ManagersResolver.getInstance().prepare(mTestActivity);
+        testActivity.setRequestedOrientation(1);
+        ManagersResolver.getInstance().prepare(testActivity);
 
         JSONObject appOrientation = new JSONObject();
         appOrientation.put(DEVICE_ORIENTATION, "landscape");
         appOrientation.put(DEVICE_ORIENTATION_LOCKED, true);
 
-        assertEquals(appOrientation.toString(), mSpyBaseJSInterface.getCurrentAppOrientation());
+        assertEquals(appOrientation.toString(), spyBaseJSInterface.getCurrentAppOrientation());
     }
 
     @Test
     public void handleScreenViewabilityChange_ExecuteOnViewableChange() {
-        mSpyBaseJSInterface.handleScreenViewabilityChange(true);
+        spyBaseJSInterface.handleScreenViewabilityChange(true);
 
-        verify(mMockJsExecutor).executeOnViewableChange(true);
+        verify(mockJsExecutor).executeOnViewableChange(true);
     }
 
     @Test
     public void handleScreenViewabilityChangeAndIsViewable_StartVolumeObserver() {
-        mSpyBaseJSInterface.handleScreenViewabilityChange(true);
+        spyBaseJSInterface.handleScreenViewabilityChange(true);
 
-        verify(mMockDeviceVolumeObserver).start();
+        verify(mockDeviceVolumeObserver).start();
     }
 
     @Test
     public void handleScreenViewabilityChangeAndNotViewable_StopVolumeObserver() {
-        mSpyBaseJSInterface.handleScreenViewabilityChange(false);
+        spyBaseJSInterface.handleScreenViewabilityChange(false);
 
-        verify(mMockDeviceVolumeObserver).stop();
+        verify(mockDeviceVolumeObserver).stop();
     }
 
     @Test
     public void handleScreenViewabilityChangeAndNotViewable_ExecuteAudioVolumeChangedNull() {
-        mSpyBaseJSInterface.handleScreenViewabilityChange(false);
+        spyBaseJSInterface.handleScreenViewabilityChange(false);
 
-        verify(mMockJsExecutor).executeAudioVolumeChange(null);
+        verify(mockJsExecutor).executeAudioVolumeChange(null);
     }
 
     @Test
     public void notifyScreenMetrics_UpdateAdStateWithJsExecutor() {
         final MraidScreenMetrics mockScreenMetrics = mock(MraidScreenMetrics.class);
 
-        mSpyBaseJSInterface.notifyScreenMetricsChanged();
+        spyBaseJSInterface.notifyScreenMetricsChanged();
 
-        verify(mMockJsExecutor).executeSetScreenSize(any(Rect.class));
-        assertNotNull(mSpyBaseJSInterface.getScreenMetrics().getCurrentMaxSizeRect());
-        verify(mMockJsExecutor).executeSetCurrentPosition(any(Rect.class));
-        verify(mMockJsExecutor).executeSetDefaultPosition(any(Rect.class));
-        verify(mMockJsExecutor).executeOnSizeChange(any(Rect.class));
+        verify(mockJsExecutor).executeSetScreenSize(any(Rect.class));
+        assertNotNull(spyBaseJSInterface.getScreenMetrics().getCurrentMaxSizeRect());
+        verify(mockJsExecutor).executeSetCurrentPosition(any(Rect.class));
+        verify(mockJsExecutor).executeSetDefaultPosition(any(Rect.class));
+        verify(mockJsExecutor).executeOnSizeChange(any(Rect.class));
     }
 
     @Test
     public void getDefaultPositionNotSet_ReturnNull() {
-        final MraidScreenMetrics screenMetrics = mSpyBaseJSInterface.getScreenMetrics();
-        assertNull(mSpyBaseJSInterface.getScreenMetrics().getDefaultPosition());
+        final MraidScreenMetrics screenMetrics = spyBaseJSInterface.getScreenMetrics();
+        assertNull(spyBaseJSInterface.getScreenMetrics().getDefaultPosition());
     }
 
     @Test
     public void getDefaultPositionAndItWasSet_ReturnSetPosition() {
-        final MraidScreenMetrics screenMetrics = mSpyBaseJSInterface.getScreenMetrics();
+        final MraidScreenMetrics screenMetrics = spyBaseJSInterface.getScreenMetrics();
         Rect rect = new Rect(0, 1, 2, 3);
 
         screenMetrics.setDefaultPosition(rect);

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/views/webview/mraid/InterstitialJSInterfaceTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/views/webview/mraid/InterstitialJSInterfaceTest.java
@@ -33,27 +33,27 @@ import static org.mockito.Mockito.mock;
 @Config(sdk = 19)
 public class InterstitialJSInterfaceTest {
 
-    private InterstitialJSInterface mInterstitialJSInterface;
-    private Context mContext;
-    private WebViewBase mMockWebViewBase;
+    private InterstitialJSInterface interstitialJSInterface;
+    private Context context;
+    private WebViewBase mockWebViewBase;
 
     @Before
     public void setUp() throws Exception {
-        mContext = Robolectric.buildActivity(Activity.class).create().get();
-        mMockWebViewBase = mock(WebViewBase.class);
+        context = Robolectric.buildActivity(Activity.class).create().get();
+        mockWebViewBase = mock(WebViewBase.class);
 
-        mInterstitialJSInterface = new InterstitialJSInterface(mContext, mMockWebViewBase, mock(JsExecutor.class));
+        interstitialJSInterface = new InterstitialJSInterface(context, mockWebViewBase, mock(JsExecutor.class));
     }
 
     @Test
     public void getPlacementTypeTest() {
-        assertEquals("interstitial", mInterstitialJSInterface.getPlacementType());
+        assertEquals("interstitial", interstitialJSInterface.getPlacementType());
     }
 
     @Test
     public void expandTest() {
         //do nothing
-        mInterstitialJSInterface.expand();
+        interstitialJSInterface.expand();
     }
 
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/views/webview/mraid/JsExecutorTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/views/webview/mraid/JsExecutorTest.java
@@ -38,30 +38,30 @@ import static org.mockito.Mockito.*;
 @RunWith(RobolectricTestRunner.class)
 public class JsExecutorTest {
     private static final String TEST_SCRIPT = "test";
-    private JsExecutor mSpyJsExecutor;
+    private JsExecutor spyJsExecutor;
 
-    @Mock WebView mMockWebView;
-    @Mock Handler mMockHandler;
-    @Mock HandlerQueueManager mMockHandlerQueueManager;
+    @Mock WebView mockWebView;
+    @Mock Handler mockHandler;
+    @Mock HandlerQueueManager mockHandlerQueueManager;
 
-    private final MraidVariableContainer mMraidVariableContainer = new MraidVariableContainer();
+    private final MraidVariableContainer mraidVariableContainer = new MraidVariableContainer();
 
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
-        final JsExecutor jsExecutor = new JsExecutor(mMockWebView, mMockHandler, mMockHandlerQueueManager);
-        jsExecutor.setMraidVariableContainer(mMraidVariableContainer);
+        final JsExecutor jsExecutor = new JsExecutor(mockWebView, mockHandler, mockHandlerQueueManager);
+        jsExecutor.setMraidVariableContainer(mraidVariableContainer);
 
-        mSpyJsExecutor = spy(jsExecutor);
+        spyJsExecutor = spy(jsExecutor);
     }
 
     @Test
     public void whenExecuteGetResizeProperties_EvaluateJavaScriptMethodWithResult() {
         Handler handler = mock(Handler.class);
 
-        mSpyJsExecutor.executeGetResizeProperties(handler);
+        spyJsExecutor.executeGetResizeProperties(handler);
 
-        verify(mSpyJsExecutor).evaluateJavaScriptMethodWithResult(eq("getResizeProperties"),
+        verify(spyJsExecutor).evaluateJavaScriptMethodWithResult(eq("getResizeProperties"),
                                                                   eq(handler));
     }
 
@@ -69,9 +69,9 @@ public class JsExecutorTest {
     public void whenExecuteGetExpandProperties_EvaluateJavaScriptMethodWithResult() {
         Handler handler = mock(Handler.class);
 
-        mSpyJsExecutor.executeGetExpandProperties(handler);
+        spyJsExecutor.executeGetExpandProperties(handler);
 
-        verify(mSpyJsExecutor).evaluateJavaScriptMethodWithResult(eq("getExpandProperties"),
+        verify(spyJsExecutor).evaluateJavaScriptMethodWithResult(eq("getExpandProperties"),
                                                                   eq(handler));
     }
 
@@ -79,65 +79,65 @@ public class JsExecutorTest {
     public void whenExecuteSetScreenSize_EvaluateJavaScript() {
         Rect mockRect = getMockRect(101, 102);
 
-        mSpyJsExecutor.executeSetScreenSize(mockRect);
+        spyJsExecutor.executeSetScreenSize(mockRect);
 
-        verify(mSpyJsExecutor).evaluateJavaScript(eq("mraid.setScreenSize(101, 102);"));
+        verify(spyJsExecutor).evaluateJavaScript(eq("mraid.setScreenSize(101, 102);"));
     }
 
     @Test
     public void whenExecuteMaxSize_EvaluateJavaScript() {
         Rect mockRect = getMockRect(103, 106);
 
-        mSpyJsExecutor.executeSetMaxSize(mockRect);
+        spyJsExecutor.executeSetMaxSize(mockRect);
 
-        verify(mSpyJsExecutor).evaluateJavaScript(eq("mraid.setMaxSize(103, 106);"));
+        verify(spyJsExecutor).evaluateJavaScript(eq("mraid.setMaxSize(103, 106);"));
     }
 
     @Test
     public void whenExecuteSetCurrentPosition_EvaluateJavaScript() {
         Rect mockRect = getMockRect(105, 101);
 
-        mSpyJsExecutor.executeSetCurrentPosition(mockRect);
+        spyJsExecutor.executeSetCurrentPosition(mockRect);
 
-        verify(mSpyJsExecutor).evaluateJavaScript(eq("mraid.setCurrentPosition(0, 0, 105, 101);"));
+        verify(spyJsExecutor).evaluateJavaScript(eq("mraid.setCurrentPosition(0, 0, 105, 101);"));
     }
 
     @Test
     public void whenExecuteSetDefaultPosition_EvaluateJavaScript() {
         Rect mockRect = getMockRect(109, 101);
 
-        mSpyJsExecutor.executeSetDefaultPosition(mockRect);
+        spyJsExecutor.executeSetDefaultPosition(mockRect);
 
-        verify(mSpyJsExecutor).evaluateJavaScript(eq("mraid.setDefaultPosition(0, 0, 109, 101);"));
+        verify(spyJsExecutor).evaluateJavaScript(eq("mraid.setDefaultPosition(0, 0, 109, 101);"));
     }
 
     @Test
     public void whenExecuteOnSizeChange_EvaluateJavaScript() {
         Rect mockRect = getMockRect(109, 102);
 
-        mSpyJsExecutor.executeOnSizeChange(mockRect);
+        spyJsExecutor.executeOnSizeChange(mockRect);
 
-        mSpyJsExecutor.evaluateJavaScript(eq("mraid.onSizeChange(109, 102);"));
+        spyJsExecutor.evaluateJavaScript(eq("mraid.onSizeChange(109, 102);"));
     }
 
     @Test
     public void whenExecuteOnViewableChange_EvaluateJavaScript() {
-        mSpyJsExecutor.executeOnViewableChange(false);
-        assertFalse(mMraidVariableContainer.getCurrentViewable());
-        verify(mSpyJsExecutor).evaluateJavaScript("mraid.onViewableChange(false);");
+        spyJsExecutor.executeOnViewableChange(false);
+        assertFalse(mraidVariableContainer.getCurrentViewable());
+        verify(spyJsExecutor).evaluateJavaScript("mraid.onViewableChange(false);");
 
-        mSpyJsExecutor.executeOnViewableChange(true);
-        assertTrue(mMraidVariableContainer.getCurrentViewable());
-        verify(mSpyJsExecutor).evaluateJavaScript("mraid.onViewableChange(true);");
+        spyJsExecutor.executeOnViewableChange(true);
+        assertTrue(mraidVariableContainer.getCurrentViewable());
+        verify(spyJsExecutor).evaluateJavaScript("mraid.onViewableChange(true);");
     }
 
     @Test
     public void whenExecuteAudioVolumeChange_EvaluateMraidScript() {
-        mSpyJsExecutor.executeAudioVolumeChange(100f);
-        verify(mSpyJsExecutor).evaluateMraidScript(eq("mraid.onAudioVolumeChange(100.0);"));
+        spyJsExecutor.executeAudioVolumeChange(100f);
+        verify(spyJsExecutor).evaluateMraidScript(eq("mraid.onAudioVolumeChange(100.0);"));
 
-        mSpyJsExecutor.executeAudioVolumeChange(null);
-        verify(mSpyJsExecutor).evaluateMraidScript(eq("mraid.onAudioVolumeChange(null);"));
+        spyJsExecutor.executeAudioVolumeChange(null);
+        verify(spyJsExecutor).evaluateMraidScript(eq("mraid.onAudioVolumeChange(null);"));
     }
 
     @Test
@@ -145,121 +145,121 @@ public class JsExecutorTest {
         ViewExposure viewExposure = new ViewExposure();
         String expectedString = String.format("mraid.onExposureChange('%1$s');", viewExposure.toString());
 
-        mSpyJsExecutor.executeExposureChange(viewExposure);
+        spyJsExecutor.executeExposureChange(viewExposure);
 
-        assertEquals(viewExposure.toString(), mMraidVariableContainer.getCurrentExposure());
-        verify(mSpyJsExecutor).evaluateMraidScript(expectedString);
+        assertEquals(viewExposure.toString(), mraidVariableContainer.getCurrentExposure());
+        verify(spyJsExecutor).evaluateMraidScript(expectedString);
     }
 
     @Test
     public void whenExecuteOnError_EvaluateJavaScript() {
-        mSpyJsExecutor.executeOnError("message", "action");
-        verify(mSpyJsExecutor).evaluateJavaScript(eq("mraid.onError('message', 'action');"));
+        spyJsExecutor.executeOnError("message", "action");
+        verify(spyJsExecutor).evaluateJavaScript(eq("mraid.onError('message', 'action');"));
     }
 
     @Test
     public void whenExecuteDisabledFlags_EvaluateMraidScript() {
-        mSpyJsExecutor.executeDisabledFlags(TEST_SCRIPT);
-        verify(mSpyJsExecutor).evaluateMraidScript(TEST_SCRIPT);
+        spyJsExecutor.executeDisabledFlags(TEST_SCRIPT);
+        verify(spyJsExecutor).evaluateMraidScript(TEST_SCRIPT);
     }
 
     @Test
     public void whenExecuteOnReadyExpanded_EvaluateMraidScript() {
-        mSpyJsExecutor.executeOnReadyExpanded();
-        assertEquals(JSInterface.STATE_EXPANDED, mMraidVariableContainer.getCurrentState());
-        verify(mSpyJsExecutor).evaluateMraidScript("mraid.onReadyExpanded();");
+        spyJsExecutor.executeOnReadyExpanded();
+        assertEquals(JSInterface.STATE_EXPANDED, mraidVariableContainer.getCurrentState());
+        verify(spyJsExecutor).evaluateMraidScript("mraid.onReadyExpanded();");
     }
 
     @Test
     public void whenExecuteOnReady_EvaluateMraidScript() {
-        mSpyJsExecutor.executeOnReady();
-        assertEquals(JSInterface.STATE_DEFAULT, mMraidVariableContainer.getCurrentState());
-        verify(mSpyJsExecutor).evaluateMraidScript("mraid.onReady();");
+        spyJsExecutor.executeOnReady();
+        assertEquals(JSInterface.STATE_DEFAULT, mraidVariableContainer.getCurrentState());
+        verify(spyJsExecutor).evaluateMraidScript("mraid.onReady();");
     }
 
     @Test
     public void whenExecuteSingleOnStateChange_EvaluateJavaScriptOnce() {
-        mSpyJsExecutor.executeStateChange(JSInterface.STATE_EXPANDED);
+        spyJsExecutor.executeStateChange(JSInterface.STATE_EXPANDED);
 
-        assertEquals(JSInterface.STATE_EXPANDED, mMraidVariableContainer.getCurrentState());
-        verify(mSpyJsExecutor, times(1))
+        assertEquals(JSInterface.STATE_EXPANDED, mraidVariableContainer.getCurrentState());
+        verify(spyJsExecutor, times(1))
             .evaluateMraidScript("mraid.onStateChange('" + JSInterface.STATE_EXPANDED + "');");
     }
 
     @Test
     public void whenExecuteMultipleSameStateChange_EvaluateJavaScriptOnce() {
-        mSpyJsExecutor.executeStateChange(JSInterface.STATE_EXPANDED);
-        mSpyJsExecutor.executeStateChange(JSInterface.STATE_EXPANDED);
+        spyJsExecutor.executeStateChange(JSInterface.STATE_EXPANDED);
+        spyJsExecutor.executeStateChange(JSInterface.STATE_EXPANDED);
 
-        assertEquals(JSInterface.STATE_EXPANDED, mMraidVariableContainer.getCurrentState());
-        verify(mSpyJsExecutor, times(1))
+        assertEquals(JSInterface.STATE_EXPANDED, mraidVariableContainer.getCurrentState());
+        verify(spyJsExecutor, times(1))
             .evaluateMraidScript("mraid.onStateChange('" + JSInterface.STATE_EXPANDED + "');");
     }
 
     @Test
     public void whenExcuteMultipleSameOnViewableStateChange_EvaluateJavaScriptOnce() {
-        mSpyJsExecutor.executeOnViewableChange(true);
-        mSpyJsExecutor.executeOnViewableChange(true);
+        spyJsExecutor.executeOnViewableChange(true);
+        spyJsExecutor.executeOnViewableChange(true);
 
-        verify(mSpyJsExecutor, times(1)).evaluateJavaScript("mraid.onViewableChange(true);");
+        verify(spyJsExecutor, times(1)).evaluateJavaScript("mraid.onViewableChange(true);");
     }
 
     @Test
     public void whenExecuteNativeCallComplete_EvaluateMraidScript() {
-        mSpyJsExecutor.executeNativeCallComplete();
+        spyJsExecutor.executeNativeCallComplete();
 
-        verify(mSpyJsExecutor).evaluateMraidScript("mraid.nativeCallComplete();");
+        verify(spyJsExecutor).evaluateMraidScript("mraid.nativeCallComplete();");
     }
 
     @Test
     public void whenExecuteLoading_ChangeStateVariable() {
-        mSpyJsExecutor.loading();
-        assertEquals(mSpyJsExecutor.getCurrentState(), JSInterface.STATE_LOADING);
+        spyJsExecutor.loading();
+        assertEquals(spyJsExecutor.getCurrentState(), JSInterface.STATE_LOADING);
     }
 
     @Test
     public void whenEvaluateJavaScriptNullWebView_DoNothing() {
-        JsExecutor jsExecutor = spy(new JsExecutor(null, mMockHandler, null));
+        JsExecutor jsExecutor = spy(new JsExecutor(null, mockHandler, null));
 
         jsExecutor.evaluateJavaScript(TEST_SCRIPT);
 
-        verifyNoMoreInteractions(mMockHandler);
+        verifyNoMoreInteractions(mockHandler);
     }
 
     @Test
     public void whenEvaluateJavaScriptValidWebView_PostScriptLoadingRunnableOnHandler() {
-        mSpyJsExecutor.evaluateJavaScript(TEST_SCRIPT);
+        spyJsExecutor.evaluateJavaScript(TEST_SCRIPT);
 
-        verify(mMockHandler).post(any(JsExecutor.EvaluateScriptRunnable.class));
+        verify(mockHandler).post(any(JsExecutor.EvaluateScriptRunnable.class));
     }
 
     @Test
     public void whenSingleEvaluateJavaScriptMethodWithResult_DispatchHandlerMessage() {
-        mSpyJsExecutor.evaluateJavaScriptMethodWithResult(TEST_SCRIPT, mMockHandler);
+        spyJsExecutor.evaluateJavaScriptMethodWithResult(TEST_SCRIPT, mockHandler);
 
-        verify(mMockHandler).dispatchMessage(any(Message.class));
+        verify(mockHandler).dispatchMessage(any(Message.class));
     }
 
     @Test
     public void whenIsMraidEvaluateJavaScriptMethodWithResult_Evaluate() {
-        mSpyJsExecutor.evaluateJavaScriptMethodWithResult(TEST_SCRIPT, mMockHandler);
+        spyJsExecutor.evaluateJavaScriptMethodWithResult(TEST_SCRIPT, mockHandler);
 
-        verify(mMockHandler).dispatchMessage(any(Message.class));
+        verify(mockHandler).dispatchMessage(any(Message.class));
     }
 
     @Test
     public void whenEvaluateMraidScriptWithNullWebView_NoInteractions() {
-        JsExecutor jsExecutor = new JsExecutor(null, mMockHandler, null);
+        JsExecutor jsExecutor = new JsExecutor(null, mockHandler, null);
         jsExecutor.evaluateMraidScript(TEST_SCRIPT);
 
-        verify(mMockHandler, times(0)).post(any(JsExecutor.EvaluateScriptRunnable.class));
+        verify(mockHandler, times(0)).post(any(JsExecutor.EvaluateScriptRunnable.class));
     }
 
     @Test
     public void whenEvaluateMraidScript_postScriptRunnable() {
-        mSpyJsExecutor.evaluateMraidScript(TEST_SCRIPT);
+        spyJsExecutor.evaluateMraidScript(TEST_SCRIPT);
 
-        verify(mMockHandler, times(1)).post(any(JsExecutor.EvaluateScriptRunnable.class));
+        verify(mockHandler, times(1)).post(any(JsExecutor.EvaluateScriptRunnable.class));
     }
 
     private Rect getMockRect(int width, int height) {

--- a/PrebidMobile/PrebidMobile-gamEventHandlers/src/main/java/org/prebid/mobile/eventhandlers/GamBannerEventHandler.java
+++ b/PrebidMobile/PrebidMobile-gamEventHandlers/src/main/java/org/prebid/mobile/eventhandlers/GamBannerEventHandler.java
@@ -39,33 +39,38 @@ import org.prebid.mobile.rendering.bidding.listeners.BannerEventListener;
  * Prebid Rendering SDK via BannerEventListener.
  */
 public class GamBannerEventHandler implements BannerEventHandler, GamAdEventListener {
+
     private static final String TAG = GamBannerEventHandler.class.getSimpleName();
 
     private static final long TIMEOUT_APP_EVENT_MS = 600;
 
-    private final Context mApplicationContext;
-    private final AdSize[] mAdSizes;
-    private final String mGamAdUnitId;
+    private final Context applicationContext;
+    private final AdSize[] adSizes;
+    private final String gamAdUnitId;
 
-    private PublisherAdViewWrapper mRequestBanner;
-    private PublisherAdViewWrapper mProxyBanner;
-    private PublisherAdViewWrapper mEmbeddedBanner;
-    private PublisherAdViewWrapper mRecycledBanner;
+    private PublisherAdViewWrapper requestBanner;
+    private PublisherAdViewWrapper proxyBanner;
+    private PublisherAdViewWrapper embeddedBanner;
+    private PublisherAdViewWrapper recycledBanner;
 
-    private BannerEventListener mBannerEventListener;
-    private Handler mAppEventHandler;
+    private BannerEventListener bannerEventListener;
+    private Handler appEventHandler;
 
-    private boolean mIsExpectingAppEvent;
+    private boolean isExpectingAppEvent;
 
     /**
      * @param context     activity or application context.
      * @param gamAdUnitId GAM AdUnitId.
      * @param adSizes     ad sizes for banner.
      */
-    public GamBannerEventHandler(Context context, String gamAdUnitId, AdSize... adSizes) {
-        mApplicationContext = context.getApplicationContext();
-        mGamAdUnitId = gamAdUnitId;
-        mAdSizes = adSizes;
+    public GamBannerEventHandler(
+            Context context,
+            String gamAdUnitId,
+            AdSize... adSizes
+    ) {
+        applicationContext = context.getApplicationContext();
+        this.gamAdUnitId = gamAdUnitId;
+        this.adSizes = adSizes;
     }
 
     public static AdSize[] convertGamAdSize(com.google.android.gms.ads.AdSize... sizes) {
@@ -89,13 +94,13 @@ public class GamBannerEventHandler implements BannerEventHandler, GamAdEventList
                 handleAppEvent();
                 break;
             case CLOSED:
-                mBannerEventListener.onAdClosed();
+                bannerEventListener.onAdClosed();
                 break;
             case FAILED:
                 handleAdFailure(adEvent.getErrorCode());
                 break;
             case CLICKED:
-                mBannerEventListener.onAdClicked();
+                bannerEventListener.onAdClicked();
                 break;
             case LOADED:
                 primaryAdReceived();
@@ -107,55 +112,54 @@ public class GamBannerEventHandler implements BannerEventHandler, GamAdEventList
     //region ==================== EventHandler Implementation
     @Override
     public AdSize[] getAdSizeArray() {
-        if (mAdSizes == null) {
+        if (adSizes == null) {
             return new AdSize[0];
         }
 
-        return mAdSizes;
+        return adSizes;
     }
 
     @Override
     public void setBannerEventListener(
         @NonNull
             BannerEventListener bannerViewListener) {
-        mBannerEventListener = bannerViewListener;
+        bannerEventListener = bannerViewListener;
     }
 
     @SuppressLint("MissingPermission")
     @Override
     public void requestAdWithBid(Bid bid) {
-        mIsExpectingAppEvent = false;
+        isExpectingAppEvent = false;
 
-        if (mRequestBanner != null) {
+        if (requestBanner != null) {
             LogUtil.error(TAG, "requestAdWithBid: Failed. Request to primaryAdServer is in progress.");
             return;
         }
 
-        if (mRecycledBanner != null) {
-            mRequestBanner = mRecycledBanner;
-            mRecycledBanner = null;
-        }
-        else {
-            mRequestBanner = createPublisherAdView();
+        if (recycledBanner != null) {
+            requestBanner = recycledBanner;
+            recycledBanner = null;
+        } else {
+            requestBanner = createPublisherAdView();
         }
 
         if (bid != null && bid.getPrice() > 0) {
-            mIsExpectingAppEvent = true;
+            isExpectingAppEvent = true;
         }
 
-        if (mRequestBanner == null) {
+        if (requestBanner == null) {
             handleAdFailure(Constants.ERROR_CODE_INTERNAL_ERROR);
             return;
         }
 
-        mRequestBanner.setManualImpressionsEnabled(true);
-        mRequestBanner.loadAd(bid);
+        requestBanner.setManualImpressionsEnabled(true);
+        requestBanner.loadAd(bid);
     }
 
     @Override
     public void trackImpression() {
-        if (mProxyBanner != null) {
-            mProxyBanner.recordManualImpression();
+        if (proxyBanner != null) {
+            proxyBanner.recordManualImpression();
         }
     }
 
@@ -167,12 +171,12 @@ public class GamBannerEventHandler implements BannerEventHandler, GamAdEventList
     //endregion ==================== EventHandler Implementation
 
     private PublisherAdViewWrapper createPublisherAdView() {
-        return PublisherAdViewWrapper.newInstance(mApplicationContext, mGamAdUnitId, this, mAdSizes);
+        return PublisherAdViewWrapper.newInstance(applicationContext, gamAdUnitId, this, adSizes);
     }
 
     private void primaryAdReceived() {
-        if (mIsExpectingAppEvent) {
-            if (mAppEventHandler != null) {
+        if (isExpectingAppEvent) {
+            if (appEventHandler != null) {
                 LogUtil.debug(TAG, "primaryAdReceived: AppEventTimer is not null. Skipping timer scheduling.");
                 return;
             }
@@ -180,52 +184,52 @@ public class GamBannerEventHandler implements BannerEventHandler, GamAdEventList
             scheduleTimer();
         }
         // RequestBanner is null when appEvent was handled before ad was loaded
-        else if (mRequestBanner != null) {
-            PublisherAdViewWrapper gamBannerView = mRequestBanner;
-            mRequestBanner = null;
+        else if (requestBanner != null) {
+            PublisherAdViewWrapper gamBannerView = requestBanner;
+            requestBanner = null;
             recycleCurrentBanner();
-            mEmbeddedBanner = gamBannerView;
-            mBannerEventListener.onAdServerWin(getView(gamBannerView));
+            embeddedBanner = gamBannerView;
+            bannerEventListener.onAdServerWin(getView(gamBannerView));
         }
     }
 
     private void handleAppEvent() {
-        if (!mIsExpectingAppEvent) {
+        if (!isExpectingAppEvent) {
             LogUtil.debug(TAG, "appEventDetected: Skipping event handling. App event is not expected");
             return;
         }
 
         cancelTimer();
-        PublisherAdViewWrapper gamBannerView = mRequestBanner;
-        mRequestBanner = null;
-        mIsExpectingAppEvent = false;
+        PublisherAdViewWrapper gamBannerView = requestBanner;
+        requestBanner = null;
+        isExpectingAppEvent = false;
         recycleCurrentBanner();
-        mProxyBanner = gamBannerView;
-        mBannerEventListener.onPrebidSdkWin();
+        proxyBanner = gamBannerView;
+        bannerEventListener.onPrebidSdkWin();
     }
 
     private void scheduleTimer() {
         cancelTimer();
 
-        mAppEventHandler = new Handler(Looper.getMainLooper());
-        mAppEventHandler.postDelayed(this::handleAppEventTimeout, TIMEOUT_APP_EVENT_MS);
+        appEventHandler = new Handler(Looper.getMainLooper());
+        appEventHandler.postDelayed(this::handleAppEventTimeout, TIMEOUT_APP_EVENT_MS);
     }
 
     private void cancelTimer() {
-        if (mAppEventHandler != null) {
-            mAppEventHandler.removeCallbacksAndMessages(null);
+        if (appEventHandler != null) {
+            appEventHandler.removeCallbacksAndMessages(null);
         }
-        mAppEventHandler = null;
+        appEventHandler = null;
     }
 
     private void handleAppEventTimeout() {
         cancelTimer();
-        PublisherAdViewWrapper gamBannerView = mRequestBanner;
-        mRequestBanner = null;
+        PublisherAdViewWrapper gamBannerView = requestBanner;
+        requestBanner = null;
         recycleCurrentBanner();
-        mEmbeddedBanner = gamBannerView;
-        mIsExpectingAppEvent = false;
-        mBannerEventListener.onAdServerWin(getView(gamBannerView));
+        embeddedBanner = gamBannerView;
+        isExpectingAppEvent = false;
+        bannerEventListener.onAdServerWin(getView(gamBannerView));
     }
 
     private View getView(PublisherAdViewWrapper gamBannerView) {
@@ -233,51 +237,59 @@ public class GamBannerEventHandler implements BannerEventHandler, GamAdEventList
     }
 
     private void handleAdFailure(int errorCode) {
-        mRequestBanner = null;
+        requestBanner = null;
         recycleCurrentBanner();
 
         switch (errorCode) {
             case Constants.ERROR_CODE_INTERNAL_ERROR:
-                mBannerEventListener.onAdFailed(new AdException(AdException.THIRD_PARTY, "GAM SDK encountered an internal error."));
+                bannerEventListener.onAdFailed(new AdException(
+                        AdException.THIRD_PARTY,
+                        "GAM SDK encountered an internal error."
+                ));
                 break;
             case Constants.ERROR_CODE_INVALID_REQUEST:
-                mBannerEventListener.onAdFailed(new AdException(AdException.THIRD_PARTY, "GAM SDK - invalid request error."));
+                bannerEventListener.onAdFailed(new AdException(
+                        AdException.THIRD_PARTY,
+                        "GAM SDK - invalid request error."
+                ));
                 break;
             case Constants.ERROR_CODE_NETWORK_ERROR:
-                mBannerEventListener.onAdFailed(new AdException(AdException.THIRD_PARTY, "GAM SDK - network error."));
+                bannerEventListener.onAdFailed(new AdException(AdException.THIRD_PARTY, "GAM SDK - network error."));
                 break;
             case Constants.ERROR_CODE_NO_FILL:
-                mBannerEventListener.onAdFailed(new AdException(AdException.THIRD_PARTY, "GAM SDK - no fill."));
+                bannerEventListener.onAdFailed(new AdException(AdException.THIRD_PARTY, "GAM SDK - no fill."));
                 break;
             default:
-                mBannerEventListener.onAdFailed(new AdException(AdException.THIRD_PARTY, "GAM SDK - failed with errorCode: " + errorCode));
+                bannerEventListener.onAdFailed(new AdException(
+                        AdException.THIRD_PARTY,
+                        "GAM SDK - failed with errorCode: " + errorCode
+                ));
         }
     }
 
     private void recycleCurrentBanner() {
-        if (mEmbeddedBanner != null) {
-            mRecycledBanner = mEmbeddedBanner;
-            mEmbeddedBanner = null;
-        }
-        else if (mProxyBanner != null) {
-            mRecycledBanner = mProxyBanner;
-            mProxyBanner = null;
-            mRecycledBanner.setManualImpressionsEnabled(false);
+        if (embeddedBanner != null) {
+            recycledBanner = embeddedBanner;
+            embeddedBanner = null;
+        } else if (proxyBanner != null) {
+            recycledBanner = proxyBanner;
+            proxyBanner = null;
+            recycledBanner.setManualImpressionsEnabled(false);
         }
     }
 
     private void destroyGamViews() {
-        if (mRequestBanner != null) {
-            mRequestBanner.destroy();
+        if (requestBanner != null) {
+            requestBanner.destroy();
         }
-        if (mProxyBanner != null) {
-            mProxyBanner.destroy();
+        if (proxyBanner != null) {
+            proxyBanner.destroy();
         }
-        if (mEmbeddedBanner != null) {
-            mEmbeddedBanner.destroy();
+        if (embeddedBanner != null) {
+            embeddedBanner.destroy();
         }
-        if (mRecycledBanner != null) {
-            mRecycledBanner.destroy();
+        if (recycledBanner != null) {
+            recycledBanner.destroy();
         }
     }
 }

--- a/PrebidMobile/PrebidMobile-gamEventHandlers/src/main/java/org/prebid/mobile/eventhandlers/GamInterstitialEventHandler.java
+++ b/PrebidMobile/PrebidMobile-gamEventHandlers/src/main/java/org/prebid/mobile/eventhandlers/GamInterstitialEventHandler.java
@@ -31,24 +31,28 @@ import org.prebid.mobile.rendering.bidding.listeners.InterstitialEventListener;
 import java.lang.ref.WeakReference;
 
 public class GamInterstitialEventHandler implements InterstitialEventHandler, GamAdEventListener {
+
     private static final String TAG = GamInterstitialEventHandler.class.getSimpleName();
 
     private static final long TIMEOUT_APP_EVENT_MS = 600;
 
-    private PublisherInterstitialAdWrapper mRequestInterstitial;
+    private PublisherInterstitialAdWrapper requestInterstitial;
 
-    private final WeakReference<Activity> mActivityWeakReference;
-    private final String mGamAdUnitId;
+    private final WeakReference<Activity> activityWeakReference;
+    private final String gamAdUnitId;
 
-    private InterstitialEventListener mInterstitialEventListener;
-    private Handler mAppEventHandler;
+    private InterstitialEventListener interstitialEventListener;
+    private Handler appEventHandler;
 
-    private boolean mIsExpectingAppEvent;
-    private boolean mDidNotifiedBidWin;
+    private boolean isExpectingAppEvent;
+    private boolean didNotifiedBidWin;
 
-    public GamInterstitialEventHandler(Activity activity, String gamAdUnitId) {
-        mActivityWeakReference = new WeakReference<>(activity);
-        mGamAdUnitId = gamAdUnitId;
+    public GamInterstitialEventHandler(
+            Activity activity,
+            String gamAdUnitId
+    ) {
+        activityWeakReference = new WeakReference<>(activity);
+        this.gamAdUnitId = gamAdUnitId;
     }
 
     //region ==================== GAM AppEventsListener Implementation
@@ -59,13 +63,13 @@ public class GamInterstitialEventHandler implements InterstitialEventHandler, Ga
                 handleAppEvent();
                 break;
             case CLOSED:
-                mInterstitialEventListener.onAdClosed();
+                interstitialEventListener.onAdClosed();
                 break;
             case FAILED:
                 handleAdFailure(adEvent.getErrorCode());
                 break;
             case DISPLAYED:
-                mInterstitialEventListener.onAdDisplayed();
+                interstitialEventListener.onAdDisplayed();
                 break;
             case LOADED:
                 primaryAdReceived();
@@ -77,11 +81,13 @@ public class GamInterstitialEventHandler implements InterstitialEventHandler, Ga
     //region ==================== EventHandler Implementation
     @Override
     public void show() {
-        if (mRequestInterstitial != null && mRequestInterstitial.isLoaded()) {
-            mRequestInterstitial.show();
-        }
-        else {
-            mInterstitialEventListener.onAdFailed(new AdException(AdException.THIRD_PARTY, "GAM SDK - failed to display ad."));
+        if (requestInterstitial != null && requestInterstitial.isLoaded()) {
+            requestInterstitial.show();
+        } else {
+            interstitialEventListener.onAdFailed(new AdException(
+                    AdException.THIRD_PARTY,
+                    "GAM SDK - failed to display ad."
+            ));
         }
     }
 
@@ -89,27 +95,27 @@ public class GamInterstitialEventHandler implements InterstitialEventHandler, Ga
     public void setInterstitialEventListener(
         @NonNull
             InterstitialEventListener interstitialEventListener) {
-        mInterstitialEventListener = interstitialEventListener;
+        this.interstitialEventListener = interstitialEventListener;
     }
 
     @SuppressLint("MissingPermission")
     @Override
     public void requestAdWithBid(Bid bid) {
-        mIsExpectingAppEvent = false;
-        mDidNotifiedBidWin = false;
+        isExpectingAppEvent = false;
+        didNotifiedBidWin = false;
 
         initPublisherInterstitialAd();
 
         if (bid != null && bid.getPrice() > 0) {
-            mIsExpectingAppEvent = true;
+            isExpectingAppEvent = true;
         }
 
-        if (mRequestInterstitial == null) {
+        if (requestInterstitial == null) {
             handleAdFailure(Constants.ERROR_CODE_INTERNAL_ERROR);
             return;
         }
 
-        mRequestInterstitial.loadAd(bid);
+        requestInterstitial.loadAd(bid);
     }
 
     @Override
@@ -124,75 +130,90 @@ public class GamInterstitialEventHandler implements InterstitialEventHandler, Ga
     //endregion ==================== EventHandler Implementation
 
     private void initPublisherInterstitialAd() {
-        if (mRequestInterstitial != null) {
-            mRequestInterstitial = null;
+        if (requestInterstitial != null) {
+            requestInterstitial = null;
         }
 
-        mRequestInterstitial = PublisherInterstitialAdWrapper.newInstance(mActivityWeakReference.get(), mGamAdUnitId, this);
+        requestInterstitial = PublisherInterstitialAdWrapper.newInstance(
+                activityWeakReference.get(),
+                gamAdUnitId,
+                this
+        );
     }
 
     private void primaryAdReceived() {
-        if (mIsExpectingAppEvent) {
-            if (mAppEventHandler != null) {
+        if (isExpectingAppEvent) {
+            if (appEventHandler != null) {
                 LogUtil.debug(TAG, "primaryAdReceived: AppEventTimer is not null. Skipping timer scheduling.");
                 return;
             }
 
             scheduleTimer();
-        }
-        else if (!mDidNotifiedBidWin) {
-            mInterstitialEventListener.onAdServerWin();
+        } else if (!didNotifiedBidWin) {
+            interstitialEventListener.onAdServerWin();
         }
     }
 
     private void handleAppEvent() {
-        if (!mIsExpectingAppEvent) {
+        if (!isExpectingAppEvent) {
             LogUtil.debug(TAG, "appEventDetected: Skipping event handling. App event is not expected");
             return;
         }
 
         cancelTimer();
-        mIsExpectingAppEvent = false;
-        mDidNotifiedBidWin = true;
-        mInterstitialEventListener.onPrebidSdkWin();
+        isExpectingAppEvent = false;
+        didNotifiedBidWin = true;
+        interstitialEventListener.onPrebidSdkWin();
     }
 
     private void scheduleTimer() {
         cancelTimer();
 
-        mAppEventHandler = new Handler(Looper.getMainLooper());
-        mAppEventHandler.postDelayed(this::handleAppEventTimeout, TIMEOUT_APP_EVENT_MS);
+        appEventHandler = new Handler(Looper.getMainLooper());
+        appEventHandler.postDelayed(this::handleAppEventTimeout, TIMEOUT_APP_EVENT_MS);
     }
 
     private void cancelTimer() {
-        if (mAppEventHandler != null) {
-            mAppEventHandler.removeCallbacksAndMessages(null);
+        if (appEventHandler != null) {
+            appEventHandler.removeCallbacksAndMessages(null);
         }
-        mAppEventHandler = null;
+        appEventHandler = null;
     }
 
     private void handleAppEventTimeout() {
         cancelTimer();
-        mIsExpectingAppEvent = false;
-        mInterstitialEventListener.onAdServerWin();
+        isExpectingAppEvent = false;
+        interstitialEventListener.onAdServerWin();
     }
 
     private void handleAdFailure(int errorCode) {
         switch (errorCode) {
             case Constants.ERROR_CODE_INTERNAL_ERROR:
-                mInterstitialEventListener.onAdFailed(new AdException(AdException.THIRD_PARTY, "GAM SDK encountered an internal error."));
+                interstitialEventListener.onAdFailed(new AdException(
+                        AdException.THIRD_PARTY,
+                        "GAM SDK encountered an internal error."
+                ));
                 break;
             case Constants.ERROR_CODE_INVALID_REQUEST:
-                mInterstitialEventListener.onAdFailed(new AdException(AdException.THIRD_PARTY, "GAM SDK - invalid request error."));
+                interstitialEventListener.onAdFailed(new AdException(
+                        AdException.THIRD_PARTY,
+                        "GAM SDK - invalid request error."
+                ));
                 break;
             case Constants.ERROR_CODE_NETWORK_ERROR:
-                mInterstitialEventListener.onAdFailed(new AdException(AdException.THIRD_PARTY, "GAM SDK - network error."));
+                interstitialEventListener.onAdFailed(new AdException(
+                        AdException.THIRD_PARTY,
+                        "GAM SDK - network error."
+                ));
                 break;
             case Constants.ERROR_CODE_NO_FILL:
-                mInterstitialEventListener.onAdFailed(new AdException(AdException.THIRD_PARTY, "GAM SDK - no fill."));
+                interstitialEventListener.onAdFailed(new AdException(AdException.THIRD_PARTY, "GAM SDK - no fill."));
                 break;
             default:
-                mInterstitialEventListener.onAdFailed(new AdException(AdException.THIRD_PARTY, "GAM SDK - failed with errorCode: " + errorCode));
+                interstitialEventListener.onAdFailed(new AdException(
+                        AdException.THIRD_PARTY,
+                        "GAM SDK - failed with errorCode: " + errorCode
+                ));
         }
     }
 }

--- a/PrebidMobile/PrebidMobile-gamEventHandlers/src/main/java/org/prebid/mobile/eventhandlers/GamRewardedEventHandler.java
+++ b/PrebidMobile/PrebidMobile-gamEventHandlers/src/main/java/org/prebid/mobile/eventhandlers/GamRewardedEventHandler.java
@@ -32,23 +32,27 @@ import org.prebid.mobile.rendering.bidding.listeners.RewardedVideoEventListener;
 import java.lang.ref.WeakReference;
 
 public class GamRewardedEventHandler implements RewardedEventHandler, GamAdEventListener {
+
     private static final String TAG = GamRewardedEventHandler.class.getSimpleName();
     private static final long TIMEOUT_APP_EVENT_MS = 600;
 
-    private RewardedAdWrapper mRewardedAd;
+    private RewardedAdWrapper rewardedAd;
 
-    private final WeakReference<Activity> mActivityWeakReference;
-    private final String mGamAdUnitId;
+    private final WeakReference<Activity> activityWeakReference;
+    private final String gamAdUnitId;
 
-    private RewardedVideoEventListener mListener;
-    private Handler mAppEventHandler;
+    private RewardedVideoEventListener listener;
+    private Handler appEventHandler;
 
-    private boolean mIsExpectingAppEvent;
-    private boolean mDidNotifiedBidWin;
+    private boolean isExpectingAppEvent;
+    private boolean didNotifiedBidWin;
 
-    public GamRewardedEventHandler(Activity activity, String gamAdUnitId) {
-        mActivityWeakReference = new WeakReference<>(activity);
-        mGamAdUnitId = gamAdUnitId;
+    public GamRewardedEventHandler(
+            Activity activity,
+            String gamAdUnitId
+    ) {
+        activityWeakReference = new WeakReference<>(activity);
+        this.gamAdUnitId = gamAdUnitId;
     }
 
     //region ==================== EventListener Implementation
@@ -62,16 +66,16 @@ public class GamRewardedEventHandler implements RewardedEventHandler, GamAdEvent
                 primaryAdReceived();
                 break;
             case DISPLAYED:
-                mListener.onAdDisplayed();
+                listener.onAdDisplayed();
                 break;
             case CLOSED:
-                mListener.onAdClosed();
+                listener.onAdClosed();
                 break;
             case FAILED:
                 notifyErrorListener(adEvent.getErrorCode());
                 break;
             case REWARD_EARNED:
-                mListener.onUserEarnedReward();
+                listener.onUserEarnedReward();
                 break;
         }
     }
@@ -82,7 +86,7 @@ public class GamRewardedEventHandler implements RewardedEventHandler, GamAdEvent
     public void setRewardedEventListener(
         @NonNull
             RewardedVideoEventListener listener) {
-        mListener = listener;
+        this.listener = listener;
     }
 
     @SuppressLint("MissingPermission")
@@ -90,30 +94,29 @@ public class GamRewardedEventHandler implements RewardedEventHandler, GamAdEvent
     public void requestAdWithBid(
         @Nullable
             Bid bid) {
-        mIsExpectingAppEvent = false;
-        mDidNotifiedBidWin = false;
+        isExpectingAppEvent = false;
+        didNotifiedBidWin = false;
 
         initPublisherRewardedAd();
 
         if (bid != null && bid.getPrice() > 0) {
-            mIsExpectingAppEvent = true;
+            isExpectingAppEvent = true;
         }
 
-        if (mRewardedAd == null) {
+        if (rewardedAd == null) {
             notifyErrorListener(Constants.ERROR_CODE_INTERNAL_ERROR);
             return;
         }
 
-        mRewardedAd.loadAd(bid);
+        rewardedAd.loadAd(bid);
     }
 
     @Override
     public void show() {
-        if (mRewardedAd != null && mRewardedAd.isLoaded()) {
-            mRewardedAd.show(mActivityWeakReference.get());
-        }
-        else {
-            mListener.onAdFailed(new AdException(AdException.THIRD_PARTY, "GAM SDK - failed to display ad."));
+        if (rewardedAd != null && rewardedAd.isLoaded()) {
+            rewardedAd.show(activityWeakReference.get());
+        } else {
+            listener.onAdFailed(new AdException(AdException.THIRD_PARTY, "GAM SDK - failed to display ad."));
         }
     }
 
@@ -129,75 +132,77 @@ public class GamRewardedEventHandler implements RewardedEventHandler, GamAdEvent
     //endregion ==================== EventHandler Implementation
 
     private void initPublisherRewardedAd() {
-        mRewardedAd = RewardedAdWrapper.newInstance(mActivityWeakReference.get(), mGamAdUnitId, this);
+        rewardedAd = RewardedAdWrapper.newInstance(activityWeakReference.get(), gamAdUnitId, this);
     }
 
     private void primaryAdReceived() {
-        if (mIsExpectingAppEvent) {
-            if (mAppEventHandler != null) {
+        if (isExpectingAppEvent) {
+            if (appEventHandler != null) {
                 LogUtil.debug(TAG, "primaryAdReceived: AppEventTimer is not null. Skipping timer scheduling.");
                 return;
             }
 
             scheduleTimer();
-        }
-        else if (!mDidNotifiedBidWin) {
-            mListener.onAdServerWin(getRewardItem());
+        } else if (!didNotifiedBidWin) {
+            listener.onAdServerWin(getRewardItem());
         }
     }
 
     private void handleAppEvent() {
-        if (!mIsExpectingAppEvent) {
+        if (!isExpectingAppEvent) {
             LogUtil.debug(TAG, "appEventDetected: Skipping event handling. App event is not expected");
             return;
         }
 
         cancelTimer();
-        mIsExpectingAppEvent = false;
-        mDidNotifiedBidWin = true;
-        mListener.onPrebidSdkWin();
+        isExpectingAppEvent = false;
+        didNotifiedBidWin = true;
+        listener.onPrebidSdkWin();
     }
 
     private void scheduleTimer() {
         cancelTimer();
 
-        mAppEventHandler = new Handler(Looper.getMainLooper());
-        mAppEventHandler.postDelayed(this::handleAppEventTimeout, TIMEOUT_APP_EVENT_MS);
+        appEventHandler = new Handler(Looper.getMainLooper());
+        appEventHandler.postDelayed(this::handleAppEventTimeout, TIMEOUT_APP_EVENT_MS);
     }
 
     private void cancelTimer() {
-        if (mAppEventHandler != null) {
-            mAppEventHandler.removeCallbacksAndMessages(null);
+        if (appEventHandler != null) {
+            appEventHandler.removeCallbacksAndMessages(null);
         }
-        mAppEventHandler = null;
+        appEventHandler = null;
     }
 
     private void handleAppEventTimeout() {
         cancelTimer();
-        mIsExpectingAppEvent = false;
-        mListener.onAdServerWin(getRewardItem());
+        isExpectingAppEvent = false;
+        listener.onAdServerWin(getRewardItem());
     }
 
     private Object getRewardItem() {
-        return mRewardedAd != null ? mRewardedAd.getRewardItem() : null;
+        return rewardedAd != null ? rewardedAd.getRewardItem() : null;
     }
 
     private void notifyErrorListener(int errorCode) {
         switch (errorCode) {
             case Constants.ERROR_CODE_INTERNAL_ERROR:
-                mListener.onAdFailed(new AdException(AdException.THIRD_PARTY, "GAM SDK encountered an internal error."));
+                listener.onAdFailed(new AdException(AdException.THIRD_PARTY, "GAM SDK encountered an internal error."));
                 break;
             case Constants.ERROR_CODE_INVALID_REQUEST:
-                mListener.onAdFailed(new AdException(AdException.THIRD_PARTY, "GAM SDK - invalid request error."));
+                listener.onAdFailed(new AdException(AdException.THIRD_PARTY, "GAM SDK - invalid request error."));
                 break;
             case Constants.ERROR_CODE_NETWORK_ERROR:
-                mListener.onAdFailed(new AdException(AdException.THIRD_PARTY, "GAM SDK - network error."));
+                listener.onAdFailed(new AdException(AdException.THIRD_PARTY, "GAM SDK - network error."));
                 break;
             case Constants.ERROR_CODE_NO_FILL:
-                mListener.onAdFailed(new AdException(AdException.THIRD_PARTY, "GAM SDK - no fill."));
+                listener.onAdFailed(new AdException(AdException.THIRD_PARTY, "GAM SDK - no fill."));
                 break;
             default:
-                mListener.onAdFailed(new AdException(AdException.THIRD_PARTY, "GAM SDK - failed with errorCode: " + errorCode));
+                listener.onAdFailed(new AdException(
+                        AdException.THIRD_PARTY,
+                        "GAM SDK - failed with errorCode: " + errorCode
+                ));
         }
     }
 }

--- a/PrebidMobile/PrebidMobile-gamEventHandlers/src/main/java/org/prebid/mobile/eventhandlers/PublisherAdViewWrapper.java
+++ b/PrebidMobile/PrebidMobile-gamEventHandlers/src/main/java/org/prebid/mobile/eventhandlers/PublisherAdViewWrapper.java
@@ -44,19 +44,23 @@ public class PublisherAdViewWrapper extends AdListener implements AppEventListen
 
     private static final String TAG = PublisherAdViewWrapper.class.getSimpleName();
 
-    private final AdManagerAdView mAdView;
-    private final GamAdEventListener mListener;
+    private final AdManagerAdView adView;
+    private final GamAdEventListener listener;
 
-    private PublisherAdViewWrapper(Context context, String gamAdUnit,
-                                   GamAdEventListener eventListener, AdSize... adSizes) {
-        mListener = eventListener;
+    private PublisherAdViewWrapper(
+            Context context,
+            String gamAdUnit,
+            GamAdEventListener eventListener,
+            AdSize... adSizes
+    ) {
+        listener = eventListener;
 
-        mAdView = new AdManagerAdView(context);
-        mAdView.setAdSizes(mapToGamAdSizes(adSizes));
-        mAdView.setAdUnitId(gamAdUnit);
-        mAdView.setAdListener(this);
-        mAdView.setAppEventListener(this);
-        mAdView.setAdListener(this);
+        adView = new AdManagerAdView(context);
+        adView.setAdSizes(mapToGamAdSizes(adSizes));
+        adView.setAdUnitId(gamAdUnit);
+        adView.setAdListener(this);
+        adView.setAppEventListener(this);
+        adView.setAdListener(this);
     }
 
     @Nullable
@@ -82,7 +86,7 @@ public class PublisherAdViewWrapper extends AdListener implements AppEventListen
         @NonNull
             String info) {
         if (Constants.APP_EVENT.equals(name)) {
-            mListener.onEvent(AdEvent.APP_EVENT_RECEIVED);
+            listener.onEvent(AdEvent.APP_EVENT_RECEIVED);
         }
     }
     //endregion ==================== GAM AppEventsListener Implementation
@@ -90,7 +94,7 @@ public class PublisherAdViewWrapper extends AdListener implements AppEventListen
     //region ==================== GAM AdEventListener Implementation
     @Override
     public void onAdClosed() {
-        mListener.onEvent(AdEvent.CLOSED);
+        listener.onEvent(AdEvent.CLOSED);
     }
 
     @Override
@@ -100,17 +104,17 @@ public class PublisherAdViewWrapper extends AdListener implements AppEventListen
         final AdEvent adEvent = AdEvent.FAILED;
         adEvent.setErrorCode(loadAdError.getCode());
 
-        mListener.onEvent(adEvent);
+        listener.onEvent(adEvent);
     }
 
     @Override
     public void onAdOpened() {
-        mListener.onEvent(AdEvent.CLICKED);
+        listener.onEvent(AdEvent.CLICKED);
     }
 
     @Override
     public void onAdLoaded() {
-        mListener.onEvent(AdEvent.LOADED);
+        listener.onEvent(AdEvent.LOADED);
     }
     //endregion ==================== GAM AdEventListener Implementation
 
@@ -123,7 +127,7 @@ public class PublisherAdViewWrapper extends AdListener implements AppEventListen
                 GamUtils.handleGamCustomTargetingUpdate(adRequest, targetingMap);
             }
 
-            mAdView.loadAd(adRequest);
+            adView.loadAd(adRequest);
         }
         catch (Throwable throwable) {
             LogUtil.error(TAG, Log.getStackTraceString(throwable));
@@ -132,7 +136,7 @@ public class PublisherAdViewWrapper extends AdListener implements AppEventListen
 
     public void setManualImpressionsEnabled(boolean enabled) {
         try {
-            mAdView.setManualImpressionsEnabled(enabled);
+            adView.setManualImpressionsEnabled(enabled);
         }
         catch (Throwable throwable) {
             LogUtil.error(TAG, Log.getStackTraceString(throwable));
@@ -141,7 +145,7 @@ public class PublisherAdViewWrapper extends AdListener implements AppEventListen
 
     public void recordManualImpression() {
         try {
-            mAdView.recordManualImpression();
+            adView.recordManualImpression();
         }
         catch (Throwable throwable) {
             LogUtil.error(TAG, Log.getStackTraceString(throwable));
@@ -150,7 +154,7 @@ public class PublisherAdViewWrapper extends AdListener implements AppEventListen
 
     public void destroy() {
         try {
-            mAdView.destroy();
+            adView.destroy();
         }
         catch (Throwable throwable) {
             LogUtil.error(TAG, Log.getStackTraceString(throwable));
@@ -158,7 +162,7 @@ public class PublisherAdViewWrapper extends AdListener implements AppEventListen
     }
 
     public View getView() {
-        return mAdView;
+        return adView;
     }
 
     private com.google.android.gms.ads.AdSize[] mapToGamAdSizes(AdSize[] adSizes) {

--- a/PrebidMobile/PrebidMobile-gamEventHandlers/src/test/java/org/prebid/mobile/eventhandlers/GamBannerEventHandlerTest.java
+++ b/PrebidMobile/PrebidMobile-gamEventHandlers/src/test/java/org/prebid/mobile/eventhandlers/GamBannerEventHandlerTest.java
@@ -45,13 +45,14 @@ import static org.mockito.Mockito.*;
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 21)
 public class GamBannerEventHandlerTest {
+
     private static final String GAM_AD_UNIT_ID = "12345678";
-    private static final AdSize GAM_AD_SIZE = new AdSize(350 ,50);
+    private static final AdSize GAM_AD_SIZE = new AdSize(350, 50);
 
-    private GamBannerEventHandler mBannerEventHandler;
+    private GamBannerEventHandler bannerEventHandler;
 
-    @Mock private BannerEventListener mMockBannerEventListener;
-    @Mock private Handler mMockAppEventHandler;
+    @Mock private BannerEventListener mockBannerEventListener;
+    @Mock private Handler mockAppEventHandler;
 
     @Before
     public void setup() {
@@ -59,25 +60,25 @@ public class GamBannerEventHandlerTest {
 
         Context context = Robolectric.buildActivity(Activity.class).get();
 
-        mBannerEventHandler = new GamBannerEventHandler(context, GAM_AD_UNIT_ID, GAM_AD_SIZE);
-        mBannerEventHandler.setBannerEventListener(mMockBannerEventListener);
+        bannerEventHandler = new GamBannerEventHandler(context, GAM_AD_UNIT_ID, GAM_AD_SIZE);
+        bannerEventHandler.setBannerEventListener(mockBannerEventListener);
     }
 
     @Test
     public void onAppEventWithValidNameAndExpectedAppEvent_HandleAppEvent() {
         changeExpectingAppEventStatus(true);
 
-        mBannerEventHandler.onEvent(AdEvent.APP_EVENT_RECEIVED);
+        bannerEventHandler.onEvent(AdEvent.APP_EVENT_RECEIVED);
 
-        verify(mMockBannerEventListener, times(1)).onPrebidSdkWin();
+        verify(mockBannerEventListener, times(1)).onPrebidSdkWin();
         assertFalse(getExpectingAppEventStatus());
     }
 
     @Test
     public void onGamAdClosed_NotifyBannerEventCloseListener() {
-        mBannerEventHandler.onEvent(AdEvent.CLOSED);
+        bannerEventHandler.onEvent(AdEvent.CLOSED);
 
-        verify(mMockBannerEventListener, times(1)).onAdClosed();
+        verify(mockBannerEventListener, times(1)).onAdClosed();
     }
 
     @Test
@@ -87,25 +88,25 @@ public class GamBannerEventHandlerTest {
         for (int i = 0; i < wantedNumberOfInvocations; i++) {
             final AdEvent adEvent = AdEvent.FAILED;
             adEvent.setErrorCode(i);
-            mBannerEventHandler.onEvent(adEvent);
+            bannerEventHandler.onEvent(adEvent);
         }
-        verify(mMockBannerEventListener, times(wantedNumberOfInvocations)).onAdFailed(any(AdException.class));
+        verify(mockBannerEventListener, times(wantedNumberOfInvocations)).onAdFailed(any(AdException.class));
     }
 
     @Test
     public void onGamAdOpened_NotifyBannerEventClickedListener() {
-        mBannerEventHandler.onEvent(AdEvent.CLICKED);
+        bannerEventHandler.onEvent(AdEvent.CLICKED);
 
-        verify(mMockBannerEventListener, times(1)).onAdClicked();
+        verify(mockBannerEventListener, times(1)).onAdClicked();
     }
 
     @Test
     public void onGamAdLoadedAppEventExpected_ScheduleAppEventHandler() {
         changeExpectingAppEventStatus(true);
 
-        mBannerEventHandler.onEvent(AdEvent.LOADED);
+        bannerEventHandler.onEvent(AdEvent.LOADED);
 
-        assertNotNull(WhiteBox.getInternalState(mBannerEventHandler, "mAppEventHandler"));
+        assertNotNull(WhiteBox.getInternalState(bannerEventHandler, "appEventHandler"));
     }
 
     @Test
@@ -116,28 +117,28 @@ public class GamBannerEventHandlerTest {
         final View mockView = mock(View.class);
         when(mockPublisherAdView.getView()).thenReturn(mockView);
 
-        WhiteBox.field(GamBannerEventHandler.class, "mRequestBanner").set(mBannerEventHandler, mockPublisherAdView);
+        WhiteBox.field(GamBannerEventHandler.class, "requestBanner").set(bannerEventHandler, mockPublisherAdView);
 
-        mBannerEventHandler.onEvent(AdEvent.LOADED);
+        bannerEventHandler.onEvent(AdEvent.LOADED);
 
-        verify(mMockBannerEventListener, times(1)).onAdServerWin(eq(mockView));
+        verify(mockBannerEventListener, times(1)).onAdServerWin(eq(mockView));
     }
 
     @Test
     public void onAppEventTimeout_NotifyBannerEventOnAdServerWin() throws Exception {
-        WhiteBox.method(GamBannerEventHandler.class, "handleAppEventTimeout").invoke(mBannerEventHandler);
+        WhiteBox.method(GamBannerEventHandler.class, "handleAppEventTimeout").invoke(bannerEventHandler);
 
-        verify(mMockBannerEventListener, times(1)).onAdServerWin(any());
+        verify(mockBannerEventListener, times(1)).onAdServerWin(any());
     }
 
     @Test
     public void destroy_CancelTimer() throws IllegalAccessException {
         // by default apEventHandler is null if not scheduled
-        WhiteBox.field(GamBannerEventHandler.class, "mAppEventHandler").set(mBannerEventHandler, mMockAppEventHandler);
+        WhiteBox.field(GamBannerEventHandler.class, "appEventHandler").set(bannerEventHandler, mockAppEventHandler);
 
-        mBannerEventHandler.destroy();
+        bannerEventHandler.destroy();
 
-        verify(mMockAppEventHandler, times(1)).removeCallbacksAndMessages(null);
+        verify(mockAppEventHandler, times(1)).removeCallbacksAndMessages(null);
     }
 
     @Test
@@ -148,14 +149,14 @@ public class GamBannerEventHandlerTest {
 
         when(mockBid.getPrebid()).thenReturn(mockPrebid);
         when(mockBid.getPrice()).thenReturn(0.2);
-        mBannerEventHandler.requestAdWithBid(mockBid);
+        bannerEventHandler.requestAdWithBid(mockBid);
         assertTrue(getExpectingAppEventStatus());
 
         when(mockBid.getPrice()).thenReturn(0.0);
-        mBannerEventHandler.requestAdWithBid(mockBid);
+        bannerEventHandler.requestAdWithBid(mockBid);
         assertFalse(getExpectingAppEventStatus());
 
-        mBannerEventHandler.requestAdWithBid(null);
+        bannerEventHandler.requestAdWithBid(null);
         assertFalse(getExpectingAppEventStatus());
     }
 
@@ -176,10 +177,10 @@ public class GamBannerEventHandlerTest {
     }
 
     private void changeExpectingAppEventStatus(boolean status) {
-        WhiteBox.setInternalState(mBannerEventHandler, "mIsExpectingAppEvent", status);
+        WhiteBox.setInternalState(bannerEventHandler, "isExpectingAppEvent", status);
     }
 
     private boolean getExpectingAppEventStatus() {
-        return WhiteBox.getInternalState(mBannerEventHandler, "mIsExpectingAppEvent");
+        return WhiteBox.getInternalState(bannerEventHandler, "isExpectingAppEvent");
     }
 }

--- a/PrebidMobile/PrebidMobile-gamEventHandlers/src/test/java/org/prebid/mobile/eventhandlers/GamInterstitialEventHandlerTest.java
+++ b/PrebidMobile/PrebidMobile-gamEventHandlers/src/test/java/org/prebid/mobile/eventhandlers/GamInterstitialEventHandlerTest.java
@@ -43,12 +43,10 @@ import static org.mockito.Mockito.*;
 public class GamInterstitialEventHandlerTest {
     private static final String GAM_AD_UNIT_ID = "12345678";
 
-    private GamInterstitialEventHandler mEventHandler;
+    private GamInterstitialEventHandler eventHandler;
 
-    @Mock
-    private InterstitialEventListener mMockEventListener;
-    @Mock
-    private Handler mMockAppEventHandler;
+    @Mock private InterstitialEventListener mockEventListener;
+    @Mock private Handler mockAppEventHandler;
 
     @Before
     public void setup() {
@@ -56,25 +54,25 @@ public class GamInterstitialEventHandlerTest {
 
         Activity activity = Robolectric.buildActivity(Activity.class).get();
 
-        mEventHandler = new GamInterstitialEventHandler(activity, GAM_AD_UNIT_ID);
-        mEventHandler.setInterstitialEventListener(mMockEventListener);
+        eventHandler = new GamInterstitialEventHandler(activity, GAM_AD_UNIT_ID);
+        eventHandler.setInterstitialEventListener(mockEventListener);
     }
 
     @Test
     public void onAppEventWithValidNameAndExpectedAppEvent_HandleAppEvent() {
         changeExpectingAppEventStatus(true);
 
-        mEventHandler.onEvent(AdEvent.APP_EVENT_RECEIVED);
+        eventHandler.onEvent(AdEvent.APP_EVENT_RECEIVED);
 
-        verify(mMockEventListener, times(1)).onPrebidSdkWin();
+        verify(mockEventListener, times(1)).onPrebidSdkWin();
         assertFalse(getExpectingAppEventStatus());
     }
 
     @Test
     public void onGamAdClosed_NotifyEventCloseListener() {
-        mEventHandler.onEvent(AdEvent.CLOSED);
+        eventHandler.onEvent(AdEvent.CLOSED);
 
-        verify(mMockEventListener, times(1)).onAdClosed();
+        verify(mockEventListener, times(1)).onAdClosed();
     }
 
     @Test
@@ -84,55 +82,54 @@ public class GamInterstitialEventHandlerTest {
         for (int i = 0; i < wantedNumberOfInvocations; i++) {
             final AdEvent adEvent = AdEvent.FAILED;
             adEvent.setErrorCode(i);
-            mEventHandler.onEvent(adEvent);
+            eventHandler.onEvent(adEvent);
         }
-        verify(mMockEventListener, times(wantedNumberOfInvocations)).onAdFailed(any(AdException.class));
+        verify(mockEventListener, times(wantedNumberOfInvocations)).onAdFailed(any(AdException.class));
     }
 
     @Test
     public void onGamAdOpened_NotifyBannerEventDisplayListener() {
-        mEventHandler.onEvent(AdEvent.DISPLAYED);
+        eventHandler.onEvent(AdEvent.DISPLAYED);
 
-        verify(mMockEventListener, times(1)).onAdDisplayed();
+        verify(mockEventListener, times(1)).onAdDisplayed();
     }
 
     @Test
     public void onGamAdLoadedAppEventExpected_ScheduleAppEventHandler() {
         changeExpectingAppEventStatus(true);
 
-        mEventHandler.onEvent(AdEvent.LOADED);
+        eventHandler.onEvent(AdEvent.LOADED);
 
-        assertNotNull(WhiteBox.getInternalState(mEventHandler, "mAppEventHandler"));
+        assertNotNull(WhiteBox.getInternalState(eventHandler, "appEventHandler"));
     }
 
     @Test
     public void onGamAdLoadedAppEventNotExpectedAndRequestInterstitialNotNull_NotifyEventListenerOnAdServerWin()
     throws Exception {
         PublisherInterstitialAdWrapper publisherInterstitialAd = mock(PublisherInterstitialAdWrapper.class);
-        WhiteBox.field(GamInterstitialEventHandler.class, "mRequestInterstitial")
-                .set(mEventHandler, publisherInterstitialAd);
+        WhiteBox.field(GamInterstitialEventHandler.class, "requestInterstitial")
+                .set(eventHandler, publisherInterstitialAd);
 
-        mEventHandler.onEvent(AdEvent.LOADED);
+        eventHandler.onEvent(AdEvent.LOADED);
 
-        verify(mMockEventListener, times(1)).onAdServerWin();
+        verify(mockEventListener, times(1)).onAdServerWin();
     }
 
     @Test
     public void onAppEventTimeout_NotifyBannerEventOnAdServerWin() throws Exception {
-        WhiteBox.method(GamInterstitialEventHandler.class, "handleAppEventTimeout").invoke(mEventHandler);
+        WhiteBox.method(GamInterstitialEventHandler.class, "handleAppEventTimeout").invoke(eventHandler);
 
-        verify(mMockEventListener, times(1)).onAdServerWin();
+        verify(mockEventListener, times(1)).onAdServerWin();
     }
 
     @Test
     public void destroy_CancelTimer() throws IllegalAccessException {
         // by default apEventHandler is null if not scheduled
-        WhiteBox.field(GamInterstitialEventHandler.class, "mAppEventHandler")
-                .set(mEventHandler, mMockAppEventHandler);
+        WhiteBox.field(GamInterstitialEventHandler.class, "appEventHandler").set(eventHandler, mockAppEventHandler);
 
-        mEventHandler.destroy();
+        eventHandler.destroy();
 
-        verify(mMockAppEventHandler, times(1)).removeCallbacksAndMessages(null);
+        verify(mockAppEventHandler, times(1)).removeCallbacksAndMessages(null);
     }
 
     @Test
@@ -143,29 +140,29 @@ public class GamInterstitialEventHandlerTest {
 
         when(mockBid.getPrebid()).thenReturn(mockPrebid);
         when(mockBid.getPrice()).thenReturn(0.2);
-        mEventHandler.requestAdWithBid(mockBid);
+        eventHandler.requestAdWithBid(mockBid);
         assertTrue(getExpectingAppEventStatus());
 
         when(mockBid.getPrice()).thenReturn(0.0);
-        mEventHandler.requestAdWithBid(mockBid);
+        eventHandler.requestAdWithBid(mockBid);
         assertFalse(getExpectingAppEventStatus());
 
-        mEventHandler.requestAdWithBid(null);
+        eventHandler.requestAdWithBid(null);
         assertFalse(getExpectingAppEventStatus());
     }
 
     @Test
     public void showWhenEmbeddedInterstitialIsNull_NotifyEventErrorListener() {
-        mEventHandler.show();
+        eventHandler.show();
 
-        verify(mMockEventListener).onAdFailed(any(AdException.class));
+        verify(mockEventListener).onAdFailed(any(AdException.class));
     }
 
     private void changeExpectingAppEventStatus(boolean status) {
-        WhiteBox.setInternalState(mEventHandler, "mIsExpectingAppEvent", status);
+        WhiteBox.setInternalState(eventHandler, "isExpectingAppEvent", status);
     }
 
     private boolean getExpectingAppEventStatus() {
-        return WhiteBox.getInternalState(mEventHandler, "mIsExpectingAppEvent");
+        return WhiteBox.getInternalState(eventHandler, "isExpectingAppEvent");
     }
 }

--- a/PrebidMobile/PrebidMobile-gamEventHandlers/src/test/java/org/prebid/mobile/eventhandlers/GamRewardedEventHandlerTest.java
+++ b/PrebidMobile/PrebidMobile-gamEventHandlers/src/test/java/org/prebid/mobile/eventhandlers/GamRewardedEventHandlerTest.java
@@ -41,45 +41,47 @@ import static org.mockito.Mockito.*;
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 21)
 public class GamRewardedEventHandlerTest {
+
     private static final String GAM_AD_UNIT_ID = "12345678";
 
-    private GamRewardedEventHandler mEventHandler;
-    private Activity mActivity;
+    private GamRewardedEventHandler eventHandler;
+    private Activity activity;
 
-    @Mock
-    private RewardedVideoEventListener mMockEventListener;
-    @Mock
-    private Handler mMockAppEventHandler;
+    @Mock private RewardedVideoEventListener mockEventListener;
+    @Mock private Handler mockAppEventHandler;
 
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
 
-        mActivity = Robolectric.buildActivity(Activity.class).get();
+        activity = Robolectric.buildActivity(Activity.class).get();
 
-        mEventHandler = new GamRewardedEventHandler(mActivity, GAM_AD_UNIT_ID);
-        mEventHandler.setRewardedEventListener(mMockEventListener);
+        eventHandler = new GamRewardedEventHandler(activity, GAM_AD_UNIT_ID);
+        eventHandler.setRewardedEventListener(mockEventListener);
     }
 
     @Test
     public void onAdMetadataChangedWithMetadataContainsAdEvent_HandleAppEvent() throws Exception {
         changeExpectingAppEventStatus(true);
 
-        GamRewardedEventHandler spyEventHandler = spy(mEventHandler);
+        GamRewardedEventHandler spyEventHandler = spy(eventHandler);
 
         spyEventHandler.onEvent(AdEvent.APP_EVENT_RECEIVED);
 
-        final boolean isExpectingAppEvent = ((boolean) WhiteBox.field(GamRewardedEventHandler.class, "mIsExpectingAppEvent").get(spyEventHandler));
+        final boolean isExpectingAppEvent = ((boolean) WhiteBox.field(
+                GamRewardedEventHandler.class,
+                "isExpectingAppEvent"
+        ).get(spyEventHandler));
 
-        verify(mMockEventListener, times(1)).onPrebidSdkWin();
+        verify(mockEventListener, times(1)).onPrebidSdkWin();
         assertFalse(isExpectingAppEvent);
     }
 
     @Test
     public void onGamAdClosed_NotifyEventCloseListener() {
-        mEventHandler.onEvent(AdEvent.CLOSED);
+        eventHandler.onEvent(AdEvent.CLOSED);
 
-        verify(mMockEventListener, times(1)).onAdClosed();
+        verify(mockEventListener, times(1)).onAdClosed();
     }
 
     @Test
@@ -89,55 +91,53 @@ public class GamRewardedEventHandlerTest {
         for (int i = 0; i < wantedNumberOfInvocations; i++) {
             final AdEvent adEvent = AdEvent.FAILED;
             adEvent.setErrorCode(i);
-            mEventHandler.onEvent(adEvent);
+            eventHandler.onEvent(adEvent);
         }
-        verify(mMockEventListener, times(wantedNumberOfInvocations)).onAdFailed(any(AdException.class));
+        verify(mockEventListener, times(wantedNumberOfInvocations)).onAdFailed(any(AdException.class));
     }
 
     @Test
     public void onGamAdOpened_NotifyBannerEventDisplayListener() {
-        mEventHandler.onEvent(AdEvent.DISPLAYED);
+        eventHandler.onEvent(AdEvent.DISPLAYED);
 
-        verify(mMockEventListener, times(1)).onAdDisplayed();
+        verify(mockEventListener, times(1)).onAdDisplayed();
     }
 
     @Test
     public void onGamAdLoadedAppEventExpected_ScheduleAppEventHandler() {
         changeExpectingAppEventStatus(true);
 
-        mEventHandler.onEvent(AdEvent.LOADED);
+        eventHandler.onEvent(AdEvent.LOADED);
 
-        assertNotNull(WhiteBox.getInternalState(mEventHandler, "mAppEventHandler"));
+        assertNotNull(WhiteBox.getInternalState(eventHandler, "appEventHandler"));
     }
 
     @Test
     public void onGamAdLoadedAppEventNotExpectedAndRequestInterstitialNotNull_NotifyEventListenerOnAdServerWin()
     throws Exception {
         RewardedAdWrapper publisherInterstitialAd = mock(RewardedAdWrapper.class);
-        WhiteBox.field(GamRewardedEventHandler.class, "mRewardedAd")
-                .set(mEventHandler, publisherInterstitialAd);
+        WhiteBox.field(GamRewardedEventHandler.class, "rewardedAd").set(eventHandler, publisherInterstitialAd);
 
-        mEventHandler.onEvent(AdEvent.LOADED);
+        eventHandler.onEvent(AdEvent.LOADED);
 
-        verify(mMockEventListener, times(1)).onAdServerWin(any());
+        verify(mockEventListener, times(1)).onAdServerWin(any());
     }
 
     @Test
     public void onAppEventTimeout_NotifyBannerEventOnAdServerWin() throws Exception {
-        WhiteBox.method(GamRewardedEventHandler.class, "handleAppEventTimeout").invoke(mEventHandler);
+        WhiteBox.method(GamRewardedEventHandler.class, "handleAppEventTimeout").invoke(eventHandler);
 
-        verify(mMockEventListener, times(1)).onAdServerWin(any());
+        verify(mockEventListener, times(1)).onAdServerWin(any());
     }
 
     @Test
     public void destroy_CancelTimer() throws IllegalAccessException {
         // by default apEventHandler is null if not scheduled
-        WhiteBox.field(GamRewardedEventHandler.class, "mAppEventHandler")
-                .set(mEventHandler, mMockAppEventHandler);
+        WhiteBox.field(GamRewardedEventHandler.class, "appEventHandler").set(eventHandler, mockAppEventHandler);
 
-        mEventHandler.destroy();
+        eventHandler.destroy();
 
-        verify(mMockAppEventHandler, times(1)).removeCallbacksAndMessages(null);
+        verify(mockAppEventHandler, times(1)).removeCallbacksAndMessages(null);
     }
 
     @Test
@@ -148,29 +148,29 @@ public class GamRewardedEventHandlerTest {
 
         when(mockBid.getPrebid()).thenReturn(mockPrebid);
         when(mockBid.getPrice()).thenReturn(0.2);
-        mEventHandler.requestAdWithBid(mockBid);
+        eventHandler.requestAdWithBid(mockBid);
         assertTrue(getExpectingAppEventStatus());
 
         when(mockBid.getPrice()).thenReturn(0.0);
-        mEventHandler.requestAdWithBid(mockBid);
+        eventHandler.requestAdWithBid(mockBid);
         assertFalse(getExpectingAppEventStatus());
 
-        mEventHandler.requestAdWithBid(null);
+        eventHandler.requestAdWithBid(null);
         assertFalse(getExpectingAppEventStatus());
     }
 
     @Test
     public void showWhenEmbeddedInterstitialIsNull_NotifyEventErrorListener() {
-        mEventHandler.show();
+        eventHandler.show();
 
-        verify(mMockEventListener).onAdFailed(any(AdException.class));
+        verify(mockEventListener).onAdFailed(any(AdException.class));
     }
 
     private void changeExpectingAppEventStatus(boolean status) {
-        WhiteBox.setInternalState(mEventHandler, "mIsExpectingAppEvent", status);
+        WhiteBox.setInternalState(eventHandler, "isExpectingAppEvent", status);
     }
 
     private boolean getExpectingAppEventStatus() {
-        return WhiteBox.getInternalState(mEventHandler, "mIsExpectingAppEvent");
+        return WhiteBox.getInternalState(eventHandler, "isExpectingAppEvent");
     }
 }

--- a/PrebidMobile/PrebidMobile-gamEventHandlers/src/test/java/org/prebid/mobile/eventhandlers/PublisherAdViewWrapperTest.java
+++ b/PrebidMobile/PrebidMobile-gamEventHandlers/src/test/java/org/prebid/mobile/eventhandlers/PublisherAdViewWrapperTest.java
@@ -41,46 +41,49 @@ import static org.mockito.Mockito.*;
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 19)
 public class PublisherAdViewWrapperTest {
-    private PublisherAdViewWrapper mPublisherAdViewWrapper;
+    private PublisherAdViewWrapper publisherAdViewWrapper;
 
-    @Mock
-    GamAdEventListener mMockListener;
+    @Mock GamAdEventListener mockListener;
 
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
         Context context = Robolectric.buildActivity(Activity.class).create().get();
 
-        mPublisherAdViewWrapper = PublisherAdViewWrapper.newInstance(context, "124", mMockListener, new AdSize(300, 250));
+        publisherAdViewWrapper = PublisherAdViewWrapper.newInstance(context, "124", mockListener, new AdSize(300, 250));
     }
 
     @Test
     public void newInstance_WithNullContext_NullValueReturned() {
-        PublisherAdViewWrapper publisherAdViewWrapper = PublisherAdViewWrapper
-            .newInstance(null, "124", mMockListener, new AdSize(300, 250));
+        PublisherAdViewWrapper publisherAdViewWrapper = PublisherAdViewWrapper.newInstance(
+                null,
+                "124",
+                mockListener,
+                new AdSize(300, 250)
+        );
 
         assertNull(publisherAdViewWrapper);
     }
 
     @Test
     public void onAppEvent_WithValidNameAndExpectedAppEvent_NotifyAppEventListener() {
-        mPublisherAdViewWrapper.onAppEvent(Constants.APP_EVENT, "");
+        publisherAdViewWrapper.onAppEvent(Constants.APP_EVENT, "");
 
-        verify(mMockListener, times(1)).onEvent(AdEvent.APP_EVENT_RECEIVED);
+        verify(mockListener, times(1)).onEvent(AdEvent.APP_EVENT_RECEIVED);
     }
 
     @Test
     public void onAppEvent_WithInvalidNameAndExpectedAppEvent_DoNothing() {
-        mPublisherAdViewWrapper.onAppEvent("test", "");
+        publisherAdViewWrapper.onAppEvent("test", "");
 
-        verifyZeroInteractions(mMockListener);
+        verifyZeroInteractions(mockListener);
     }
 
     @Test
     public void onGamAdClosed_NotifyBannerEventCloseListener() {
-        mPublisherAdViewWrapper.onAdClosed();
+        publisherAdViewWrapper.onAdClosed();
 
-        verify(mMockListener, times(1)).onEvent(eq(AdEvent.CLOSED));
+        verify(mockListener, times(1)).onEvent(eq(AdEvent.CLOSED));
     }
 
     @Test
@@ -89,23 +92,23 @@ public class PublisherAdViewWrapperTest {
 
         for (int i = 0; i < wantedNumberOfInvocations; i++) {
             LoadAdError loadAdError = new LoadAdError(i, "", "", null, null);
-            mPublisherAdViewWrapper.onAdFailedToLoad(loadAdError);
+            publisherAdViewWrapper.onAdFailedToLoad(loadAdError);
         }
-        verify(mMockListener, times(wantedNumberOfInvocations)).onEvent(eq(AdEvent.FAILED));
+        verify(mockListener, times(wantedNumberOfInvocations)).onEvent(eq(AdEvent.FAILED));
     }
 
     @Test
     public void onGamAdOpened_NotifyBannerEventClickedListener() {
-        mPublisherAdViewWrapper.onAdOpened();
+        publisherAdViewWrapper.onAdOpened();
 
-        verify(mMockListener, times(1)).onEvent(AdEvent.CLICKED);
+        verify(mockListener, times(1)).onEvent(AdEvent.CLICKED);
     }
 
     @Test
     public void onGamAdLoadedAppEventExpected_NotifyLoadedListener() {
-        mPublisherAdViewWrapper.onAdLoaded();
+        publisherAdViewWrapper.onAdLoaded();
 
-        verify(mMockListener, times(1)).onEvent(AdEvent.LOADED);
+        verify(mockListener, times(1)).onEvent(AdEvent.LOADED);
     }
 
     @Test
@@ -113,9 +116,9 @@ public class PublisherAdViewWrapperTest {
         final Activity activity = Robolectric.buildActivity(Activity.class).create().get();
         AdManagerAdView publisherAdView = new AdManagerAdView(activity);
 
-        WhiteBox.field(PublisherAdViewWrapper.class, "mAdView").set(mPublisherAdViewWrapper, publisherAdView);
+        WhiteBox.field(PublisherAdViewWrapper.class, "adView").set(publisherAdViewWrapper, publisherAdView);
 
-        final View view = mPublisherAdViewWrapper.getView();
+        final View view = publisherAdViewWrapper.getView();
 
         assertEquals(publisherAdView, view);
     }

--- a/PrebidMobile/PrebidMobile-gamEventHandlers/src/test/java/org/prebid/mobile/eventhandlers/PublisherInterstitialAdWrapperTest.java
+++ b/PrebidMobile/PrebidMobile-gamEventHandlers/src/test/java/org/prebid/mobile/eventhandlers/PublisherInterstitialAdWrapperTest.java
@@ -38,46 +38,48 @@ import static org.mockito.Mockito.*;
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 19)
 public class PublisherInterstitialAdWrapperTest {
-    private PublisherInterstitialAdWrapper mPublisherInterstitialAdWrapper;
+    private PublisherInterstitialAdWrapper publisherInterstitialAdWrapper;
 
-    @Mock
-    GamAdEventListener mMockListener;
+    @Mock GamAdEventListener mockListener;
 
     @Before
     public void setup() {
         MockitoAnnotations.initMocks(this);
         Activity context = Robolectric.buildActivity(Activity.class).create().get();
 
-        mPublisherInterstitialAdWrapper = PublisherInterstitialAdWrapper.newInstance(context, "123", mMockListener);
+        publisherInterstitialAdWrapper = PublisherInterstitialAdWrapper.newInstance(context, "123", mockListener);
     }
 
     @Test
     public void newInstance_WithNullContext_NullValueReturned() {
-        PublisherInterstitialAdWrapper publisherInterstitialAdWrapper = PublisherInterstitialAdWrapper
-            .newInstance(null, "124", mMockListener);
+        PublisherInterstitialAdWrapper publisherInterstitialAdWrapper = PublisherInterstitialAdWrapper.newInstance(
+                null,
+                "124",
+                mockListener
+        );
 
         assertNull(publisherInterstitialAdWrapper);
     }
 
     @Test
     public void onAppEvent_WithValidNameAndExpectedAppEvent_NotifyAppEventListener() {
-        mPublisherInterstitialAdWrapper.onAppEvent(Constants.APP_EVENT, "");
+        publisherInterstitialAdWrapper.onAppEvent(Constants.APP_EVENT, "");
 
-        verify(mMockListener, times(1)).onEvent(AdEvent.APP_EVENT_RECEIVED);
+        verify(mockListener, times(1)).onEvent(AdEvent.APP_EVENT_RECEIVED);
     }
 
     @Test
     public void onAppEvent_WithInvalidNameAndExpectedAppEvent_DoNothing() {
-        mPublisherInterstitialAdWrapper.onAppEvent("test", "");
+        publisherInterstitialAdWrapper.onAppEvent("test", "");
 
-        verifyZeroInteractions(mMockListener);
+        verifyZeroInteractions(mockListener);
     }
 
     @Test
     public void onGamAdClosed_NotifyEventCloseListener() {
-        mPublisherInterstitialAdWrapper.onAdDismissedFullScreenContent();
+        publisherInterstitialAdWrapper.onAdDismissedFullScreenContent();
 
-        verify(mMockListener, times(1)).onEvent(eq(AdEvent.CLOSED));
+        verify(mockListener, times(1)).onEvent(eq(AdEvent.CLOSED));
     }
 
     @Test
@@ -86,16 +88,16 @@ public class PublisherInterstitialAdWrapperTest {
 
         for (int i = 0; i < wantedNumberOfInvocations; i++) {
             AdError adError = new AdError(i, "", "");
-            mPublisherInterstitialAdWrapper.onAdFailedToShowFullScreenContent(adError);
+            publisherInterstitialAdWrapper.onAdFailedToShowFullScreenContent(adError);
         }
-        verify(mMockListener, times(wantedNumberOfInvocations)).onEvent(eq(AdEvent.FAILED));
+        verify(mockListener, times(wantedNumberOfInvocations)).onEvent(eq(AdEvent.FAILED));
     }
 
     @Test
     public void onGamAdOpened_NotifyEventDisplayedListener() {
-        mPublisherInterstitialAdWrapper.onAdShowedFullScreenContent();
+        publisherInterstitialAdWrapper.onAdShowedFullScreenContent();
 
-        verify(mMockListener, times(1)).onEvent(AdEvent.DISPLAYED);
+        verify(mockListener, times(1)).onEvent(AdEvent.DISPLAYED);
     }
 
     @Test
@@ -105,22 +107,22 @@ public class PublisherInterstitialAdWrapperTest {
         final AdManagerInterstitialAd mock = mock(AdManagerInterstitialAd.class);
         listener.onAdLoaded(mock);
 
-        verify(mMockListener, times(1)).onEvent(AdEvent.LOADED);
+        verify(mockListener, times(1)).onEvent(AdEvent.LOADED);
     }
 
     @Test
     public void isLoaded_adIsNull_ReturnFalse() {
-        assertFalse(mPublisherInterstitialAdWrapper.isLoaded());
+        assertFalse(publisherInterstitialAdWrapper.isLoaded());
     }
 
     @Test
     public void isLoaded_adIsNonNull_ReturnTrue() {
         getAdLoadCallback().onAdLoaded(mock(AdManagerInterstitialAd.class));
 
-        assertTrue(mPublisherInterstitialAdWrapper.isLoaded());
+        assertTrue(publisherInterstitialAdWrapper.isLoaded());
     }
 
     private AdManagerInterstitialAdLoadCallback getAdLoadCallback() {
-        return WhiteBox.getInternalState(mPublisherInterstitialAdWrapper, "mAdLoadCallback");
+        return WhiteBox.getInternalState(publisherInterstitialAdWrapper, "adLoadCallback");
     }
 }

--- a/PrebidMobile/PrebidMobile-gamEventHandlers/src/test/java/org/prebid/mobile/eventhandlers/RewardedAdWrapperTest.java
+++ b/PrebidMobile/PrebidMobile-gamEventHandlers/src/test/java/org/prebid/mobile/eventhandlers/RewardedAdWrapperTest.java
@@ -19,11 +19,9 @@ package org.prebid.mobile.eventhandlers;
 import android.app.Activity;
 import android.content.Context;
 import android.os.Bundle;
-
 import com.google.android.gms.ads.AdError;
 import com.google.android.gms.ads.rewarded.RewardedAd;
 import com.google.android.gms.ads.rewarded.RewardedAdLoadCallback;
-
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -37,23 +35,17 @@ import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.*;
 import static org.mockito.Matchers.eq;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.times;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.*;
 import static org.prebid.mobile.eventhandlers.global.Constants.APP_EVENT;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 19)
 public class RewardedAdWrapperTest {
-    private RewardedAdWrapper mRewardedAdWrapper;
+    private RewardedAdWrapper rewardedAdWrapper;
 
-    @Mock
-    GamAdEventListener mMockListener;
+    @Mock GamAdEventListener mockListener;
 
     @Rule
     public MockitoRule rule = MockitoJUnit.rule();
@@ -64,13 +56,12 @@ public class RewardedAdWrapperTest {
         MockitoAnnotations.initMocks(this);
         Context context = Robolectric.buildActivity(Activity.class).create().get();
 
-        mRewardedAdWrapper = RewardedAdWrapper.newInstance(context, "123", mMockListener);
+        rewardedAdWrapper = RewardedAdWrapper.newInstance(context, "123", mockListener);
     }
 
     @Test
     public void newInstance_WithNullContext_NullValueReturned() {
-        RewardedAdWrapper rewardedAdWrapper = RewardedAdWrapper
-            .newInstance(null, "124", mMockListener);
+        RewardedAdWrapper rewardedAdWrapper = RewardedAdWrapper.newInstance(null, "124", mockListener);
 
         assertNull(rewardedAdWrapper);
     }
@@ -85,7 +76,7 @@ public class RewardedAdWrapperTest {
 
         rewardedAdLoadCallback.onAdLoaded(mockRewardedAd);
 
-        verify(mMockListener, times(1)).onEvent(eq(AdEvent.APP_EVENT_RECEIVED));
+        verify(mockListener, times(1)).onEvent(eq(AdEvent.APP_EVENT_RECEIVED));
     }
 
     @Test
@@ -97,14 +88,14 @@ public class RewardedAdWrapperTest {
 
         rewardedAdLoadCallback.onAdLoaded(mockRewardedAd);
 
-        verify(mMockListener, times(0)).onEvent(eq(AdEvent.APP_EVENT_RECEIVED));
+        verify(mockListener, times(0)).onEvent(eq(AdEvent.APP_EVENT_RECEIVED));
     }
 
     @Test
     public void onGamAdClosed_NotifyEventCloseListener() {
-        mRewardedAdWrapper.onAdDismissedFullScreenContent();
+        rewardedAdWrapper.onAdDismissedFullScreenContent();
 
-        verify(mMockListener, times(1)).onEvent(AdEvent.CLOSED);
+        verify(mockListener, times(1)).onEvent(AdEvent.CLOSED);
     }
 
     @Test
@@ -113,46 +104,46 @@ public class RewardedAdWrapperTest {
 
         for (int i = 0; i < wantedNumberOfInvocations; i++) {
             AdError adError = new AdError(i, "", "");
-            mRewardedAdWrapper.onAdFailedToShowFullScreenContent(adError);
+            rewardedAdWrapper.onAdFailedToShowFullScreenContent(adError);
         }
-        verify(mMockListener, times(wantedNumberOfInvocations)).onEvent(eq(AdEvent.FAILED));
+        verify(mockListener, times(wantedNumberOfInvocations)).onEvent(eq(AdEvent.FAILED));
     }
 
     @Test
     public void onGamAdOpened_NotifyBannerEventDisplayListener() {
-        mRewardedAdWrapper.onAdShowedFullScreenContent();
+        rewardedAdWrapper.onAdShowedFullScreenContent();
 
-        verify(mMockListener, times(1)).onEvent(AdEvent.DISPLAYED);
+        verify(mockListener, times(1)).onEvent(AdEvent.DISPLAYED);
     }
 
     @Test
     public void onUserEarnedReward_NotifyClosedAndRewardEarnedListeners() {
-        mRewardedAdWrapper.onUserEarnedReward(null);
+        rewardedAdWrapper.onUserEarnedReward(null);
 
-        verify(mMockListener, times(1)).onEvent(eq(AdEvent.REWARD_EARNED));
-        verify(mMockListener, times(1)).onEvent(eq(AdEvent.CLOSED));
+        verify(mockListener, times(1)).onEvent(eq(AdEvent.REWARD_EARNED));
+        verify(mockListener, times(1)).onEvent(eq(AdEvent.CLOSED));
     }
 
     @Test
     public void onGamAdLoadedAppEventExpected_ScheduleAppEventHandler() {
         getRewardedAdLoadCallback().onAdLoaded(mock(RewardedAd.class));
 
-        verify(mMockListener, times(1)).onEvent(eq(AdEvent.LOADED));
+        verify(mockListener, times(1)).onEvent(eq(AdEvent.LOADED));
     }
 
     @Test
     public void isLoaded_adIsNull_ReturnFalse() {
-        assertFalse(mRewardedAdWrapper.isLoaded());
+        assertFalse(rewardedAdWrapper.isLoaded());
     }
 
     @Test
     public void isLoaded_adIsNonNull_ReturnTrue() {
         getRewardedAdLoadCallback().onAdLoaded(mock(RewardedAd.class));
 
-        assertTrue(mRewardedAdWrapper.isLoaded());
+        assertTrue(rewardedAdWrapper.isLoaded());
     }
 
     private RewardedAdLoadCallback getRewardedAdLoadCallback() {
-        return WhiteBox.getInternalState(mRewardedAdWrapper, "mRewardedAdLoadCallback");
+        return WhiteBox.getInternalState(rewardedAdWrapper, "rewardedAdLoadCallback");
     }
 }

--- a/PrebidMobile/test-utils/src/main/java/org/prebid/mobile/test/utils/WhiteBoxHelpers.java
+++ b/PrebidMobile/test-utils/src/main/java/org/prebid/mobile/test/utils/WhiteBoxHelpers.java
@@ -97,19 +97,28 @@ class WhiteBoxHelpers {
     }
 
     private static class ParameterTypesMatcher {
-        private final boolean mIsVarArgs;
-        private final Class<?>[] mExpectedParameterTypes;
-        private final Class<?>[] mActualParameterTypes;
 
-        public ParameterTypesMatcher(boolean isVarArgs, Class<?>[] expectedParameterTypes, Class<?>... actualParameterTypes) {
-            mIsVarArgs = isVarArgs;
-            mExpectedParameterTypes = expectedParameterTypes;
-            mActualParameterTypes = actualParameterTypes;
+        private final boolean isVarArgs;
+        private final Class<?>[] expectedParameterTypes;
+        private final Class<?>[] actualParameterTypes;
+
+        public ParameterTypesMatcher(
+                boolean isVarArgs,
+                Class<?>[] expectedParameterTypes,
+                Class<?>... actualParameterTypes
+        ) {
+            this.isVarArgs = isVarArgs;
+            this.expectedParameterTypes = expectedParameterTypes;
+            this.actualParameterTypes = actualParameterTypes;
         }
 
-        private boolean isRemainParamsVarArgs(int index, Class<?> actualParameterType) {
-            return mIsVarArgs && index == mExpectedParameterTypes.length - 1
-                   && actualParameterType.getComponentType().isAssignableFrom(mExpectedParameterTypes[index]);
+        private boolean isRemainParamsVarArgs(
+                int index,
+                Class<?> actualParameterType
+        ) {
+            return isVarArgs && index == expectedParameterTypes.length - 1 && actualParameterType.getComponentType()
+                                                                                                 .isAssignableFrom(
+                                                                                                         expectedParameterTypes[index]);
         }
 
         private boolean isParameterTypesNotMatch(Class<?> actualParameterType, Class<?> expectedParameterType) {
@@ -132,22 +141,21 @@ class WhiteBoxHelpers {
             }
         }
 
-        private boolean isParametersLengthMatch() {return mExpectedParameterTypes.length != mActualParameterTypes.length;}
+        private boolean isParametersLengthMatch() {return expectedParameterTypes.length != actualParameterTypes.length;}
 
         private void assertParametersTypesNotNull() {
-            if (mExpectedParameterTypes == null || mActualParameterTypes == null) {
+            if (expectedParameterTypes == null || actualParameterTypes == null) {
                 throw new IllegalArgumentException("parameter types cannot be null");
             }
         }
 
         private Boolean isParametersMatch() {
-            for (int index = 0; index < mExpectedParameterTypes.length; index++) {
-                final Class<?> actualParameterType = getType(mActualParameterTypes[index]);
+            for (int index = 0; index < expectedParameterTypes.length; index++) {
+                final Class<?> actualParameterType = getType(actualParameterTypes[index]);
                 if (isRemainParamsVarArgs(index, actualParameterType)) {
                     return true;
-                }
-                else {
-                    final Class<?> expectedParameterType = mExpectedParameterTypes[index];
+                } else {
+                    final Class<?> expectedParameterType = expectedParameterTypes[index];
                     if (isParameterTypesNotMatch(actualParameterType, expectedParameterType)) {
                         return false;
                     }

--- a/build.gradle
+++ b/build.gradle
@@ -31,6 +31,6 @@ allprojects {
         mavenCentral()
         maven { url 'https://maven.google.com' }
         maven { url 'https://jitpack.io' }
-        maven { url "https://oss.sonatype.org/content/repositories/orgprebid-1070" }
+        maven { url "https://oss.sonatype.org/content/repositories/orgprebid-1083" }
     }
 }

--- a/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/managers/LineItemKeywordManager.java
+++ b/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/managers/LineItemKeywordManager.java
@@ -4,7 +4,7 @@ import android.content.Context;
 import android.net.Uri;
 import android.text.TextUtils;
 import android.util.Log;
-
+import okhttp3.*;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
@@ -19,14 +19,6 @@ import java.io.InputStream;
 import java.util.HashMap;
 import java.util.Locale;
 import java.util.Map;
-
-import okhttp3.Call;
-import okhttp3.Callback;
-import okhttp3.MediaType;
-import okhttp3.OkHttpClient;
-import okhttp3.Request;
-import okhttp3.RequestBody;
-import okhttp3.Response;
 
 public class LineItemKeywordManager {
     public static final String TAG = LineItemKeywordManager.class.getSimpleName();
@@ -50,27 +42,27 @@ public class LineItemKeywordManager {
     public static final String CREATIVE_320x480 = "{\"id\":\"7438652069000399098\",\"impid\":\"Home\",\"price\":0.5,\"adm\":\"<script type=\\\"text/javascript\\\">document.write('<a href=\\\"http://prebid.org\\\" target=\\\"_blank\\\"><img width=\\\"320\\\" height=\\\"480\\\" style=\\\"border-style: none\\\" src=\\\"https://vcdn.adnxs.com/p/creative-image/27/c0/52/67/27c05267-5a6d-4874-834e-18e218493c32.png\\\"/></a>');</script>\",\"adid\":\"29681110\",\"adomain\":[\"appnexus.com\"],\"iurl\":\"https://nym1-ib.adnxs.com/cr?id=29681110\",\"cid\":\"958\",\"crid\":\"29681110\",\"w\":320,\"h\":480}";
     public static final String CREATIVE_728x90 = "{\"id\":\"7438652069000399098\",\"impid\":\"Home\",\"price\":0.5,\"adm\":\"<script type=\\\"text/javascript\\\">document.write('<a href=\\\"http://prebid.org\\\" target=\\\"_blank\\\"><img width=\\\"7280\\\" height=\\\"90\\\" style=\\\"border-style: none\\\" src=\\\"https://vcdn.adnxs.com/p/creative-image/27/c0/52/67/27c05267-5a6d-4874-834e-18e218493c32.png\\\"/></a>');</script>\",\"adid\":\"29681110\",\"adomain\":[\"appnexus.com\"],\"iurl\":\"https://nym1-ib.adnxs.com/cr?id=29681110\",\"cid\":\"958\",\"crid\":\"29681110\",\"w\":728,\"h\":90}";
 
-    private Map<String, String> mAppNexusCacheIds;
-    private Map<String, String> mRubiconCacheIds;
-    private Map<String, String> mCustomServerCacheIds;
+    private Map<String, String> appNexusCacheIds;
+    private Map<String, String> rubiconCacheIds;
+    private Map<String, String> customServerCacheIds;
 
-    private static LineItemKeywordManager sInstance;
+    private static LineItemKeywordManager instance;
 
     private LineItemKeywordManager() {
 
     }
 
     public static LineItemKeywordManager getInstance() {
-        if (sInstance == null) {
-            sInstance = new LineItemKeywordManager();
+        if (instance == null) {
+            instance = new LineItemKeywordManager();
         }
-        return sInstance;
+        return instance;
     }
 
     public void refreshCacheIds(Context context) {
-        mAppNexusCacheIds = new HashMap<>();
-        mRubiconCacheIds = new HashMap<>();
-        mCustomServerCacheIds = new HashMap<>();
+        appNexusCacheIds = new HashMap<>();
+        rubiconCacheIds = new HashMap<>();
+        customServerCacheIds = new HashMap<>();
 
         PrebidServerSettings serverSettings = SettingsManager.getInstance(context).getPrebidServerSettings();
         String customServerCacheUrl = null;
@@ -156,13 +148,12 @@ public class LineItemKeywordManager {
                             JSONObject responseJson = new JSONObject(responseText);
                             JSONArray uuids = responseJson.getJSONArray("responses");
 
-                            mAppNexusCacheIds.put("300x250", uuids.getJSONObject(0).getString("uuid"));
-                            mAppNexusCacheIds.put("300x600", uuids.getJSONObject(1).getString("uuid"));
-                            mAppNexusCacheIds.put("320x50", uuids.getJSONObject(2).getString("uuid"));
-                            mAppNexusCacheIds.put("320x100", uuids.getJSONObject(3).getString("uuid"));
-                            mAppNexusCacheIds.put("320x480", uuids.getJSONObject(4).getString("uuid"));
-                            mAppNexusCacheIds.put("728x90", uuids.getJSONObject(5).getString("uuid"));
-
+                            appNexusCacheIds.put("300x250", uuids.getJSONObject(0).getString("uuid"));
+                            appNexusCacheIds.put("300x600", uuids.getJSONObject(1).getString("uuid"));
+                            appNexusCacheIds.put("320x50", uuids.getJSONObject(2).getString("uuid"));
+                            appNexusCacheIds.put("320x100", uuids.getJSONObject(3).getString("uuid"));
+                            appNexusCacheIds.put("320x480", uuids.getJSONObject(4).getString("uuid"));
+                            appNexusCacheIds.put("728x90", uuids.getJSONObject(5).getString("uuid"));
                         } catch (JSONException exception) {
                             Log.e(TAG, exception.getMessage());
                         }
@@ -187,13 +178,12 @@ public class LineItemKeywordManager {
                             JSONObject responseJson = new JSONObject(responseText);
                             JSONArray uuids = responseJson.getJSONArray("responses");
 
-                            mRubiconCacheIds.put("300x250", uuids.getJSONObject(0).getString("uuid"));
-                            mRubiconCacheIds.put("300x600", uuids.getJSONObject(1).getString("uuid"));
-                            mRubiconCacheIds.put("320x50", uuids.getJSONObject(2).getString("uuid"));
-                            mRubiconCacheIds.put("320x100", uuids.getJSONObject(3).getString("uuid"));
-                            mRubiconCacheIds.put("320x480", uuids.getJSONObject(4).getString("uuid"));
-                            mRubiconCacheIds.put("728x90", uuids.getJSONObject(5).getString("uuid"));
-
+                            rubiconCacheIds.put("300x250", uuids.getJSONObject(0).getString("uuid"));
+                            rubiconCacheIds.put("300x600", uuids.getJSONObject(1).getString("uuid"));
+                            rubiconCacheIds.put("320x50", uuids.getJSONObject(2).getString("uuid"));
+                            rubiconCacheIds.put("320x100", uuids.getJSONObject(3).getString("uuid"));
+                            rubiconCacheIds.put("320x480", uuids.getJSONObject(4).getString("uuid"));
+                            rubiconCacheIds.put("728x90", uuids.getJSONObject(5).getString("uuid"));
                         } catch (JSONException exception) {
                             Log.e(TAG, exception.getMessage());
                         }
@@ -224,13 +214,12 @@ public class LineItemKeywordManager {
                                 JSONObject responseJson = new JSONObject(responseText);
                                 JSONArray uuids = responseJson.getJSONArray("responses");
 
-                                mCustomServerCacheIds.put("300x250", uuids.getJSONObject(0).getString("uuid"));
-                                mCustomServerCacheIds.put("300x600", uuids.getJSONObject(1).getString("uuid"));
-                                mCustomServerCacheIds.put("320x50", uuids.getJSONObject(2).getString("uuid"));
-                                mCustomServerCacheIds.put("320x100", uuids.getJSONObject(3).getString("uuid"));
-                                mCustomServerCacheIds.put("320x480", uuids.getJSONObject(4).getString("uuid"));
-                                mCustomServerCacheIds.put("728x90", uuids.getJSONObject(5).getString("uuid"));
-
+                                customServerCacheIds.put("300x250", uuids.getJSONObject(0).getString("uuid"));
+                                customServerCacheIds.put("300x600", uuids.getJSONObject(1).getString("uuid"));
+                                customServerCacheIds.put("320x50", uuids.getJSONObject(2).getString("uuid"));
+                                customServerCacheIds.put("320x100", uuids.getJSONObject(3).getString("uuid"));
+                                customServerCacheIds.put("320x480", uuids.getJSONObject(4).getString("uuid"));
+                                customServerCacheIds.put("728x90", uuids.getJSONObject(5).getString("uuid"));
                             } catch (JSONException exception) {
                                 Log.e(TAG, exception.getMessage());
                             }
@@ -247,14 +236,19 @@ public class LineItemKeywordManager {
         StringBuilder stringBuilder = new StringBuilder();
 
         if (prebidServer == PrebidServer.RUBICON) {
-            if (mRubiconCacheIds != null) {
+            if (rubiconCacheIds != null) {
                 if (adFormat == AdFormat.INTERSTITIAL) {
-                    String cacheId = mRubiconCacheIds.get("320x480");
+                    String cacheId = rubiconCacheIds.get("320x480");
                     if (!TextUtils.isEmpty(cacheId)) {
                         stringBuilder.append(KEYWORD_CACHE_ID).append(KEYWORD_DIVIDER).append(cacheId);
                     }
                 } else {
-                    String cacheId = mRubiconCacheIds.get(String.format(Locale.ENGLISH, "%dx%d", adSize.getWidth(), adSize.getHeight()));
+                    String cacheId = rubiconCacheIds.get(String.format(
+                            Locale.ENGLISH,
+                            "%dx%d",
+                            adSize.getWidth(),
+                            adSize.getHeight()
+                    ));
                     if (!TextUtils.isEmpty(cacheId)) {
                         stringBuilder.append(KEYWORD_CACHE_ID).append(KEYWORD_DIVIDER).append(cacheId);
                     }
@@ -263,14 +257,19 @@ public class LineItemKeywordManager {
                 stringBuilder.append(KEYWORD_CACHE_ID).append(KEYWORD_DIVIDER).append(FAKE_CACHE_ID);
             }
         } else if (prebidServer == PrebidServer.APPNEXUS) {
-            if (mAppNexusCacheIds != null) {
+            if (appNexusCacheIds != null) {
                 if (adFormat == AdFormat.INTERSTITIAL) {
-                    String cacheId = mAppNexusCacheIds.get("320x480");
+                    String cacheId = appNexusCacheIds.get("320x480");
                     if (!TextUtils.isEmpty(cacheId)) {
                         stringBuilder.append(KEYWORD_CACHE_ID).append(KEYWORD_DIVIDER).append(cacheId);
                     }
                 } else {
-                    String cacheId = mAppNexusCacheIds.get(String.format(Locale.ENGLISH, "%dx%d", adSize.getWidth(), adSize.getHeight()));
+                    String cacheId = appNexusCacheIds.get(String.format(
+                            Locale.ENGLISH,
+                            "%dx%d",
+                            adSize.getWidth(),
+                            adSize.getHeight()
+                    ));
                     if (!TextUtils.isEmpty(cacheId)) {
                         stringBuilder.append(KEYWORD_CACHE_ID).append(KEYWORD_DIVIDER).append(cacheId);
                     }
@@ -279,14 +278,19 @@ public class LineItemKeywordManager {
                 stringBuilder.append(KEYWORD_CACHE_ID).append(KEYWORD_DIVIDER).append(FAKE_CACHE_ID);
             }
         } else {
-            if (mCustomServerCacheIds != null) {
+            if (customServerCacheIds != null) {
                 if (adFormat == AdFormat.INTERSTITIAL) {
-                    String cacheId = mCustomServerCacheIds.get("320x480");
+                    String cacheId = customServerCacheIds.get("320x480");
                     if (!TextUtils.isEmpty(cacheId)) {
                         stringBuilder.append(KEYWORD_CACHE_ID).append(KEYWORD_DIVIDER).append(cacheId);
                     }
                 } else {
-                    String cacheId = mCustomServerCacheIds.get(String.format(Locale.ENGLISH, "%dx%d", adSize.getWidth(), adSize.getHeight()));
+                    String cacheId = customServerCacheIds.get(String.format(
+                            Locale.ENGLISH,
+                            "%dx%d",
+                            adSize.getWidth(),
+                            adSize.getHeight()
+                    ));
                     if (!TextUtils.isEmpty(cacheId)) {
                         stringBuilder.append(KEYWORD_CACHE_ID).append(KEYWORD_DIVIDER).append(cacheId);
                     }
@@ -313,14 +317,19 @@ public class LineItemKeywordManager {
         Map<String, String> keywords = new HashMap<>();
 
         if (prebidServer == PrebidServer.RUBICON) {
-            if (mRubiconCacheIds != null) {
+            if (rubiconCacheIds != null) {
                 if (adFormat == AdFormat.INTERSTITIAL) {
-                    String cacheId = mRubiconCacheIds.get("320x480");
+                    String cacheId = rubiconCacheIds.get("320x480");
                     if (!TextUtils.isEmpty(cacheId)) {
                         keywords.put(KEYWORD_CACHE_ID, cacheId);
                     }
                 } else {
-                    String cacheId = mRubiconCacheIds.get(String.format(Locale.ENGLISH, "%dx%d", adSize.getWidth(), adSize.getHeight()));
+                    String cacheId = rubiconCacheIds.get(String.format(
+                            Locale.ENGLISH,
+                            "%dx%d",
+                            adSize.getWidth(),
+                            adSize.getHeight()
+                    ));
                     if (!TextUtils.isEmpty(cacheId)) {
                         keywords.put(KEYWORD_CACHE_ID, cacheId);
                     }
@@ -329,14 +338,19 @@ public class LineItemKeywordManager {
                 keywords.put(KEYWORD_CACHE_ID, FAKE_CACHE_ID);
             }
         } else if (prebidServer == PrebidServer.APPNEXUS) {
-            if (mAppNexusCacheIds != null) {
+            if (appNexusCacheIds != null) {
                 if (adFormat == AdFormat.INTERSTITIAL) {
-                    String cacheId = mAppNexusCacheIds.get("320x480");
+                    String cacheId = appNexusCacheIds.get("320x480");
                     if (!TextUtils.isEmpty(cacheId)) {
                         keywords.put(KEYWORD_CACHE_ID, cacheId);
                     }
                 } else {
-                    String cacheId = mAppNexusCacheIds.get(String.format(Locale.ENGLISH, "%dx%d", adSize.getWidth(), adSize.getHeight()));
+                    String cacheId = appNexusCacheIds.get(String.format(
+                            Locale.ENGLISH,
+                            "%dx%d",
+                            adSize.getWidth(),
+                            adSize.getHeight()
+                    ));
                     if (!TextUtils.isEmpty(cacheId)) {
                         keywords.put(KEYWORD_CACHE_ID, cacheId);
                     }
@@ -345,14 +359,19 @@ public class LineItemKeywordManager {
                 keywords.put(KEYWORD_CACHE_ID, FAKE_CACHE_ID);
             }
         } else {
-            if (mCustomServerCacheIds != null) {
+            if (customServerCacheIds != null) {
                 if (adFormat == AdFormat.INTERSTITIAL) {
-                    String cacheId = mCustomServerCacheIds.get("320x480");
+                    String cacheId = customServerCacheIds.get("320x480");
                     if (!TextUtils.isEmpty(cacheId)) {
                         keywords.put(KEYWORD_CACHE_ID, cacheId);
                     }
                 } else {
-                    String cacheId = mCustomServerCacheIds.get(String.format(Locale.ENGLISH, "%dx%d", adSize.getWidth(), adSize.getHeight()));
+                    String cacheId = customServerCacheIds.get(String.format(
+                            Locale.ENGLISH,
+                            "%dx%d",
+                            adSize.getWidth(),
+                            adSize.getHeight()
+                    ));
                     if (!TextUtils.isEmpty(cacheId)) {
                         keywords.put(KEYWORD_CACHE_ID, cacheId);
                     }

--- a/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/managers/QrCodeScanCacheManager.java
+++ b/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/managers/QrCodeScanCacheManager.java
@@ -2,23 +2,22 @@ package org.prebid.mobile.drprebid.managers;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-
 import org.prebid.mobile.drprebid.Constants;
 
 public class QrCodeScanCacheManager {
     private static final String PREFERENCES_NAME = "dr_prebid_qr_scan_cache";
-    private final SharedPreferences mSharedPreferences;
+    private final SharedPreferences sharedPreferences;
 
-    private static volatile QrCodeScanCacheManager sInstance;
+    private static volatile QrCodeScanCacheManager instance;
     private static final Object mutex = new Object();
 
     public static QrCodeScanCacheManager getInstance(Context context) {
-        QrCodeScanCacheManager result = sInstance;
+        QrCodeScanCacheManager result = instance;
         if (result == null) {
             synchronized (mutex) {
-                result = sInstance;
+                result = instance;
                 if (result == null) {
-                    sInstance = result = new QrCodeScanCacheManager(context);
+                    instance = result = new QrCodeScanCacheManager(context);
                 }
             }
         }
@@ -27,26 +26,26 @@ public class QrCodeScanCacheManager {
     }
 
     private QrCodeScanCacheManager(Context context) {
-        mSharedPreferences = context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE);
+        sharedPreferences = context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE);
     }
 
     public void setCache(String qrCodeValue) {
-        SharedPreferences.Editor editor = mSharedPreferences.edit();
+        SharedPreferences.Editor editor = sharedPreferences.edit();
         editor.putString(Constants.Preferences.QR_CODE_SCAN_CACHE, qrCodeValue);
         editor.apply();
     }
 
     public boolean hasCache() {
-        return mSharedPreferences.contains(Constants.Preferences.QR_CODE_SCAN_CACHE);
+        return sharedPreferences.contains(Constants.Preferences.QR_CODE_SCAN_CACHE);
     }
 
     public String getCache() {
-        String cache = mSharedPreferences.getString(Constants.Preferences.QR_CODE_SCAN_CACHE, "");
+        String cache = sharedPreferences.getString(Constants.Preferences.QR_CODE_SCAN_CACHE, "");
         clearCache();
         return cache;
     }
 
     public void clearCache() {
-        mSharedPreferences.edit().remove(Constants.Preferences.QR_CODE_SCAN_CACHE).apply();
+        sharedPreferences.edit().remove(Constants.Preferences.QR_CODE_SCAN_CACHE).apply();
     }
 }

--- a/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/managers/SettingsManager.java
+++ b/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/managers/SettingsManager.java
@@ -2,30 +2,23 @@ package org.prebid.mobile.drprebid.managers;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-
 import org.prebid.mobile.drprebid.Constants;
-import org.prebid.mobile.drprebid.model.AdFormat;
-import org.prebid.mobile.drprebid.model.AdServer;
-import org.prebid.mobile.drprebid.model.AdServerSettings;
-import org.prebid.mobile.drprebid.model.AdSize;
-import org.prebid.mobile.drprebid.model.GeneralSettings;
-import org.prebid.mobile.drprebid.model.PrebidServer;
-import org.prebid.mobile.drprebid.model.PrebidServerSettings;
+import org.prebid.mobile.drprebid.model.*;
 
 public class SettingsManager {
     private static final String PREFERENCES_NAME = "dr_prebid_settings";
-    private final SharedPreferences mSharedPreferences;
+    private final SharedPreferences sharedPreferences;
 
-    private static volatile SettingsManager sInstance;
+    private static volatile SettingsManager instance;
     private static final Object mutex = new Object();
 
     public static SettingsManager getInstance(final Context context) {
-        SettingsManager result = sInstance;
+        SettingsManager result = instance;
         if (result == null) {
             synchronized (mutex) {
-                result = sInstance;
+                result = instance;
                 if (result == null) {
-                    sInstance = result = new SettingsManager(context);
+                    instance = result = new SettingsManager(context);
                 }
             }
         }
@@ -34,13 +27,13 @@ public class SettingsManager {
     }
 
     private SettingsManager(Context context) {
-        mSharedPreferences = context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE);
+        sharedPreferences = context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE);
     }
 
     public GeneralSettings getGeneralSettings() {
         GeneralSettings settings = new GeneralSettings();
 
-        switch (mSharedPreferences.getInt(Constants.Settings.AD_FORMAT, Constants.Settings.AdFormatCodes.BANNER)) {
+        switch (sharedPreferences.getInt(Constants.Settings.AD_FORMAT, Constants.Settings.AdFormatCodes.BANNER)) {
             case Constants.Settings.AdFormatCodes.BANNER:
                 settings.setAdFormat(AdFormat.BANNER);
                 break;
@@ -51,7 +44,7 @@ public class SettingsManager {
                 settings.setAdFormat(AdFormat.BANNER);
         }
 
-        switch (mSharedPreferences.getInt(Constants.Settings.AD_SIZE, Constants.Settings.AdSizeCodes.SIZE_300x250)) {
+        switch (sharedPreferences.getInt(Constants.Settings.AD_SIZE, Constants.Settings.AdSizeCodes.SIZE_300x250)) {
             case Constants.Settings.AdSizeCodes.SIZE_300x250:
                 settings.setAdSize(AdSize.BANNER_300x250);
                 break;
@@ -80,12 +73,15 @@ public class SettingsManager {
     public AdServerSettings getAdServerSettings() {
         AdServerSettings settings = new AdServerSettings();
 
-        if (mSharedPreferences.getInt(Constants.Settings.AD_SERVER, Constants.Settings.AdServerCodes.GOOGLE_AD_MANAGER) == Constants.Settings.AdServerCodes.GOOGLE_AD_MANAGER) {
+        if (sharedPreferences.getInt(
+                Constants.Settings.AD_SERVER,
+                Constants.Settings.AdServerCodes.GOOGLE_AD_MANAGER
+        ) == Constants.Settings.AdServerCodes.GOOGLE_AD_MANAGER) {
             settings.setAdServer(AdServer.GOOGLE_AD_MANAGER);
         }
 
-        settings.setBidPrice(mSharedPreferences.getFloat(Constants.Settings.BID_PRICE, 0.0f));
-        settings.setAdUnitId(mSharedPreferences.getString(Constants.Settings.AD_UNIT_ID, ""));
+        settings.setBidPrice(sharedPreferences.getFloat(Constants.Settings.BID_PRICE, 0.0f));
+        settings.setAdUnitId(sharedPreferences.getString(Constants.Settings.AD_UNIT_ID, ""));
 
         return settings;
     }
@@ -93,7 +89,10 @@ public class SettingsManager {
     public PrebidServerSettings getPrebidServerSettings() {
         PrebidServerSettings settings = new PrebidServerSettings();
 
-        switch (mSharedPreferences.getInt(Constants.Settings.PREBID_SERVER, Constants.Settings.PrebidServerCodes.APPNEXUS)) {
+        switch (sharedPreferences.getInt(
+                Constants.Settings.PREBID_SERVER,
+                Constants.Settings.PrebidServerCodes.APPNEXUS
+        )) {
             case Constants.Settings.PrebidServerCodes.APPNEXUS:
                 settings.setPrebidServer(PrebidServer.APPNEXUS);
                 settings.setCustomPrebidServerUrl("");
@@ -104,51 +103,54 @@ public class SettingsManager {
                 break;
             case Constants.Settings.PrebidServerCodes.CUSTOM:
                 settings.setPrebidServer(PrebidServer.CUSTOM);
-                settings.setCustomPrebidServerUrl(mSharedPreferences.getString(Constants.Settings.PREBID_SERVER_CUSTOM_URL, ""));
+                settings.setCustomPrebidServerUrl(sharedPreferences.getString(
+                        Constants.Settings.PREBID_SERVER_CUSTOM_URL,
+                        ""
+                ));
                 break;
             default:
                 settings.setPrebidServer(PrebidServer.APPNEXUS);
         }
 
-        settings.setAccountId(mSharedPreferences.getString(Constants.Settings.ACCOUNT_ID, ""));
-        settings.setConfigId(mSharedPreferences.getString(Constants.Settings.CONFIG_ID, ""));
+        settings.setAccountId(sharedPreferences.getString(Constants.Settings.ACCOUNT_ID, ""));
+        settings.setConfigId(sharedPreferences.getString(Constants.Settings.CONFIG_ID, ""));
 
         return settings;
     }
 
     public void setAdFormat(AdFormat adFormat) {
-        mSharedPreferences.edit().putInt(Constants.Settings.AD_FORMAT, adFormat.getCode()).apply();
+        sharedPreferences.edit().putInt(Constants.Settings.AD_FORMAT, adFormat.getCode()).apply();
     }
 
     public void setAdSize(AdSize adSize) {
-        mSharedPreferences.edit().putInt(Constants.Settings.AD_SIZE, adSize.getCode()).apply();
+        sharedPreferences.edit().putInt(Constants.Settings.AD_SIZE, adSize.getCode()).apply();
     }
 
     public void setAdServer(AdServer adServer) {
-        mSharedPreferences.edit().putInt(Constants.Settings.AD_SERVER, adServer.getCode()).apply();
+        sharedPreferences.edit().putInt(Constants.Settings.AD_SERVER, adServer.getCode()).apply();
     }
 
     public void setBidPrice(float bidPrice) {
-        mSharedPreferences.edit().putFloat(Constants.Settings.BID_PRICE, bidPrice).apply();
+        sharedPreferences.edit().putFloat(Constants.Settings.BID_PRICE, bidPrice).apply();
     }
 
     public void setAdUnitId(String adUnitId) {
-        mSharedPreferences.edit().putString(Constants.Settings.AD_UNIT_ID, adUnitId).apply();
+        sharedPreferences.edit().putString(Constants.Settings.AD_UNIT_ID, adUnitId).apply();
     }
 
     public void setPrebidServer(PrebidServer prebidServer) {
-        mSharedPreferences.edit().putInt(Constants.Settings.PREBID_SERVER, prebidServer.getCode()).apply();
+        sharedPreferences.edit().putInt(Constants.Settings.PREBID_SERVER, prebidServer.getCode()).apply();
     }
 
     public void setPrebidServerCustomUrl(String customUrl) {
-        mSharedPreferences.edit().putString(Constants.Settings.PREBID_SERVER_CUSTOM_URL, customUrl).apply();
+        sharedPreferences.edit().putString(Constants.Settings.PREBID_SERVER_CUSTOM_URL, customUrl).apply();
     }
 
     public void setAccountId(String accountId) {
-        mSharedPreferences.edit().putString(Constants.Settings.ACCOUNT_ID, accountId).apply();
+        sharedPreferences.edit().putString(Constants.Settings.ACCOUNT_ID, accountId).apply();
     }
 
     public void setConfigId(String configId) {
-        mSharedPreferences.edit().putString(Constants.Settings.CONFIG_ID, configId).apply();
+        sharedPreferences.edit().putString(Constants.Settings.CONFIG_ID, configId).apply();
     }
 }

--- a/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/managers/UserPrefsManager.java
+++ b/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/managers/UserPrefsManager.java
@@ -2,23 +2,22 @@ package org.prebid.mobile.drprebid.managers;
 
 import android.content.Context;
 import android.content.SharedPreferences;
-
 import org.prebid.mobile.drprebid.Constants;
 
 public class UserPrefsManager {
     private static final String PREFERENCES_NAME = "dr_prebid_user_prefs";
-    private final SharedPreferences mSharedPreferences;
+    private final SharedPreferences sharedPreferences;
 
-    private static volatile UserPrefsManager sInstance;
+    private static volatile UserPrefsManager instance;
     private static final Object mutex = new Object();
 
     public static UserPrefsManager getInstance(Context context) {
-        UserPrefsManager result = sInstance;
+        UserPrefsManager result = instance;
         if (result == null) {
             synchronized (mutex) {
-                result = sInstance;
+                result = instance;
                 if (result == null) {
-                    sInstance = result = new UserPrefsManager(context);
+                    instance = result = new UserPrefsManager(context);
                 }
             }
         }
@@ -27,16 +26,16 @@ public class UserPrefsManager {
     }
 
     private UserPrefsManager(Context context) {
-        mSharedPreferences = context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE);
+        sharedPreferences = context.getSharedPreferences(PREFERENCES_NAME, Context.MODE_PRIVATE);
     }
 
     public void setHasWelcomeBeenShown(boolean hasBeenShown) {
-        SharedPreferences.Editor editor = mSharedPreferences.edit();
+        SharedPreferences.Editor editor = sharedPreferences.edit();
         editor.putBoolean(Constants.Preferences.WELCOME_SHOWN, hasBeenShown);
         editor.apply();
     }
 
     public boolean hasWelcomeBeenShown() {
-        return mSharedPreferences.getBoolean(Constants.Preferences.WELCOME_SHOWN, false);
+        return sharedPreferences.getBoolean(Constants.Preferences.WELCOME_SHOWN, false);
     }
 }

--- a/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/qrscanning/CodeGraphic.java
+++ b/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/qrscanning/CodeGraphic.java
@@ -4,52 +4,47 @@ import android.graphics.Canvas;
 import android.graphics.Color;
 import android.graphics.Paint;
 import android.graphics.RectF;
-
 import com.google.android.gms.vision.barcode.Barcode;
-
 import org.prebid.mobile.drprebid.qrscanning.camera.GraphicOverlay;
 
 public class CodeGraphic extends GraphicOverlay.Graphic {
-    private int mId;
 
-    private static final int COLOR_CHOICES[] = {
-            Color.BLUE,
-            Color.CYAN,
-            Color.GREEN
-    };
+    private int id;
 
-    private static int mCurrentColorIndex = 0;
+    private static final int COLOR_CHOICES[] = {Color.BLUE, Color.CYAN, Color.GREEN};
 
-    private Paint mRectPaint;
-    private Paint mTextPaint;
-    private volatile Barcode mBarcode;
+    private static int currentColorIndex = 0;
+
+    private Paint rectPaint;
+    private Paint textPaint;
+    private volatile Barcode barcode;
 
     CodeGraphic(GraphicOverlay overlay) {
         super(overlay);
 
-        mCurrentColorIndex = (mCurrentColorIndex + 1) % COLOR_CHOICES.length;
-        final int selectedColor = COLOR_CHOICES[mCurrentColorIndex];
+        currentColorIndex = (currentColorIndex + 1) % COLOR_CHOICES.length;
+        final int selectedColor = COLOR_CHOICES[currentColorIndex];
 
-        mRectPaint = new Paint();
-        mRectPaint.setColor(selectedColor);
-        mRectPaint.setStyle(Paint.Style.STROKE);
-        mRectPaint.setStrokeWidth(4.0f);
+        rectPaint = new Paint();
+        rectPaint.setColor(selectedColor);
+        rectPaint.setStyle(Paint.Style.STROKE);
+        rectPaint.setStrokeWidth(4.0f);
 
-        mTextPaint = new Paint();
-        mTextPaint.setColor(selectedColor);
-        mTextPaint.setTextSize(36.0f);
+        textPaint = new Paint();
+        textPaint.setColor(selectedColor);
+        textPaint.setTextSize(36.0f);
     }
 
     public int getId() {
-        return mId;
+        return id;
     }
 
     public void setId(int id) {
-        this.mId = id;
+        this.id = id;
     }
 
     public Barcode getBarcode() {
-        return mBarcode;
+        return barcode;
     }
 
     /**
@@ -57,7 +52,7 @@ public class CodeGraphic extends GraphicOverlay.Graphic {
      * relevant portions of the overlay to trigger a redraw.
      */
     void updateItem(Barcode barcode) {
-        mBarcode = barcode;
+        this.barcode = barcode;
         postInvalidate();
     }
 
@@ -66,7 +61,7 @@ public class CodeGraphic extends GraphicOverlay.Graphic {
      */
     @Override
     public void draw(Canvas canvas) {
-        Barcode barcode = mBarcode;
+        Barcode barcode = this.barcode;
         if (barcode == null) {
             return;
         }
@@ -77,9 +72,9 @@ public class CodeGraphic extends GraphicOverlay.Graphic {
         rect.top = translateY(rect.top);
         rect.right = translateX(rect.right);
         rect.bottom = translateY(rect.bottom);
-        canvas.drawRect(rect, mRectPaint);
+        canvas.drawRect(rect, rectPaint);
 
         // Draws a label at the bottom of the barcode indicate the barcode value that was detected.
-        canvas.drawText(barcode.rawValue, rect.left, rect.bottom, mTextPaint);
+        canvas.drawText(barcode.rawValue, rect.left, rect.bottom, textPaint);
     }
 }

--- a/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/qrscanning/CodeGraphicTracker.java
+++ b/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/qrscanning/CodeGraphicTracker.java
@@ -2,34 +2,37 @@ package org.prebid.mobile.drprebid.qrscanning;
 
 import android.content.Context;
 import androidx.annotation.UiThread;
-
 import com.google.android.gms.vision.Detector;
 import com.google.android.gms.vision.Tracker;
 import com.google.android.gms.vision.barcode.Barcode;
-
 import org.prebid.mobile.drprebid.qrscanning.camera.GraphicOverlay;
 
 public class CodeGraphicTracker extends Tracker<Barcode> {
-    private GraphicOverlay<CodeGraphic> mOverlay;
-    private CodeGraphic mGraphic;
 
-    private CodeUpdateListener mCodeUpdateListener;
+    private GraphicOverlay<CodeGraphic> overlay;
+    private CodeGraphic graphic;
+
+    private CodeUpdateListener codeUpdateListener;
 
     /**
      * Consume the item instance detected from an Activity or Fragment level by implementing the
      * CodeUpdateListener interface method onBarcodeDetected.
      */
     public interface CodeUpdateListener {
+
         @UiThread
         void onBarcodeDetected(Barcode barcode);
     }
 
-    CodeGraphicTracker(GraphicOverlay<CodeGraphic> mOverlay, CodeGraphic mGraphic,
-                       Context context) {
-        this.mOverlay = mOverlay;
-        this.mGraphic = mGraphic;
+    CodeGraphicTracker(
+            GraphicOverlay<CodeGraphic> overlay,
+            CodeGraphic graphic,
+            Context context
+    ) {
+        this.overlay = overlay;
+        this.graphic = graphic;
         if (context instanceof CodeUpdateListener) {
-            this.mCodeUpdateListener = (CodeUpdateListener) context;
+            this.codeUpdateListener = (CodeUpdateListener) context;
         } else {
             throw new RuntimeException("Hosting activity must implement CodeUpdateListener");
         }
@@ -40,8 +43,8 @@ public class CodeGraphicTracker extends Tracker<Barcode> {
      */
     @Override
     public void onNewItem(int id, Barcode item) {
-        mGraphic.setId(id);
-        mCodeUpdateListener.onBarcodeDetected(item);
+        graphic.setId(id);
+        codeUpdateListener.onBarcodeDetected(item);
     }
 
     /**
@@ -49,8 +52,8 @@ public class CodeGraphicTracker extends Tracker<Barcode> {
      */
     @Override
     public void onUpdate(Detector.Detections<Barcode> detectionResults, Barcode item) {
-        mOverlay.add(mGraphic);
-        mGraphic.updateItem(item);
+        overlay.add(graphic);
+        graphic.updateItem(item);
     }
 
     /**
@@ -60,7 +63,7 @@ public class CodeGraphicTracker extends Tracker<Barcode> {
      */
     @Override
     public void onMissing(Detector.Detections<Barcode> detectionResults) {
-        mOverlay.remove(mGraphic);
+        overlay.remove(graphic);
     }
 
     /**
@@ -69,6 +72,6 @@ public class CodeGraphicTracker extends Tracker<Barcode> {
      */
     @Override
     public void onDone() {
-        mOverlay.remove(mGraphic);
+        overlay.remove(graphic);
     }
 }

--- a/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/qrscanning/CodeTrackerFactory.java
+++ b/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/qrscanning/CodeTrackerFactory.java
@@ -1,26 +1,28 @@
 package org.prebid.mobile.drprebid.qrscanning;
 
 import android.content.Context;
-
 import com.google.android.gms.vision.MultiProcessor;
 import com.google.android.gms.vision.Tracker;
 import com.google.android.gms.vision.barcode.Barcode;
-
 import org.prebid.mobile.drprebid.qrscanning.camera.GraphicOverlay;
 
 public class CodeTrackerFactory implements MultiProcessor.Factory<Barcode> {
-    private GraphicOverlay<CodeGraphic> mGraphicOverlay;
-    private Context mContext;
 
-    public CodeTrackerFactory(GraphicOverlay<CodeGraphic> mGraphicOverlay,
-                              Context mContext) {
-        this.mGraphicOverlay = mGraphicOverlay;
-        this.mContext = mContext;
+    private GraphicOverlay<CodeGraphic> graphicOverlay;
+    private Context context;
+
+    public CodeTrackerFactory(
+            GraphicOverlay<CodeGraphic> graphicOverlay,
+            Context context
+    ) {
+        this.graphicOverlay = graphicOverlay;
+        this.context = context;
     }
 
     @Override
     public Tracker<Barcode> create(Barcode barcode) {
-        CodeGraphic graphic = new CodeGraphic(mGraphicOverlay);
-        return new CodeGraphicTracker(mGraphicOverlay, graphic, mContext);
+        CodeGraphic graphic = new CodeGraphic(graphicOverlay);
+        return new CodeGraphicTracker(graphicOverlay, graphic, context);
     }
+
 }

--- a/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/qrscanning/camera/CameraSourcePreview.java
+++ b/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/qrscanning/camera/CameraSourcePreview.java
@@ -3,37 +3,40 @@ package org.prebid.mobile.drprebid.qrscanning.camera;
 import android.Manifest;
 import android.content.Context;
 import android.content.res.Configuration;
-import androidx.annotation.RequiresPermission;
 import android.util.AttributeSet;
 import android.util.Log;
 import android.view.SurfaceHolder;
 import android.view.SurfaceView;
 import android.view.ViewGroup;
-
+import androidx.annotation.RequiresPermission;
 import com.google.android.gms.common.images.Size;
 
 import java.io.IOException;
 
 public class CameraSourcePreview extends ViewGroup {
+
     private static final String TAG = "CameraSourcePreview";
 
-    private Context mContext;
-    private SurfaceView mSurfaceView;
-    private boolean mStartRequested;
-    private boolean mSurfaceAvailable;
-    private CameraSource mCameraSource;
+    private Context context;
+    private SurfaceView surfaceView;
+    private boolean startRequested;
+    private boolean surfaceAvailable;
+    private CameraSource cameraSource;
 
-    private GraphicOverlay mOverlay;
+    private GraphicOverlay overlay;
 
-    public CameraSourcePreview(Context context, AttributeSet attrs) {
+    public CameraSourcePreview(
+            Context context,
+            AttributeSet attrs
+    ) {
         super(context, attrs);
-        mContext = context;
-        mStartRequested = false;
-        mSurfaceAvailable = false;
+        this.context = context;
+        startRequested = false;
+        surfaceAvailable = false;
 
-        mSurfaceView = new SurfaceView(context);
-        mSurfaceView.getHolder().addCallback(new SurfaceCallback());
-        addView(mSurfaceView);
+        surfaceView = new SurfaceView(context);
+        surfaceView.getHolder().addCallback(new SurfaceCallback());
+        addView(surfaceView);
     }
 
     @RequiresPermission(Manifest.permission.CAMERA)
@@ -42,58 +45,58 @@ public class CameraSourcePreview extends ViewGroup {
             stop();
         }
 
-        mCameraSource = cameraSource;
+        this.cameraSource = cameraSource;
 
-        if (mCameraSource != null) {
-            mStartRequested = true;
+        if (this.cameraSource != null) {
+            startRequested = true;
             startIfReady();
         }
     }
 
     @RequiresPermission(Manifest.permission.CAMERA)
     public void start(CameraSource cameraSource, GraphicOverlay overlay) throws IOException, SecurityException {
-        mOverlay = overlay;
+        this.overlay = overlay;
         start(cameraSource);
     }
 
     public void stop() {
-        if (mCameraSource != null) {
-            mCameraSource.stop();
+        if (cameraSource != null) {
+            cameraSource.stop();
         }
     }
 
     public void release() {
-        if (mCameraSource != null) {
-            mCameraSource.release();
-            mCameraSource = null;
+        if (cameraSource != null) {
+            cameraSource.release();
+            cameraSource = null;
         }
     }
 
     @RequiresPermission(Manifest.permission.CAMERA)
     private void startIfReady() throws IOException, SecurityException {
-        if (mStartRequested && mSurfaceAvailable) {
-            mCameraSource.start(mSurfaceView.getHolder());
-            if (mOverlay != null) {
-                Size size = mCameraSource.getPreviewSize();
+        if (startRequested && surfaceAvailable) {
+            cameraSource.start(surfaceView.getHolder());
+            if (overlay != null) {
+                Size size = cameraSource.getPreviewSize();
                 int min = Math.min(size.getWidth(), size.getHeight());
                 int max = Math.max(size.getWidth(), size.getHeight());
                 if (isPortraitMode()) {
                     // Swap width and height sizes when in portrait, since it will be rotated by
                     // 90 degrees
-                    mOverlay.setCameraInfo(min, max, mCameraSource.getCameraFacing());
+                    overlay.setCameraInfo(min, max, cameraSource.getCameraFacing());
                 } else {
-                    mOverlay.setCameraInfo(max, min, mCameraSource.getCameraFacing());
+                    overlay.setCameraInfo(max, min, cameraSource.getCameraFacing());
                 }
-                mOverlay.clear();
+                overlay.clear();
             }
-            mStartRequested = false;
+            startRequested = false;
         }
     }
 
     private class SurfaceCallback implements SurfaceHolder.Callback {
         @Override
         public void surfaceCreated(SurfaceHolder surface) {
-            mSurfaceAvailable = true;
+            surfaceAvailable = true;
             try {
                 startIfReady();
             } catch (SecurityException se) {
@@ -105,7 +108,7 @@ public class CameraSourcePreview extends ViewGroup {
 
         @Override
         public void surfaceDestroyed(SurfaceHolder surface) {
-            mSurfaceAvailable = false;
+            surfaceAvailable = false;
         }
 
         @Override
@@ -117,8 +120,8 @@ public class CameraSourcePreview extends ViewGroup {
     protected void onLayout(boolean changed, int left, int top, int right, int bottom) {
         int width = 320;
         int height = 240;
-        if (mCameraSource != null) {
-            Size size = mCameraSource.getPreviewSize();
+        if (cameraSource != null) {
+            Size size = cameraSource.getPreviewSize();
             if (size != null) {
                 width = size.getWidth();
                 height = size.getHeight();
@@ -160,7 +163,7 @@ public class CameraSourcePreview extends ViewGroup {
     }
 
     private boolean isPortraitMode() {
-        int orientation = mContext.getResources().getConfiguration().orientation;
+        int orientation = context.getResources().getConfiguration().orientation;
         if (orientation == Configuration.ORIENTATION_LANDSCAPE) {
             return false;
         }

--- a/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/qrscanning/camera/GraphicOverlay.java
+++ b/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/qrscanning/camera/GraphicOverlay.java
@@ -11,13 +11,14 @@ import java.util.Set;
 import java.util.Vector;
 
 public class GraphicOverlay<T extends GraphicOverlay.Graphic> extends View {
-    private final Object mLock = new Object();
-    private int mPreviewWidth;
-    private float mWidthScaleFactor = 1.0f;
-    private int mPreviewHeight;
-    private float mHeightScaleFactor = 1.0f;
-    private int mFacing = CameraSource.CAMERA_FACING_BACK;
-    private Set<T> mGraphics = new HashSet<>();
+
+    private final Object lock = new Object();
+    private int previewWidth;
+    private float widthScaleFactor = 1.0f;
+    private int previewHeight;
+    private float heightScaleFactor = 1.0f;
+    private int facing = CameraSource.CAMERA_FACING_BACK;
+    private Set<T> graphics = new HashSet<>();
 
     /**
      * Base class for a custom graphics object to be rendered within the graphic overlay.  Subclass
@@ -25,10 +26,11 @@ public class GraphicOverlay<T extends GraphicOverlay.Graphic> extends View {
      * graphics element.  Add instances to the overlay using {@link GraphicOverlay#add(Graphic)}.
      */
     public static abstract class Graphic {
-        private GraphicOverlay mOverlay;
+
+        private GraphicOverlay overlay;
 
         public Graphic(GraphicOverlay overlay) {
-            mOverlay = overlay;
+            this.overlay = overlay;
         }
 
         /**
@@ -50,14 +52,14 @@ public class GraphicOverlay<T extends GraphicOverlay.Graphic> extends View {
          * scale.
          */
         public float scaleX(float horizontal) {
-            return horizontal * mOverlay.mWidthScaleFactor;
+            return horizontal * overlay.widthScaleFactor;
         }
 
         /**
          * Adjusts a vertical value of the supplied value from the preview scale to the view scale.
          */
         public float scaleY(float vertical) {
-            return vertical * mOverlay.mHeightScaleFactor;
+            return vertical * overlay.heightScaleFactor;
         }
 
         /**
@@ -65,8 +67,8 @@ public class GraphicOverlay<T extends GraphicOverlay.Graphic> extends View {
          * system.
          */
         public float translateX(float x) {
-            if (mOverlay.mFacing == CameraSource.CAMERA_FACING_FRONT) {
-                return mOverlay.getWidth() - scaleX(x);
+            if (overlay.facing == CameraSource.CAMERA_FACING_FRONT) {
+                return overlay.getWidth() - scaleX(x);
             } else {
                 return scaleX(x);
             }
@@ -81,7 +83,7 @@ public class GraphicOverlay<T extends GraphicOverlay.Graphic> extends View {
         }
 
         public void postInvalidate() {
-            mOverlay.postInvalidate();
+            overlay.postInvalidate();
         }
     }
 
@@ -93,8 +95,8 @@ public class GraphicOverlay<T extends GraphicOverlay.Graphic> extends View {
      * Removes all graphics from the overlay.
      */
     public void clear() {
-        synchronized (mLock) {
-            mGraphics.clear();
+        synchronized (lock) {
+            graphics.clear();
         }
         postInvalidate();
     }
@@ -103,8 +105,8 @@ public class GraphicOverlay<T extends GraphicOverlay.Graphic> extends View {
      * Adds a graphic to the overlay.
      */
     public void add(T graphic) {
-        synchronized (mLock) {
-            mGraphics.add(graphic);
+        synchronized (lock) {
+            graphics.add(graphic);
         }
         postInvalidate();
     }
@@ -113,8 +115,8 @@ public class GraphicOverlay<T extends GraphicOverlay.Graphic> extends View {
      * Removes a graphic from the overlay.
      */
     public void remove(T graphic) {
-        synchronized (mLock) {
-            mGraphics.remove(graphic);
+        synchronized (lock) {
+            graphics.remove(graphic);
         }
         postInvalidate();
     }
@@ -125,8 +127,8 @@ public class GraphicOverlay<T extends GraphicOverlay.Graphic> extends View {
      * @return list of all active graphics.
      */
     public List<T> getGraphics() {
-        synchronized (mLock) {
-            return new Vector<>(mGraphics);
+        synchronized (lock) {
+            return new Vector<>(graphics);
         }
     }
 
@@ -134,14 +136,14 @@ public class GraphicOverlay<T extends GraphicOverlay.Graphic> extends View {
      * Returns the horizontal scale factor.
      */
     public float getWidthScaleFactor() {
-        return mWidthScaleFactor;
+        return widthScaleFactor;
     }
 
     /**
      * Returns the vertical scale factor.
      */
     public float getHeightScaleFactor() {
-        return mHeightScaleFactor;
+        return heightScaleFactor;
     }
 
     /**
@@ -149,10 +151,10 @@ public class GraphicOverlay<T extends GraphicOverlay.Graphic> extends View {
      * image coordinates later.
      */
     public void setCameraInfo(int previewWidth, int previewHeight, int facing) {
-        synchronized (mLock) {
-            mPreviewWidth = previewWidth;
-            mPreviewHeight = previewHeight;
-            mFacing = facing;
+        synchronized (lock) {
+            this.previewWidth = previewWidth;
+            this.previewHeight = previewHeight;
+            this.facing = facing;
         }
         postInvalidate();
     }
@@ -164,13 +166,13 @@ public class GraphicOverlay<T extends GraphicOverlay.Graphic> extends View {
     protected void onDraw(Canvas canvas) {
         super.onDraw(canvas);
 
-        synchronized (mLock) {
-            if ((mPreviewWidth != 0) && (mPreviewHeight != 0)) {
-                mWidthScaleFactor = (float) canvas.getWidth() / (float) mPreviewWidth;
-                mHeightScaleFactor = (float) canvas.getHeight() / (float) mPreviewHeight;
+        synchronized (lock) {
+            if ((previewWidth != 0) && (previewHeight != 0)) {
+                widthScaleFactor = (float) canvas.getWidth() / (float) previewWidth;
+                heightScaleFactor = (float) canvas.getHeight() / (float) previewHeight;
             }
 
-            for (Graphic graphic : mGraphics) {
+            for (Graphic graphic : graphics) {
                 graphic.draw(canvas);
             }
         }

--- a/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/ui/activities/InfoActivity.java
+++ b/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/ui/activities/InfoActivity.java
@@ -3,13 +3,12 @@ package org.prebid.mobile.drprebid.ui.activities;
 import android.content.Context;
 import android.content.Intent;
 import android.os.Bundle;
-import androidx.annotation.Nullable;
-import androidx.appcompat.app.ActionBar;
-import androidx.appcompat.app.AppCompatActivity;
 import android.text.TextUtils;
 import android.view.MenuItem;
 import android.webkit.WebView;
-
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.app.AppCompatActivity;
 import org.prebid.mobile.drprebid.R;
 
 import java.util.Locale;
@@ -18,14 +17,14 @@ public class InfoActivity extends AppCompatActivity {
     public static final String EXTRA_TITLE = "screen_title";
     public static final String EXTRA_HTML_CONTENT = "screen_html_content";
 
-    private WebView mWebView;
+    private WebView webView;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_info);
 
-        mWebView = findViewById(R.id.web_view);
+        webView = findViewById(R.id.web_view);
 
         Bundle extras = getIntent().getExtras();
 
@@ -51,7 +50,7 @@ public class InfoActivity extends AppCompatActivity {
             finish();
         } else {
             String url = String.format(Locale.ENGLISH, "file:///android_asset/%s", htmlFile);
-            mWebView.loadUrl(url);
+            webView.loadUrl(url);
         }
     }
 

--- a/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/ui/activities/MainActivity.java
+++ b/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/ui/activities/MainActivity.java
@@ -1,17 +1,15 @@
 package org.prebid.mobile.drprebid.ui.activities;
 
 import android.content.Intent;
-
 import android.os.Bundle;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.recyclerview.widget.DefaultItemAnimator;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
-import android.view.Menu;
-import android.view.MenuInflater;
-import android.view.MenuItem;
-
 import org.prebid.mobile.drprebid.R;
 import org.prebid.mobile.drprebid.managers.UserPrefsManager;
 import org.prebid.mobile.drprebid.model.HelpScreen;
@@ -21,7 +19,7 @@ import org.prebid.mobile.drprebid.util.HelpScreenUtil;
 public class MainActivity extends AppCompatActivity {
     private static final int REQUEST_WELCOME = 2000;
 
-    private RecyclerView mListView;
+    private RecyclerView listView;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
@@ -34,7 +32,7 @@ public class MainActivity extends AppCompatActivity {
             }
         }
 
-        mListView = findViewById(R.id.list_settings);
+        listView = findViewById(R.id.list_settings);
         setupSettingsList();
 
     }
@@ -42,9 +40,9 @@ public class MainActivity extends AppCompatActivity {
     private void setupSettingsList() {
         SettingsAdapter adapter = new SettingsAdapter(this);
 
-        mListView.setLayoutManager(new LinearLayoutManager(this, RecyclerView.VERTICAL, false));
-        mListView.setItemAnimator(new DefaultItemAnimator());
-        mListView.setAdapter(adapter);
+        listView.setLayoutManager(new LinearLayoutManager(this, RecyclerView.VERTICAL, false));
+        listView.setItemAnimator(new DefaultItemAnimator());
+        listView.setAdapter(adapter);
     }
 
     @Override

--- a/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/ui/activities/QrCodeCaptureActivity.java
+++ b/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/ui/activities/QrCodeCaptureActivity.java
@@ -12,25 +12,23 @@ import android.content.pm.PackageManager;
 import android.hardware.Camera;
 import android.os.Build;
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import com.google.android.material.snackbar.Snackbar;
-import androidx.core.app.ActivityCompat;
-import androidx.appcompat.app.AlertDialog;
-import androidx.appcompat.app.AppCompatActivity;
 import android.util.Log;
 import android.view.GestureDetector;
 import android.view.MotionEvent;
 import android.view.ScaleGestureDetector;
 import android.view.View;
 import android.widget.Toast;
-
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AlertDialog;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.core.app.ActivityCompat;
 import com.google.android.gms.common.ConnectionResult;
 import com.google.android.gms.common.GoogleApiAvailability;
 import com.google.android.gms.common.api.CommonStatusCodes;
 import com.google.android.gms.vision.MultiProcessor;
 import com.google.android.gms.vision.barcode.Barcode;
 import com.google.android.gms.vision.barcode.BarcodeDetector;
-
+import com.google.android.material.snackbar.Snackbar;
 import org.prebid.mobile.drprebid.R;
 import org.prebid.mobile.drprebid.managers.QrCodeScanCacheManager;
 import org.prebid.mobile.drprebid.qrscanning.CodeGraphic;
@@ -57,9 +55,9 @@ public class QrCodeCaptureActivity extends AppCompatActivity implements CodeGrap
     public static final String EXTRA_USE_FLASH = "UseFlash";
     public static final String BarcodeObject = "Barcode";
 
-    private CameraSource mCameraSource;
-    private CameraSourcePreview mPreview;
-    private GraphicOverlay<CodeGraphic> mGraphicOverlay;
+    private CameraSource cameraSource;
+    private CameraSourcePreview preview;
+    private GraphicOverlay<CodeGraphic> graphicOverlay;
 
     // helper objects for detecting taps and pinches.
     private ScaleGestureDetector scaleGestureDetector;
@@ -75,8 +73,8 @@ public class QrCodeCaptureActivity extends AppCompatActivity implements CodeGrap
 
         setTitle(R.string.qr_code_scan_title);
 
-        mPreview = findViewById(R.id.preview);
-        mGraphicOverlay = findViewById(R.id.graphicOverlay);
+        preview = findViewById(R.id.preview);
+        graphicOverlay = findViewById(R.id.graphicOverlay);
 
         // read parameters from the intent used to launch the activity.
         boolean autoFocus = getIntent().getBooleanExtra(EXTRA_AUTO_FOCUS, false);
@@ -94,8 +92,7 @@ public class QrCodeCaptureActivity extends AppCompatActivity implements CodeGrap
         gestureDetector = new GestureDetector(this, new CaptureGestureListener());
         scaleGestureDetector = new ScaleGestureDetector(this, new ScaleListener());
 
-        Snackbar.make(mGraphicOverlay, "Tap to capture. Pinch/Stretch to zoom",
-                Snackbar.LENGTH_LONG)
+        Snackbar.make(graphicOverlay, "Tap to capture. Pinch/Stretch to zoom", Snackbar.LENGTH_LONG)
                 .show();
     }
 
@@ -121,8 +118,7 @@ public class QrCodeCaptureActivity extends AppCompatActivity implements CodeGrap
                 RC_HANDLE_CAMERA_PERM);
 
         findViewById(R.id.topLayout).setOnClickListener(listener);
-        Snackbar.make(mGraphicOverlay, R.string.permission_camera_rationale,
-                Snackbar.LENGTH_INDEFINITE)
+        Snackbar.make(graphicOverlay, R.string.permission_camera_rationale, Snackbar.LENGTH_INDEFINITE)
                 .setAction(R.string.action_ok, listener)
                 .show();
     }
@@ -153,7 +149,7 @@ public class QrCodeCaptureActivity extends AppCompatActivity implements CodeGrap
         // graphics for each barcode on screen.  The factory is used by the multi-processor to
         // create a separate tracker instance for each barcode.
         BarcodeDetector barcodeDetector = new BarcodeDetector.Builder(context).build();
-        CodeTrackerFactory barcodeFactory = new CodeTrackerFactory(mGraphicOverlay, this);
+        CodeTrackerFactory barcodeFactory = new CodeTrackerFactory(graphicOverlay, this);
         barcodeDetector.setProcessor(
                 new MultiProcessor.Builder<>(barcodeFactory).build());
 
@@ -194,9 +190,7 @@ public class QrCodeCaptureActivity extends AppCompatActivity implements CodeGrap
                     autoFocus ? Camera.Parameters.FOCUS_MODE_CONTINUOUS_PICTURE : null);
         }
 
-        mCameraSource = builder
-                .setFlashMode(useFlash ? Camera.Parameters.FLASH_MODE_TORCH : null)
-                .build();
+        cameraSource = builder.setFlashMode(useFlash ? Camera.Parameters.FLASH_MODE_TORCH : null).build();
     }
 
     /**
@@ -214,8 +208,8 @@ public class QrCodeCaptureActivity extends AppCompatActivity implements CodeGrap
     @Override
     protected void onPause() {
         super.onPause();
-        if (mPreview != null) {
-            mPreview.stop();
+        if (preview != null) {
+            preview.stop();
         }
     }
 
@@ -226,8 +220,8 @@ public class QrCodeCaptureActivity extends AppCompatActivity implements CodeGrap
     @Override
     protected void onDestroy() {
         super.onDestroy();
-        if (mPreview != null) {
-            mPreview.release();
+        if (preview != null) {
+            preview.release();
         }
     }
 
@@ -293,13 +287,13 @@ public class QrCodeCaptureActivity extends AppCompatActivity implements CodeGrap
             dlg.show();
         }
 
-        if (mCameraSource != null) {
+        if (cameraSource != null) {
             try {
-                mPreview.start(mCameraSource, mGraphicOverlay);
+                preview.start(cameraSource, graphicOverlay);
             } catch (IOException e) {
                 Log.e(TAG, "Unable to start camera source.", e);
-                mCameraSource.release();
-                mCameraSource = null;
+                cameraSource.release();
+                cameraSource = null;
             }
         }
     }
@@ -314,14 +308,14 @@ public class QrCodeCaptureActivity extends AppCompatActivity implements CodeGrap
     private boolean onTap(float rawX, float rawY) {
         // Find tap point in preview frame coordinates.
         int[] location = new int[2];
-        mGraphicOverlay.getLocationOnScreen(location);
-        float x = (rawX - location[0]) / mGraphicOverlay.getWidthScaleFactor();
-        float y = (rawY - location[1]) / mGraphicOverlay.getHeightScaleFactor();
+        graphicOverlay.getLocationOnScreen(location);
+        float x = (rawX - location[0]) / graphicOverlay.getWidthScaleFactor();
+        float y = (rawY - location[1]) / graphicOverlay.getHeightScaleFactor();
 
         // Find the barcode whose center is closest to the tapped point.
         Barcode best = null;
         float bestDistance = Float.MAX_VALUE;
-        for (CodeGraphic graphic : mGraphicOverlay.getGraphics()) {
+        for (CodeGraphic graphic : graphicOverlay.getGraphics()) {
             Barcode barcode = graphic.getBarcode();
             if (barcode.getBoundingBox().contains((int) x, (int) y)) {
                 // Exact hit, no need to keep looking.
@@ -407,7 +401,7 @@ public class QrCodeCaptureActivity extends AppCompatActivity implements CodeGrap
          */
         @Override
         public void onScaleEnd(ScaleGestureDetector detector) {
-            mCameraSource.doZoom(detector.getScaleFactor());
+            cameraSource.doZoom(detector.getScaleFactor());
         }
     }
 

--- a/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/ui/activities/TestResultsActivity.java
+++ b/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/ui/activities/TestResultsActivity.java
@@ -1,20 +1,15 @@
 package org.prebid.mobile.drprebid.ui.activities;
 
 import android.os.Bundle;
-
 import androidx.annotation.Nullable;
 import androidx.appcompat.app.AppCompatActivity;
 import androidx.lifecycle.ViewModelProviders;
 import androidx.recyclerview.widget.DefaultItemAnimator;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
-
 import com.google.android.gms.ads.MobileAds;
-
-
 import org.prebid.mobile.drprebid.R;
 import org.prebid.mobile.drprebid.managers.SettingsManager;
-import org.prebid.mobile.drprebid.model.AdServer;
 import org.prebid.mobile.drprebid.model.AdServerSettings;
 import org.prebid.mobile.drprebid.ui.adapters.TestResultsAdapter;
 import org.prebid.mobile.drprebid.ui.viewmodels.AdServerValidationViewModel;
@@ -26,23 +21,23 @@ import org.prebid.mobile.drprebid.validation.SdkTest;
 
 public class TestResultsActivity extends AppCompatActivity {
 
-    private RecyclerView mListView;
+    private RecyclerView listView;
 
-    private AdServerValidationViewModel mAdServerValidationViewModel;
-    private PrebidServerValidationViewModel mDemandValidationViewModel;
-    private SdkValidationViewModel mSdkValidationViewModel;
+    private AdServerValidationViewModel adServerValidationViewModel;
+    private PrebidServerValidationViewModel demandValidationViewModel;
+    private SdkValidationViewModel sdkValidationViewModel;
 
     @Override
     protected void onCreate(Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
         setContentView(R.layout.activity_test_results);
 
-        mListView = findViewById(R.id.list_results);
+        listView = findViewById(R.id.list_results);
         setupResultsList();
 
-        mAdServerValidationViewModel = ViewModelProviders.of(this).get(AdServerValidationViewModel.class);
-        mDemandValidationViewModel = ViewModelProviders.of(this).get(PrebidServerValidationViewModel.class);
-        mSdkValidationViewModel = ViewModelProviders.of(this).get(SdkValidationViewModel.class);
+        adServerValidationViewModel = ViewModelProviders.of(this).get(AdServerValidationViewModel.class);
+        demandValidationViewModel = ViewModelProviders.of(this).get(PrebidServerValidationViewModel.class);
+        sdkValidationViewModel = ViewModelProviders.of(this).get(SdkValidationViewModel.class);
 
         AdServerSettings adServerSettings = SettingsManager.getInstance(this).getAdServerSettings();
 
@@ -60,9 +55,9 @@ public class TestResultsActivity extends AppCompatActivity {
     private void setupResultsList() {
         TestResultsAdapter adapter = new TestResultsAdapter();
 
-        mListView.setLayoutManager(new LinearLayoutManager(this, RecyclerView.VERTICAL, false));
-        mListView.setItemAnimator(new DefaultItemAnimator());
-        mListView.setAdapter(adapter);
+        listView.setLayoutManager(new LinearLayoutManager(this, RecyclerView.VERTICAL, false));
+        listView.setItemAnimator(new DefaultItemAnimator());
+        listView.setAdapter(adapter);
     }
 
     private void runTests() {
@@ -73,17 +68,17 @@ public class TestResultsActivity extends AppCompatActivity {
         AdServerTest adServerTest = new AdServerTest(this, new AdServerTest.Listener() {
             @Override
             public void onPrebidKeywordsFoundOnRequest() {
-                mAdServerValidationViewModel.setRequestSent(true);
+                adServerValidationViewModel.setRequestSent(true);
             }
 
             @Override
             public void onPrebidKeywordsNotFoundOnRequest() {
-                mAdServerValidationViewModel.setRequestSent(false);
+                adServerValidationViewModel.setRequestSent(false);
             }
 
             @Override
             public void adServerResponseContainsPrebidCreative(@Nullable Boolean contains) {
-                mAdServerValidationViewModel.setCreativeServed(contains);
+                adServerValidationViewModel.setCreativeServed(contains);
             }
 
             @Override
@@ -99,47 +94,47 @@ public class TestResultsActivity extends AppCompatActivity {
         RealTimeDemandTest demandValidator = new RealTimeDemandTest(this, results -> {
             int totalBids = results.getTotalBids();
 
-            mDemandValidationViewModel.setBidResponseReceivedCount(totalBids);
-            mDemandValidationViewModel.setAverageCpm(results.getAvgEcpm());
-            mDemandValidationViewModel.setAverageResponseTime(results.getAvgResponseTime());
+            demandValidationViewModel.setBidResponseReceivedCount(totalBids);
+            demandValidationViewModel.setAverageCpm(results.getAvgEcpm());
+            demandValidationViewModel.setAverageResponseTime(results.getAvgResponseTime());
 
             runSdkValidationTest();
         });
 
         demandValidator.startTest();
-        mDemandValidationViewModel.setBidRequestsSent(true);
+        demandValidationViewModel.setBidRequestsSent(true);
     }
 
     private void runSdkValidationTest() {
         SdkTest sdkTest = new SdkTest(this, new SdkTest.Listener() {
             @Override
             public void onAdUnitRegistered() {
-                mSdkValidationViewModel.setAdUnitRegistered(true);
+                sdkValidationViewModel.setAdUnitRegistered(true);
             }
 
             @Override
             public void requestToPrebidServerSent(boolean sent) {
-                mSdkValidationViewModel.setPrebidRequestSent(sent);
+                sdkValidationViewModel.setPrebidRequestSent(sent);
             }
 
             @Override
             public void responseFromPrebidServerReceived(boolean received) {
-                mSdkValidationViewModel.setPrebidResponseReceived(received);
+                sdkValidationViewModel.setPrebidResponseReceived(received);
             }
 
             @Override
             public void bidReceivedAndCached(boolean received) {
-                mSdkValidationViewModel.setCreativeContentCached(received);
+                sdkValidationViewModel.setCreativeContentCached(received);
             }
 
             @Override
             public void requestSentToAdServer(String request, String postBody) {
-                mSdkValidationViewModel.setAdServerRequestSent(true);
+                sdkValidationViewModel.setAdServerRequestSent(true);
             }
 
             @Override
             public void adServerResponseContainsPrebidCreative(@Nullable Boolean contains) {
-                mSdkValidationViewModel.setCreativeServed(contains);
+                sdkValidationViewModel.setCreativeServed(contains);
             }
 
             @Override

--- a/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/ui/activities/WelcomeActivity.java
+++ b/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/ui/activities/WelcomeActivity.java
@@ -1,17 +1,16 @@
 package org.prebid.mobile.drprebid.ui.activities;
 
 import android.os.Bundle;
+import android.view.View;
+import android.widget.Button;
 import androidx.annotation.Nullable;
+import androidx.appcompat.app.ActionBar;
+import androidx.appcompat.app.AppCompatActivity;
 import androidx.fragment.app.Fragment;
 import androidx.fragment.app.FragmentManager;
 import androidx.fragment.app.FragmentStatePagerAdapter;
 import androidx.viewpager.widget.PagerAdapter;
 import androidx.viewpager.widget.ViewPager;
-import androidx.appcompat.app.ActionBar;
-import androidx.appcompat.app.AppCompatActivity;
-import android.view.View;
-import android.widget.Button;
-
 import org.prebid.mobile.drprebid.R;
 import org.prebid.mobile.drprebid.ui.fragments.ImageFragment;
 import org.prebid.mobile.drprebid.ui.views.SlideIndicatorsView;
@@ -21,10 +20,10 @@ import java.util.List;
 
 public class WelcomeActivity extends AppCompatActivity {
 
-    private ViewPager mPager;
-    private PagerAdapter mPagerAdapter;
-    private SlideIndicatorsView mIndicatorsView;
-    private Button mSkipButton;
+    private ViewPager pager;
+    private PagerAdapter pagerAdapter;
+    private SlideIndicatorsView indicatorsView;
+    private Button skipButton;
 
     @Override
     protected void onCreate(@Nullable Bundle savedInstanceState) {
@@ -37,16 +36,16 @@ public class WelcomeActivity extends AppCompatActivity {
             actionBar.hide();
         }
 
-        mPager = findViewById(R.id.pager_images);
-        mPagerAdapter = new SlideImageAdapter(getSupportFragmentManager());
-        mPager.addOnPageChangeListener(onPageChangeListener);
-        mPager.setAdapter(mPagerAdapter);
+        pager = findViewById(R.id.pager_images);
+        pagerAdapter = new SlideImageAdapter(getSupportFragmentManager());
+        pager.addOnPageChangeListener(onPageChangeListener);
+        pager.setAdapter(pagerAdapter);
 
-        mIndicatorsView = findViewById(R.id.view_indicators);
-        mIndicatorsView.setSelectedPosition(0);
+        indicatorsView = findViewById(R.id.view_indicators);
+        indicatorsView.setSelectedPosition(0);
 
-        mSkipButton = findViewById(R.id.button_skip);
-        mSkipButton.setOnClickListener(new View.OnClickListener() {
+        skipButton = findViewById(R.id.button_skip);
+        skipButton.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
                 finish();
@@ -56,10 +55,10 @@ public class WelcomeActivity extends AppCompatActivity {
 
     @Override
     public void onBackPressed() {
-        if (mPager.getCurrentItem() == 0) {
+        if (pager.getCurrentItem() == 0) {
             super.onBackPressed();
         } else {
-            mPager.setCurrentItem(mPager.getCurrentItem() - 1);
+            pager.setCurrentItem(pager.getCurrentItem() - 1);
         }
     }
 
@@ -67,36 +66,37 @@ public class WelcomeActivity extends AppCompatActivity {
         @Override
         public void onPageSelected(int position) {
             super.onPageSelected(position);
-            if (position == mPagerAdapter.getCount() - 1) {
-                mSkipButton.setText(R.string.action_continue);
+            if (position == pagerAdapter.getCount() - 1) {
+                skipButton.setText(R.string.action_continue);
             } else {
-                mSkipButton.setText(R.string.action_skip);
+                skipButton.setText(R.string.action_skip);
             }
 
-            mIndicatorsView.setSelectedPosition(position);
+            indicatorsView.setSelectedPosition(position);
         }
     };
 
     private class SlideImageAdapter extends FragmentStatePagerAdapter {
-        private final List<ImageFragment> mFragments;
+
+        private final List<ImageFragment> fragments;
 
         SlideImageAdapter(FragmentManager fragmentManager) {
             super(fragmentManager);
 
-            mFragments = new ArrayList<>();
-            mFragments.add(ImageFragment.newInstance(R.drawable.welcome_1));
-            mFragments.add(ImageFragment.newInstance(R.drawable.welcome_2));
-            mFragments.add(ImageFragment.newInstance(R.drawable.welcome_3));
+            fragments = new ArrayList<>();
+            fragments.add(ImageFragment.newInstance(R.drawable.welcome_1));
+            fragments.add(ImageFragment.newInstance(R.drawable.welcome_2));
+            fragments.add(ImageFragment.newInstance(R.drawable.welcome_3));
         }
 
         @Override
         public Fragment getItem(int position) {
-            return mFragments.get(position);
+            return fragments.get(position);
         }
 
         @Override
         public int getCount() {
-            return mFragments.size();
+            return fragments.size();
         }
     }
 }

--- a/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/ui/adapters/SettingsAdapter.java
+++ b/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/ui/adapters/SettingsAdapter.java
@@ -1,24 +1,14 @@
 package org.prebid.mobile.drprebid.ui.adapters;
 
 import android.content.Context;
-import androidx.annotation.NonNull;
-import androidx.recyclerview.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.ViewGroup;
-
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
 import org.prebid.mobile.drprebid.R;
 import org.prebid.mobile.drprebid.managers.SettingsManager;
-import org.prebid.mobile.drprebid.model.AdServerSettings;
-import org.prebid.mobile.drprebid.model.GeneralSettings;
-import org.prebid.mobile.drprebid.model.PrebidServerSettings;
-import org.prebid.mobile.drprebid.model.SettingsItem;
-import org.prebid.mobile.drprebid.model.SubmitSettings;
-import org.prebid.mobile.drprebid.ui.viewholders.AdServerSettingsViewHolder;
-import org.prebid.mobile.drprebid.ui.viewholders.DividerViewHolder;
-import org.prebid.mobile.drprebid.ui.viewholders.GeneralSettingsViewHolder;
-import org.prebid.mobile.drprebid.ui.viewholders.PrebidServerSettingsViewholder;
-import org.prebid.mobile.drprebid.ui.viewholders.SettingsViewHolder;
-import org.prebid.mobile.drprebid.ui.viewholders.SubmitViewHolder;
+import org.prebid.mobile.drprebid.model.*;
+import org.prebid.mobile.drprebid.ui.viewholders.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -30,10 +20,10 @@ public class SettingsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
     private static final int VIEW_TYPE_PREBID_SERVER_SETTINGS = 3;
     private static final int VIEW_TYPE_SUBMIT = 4;
 
-    private final List<SettingsItem> mItems;
+    private final List<SettingsItem> items;
 
     public SettingsAdapter(Context context) {
-        mItems = new ArrayList<>();
+        items = new ArrayList<>();
 
         setupSettings(context);
     }
@@ -57,7 +47,7 @@ public class SettingsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
 
     @Override
     public int getItemViewType(int position) {
-        SettingsItem item = mItems.get(position);
+        SettingsItem item = items.get(position);
         if (item instanceof GeneralSettings) {
             return VIEW_TYPE_GENERAL_SETTINGS;
         } else if (item instanceof AdServerSettings) {
@@ -79,13 +69,13 @@ public class SettingsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolde
 
     @Override
     public int getItemCount() {
-        return mItems.size();
+        return items.size();
     }
 
     private void setupSettings(Context context) {
-        mItems.add(SettingsManager.getInstance(context).getGeneralSettings());
-        mItems.add(SettingsManager.getInstance(context).getAdServerSettings());
-        mItems.add(SettingsManager.getInstance(context).getPrebidServerSettings());
-        mItems.add(new SubmitSettings());
+        items.add(SettingsManager.getInstance(context).getGeneralSettings());
+        items.add(SettingsManager.getInstance(context).getAdServerSettings());
+        items.add(SettingsManager.getInstance(context).getPrebidServerSettings());
+        items.add(new SubmitSettings());
     }
 }

--- a/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/ui/adapters/TestResultsAdapter.java
+++ b/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/ui/adapters/TestResultsAdapter.java
@@ -1,20 +1,15 @@
 package org.prebid.mobile.drprebid.ui.adapters;
 
-import androidx.annotation.NonNull;
-import androidx.recyclerview.widget.RecyclerView;
 import android.view.LayoutInflater;
 import android.view.ViewGroup;
-
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
 import org.prebid.mobile.drprebid.R;
 import org.prebid.mobile.drprebid.model.AdServerValidationResult;
 import org.prebid.mobile.drprebid.model.PrebidServerValidationResult;
 import org.prebid.mobile.drprebid.model.ResultItem;
 import org.prebid.mobile.drprebid.model.SdkValidationResult;
-import org.prebid.mobile.drprebid.ui.viewholders.AdServerValidationViewHolder;
-import org.prebid.mobile.drprebid.ui.viewholders.DividerViewHolder;
-import org.prebid.mobile.drprebid.ui.viewholders.PrebidServerValidationViewHolder;
-import org.prebid.mobile.drprebid.ui.viewholders.SdkValidationViewHolder;
-import org.prebid.mobile.drprebid.ui.viewholders.TestResultViewHolder;
+import org.prebid.mobile.drprebid.ui.viewholders.*;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -25,10 +20,10 @@ public class TestResultsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHo
     private static final int VIEW_TYPE_PREBID_SERVER_RESULTS = 2;
     private static final int VIEW_TYPE_SDK_RESULTS = 3;
 
-    private final List<ResultItem> mItems;
+    private final List<ResultItem> items;
 
     public TestResultsAdapter() {
-        mItems = new ArrayList<>();
+        items = new ArrayList<>();
 
         setupItems();
     }
@@ -50,7 +45,7 @@ public class TestResultsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHo
 
     @Override
     public int getItemViewType(int position) {
-        ResultItem item = mItems.get(position);
+        ResultItem item = items.get(position);
         if (item instanceof AdServerValidationResult) {
             return VIEW_TYPE_AD_SERVER_RESULTS;
         } else if (item instanceof PrebidServerValidationResult) {
@@ -70,12 +65,12 @@ public class TestResultsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHo
 
     @Override
     public int getItemCount() {
-        return mItems.size();
+        return items.size();
     }
 
     private void setupItems() {
-        mItems.add(new AdServerValidationResult());
-        mItems.add(new PrebidServerValidationResult());
-        mItems.add(new SdkValidationResult());
+        items.add(new AdServerValidationResult());
+        items.add(new PrebidServerValidationResult());
+        items.add(new SdkValidationResult());
     }
 }

--- a/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/ui/dialog/AdSizeDialog.java
+++ b/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/ui/dialog/AdSizeDialog.java
@@ -1,16 +1,15 @@
 package org.prebid.mobile.drprebid.ui.dialog;
 
 import android.app.Dialog;
-import androidx.lifecycle.ViewModelProviders;
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.fragment.app.DialogFragment;
-import androidx.appcompat.app.AlertDialog;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.RadioGroup;
-
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
+import androidx.fragment.app.DialogFragment;
+import androidx.lifecycle.ViewModelProviders;
 import org.prebid.mobile.drprebid.R;
 import org.prebid.mobile.drprebid.managers.SettingsManager;
 import org.prebid.mobile.drprebid.model.AdSize;
@@ -18,10 +17,11 @@ import org.prebid.mobile.drprebid.model.GeneralSettings;
 import org.prebid.mobile.drprebid.ui.viewmodels.SettingsViewModel;
 
 public class AdSizeDialog extends DialogFragment {
+
     public static final String TAG = AdSizeDialog.class.getSimpleName();
 
-    private RadioGroup mSizeGroup;
-    private SettingsViewModel mSettingsViewModel;
+    private RadioGroup sizeGroup;
+    private SettingsViewModel settingsViewModel;
 
     public AdSizeDialog() {
 
@@ -42,35 +42,35 @@ public class AdSizeDialog extends DialogFragment {
             View view = LayoutInflater.from(getActivity()).inflate(R.layout.dialog_ad_size_selection, null, false);
             builder.setView(view);
 
-            mSettingsViewModel = ViewModelProviders.of(getActivity()).get(SettingsViewModel.class);
-            mSizeGroup = view.findViewById(R.id.group_size);
+            settingsViewModel = ViewModelProviders.of(getActivity()).get(SettingsViewModel.class);
+            sizeGroup = view.findViewById(R.id.group_size);
 
             fillValues();
 
             builder.setPositiveButton(R.string.action_accept, (dialog, which) -> {
-                switch (mSizeGroup.getCheckedRadioButtonId()) {
+                switch (sizeGroup.getCheckedRadioButtonId()) {
                     case R.id.radio_300_250:
-                        mSettingsViewModel.setAdSize(AdSize.BANNER_300x250);
+                        settingsViewModel.setAdSize(AdSize.BANNER_300x250);
                         SettingsManager.getInstance(getActivity()).setAdSize(AdSize.BANNER_300x250);
                         break;
                     case R.id.radio_300_600:
-                        mSettingsViewModel.setAdSize(AdSize.BANNER_300x600);
+                        settingsViewModel.setAdSize(AdSize.BANNER_300x600);
                         SettingsManager.getInstance(getActivity()).setAdSize(AdSize.BANNER_300x600);
                         break;
                     case R.id.radio_320_50:
-                        mSettingsViewModel.setAdSize(AdSize.BANNER_320x50);
+                        settingsViewModel.setAdSize(AdSize.BANNER_320x50);
                         SettingsManager.getInstance(getActivity()).setAdSize(AdSize.BANNER_320x50);
                         break;
                     case R.id.radio_320_100:
-                        mSettingsViewModel.setAdSize(AdSize.BANNER_320x100);
+                        settingsViewModel.setAdSize(AdSize.BANNER_320x100);
                         SettingsManager.getInstance(getActivity()).setAdSize(AdSize.BANNER_320x100);
                         break;
                     case R.id.radio_320_480:
-                        mSettingsViewModel.setAdSize(AdSize.BANNER_320x480);
+                        settingsViewModel.setAdSize(AdSize.BANNER_320x480);
                         SettingsManager.getInstance(getActivity()).setAdSize(AdSize.BANNER_320x480);
                         break;
                     case R.id.radio_728_90:
-                        mSettingsViewModel.setAdSize(AdSize.BANNER_728x90);
+                        settingsViewModel.setAdSize(AdSize.BANNER_728x90);
                         SettingsManager.getInstance(getActivity()).setAdSize(AdSize.BANNER_728x90);
                         break;
                 }
@@ -90,25 +90,25 @@ public class AdSizeDialog extends DialogFragment {
         GeneralSettings generalSettings = SettingsManager.getInstance(getActivity()).getGeneralSettings();
         switch (generalSettings.getAdSize()) {
             case BANNER_300x250:
-                mSizeGroup.check(R.id.radio_300_250);
+                sizeGroup.check(R.id.radio_300_250);
                 break;
             case BANNER_300x600:
-                mSizeGroup.check(R.id.radio_300_600);
+                sizeGroup.check(R.id.radio_300_600);
                 break;
             case BANNER_320x50:
-                mSizeGroup.check(R.id.radio_320_50);
+                sizeGroup.check(R.id.radio_320_50);
                 break;
             case BANNER_320x100:
-                mSizeGroup.check(R.id.radio_320_100);
+                sizeGroup.check(R.id.radio_320_100);
                 break;
             case BANNER_320x480:
-                mSizeGroup.check(R.id.radio_320_480);
+                sizeGroup.check(R.id.radio_320_480);
                 break;
             case BANNER_728x90:
-                mSizeGroup.check(R.id.radio_728_90);
+                sizeGroup.check(R.id.radio_728_90);
                 break;
             default:
-                mSizeGroup.check(R.id.radio_300_250);
+                sizeGroup.check(R.id.radio_300_250);
         }
     }
 }

--- a/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/ui/dialog/InputDialog.java
+++ b/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/ui/dialog/InputDialog.java
@@ -1,20 +1,19 @@
 package org.prebid.mobile.drprebid.ui.dialog;
 
 import android.app.Dialog;
-import androidx.lifecycle.ViewModelProviders;
 import android.content.Intent;
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.fragment.app.DialogFragment;
-import androidx.appcompat.app.AlertDialog;
 import android.text.InputType;
 import android.text.TextUtils;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.EditText;
 import android.widget.ImageButton;
-
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
+import androidx.fragment.app.DialogFragment;
+import androidx.lifecycle.ViewModelProviders;
 import org.prebid.mobile.drprebid.Constants;
 import org.prebid.mobile.drprebid.R;
 import org.prebid.mobile.drprebid.managers.QrCodeScanCacheManager;
@@ -23,16 +22,22 @@ import org.prebid.mobile.drprebid.ui.activities.QrCodeCaptureActivity;
 import org.prebid.mobile.drprebid.ui.viewmodels.SettingsViewModel;
 
 public class InputDialog extends DialogFragment {
+
     public static final String TAG = InputDialog.class.getSimpleName();
 
-    private EditText mInput;
-    private SettingsViewModel mSettingsViewModel;
+    private EditText input;
+    private SettingsViewModel settingsViewModel;
 
     public InputDialog() {
 
     }
 
-    public static InputDialog newInstance(String title, int type, int format, boolean shouldShowQrScanner) {
+    public static InputDialog newInstance(
+            String title,
+            int type,
+            int format,
+            boolean shouldShowQrScanner
+    ) {
         InputDialog fragment = new InputDialog();
         Bundle args = new Bundle();
         args.putString(Constants.Params.INPUT_TITLE, title);
@@ -58,7 +63,7 @@ public class InputDialog extends DialogFragment {
             final View view = LayoutInflater.from(getActivity()).inflate(R.layout.dialog_input, null, false);
             builder.setView(view);
 
-            mInput = view.findViewById(R.id.field_input);
+            input = view.findViewById(R.id.field_input);
 
             if (getArguments() != null && getArguments().containsKey(Constants.Params.INPUT_TYPE)) {
                 int type = getArguments().getInt(Constants.Params.INPUT_TYPE, -1);
@@ -67,16 +72,16 @@ public class InputDialog extends DialogFragment {
 
                 switch (type) {
                     case Constants.Params.TYPE_AD_UNIT_ID:
-                        mInput.setText(settingsManager.getAdServerSettings().getAdUnitId());
+                        input.setText(settingsManager.getAdServerSettings().getAdUnitId());
                         break;
                     case Constants.Params.TYPE_BID_PRICE:
-                        mInput.setText(String.valueOf(settingsManager.getAdServerSettings().getBidPrice()));
+                        input.setText(String.valueOf(settingsManager.getAdServerSettings().getBidPrice()));
                         break;
                     case Constants.Params.TYPE_ACCOUNT_ID:
-                        mInput.setText(settingsManager.getPrebidServerSettings().getAccountId());
+                        input.setText(settingsManager.getPrebidServerSettings().getAccountId());
                         break;
                     case Constants.Params.TYPE_CONFIG_ID:
-                        mInput.setText(settingsManager.getPrebidServerSettings().getConfigId());
+                        input.setText(settingsManager.getPrebidServerSettings().getConfigId());
                         break;
                 }
             }
@@ -87,16 +92,16 @@ public class InputDialog extends DialogFragment {
 
                 switch (format) {
                     case Constants.Params.FORMAT_TEXT:
-                        mInput.setInputType(InputType.TYPE_CLASS_TEXT);
+                        input.setInputType(InputType.TYPE_CLASS_TEXT);
                         break;
                     case Constants.Params.FORMAT_INT:
-                        mInput.setInputType(InputType.TYPE_CLASS_NUMBER);
+                        input.setInputType(InputType.TYPE_CLASS_NUMBER);
                         break;
                     case Constants.Params.FORMAT_FLOAT:
-                        mInput.setInputType(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_DECIMAL);
+                        input.setInputType(InputType.TYPE_CLASS_NUMBER | InputType.TYPE_NUMBER_FLAG_DECIMAL);
                         break;
                     default:
-                        mInput.setInputType(InputType.TYPE_CLASS_TEXT);
+                        input.setInputType(InputType.TYPE_CLASS_TEXT);
 
                 }
             }
@@ -114,32 +119,32 @@ public class InputDialog extends DialogFragment {
 
                 if (getArguments() != null && getArguments().containsKey(Constants.Params.INPUT_TYPE)) {
                     int type = getArguments().getInt(Constants.Params.INPUT_TYPE, -1);
-                    mSettingsViewModel = ViewModelProviders.of(getActivity()).get(SettingsViewModel.class);
+                    settingsViewModel = ViewModelProviders.of(getActivity()).get(SettingsViewModel.class);
 
-                    String text = mInput.getText().toString();
+                    String text = input.getText().toString();
                     SettingsManager settingsManager = SettingsManager.getInstance(getActivity());
 
                     switch (type) {
                         case Constants.Params.TYPE_AD_UNIT_ID:
-                            mSettingsViewModel.setAdUnitId(text);
+                            settingsViewModel.setAdUnitId(text);
                             settingsManager.setAdUnitId(text);
                             break;
                         case Constants.Params.TYPE_BID_PRICE:
                             if (TextUtils.isEmpty(text)) {
-                                mSettingsViewModel.setBidPrice(0.0f);
+                                settingsViewModel.setBidPrice(0.0f);
                                 settingsManager.setBidPrice(0.0f);
                             } else {
                                 float value = Float.valueOf(text);
-                                mSettingsViewModel.setBidPrice(value);
+                                settingsViewModel.setBidPrice(value);
                                 settingsManager.setBidPrice(value);
                             }
                             break;
                         case Constants.Params.TYPE_ACCOUNT_ID:
-                            mSettingsViewModel.setAccountId(text);
+                            settingsViewModel.setAccountId(text);
                             settingsManager.setAccountId(text);
                             break;
                         case Constants.Params.TYPE_CONFIG_ID:
-                            mSettingsViewModel.setConfigId(text);
+                            settingsViewModel.setConfigId(text);
                             settingsManager.setConfigId(text);
                             break;
                     }
@@ -186,7 +191,7 @@ public class InputDialog extends DialogFragment {
             if (QrCodeScanCacheManager.getInstance(getContext()).hasCache()) {
                 String readValue = QrCodeScanCacheManager.getInstance(getContext()).getCache();
                 if (!TextUtils.isEmpty(readValue)) {
-                    mInput.setText(readValue);
+                    input.setText(readValue);
                 }
             }
     }

--- a/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/ui/dialog/PrebidServerDialog.java
+++ b/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/ui/dialog/PrebidServerDialog.java
@@ -1,17 +1,16 @@
 package org.prebid.mobile.drprebid.ui.dialog;
 
 import android.app.Dialog;
-import androidx.lifecycle.ViewModelProviders;
 import android.os.Bundle;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
-import androidx.fragment.app.DialogFragment;
-import androidx.appcompat.app.AlertDialog;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.EditText;
 import android.widget.RadioGroup;
-
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import androidx.appcompat.app.AlertDialog;
+import androidx.fragment.app.DialogFragment;
+import androidx.lifecycle.ViewModelProviders;
 import org.prebid.mobile.drprebid.R;
 import org.prebid.mobile.drprebid.managers.SettingsManager;
 import org.prebid.mobile.drprebid.model.PrebidServer;
@@ -19,11 +18,12 @@ import org.prebid.mobile.drprebid.model.PrebidServerSettings;
 import org.prebid.mobile.drprebid.ui.viewmodels.SettingsViewModel;
 
 public class PrebidServerDialog extends DialogFragment {
+
     public static final String TAG = PrebidServerDialog.class.getSimpleName();
 
-    private RadioGroup mServerGroup;
-    private EditText mCustomServerField;
-    private SettingsViewModel mSettingsViewModel;
+    private RadioGroup serverGroup;
+    private EditText customServerField;
+    private SettingsViewModel settingsViewModel;
 
     public PrebidServerDialog() {
 
@@ -40,22 +40,23 @@ public class PrebidServerDialog extends DialogFragment {
             AlertDialog.Builder builder = new AlertDialog.Builder(getActivity());
 
             builder.setTitle(R.string.prebid_server);
-            View view = LayoutInflater.from(getActivity()).inflate(R.layout.dialog_prebid_server_selection, null, false);
+            View view = LayoutInflater.from(getActivity())
+                                      .inflate(R.layout.dialog_prebid_server_selection, null, false);
             builder.setView(view);
 
-            mServerGroup = view.findViewById(R.id.group_server);
-            mCustomServerField = view.findViewById(R.id.field_custom_server);
+            serverGroup = view.findViewById(R.id.group_server);
+            customServerField = view.findViewById(R.id.field_custom_server);
 
-            mServerGroup.setOnCheckedChangeListener((group, checkedId) -> {
+            serverGroup.setOnCheckedChangeListener((group, checkedId) -> {
                 switch (checkedId) {
                     case R.id.radio_appnexus:
-                        mCustomServerField.setVisibility(View.GONE);
+                        customServerField.setVisibility(View.GONE);
                         break;
                     case R.id.radio_rubicon:
-                        mCustomServerField.setVisibility(View.GONE);
+                        customServerField.setVisibility(View.GONE);
                         break;
                     case R.id.radio_custom:
-                        mCustomServerField.setVisibility(View.VISIBLE);
+                        customServerField.setVisibility(View.VISIBLE);
                         break;
                 }
             });
@@ -64,23 +65,23 @@ public class PrebidServerDialog extends DialogFragment {
 
             builder.setPositiveButton(R.string.action_accept, (dialog, which) -> {
                 SettingsManager settingsManager = SettingsManager.getInstance(getActivity());
-                mSettingsViewModel = ViewModelProviders.of(getActivity()).get(SettingsViewModel.class);
+                settingsViewModel = ViewModelProviders.of(getActivity()).get(SettingsViewModel.class);
 
-                switch (mServerGroup.getCheckedRadioButtonId()) {
+                switch (serverGroup.getCheckedRadioButtonId()) {
                     case R.id.radio_appnexus:
                         settingsManager.setPrebidServer(PrebidServer.APPNEXUS);
                         settingsManager.setPrebidServerCustomUrl("");
-                        mSettingsViewModel.setPrebidServer(PrebidServer.APPNEXUS);
+                        settingsViewModel.setPrebidServer(PrebidServer.APPNEXUS);
                         break;
                     case R.id.radio_rubicon:
                         settingsManager.setPrebidServer(PrebidServer.RUBICON);
                         settingsManager.setPrebidServerCustomUrl("");
-                        mSettingsViewModel.setPrebidServer(PrebidServer.RUBICON);
+                        settingsViewModel.setPrebidServer(PrebidServer.RUBICON);
                         break;
                     case R.id.radio_custom:
                         settingsManager.setPrebidServer(PrebidServer.CUSTOM);
-                        settingsManager.setPrebidServerCustomUrl(mCustomServerField.getText().toString());
-                        mSettingsViewModel.setPrebidServer(PrebidServer.CUSTOM);
+                        settingsManager.setPrebidServerCustomUrl(customServerField.getText().toString());
+                        settingsViewModel.setPrebidServer(PrebidServer.CUSTOM);
                         break;
                 }
                 dismiss();
@@ -98,14 +99,14 @@ public class PrebidServerDialog extends DialogFragment {
         PrebidServerSettings settings = SettingsManager.getInstance(getActivity()).getPrebidServerSettings();
         switch (settings.getPrebidServer()) {
             case APPNEXUS:
-                mServerGroup.check(R.id.radio_appnexus);
+                serverGroup.check(R.id.radio_appnexus);
                 break;
             case RUBICON:
-                mServerGroup.check(R.id.radio_rubicon);
+                serverGroup.check(R.id.radio_rubicon);
                 break;
             case CUSTOM:
-                mServerGroup.check(R.id.radio_custom);
-                mCustomServerField.setText(settings.getCustomPrebidServerUrl());
+                serverGroup.check(R.id.radio_custom);
+                customServerField.setText(settings.getCustomPrebidServerUrl());
                 break;
         }
     }

--- a/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/ui/viewholders/AdServerSettingsViewHolder.java
+++ b/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/ui/viewholders/AdServerSettingsViewHolder.java
@@ -1,18 +1,17 @@
 package org.prebid.mobile.drprebid.ui.viewholders;
 
-import androidx.lifecycle.Lifecycle;
-import androidx.lifecycle.LifecycleOwner;
-import androidx.lifecycle.ViewModelProviders;
 import android.content.Intent;
-import androidx.annotation.NonNull;
-import androidx.fragment.app.FragmentManager;
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.recyclerview.widget.RecyclerView;
 import android.text.TextUtils;
 import android.view.View;
 import android.widget.RadioGroup;
 import android.widget.TextView;
-
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.FragmentManager;
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.LifecycleOwner;
+import androidx.lifecycle.ViewModelProviders;
+import androidx.recyclerview.widget.RecyclerView;
 import org.prebid.mobile.drprebid.Constants;
 import org.prebid.mobile.drprebid.R;
 import org.prebid.mobile.drprebid.managers.SettingsManager;
@@ -27,58 +26,68 @@ import org.prebid.mobile.drprebid.util.HelpScreenUtil;
 import java.util.Locale;
 
 public class AdServerSettingsViewHolder extends RecyclerView.ViewHolder implements SettingsViewHolder, LifecycleOwner {
-    private RadioGroup mAdServerGroup;
-    private TextView mAdUnitIdView;
-    private TextView mBidPriceView;
-    private SettingsViewModel mSettingsViewModel;
+
+    private RadioGroup adServerGroup;
+    private TextView adUnitIdView;
+    private TextView bidPriceView;
+    private SettingsViewModel settingsViewModel;
 
     public AdServerSettingsViewHolder(@NonNull final View itemView) {
         super(itemView);
 
         itemView.findViewById(R.id.button_info).setOnClickListener(v -> {
             HelpScreen aboutScreen = HelpScreenUtil.getAdServerInfo(itemView.getContext());
-            Intent intent = InfoActivity.newIntent(itemView.getContext(), aboutScreen.getTitle(), aboutScreen.getHtmlAsset());
+            Intent intent = InfoActivity.newIntent(
+                    itemView.getContext(),
+                    aboutScreen.getTitle(),
+                    aboutScreen.getHtmlAsset()
+            );
             itemView.getContext().startActivity(intent);
         });
 
-        mBidPriceView = itemView.findViewById(R.id.view_bid_price);
-        mBidPriceView.setOnClickListener(v -> {
+        bidPriceView = itemView.findViewById(R.id.view_bid_price);
+        bidPriceView.setOnClickListener(v -> {
             FragmentManager fragmentManager = ((AppCompatActivity) itemView.getContext()).getSupportFragmentManager();
             InputDialog dialog = InputDialog.newInstance(itemView.getContext().getString(R.string.bid_price),
                     Constants.Params.TYPE_BID_PRICE,
-                    Constants.Params.FORMAT_FLOAT, false);
+                    Constants.Params.FORMAT_FLOAT,
+                    false
+            );
             dialog.show(fragmentManager, InputDialog.TAG);
         });
 
-        mAdUnitIdView = itemView.findViewById(R.id.view_ad_unit_id);
-        mAdUnitIdView.setOnClickListener(v -> {
+        adUnitIdView = itemView.findViewById(R.id.view_ad_unit_id);
+        adUnitIdView.setOnClickListener(v -> {
             FragmentManager fragmentManager = ((AppCompatActivity) itemView.getContext()).getSupportFragmentManager();
             InputDialog dialog = InputDialog.newInstance(itemView.getContext().getString(R.string.ad_unit_id),
                     Constants.Params.TYPE_AD_UNIT_ID,
-                    Constants.Params.FORMAT_TEXT, true);
+                    Constants.Params.FORMAT_TEXT,
+                    true
+            );
             dialog.show(fragmentManager, InputDialog.TAG);
         });
 
-        mAdServerGroup = itemView.findViewById(R.id.group_ad_server);
-        mAdServerGroup.setOnCheckedChangeListener((group, checkedId) -> {
+        adServerGroup = itemView.findViewById(R.id.group_ad_server);
+        adServerGroup.setOnCheckedChangeListener((group, checkedId) -> {
             if (checkedId == R.id.radio_dfp) {
                 SettingsManager.getInstance(itemView.getContext()).setAdServer(AdServer.GOOGLE_AD_MANAGER);
             }
         });
 
-        mSettingsViewModel = ViewModelProviders.of((AppCompatActivity) itemView.getContext()).get(SettingsViewModel.class);
+        settingsViewModel = ViewModelProviders.of((AppCompatActivity) itemView.getContext())
+                                              .get(SettingsViewModel.class);
 
-        mSettingsViewModel.getBidPrice().observe(this, bidPrice -> {
+        settingsViewModel.getBidPrice().observe(this, bidPrice -> {
             if (bidPrice != null) {
-                mBidPriceView.setText(String.format(Locale.ENGLISH, "$ %.2f", bidPrice));
+                bidPriceView.setText(String.format(Locale.ENGLISH, "$ %.2f", bidPrice));
             }
         });
 
-        mSettingsViewModel.getAdUnitId().observe(this, adUnitId -> {
+        settingsViewModel.getAdUnitId().observe(this, adUnitId -> {
             if (!TextUtils.isEmpty(adUnitId)) {
-                mAdUnitIdView.setText(adUnitId);
+                adUnitIdView.setText(adUnitId);
             } else {
-                mAdUnitIdView.setText(R.string.click_to_choose);
+                adUnitIdView.setText(R.string.click_to_choose);
             }
         });
     }
@@ -97,13 +106,13 @@ public class AdServerSettingsViewHolder extends RecyclerView.ViewHolder implemen
     private void fillValues() {
         AdServerSettings settings = SettingsManager.getInstance(itemView.getContext()).getAdServerSettings();
 
-        mAdServerGroup.check(R.id.radio_dfp);
+        adServerGroup.check(R.id.radio_dfp);
 
 
-        mBidPriceView.setText(String.format(Locale.ENGLISH, "$ %.2f", settings.getBidPrice()));
+        bidPriceView.setText(String.format(Locale.ENGLISH, "$ %.2f", settings.getBidPrice()));
 
         if (!TextUtils.isEmpty(settings.getAdUnitId())) {
-            mAdUnitIdView.setText(settings.getAdUnitId());
+            adUnitIdView.setText(settings.getAdUnitId());
         }
     }
 }

--- a/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/ui/viewholders/GeneralSettingsViewHolder.java
+++ b/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/ui/viewholders/GeneralSettingsViewHolder.java
@@ -1,17 +1,16 @@
 package org.prebid.mobile.drprebid.ui.viewholders;
 
-import androidx.lifecycle.Lifecycle;
-import androidx.lifecycle.LifecycleOwner;
-import androidx.lifecycle.ViewModelProviders;
 import android.content.Intent;
-import androidx.annotation.NonNull;
-import androidx.fragment.app.FragmentManager;
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.recyclerview.widget.RecyclerView;
 import android.view.View;
 import android.widget.RadioGroup;
 import android.widget.TextView;
-
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.FragmentManager;
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.LifecycleOwner;
+import androidx.lifecycle.ViewModelProviders;
+import androidx.recyclerview.widget.RecyclerView;
 import org.prebid.mobile.drprebid.R;
 import org.prebid.mobile.drprebid.managers.SettingsManager;
 import org.prebid.mobile.drprebid.model.AdFormat;
@@ -24,21 +23,26 @@ import org.prebid.mobile.drprebid.ui.viewmodels.SettingsViewModel;
 import org.prebid.mobile.drprebid.util.HelpScreenUtil;
 
 public class GeneralSettingsViewHolder extends RecyclerView.ViewHolder implements SettingsViewHolder, LifecycleOwner {
-    private RadioGroup mAdFormatGroup;
-    private TextView mAdSizeView;
-    private SettingsViewModel mSettingsViewModel;
+
+    private RadioGroup adFormatGroup;
+    private TextView adSizeView;
+    private SettingsViewModel settingsViewModel;
 
     public GeneralSettingsViewHolder(@NonNull final View itemView) {
         super(itemView);
 
         itemView.findViewById(R.id.button_info).setOnClickListener(v -> {
             HelpScreen aboutScreen = HelpScreenUtil.getGeneralInfo(itemView.getContext());
-            Intent intent = InfoActivity.newIntent(itemView.getContext(), aboutScreen.getTitle(), aboutScreen.getHtmlAsset());
+            Intent intent = InfoActivity.newIntent(
+                    itemView.getContext(),
+                    aboutScreen.getTitle(),
+                    aboutScreen.getHtmlAsset()
+            );
             itemView.getContext().startActivity(intent);
         });
 
-        mAdFormatGroup = itemView.findViewById(R.id.group_format);
-        mAdFormatGroup.setOnCheckedChangeListener((group, checkedId) -> {
+        adFormatGroup = itemView.findViewById(R.id.group_format);
+        adFormatGroup.setOnCheckedChangeListener((group, checkedId) -> {
             switch (checkedId) {
                 case R.id.radio_banner:
                     SettingsManager.getInstance(itemView.getContext()).setAdFormat(AdFormat.BANNER);
@@ -49,16 +53,17 @@ public class GeneralSettingsViewHolder extends RecyclerView.ViewHolder implement
             }
         });
 
-        mAdSizeView = itemView.findViewById(R.id.view_ad_size);
-        mAdSizeView.setOnClickListener(v -> {
+        adSizeView = itemView.findViewById(R.id.view_ad_size);
+        adSizeView.setOnClickListener(v -> {
             FragmentManager fragmentManager = ((AppCompatActivity) itemView.getContext()).getSupportFragmentManager();
             AdSizeDialog dialog = AdSizeDialog.newInstance();
             dialog.show(fragmentManager, AdSizeDialog.TAG);
         });
 
-        mSettingsViewModel = ViewModelProviders.of((AppCompatActivity) itemView.getContext()).get(SettingsViewModel.class);
+        settingsViewModel = ViewModelProviders.of((AppCompatActivity) itemView.getContext())
+                                              .get(SettingsViewModel.class);
 
-        mSettingsViewModel.getAdSize().observe(this, adSize -> {
+        settingsViewModel.getAdSize().observe(this, adSize -> {
             if (adSize != null) {
                 fillAdSize(adSize);
             }
@@ -83,35 +88,35 @@ public class GeneralSettingsViewHolder extends RecyclerView.ViewHolder implement
 
         switch (settings.getAdFormat()) {
             case BANNER:
-                mAdFormatGroup.check(R.id.radio_banner);
+                adFormatGroup.check(R.id.radio_banner);
                 break;
             case INTERSTITIAL:
-                mAdFormatGroup.check(R.id.radio_interstitial);
+                adFormatGroup.check(R.id.radio_interstitial);
                 break;
             default:
-                mAdFormatGroup.check(R.id.radio_banner);
+                adFormatGroup.check(R.id.radio_banner);
         }
     }
 
     private void fillAdSize(AdSize adSize) {
         switch (adSize) {
             case BANNER_300x250:
-                mAdSizeView.setText(R.string.ad_size_300_250);
+                adSizeView.setText(R.string.ad_size_300_250);
                 break;
             case BANNER_300x600:
-                mAdSizeView.setText(R.string.ad_size_300_600);
+                adSizeView.setText(R.string.ad_size_300_600);
                 break;
             case BANNER_320x50:
-                mAdSizeView.setText(R.string.ad_size_320_50);
+                adSizeView.setText(R.string.ad_size_320_50);
                 break;
             case BANNER_320x100:
-                mAdSizeView.setText(R.string.ad_size_320_100);
+                adSizeView.setText(R.string.ad_size_320_100);
                 break;
             case BANNER_320x480:
-                mAdSizeView.setText(R.string.ad_size_320_480);
+                adSizeView.setText(R.string.ad_size_320_480);
                 break;
             case BANNER_728x90:
-                mAdSizeView.setText(R.string.ad_size_728_90);
+                adSizeView.setText(R.string.ad_size_728_90);
                 break;
         }
     }

--- a/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/ui/viewholders/PrebidServerSettingsViewholder.java
+++ b/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/ui/viewholders/PrebidServerSettingsViewholder.java
@@ -1,17 +1,16 @@
 package org.prebid.mobile.drprebid.ui.viewholders;
 
-import androidx.lifecycle.Lifecycle;
-import androidx.lifecycle.LifecycleOwner;
-import androidx.lifecycle.ViewModelProviders;
 import android.content.Intent;
-import androidx.annotation.NonNull;
-import androidx.fragment.app.FragmentManager;
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.recyclerview.widget.RecyclerView;
 import android.text.TextUtils;
 import android.view.View;
 import android.widget.TextView;
-
+import androidx.annotation.NonNull;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.fragment.app.FragmentManager;
+import androidx.lifecycle.Lifecycle;
+import androidx.lifecycle.LifecycleOwner;
+import androidx.lifecycle.ViewModelProviders;
+import androidx.recyclerview.widget.RecyclerView;
 import org.prebid.mobile.drprebid.Constants;
 import org.prebid.mobile.drprebid.R;
 import org.prebid.mobile.drprebid.managers.SettingsManager;
@@ -25,44 +24,46 @@ import org.prebid.mobile.drprebid.ui.viewmodels.SettingsViewModel;
 import org.prebid.mobile.drprebid.util.HelpScreenUtil;
 
 public class PrebidServerSettingsViewholder extends RecyclerView.ViewHolder implements SettingsViewHolder, LifecycleOwner, View.OnClickListener {
-    private TextView mServerView;
-    private TextView mAccountIdView;
-    private TextView mConfigIdView;
-    private SettingsViewModel mSettingsViewModel;
+
+    private TextView serverView;
+    private TextView accountIdView;
+    private TextView configIdView;
+    private SettingsViewModel settingsViewModel;
 
     public PrebidServerSettingsViewholder(@NonNull final View itemView) {
         super(itemView);
 
         itemView.findViewById(R.id.button_info).setOnClickListener(this);
 
-        mServerView = itemView.findViewById(R.id.view_prebid_server);
-        mServerView.setOnClickListener(this);
-        mAccountIdView = itemView.findViewById(R.id.view_account_id);
-        mAccountIdView.setOnClickListener(this);
-        mConfigIdView = itemView.findViewById(R.id.view_config_id);
-        mConfigIdView.setOnClickListener(this);
+        serverView = itemView.findViewById(R.id.view_prebid_server);
+        serverView.setOnClickListener(this);
+        accountIdView = itemView.findViewById(R.id.view_account_id);
+        accountIdView.setOnClickListener(this);
+        configIdView = itemView.findViewById(R.id.view_config_id);
+        configIdView.setOnClickListener(this);
 
-        mSettingsViewModel = ViewModelProviders.of((AppCompatActivity) itemView.getContext()).get(SettingsViewModel.class);
+        settingsViewModel = ViewModelProviders.of((AppCompatActivity) itemView.getContext())
+                                              .get(SettingsViewModel.class);
 
-        mSettingsViewModel.getPrebidServer().observe(this, prebidServer -> {
+        settingsViewModel.getPrebidServer().observe(this, prebidServer -> {
             if (prebidServer != null) {
                 fillPrebidServer(prebidServer);
             }
         });
 
-        mSettingsViewModel.getAccountId().observe(this, accountId -> {
+        settingsViewModel.getAccountId().observe(this, accountId -> {
             if (!TextUtils.isEmpty(accountId)) {
-                mAccountIdView.setText(accountId);
+                accountIdView.setText(accountId);
             } else {
-                mAccountIdView.setText(R.string.click_to_choose);
+                accountIdView.setText(R.string.click_to_choose);
             }
         });
 
-        mSettingsViewModel.getConfigId().observe(this, configId -> {
+        settingsViewModel.getConfigId().observe(this, configId -> {
             if (!TextUtils.isEmpty(configId)) {
-                mConfigIdView.setText(configId);
+                configIdView.setText(configId);
             } else {
-                mConfigIdView.setText(R.string.click_to_choose);
+                configIdView.setText(R.string.click_to_choose);
             }
         });
     }
@@ -84,24 +85,24 @@ public class PrebidServerSettingsViewholder extends RecyclerView.ViewHolder impl
         fillPrebidServer(settings.getPrebidServer());
 
         if (!TextUtils.isEmpty(settings.getAccountId())) {
-            mAccountIdView.setText(settings.getAccountId());
+            accountIdView.setText(settings.getAccountId());
         }
 
         if (!TextUtils.isEmpty(settings.getConfigId())) {
-            mConfigIdView.setText(settings.getConfigId());
+            configIdView.setText(settings.getConfigId());
         }
     }
 
     private void fillPrebidServer(PrebidServer prebidServer) {
         switch (prebidServer) {
             case APPNEXUS:
-                mServerView.setText(R.string.prebid_server_appnexus);
+                serverView.setText(R.string.prebid_server_appnexus);
                 break;
             case RUBICON:
-                mServerView.setText(R.string.prebid_server_rubicon);
+                serverView.setText(R.string.prebid_server_rubicon);
                 break;
             case CUSTOM:
-                mServerView.setText(R.string.prebid_server_custom);
+                serverView.setText(R.string.prebid_server_custom);
                 break;
         }
     }

--- a/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/ui/viewmodels/AdServerValidationViewModel.java
+++ b/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/ui/viewmodels/AdServerValidationViewModel.java
@@ -6,27 +6,28 @@ import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
 
 public class AdServerValidationViewModel extends ViewModel {
-    private final MutableLiveData<Boolean> mRequestSent;
-    private final MutableLiveData<Boolean> mCreativeServed;
+
+    private final MutableLiveData<Boolean> requestSent;
+    private final MutableLiveData<Boolean> creativeServed;
 
     public AdServerValidationViewModel() {
-        mRequestSent = new MutableLiveData<>();
-        mCreativeServed = new MutableLiveData<>();
+        requestSent = new MutableLiveData<>();
+        creativeServed = new MutableLiveData<>();
     }
 
     public LiveData<Boolean> getRequestSent() {
-        return mRequestSent;
+        return requestSent;
     }
 
     public void setRequestSent(boolean requestSent) {
-        mRequestSent.setValue(requestSent);
+        this.requestSent.setValue(requestSent);
     }
 
     public LiveData<Boolean> getCreativeServed() {
-        return mCreativeServed;
+        return creativeServed;
     }
 
     public void setCreativeServed(@Nullable Boolean creativeServed) {
-        mCreativeServed.setValue(creativeServed);
+        this.creativeServed.setValue(creativeServed);
     }
 }

--- a/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/ui/viewmodels/PrebidServerValidationViewModel.java
+++ b/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/ui/viewmodels/PrebidServerValidationViewModel.java
@@ -5,59 +5,60 @@ import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
 
 public class PrebidServerValidationViewModel extends ViewModel {
-    private final MutableLiveData<Boolean> mBidRequestsSent;
-    private final MutableLiveData<Integer> mBidRequestSentCount;
-    private final MutableLiveData<Boolean> mBidResponsesReceived;
-    private final MutableLiveData<Integer> mBidResponseReceivedCount;
-    private final MutableLiveData<Float> mAverageCpm;
-    private final MutableLiveData<Long> mAverageResponseTime;
+
+    private final MutableLiveData<Boolean> bidRequestsSent;
+    private final MutableLiveData<Integer> bidRequestSentCount;
+    private final MutableLiveData<Boolean> bidResponsesReceived;
+    private final MutableLiveData<Integer> bidResponseReceivedCount;
+    private final MutableLiveData<Float> averageCpm;
+    private final MutableLiveData<Long> averageResponseTime;
 
     public PrebidServerValidationViewModel() {
-        mBidRequestsSent = new MutableLiveData<>();
-        mBidRequestSentCount = new MutableLiveData<>();
-        mBidResponsesReceived = new MutableLiveData<>();
-        mBidResponseReceivedCount = new MutableLiveData<>();
-        mAverageCpm = new MutableLiveData<>();
-        mAverageResponseTime = new MutableLiveData<>();
+        bidRequestsSent = new MutableLiveData<>();
+        bidRequestSentCount = new MutableLiveData<>();
+        bidResponsesReceived = new MutableLiveData<>();
+        bidResponseReceivedCount = new MutableLiveData<>();
+        averageCpm = new MutableLiveData<>();
+        averageResponseTime = new MutableLiveData<>();
     }
 
     public LiveData<Boolean> getBidRequestsSent() {
-        return mBidRequestsSent;
+        return bidRequestsSent;
     }
 
     public void setBidRequestsSent(boolean requestsSent) {
-        mBidRequestsSent.setValue(requestsSent);
+        bidRequestsSent.setValue(requestsSent);
     }
 
     public LiveData<Integer> getBidRequestSentCount() {
-        return mBidRequestSentCount;
+        return bidRequestSentCount;
     }
 
     public void setBidRequestSentCount(int sentCount) {
-        mBidRequestSentCount.setValue(sentCount);
+        bidRequestSentCount.setValue(sentCount);
     }
 
     public LiveData<Integer> getBidResponsesReceived() {
-        return mBidResponseReceivedCount;
+        return bidResponseReceivedCount;
     }
 
     public void setBidResponseReceivedCount(int receivedCount) {
-        mBidResponseReceivedCount.setValue(receivedCount);
+        bidResponseReceivedCount.setValue(receivedCount);
     }
 
     public LiveData<Float> getAverageCpm() {
-        return mAverageCpm;
+        return averageCpm;
     }
 
     public void setAverageCpm(float averageCpm) {
-        mAverageCpm.setValue(averageCpm);
+        this.averageCpm.setValue(averageCpm);
     }
 
     public LiveData<Long> getAverageResponseTime() {
-        return mAverageResponseTime;
+        return averageResponseTime;
     }
 
     public void setAverageResponseTime(long responseTime) {
-        mAverageResponseTime.setValue(responseTime);
+        averageResponseTime.setValue(responseTime);
     }
 }

--- a/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/ui/viewmodels/SdkValidationViewModel.java
+++ b/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/ui/viewmodels/SdkValidationViewModel.java
@@ -6,67 +6,68 @@ import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
 
 public class SdkValidationViewModel extends ViewModel {
-    private final MutableLiveData<Boolean> mAdUnitRegistered;
-    private final MutableLiveData<Boolean> mPrebidRequestSent;
-    private final MutableLiveData<Boolean> mPrebidResponseReceived;
-    private final MutableLiveData<Boolean> mCreativeContentCached;
-    private final MutableLiveData<Boolean> mAdServerRequestSent;
-    private final MutableLiveData<Boolean> mCreativeServed;
+
+    private final MutableLiveData<Boolean> adUnitRegistered;
+    private final MutableLiveData<Boolean> prebidRequestSent;
+    private final MutableLiveData<Boolean> prebidResponseReceived;
+    private final MutableLiveData<Boolean> creativeContentCached;
+    private final MutableLiveData<Boolean> adServerRequestSent;
+    private final MutableLiveData<Boolean> creativeServed;
 
     public SdkValidationViewModel() {
-        mAdUnitRegistered = new MutableLiveData<>();
-        mPrebidRequestSent = new MutableLiveData<>();
-        mPrebidResponseReceived = new MutableLiveData<>();
-        mCreativeContentCached = new MutableLiveData<>();
-        mAdServerRequestSent = new MutableLiveData<>();
-        mCreativeServed = new MutableLiveData<>();
+        adUnitRegistered = new MutableLiveData<>();
+        prebidRequestSent = new MutableLiveData<>();
+        prebidResponseReceived = new MutableLiveData<>();
+        creativeContentCached = new MutableLiveData<>();
+        adServerRequestSent = new MutableLiveData<>();
+        creativeServed = new MutableLiveData<>();
     }
 
     public LiveData<Boolean> getAdUnitRegistered() {
-        return mAdUnitRegistered;
+        return adUnitRegistered;
     }
 
     public void setAdUnitRegistered(boolean adUnitRegistered) {
-        mAdUnitRegistered.setValue(adUnitRegistered);
+        this.adUnitRegistered.setValue(adUnitRegistered);
     }
 
     public LiveData<Boolean> getPrebidRequestSent() {
-        return mPrebidRequestSent;
+        return prebidRequestSent;
     }
 
     public void setPrebidRequestSent(boolean prebidRequestSent) {
-        mPrebidRequestSent.setValue(prebidRequestSent);
+        this.prebidRequestSent.setValue(prebidRequestSent);
     }
 
     public LiveData<Boolean> getPrebidResponseReceived() {
-        return mPrebidResponseReceived;
+        return prebidResponseReceived;
     }
 
     public void setPrebidResponseReceived(boolean prebidResponseReceived) {
-        mPrebidResponseReceived.setValue(prebidResponseReceived);
+        this.prebidResponseReceived.setValue(prebidResponseReceived);
     }
 
     public LiveData<Boolean> getCreativeContentCached() {
-        return mCreativeContentCached;
+        return creativeContentCached;
     }
 
     public void setCreativeContentCached(boolean creativeContentCached) {
-        mCreativeContentCached.setValue(creativeContentCached);
+        this.creativeContentCached.setValue(creativeContentCached);
     }
 
     public LiveData<Boolean> getAdServerRequestSent() {
-        return mAdServerRequestSent;
+        return adServerRequestSent;
     }
 
     public void setAdServerRequestSent(boolean adServerRequestSent) {
-        mAdServerRequestSent.setValue(adServerRequestSent);
+        this.adServerRequestSent.setValue(adServerRequestSent);
     }
 
     public LiveData<Boolean> getCreativeServed() {
-        return mCreativeServed;
+        return creativeServed;
     }
 
     public void setCreativeServed(@Nullable Boolean creativeServed) {
-        mCreativeServed.setValue(creativeServed);
+        this.creativeServed.setValue(creativeServed);
     }
 }

--- a/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/ui/viewmodels/SettingsViewModel.java
+++ b/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/ui/viewmodels/SettingsViewModel.java
@@ -3,72 +3,72 @@ package org.prebid.mobile.drprebid.ui.viewmodels;
 import androidx.lifecycle.LiveData;
 import androidx.lifecycle.MutableLiveData;
 import androidx.lifecycle.ViewModel;
-
 import org.prebid.mobile.drprebid.model.AdSize;
 import org.prebid.mobile.drprebid.model.PrebidServer;
 
 public class SettingsViewModel extends ViewModel {
-    private final MutableLiveData<AdSize> mAdSize;
-    private final MutableLiveData<Float> mBidPrice;
-    private final MutableLiveData<String> mAdUnitId;
-    private final MutableLiveData<PrebidServer> mPrebidServer;
-    private final MutableLiveData<String> mAccountId;
-    private final MutableLiveData<String> mConfigId;
+
+    private final MutableLiveData<AdSize> adSize;
+    private final MutableLiveData<Float> bidPrice;
+    private final MutableLiveData<String> adUnitId;
+    private final MutableLiveData<PrebidServer> prebidServer;
+    private final MutableLiveData<String> accountId;
+    private final MutableLiveData<String> configId;
 
     public SettingsViewModel() {
-        mAdSize = new MutableLiveData<>();
-        mBidPrice = new MutableLiveData<>();
-        mAdUnitId = new MutableLiveData<>();
-        mPrebidServer = new MutableLiveData<>();
-        mAccountId = new MutableLiveData<>();
-        mConfigId = new MutableLiveData<>();
+        adSize = new MutableLiveData<>();
+        bidPrice = new MutableLiveData<>();
+        adUnitId = new MutableLiveData<>();
+        prebidServer = new MutableLiveData<>();
+        accountId = new MutableLiveData<>();
+        configId = new MutableLiveData<>();
     }
 
     public LiveData<AdSize> getAdSize() {
-        return mAdSize;
+        return adSize;
     }
 
     public void setAdSize(AdSize adSize) {
-        this.mAdSize.setValue(adSize);
+        this.adSize.setValue(adSize);
     }
 
     public LiveData<Float> getBidPrice() {
-        return mBidPrice;
+        return bidPrice;
     }
 
     public void setBidPrice(float bidPrice) {
-        this.mBidPrice.setValue(bidPrice);
+        this.bidPrice.setValue(bidPrice);
     }
 
     public LiveData<String> getAdUnitId() {
-        return mAdUnitId;
+        return adUnitId;
     }
 
     public void setAdUnitId(String adUnitId) {
-        this.mAdUnitId.setValue(adUnitId);
+        this.adUnitId.setValue(adUnitId);
     }
 
     public LiveData<PrebidServer> getPrebidServer() {
-        return mPrebidServer;
+        return prebidServer;
     }
 
     public void setPrebidServer(PrebidServer prebidServer) {
-        this.mPrebidServer.setValue(prebidServer);
+        this.prebidServer.setValue(prebidServer);
     }
 
     public LiveData<String> getAccountId() {
-        return mAccountId;
+        return accountId;
     }
 
     public void setAccountId(String accountId) {
-        this.mAccountId.setValue(accountId);
+        this.accountId.setValue(accountId);
     }
 
     public LiveData<String> getConfigId() {
-        return mConfigId;
+        return configId;
     }
 
     public void setConfigId(String configId) {
-        this.mConfigId.setValue(configId);
+        this.configId.setValue(configId);
     }
 }

--- a/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/ui/views/SlideIndicatorsView.java
+++ b/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/ui/views/SlideIndicatorsView.java
@@ -3,30 +3,37 @@ package org.prebid.mobile.drprebid.ui.views;
 import android.annotation.TargetApi;
 import android.content.Context;
 import android.os.Build;
-import androidx.annotation.NonNull;
-import androidx.annotation.Nullable;
 import android.util.AttributeSet;
 import android.view.LayoutInflater;
 import android.view.View;
 import android.widget.FrameLayout;
 import android.widget.ImageView;
-
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import org.prebid.mobile.drprebid.R;
 
 public class SlideIndicatorsView extends FrameLayout {
-    private ImageView mIndicator1;
-    private ImageView mIndicator2;
-    private ImageView mIndicator3;
+
+    private ImageView indicator1;
+    private ImageView indicator2;
+    private ImageView indicator3;
 
     public SlideIndicatorsView(@NonNull Context context) {
         this(context, null);
     }
 
-    public SlideIndicatorsView(@NonNull Context context, @Nullable AttributeSet attrs) {
+    public SlideIndicatorsView(
+            @NonNull Context context,
+            @Nullable AttributeSet attrs
+    ) {
         this(context, attrs, -1);
     }
 
-    public SlideIndicatorsView(@NonNull Context context, @Nullable AttributeSet attrs, int defStyleAttr) {
+    public SlideIndicatorsView(
+            @NonNull Context context,
+            @Nullable AttributeSet attrs,
+            int defStyleAttr
+    ) {
         super(context, attrs, defStyleAttr);
         init();
     }
@@ -41,18 +48,18 @@ public class SlideIndicatorsView extends FrameLayout {
         View view = LayoutInflater.from(getContext()).inflate(R.layout.view_indicators, null, false);
         addView(view);
 
-        mIndicator1 = view.findViewById(R.id.indicator_1);
-        mIndicator2 = view.findViewById(R.id.indicator_2);
-        mIndicator3 = view.findViewById(R.id.indicator_3);
+        indicator1 = view.findViewById(R.id.indicator_1);
+        indicator2 = view.findViewById(R.id.indicator_2);
+        indicator3 = view.findViewById(R.id.indicator_3);
     }
 
     public void setSelectedPosition(int position) {
         if (position < 0 || position >= 3) {
             throw new RuntimeException("Index out of bounds for indicator. The value must be between 0 and 2");
         } else {
-            mIndicator1.setBackgroundResource(position == 0 ? R.drawable.indicator_enabled : R.drawable.indicator_disabled);
-            mIndicator2.setBackgroundResource(position == 1 ? R.drawable.indicator_enabled : R.drawable.indicator_disabled);
-            mIndicator3.setBackgroundResource(position == 2 ? R.drawable.indicator_enabled : R.drawable.indicator_disabled);
+            indicator1.setBackgroundResource(position == 0 ? R.drawable.indicator_enabled : R.drawable.indicator_disabled);
+            indicator2.setBackgroundResource(position == 1 ? R.drawable.indicator_enabled : R.drawable.indicator_disabled);
+            indicator3.setBackgroundResource(position == 2 ? R.drawable.indicator_enabled : R.drawable.indicator_disabled);
         }
     }
 }

--- a/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/validation/AdServerTest.java
+++ b/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/validation/AdServerTest.java
@@ -1,49 +1,25 @@
 package org.prebid.mobile.drprebid.validation;
 
-import static org.prebid.mobile.drprebid.managers.LineItemKeywordManager.KEYWORD_REQUEST_ID;
-
 import android.app.Activity;
 import android.text.TextUtils;
-import android.util.Log;
-
 import androidx.annotation.Nullable;
-
 import com.google.android.gms.ads.AdListener;
 import com.google.android.gms.ads.doubleclick.PublisherAdRequest;
 import com.google.android.gms.ads.doubleclick.PublisherAdView;
 import com.google.android.gms.ads.doubleclick.PublisherInterstitialAd;
-
 import org.prebid.mobile.drprebid.managers.LineItemKeywordManager;
 import org.prebid.mobile.drprebid.managers.SettingsManager;
-import org.prebid.mobile.drprebid.model.AdFormat;
-import org.prebid.mobile.drprebid.model.AdServerSettings;
-import org.prebid.mobile.drprebid.model.AdSize;
-import org.prebid.mobile.drprebid.model.GeneralSettings;
-import org.prebid.mobile.drprebid.model.PrebidServer;
-import org.prebid.mobile.drprebid.model.PrebidServerSettings;
-import org.prebid.mobile.drprebid.util.IOUtil;
+import org.prebid.mobile.drprebid.model.*;
 
-import java.io.ByteArrayInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.Locale;
-import java.util.Map;
-import java.util.Set;
-import java.util.UUID;
+import java.util.*;
 
-import okhttp3.Call;
-import okhttp3.Callback;
-import okhttp3.MediaType;
-import okhttp3.OkHttpClient;
-import okhttp3.RequestBody;
-import okhttp3.Response;
+import static org.prebid.mobile.drprebid.managers.LineItemKeywordManager.KEYWORD_REQUEST_ID;
 
 public class AdServerTest {
     private static final String TAG = AdServerTest.class.getSimpleName();
 
     public interface Listener {
+
         void onPrebidKeywordsFoundOnRequest();
 
         void onPrebidKeywordsNotFoundOnRequest();
@@ -51,28 +27,31 @@ public class AdServerTest {
         void adServerResponseContainsPrebidCreative(@Nullable Boolean contains);
 
         void onTestFinished();
+
     }
 
-    private final Listener mListener;
-    private final Activity mContext;
+    private final Listener listener;
+    private final Activity context;
 
+    private PublisherAdView googleAd;
+    private PublisherInterstitialAd googleInterstitial;
 
-    private PublisherAdView mGoogleAd;
-    private PublisherInterstitialAd mGoogleInterstitial;
+    private String adServerResponse = "";
+    private String requestId;
+    private Map<String, String> keywords;
 
-    private String mAdServerResponse = "";
-    private String mRequestId;
-    private Map<String, String> mKeywords;
-
-    public AdServerTest(Activity context, Listener listener) {
-        mContext = context;
-        mListener = listener;
+    public AdServerTest(
+            Activity context,
+            Listener listener
+    ) {
+        this.context = context;
+        this.listener = listener;
     }
 
     public void startTest() {
-        GeneralSettings generalSettings = SettingsManager.getInstance(mContext).getGeneralSettings();
-        AdServerSettings adServerSettings = SettingsManager.getInstance(mContext).getAdServerSettings();
-        PrebidServerSettings prebidServerSettings = SettingsManager.getInstance(mContext).getPrebidServerSettings();
+        GeneralSettings generalSettings = SettingsManager.getInstance(context).getGeneralSettings();
+        AdServerSettings adServerSettings = SettingsManager.getInstance(context).getAdServerSettings();
+        PrebidServerSettings prebidServerSettings = SettingsManager.getInstance(context).getPrebidServerSettings();
 
         switch (generalSettings.getAdSize()) {
             case BANNER_300x250:
@@ -89,38 +68,41 @@ public class AdServerTest {
                 break;
         }
 
-        mKeywords = createMapKeywords(adServerSettings.getBidPrice(),
-                generalSettings.getAdSize(), generalSettings.getAdFormat(), prebidServerSettings.getPrebidServer());
+        keywords = createMapKeywords(adServerSettings.getBidPrice(),
+                generalSettings.getAdSize(),
+                generalSettings.getAdFormat(),
+                prebidServerSettings.getPrebidServer()
+        );
 
         PublisherAdRequest adRequest = null;
 
         if (generalSettings.getAdFormat() == AdFormat.BANNER) {
-            mGoogleAd = new PublisherAdView(mContext);
+            googleAd = new PublisherAdView(context);
             AdSize adSize = generalSettings.getAdSize();
-            mGoogleAd.setAdSizes(new com.google.android.gms.ads.AdSize(adSize.getWidth(), adSize.getHeight()));
-            mGoogleAd.setAdUnitId(adServerSettings.getAdUnitId());
-            mGoogleAd.setAdListener(mGoogleBannerListener);
+            googleAd.setAdSizes(new com.google.android.gms.ads.AdSize(adSize.getWidth(), adSize.getHeight()));
+            googleAd.setAdUnitId(adServerSettings.getAdUnitId());
+            googleAd.setAdListener(googleBannerListener);
 
         } else if (generalSettings.getAdFormat() == AdFormat.INTERSTITIAL) {
-            mGoogleInterstitial = new PublisherInterstitialAd(mContext);
-            mGoogleInterstitial.setAdUnitId(adServerSettings.getAdUnitId());
-            mGoogleInterstitial.setAdListener(mGoogleInterstitialListener);
+            googleInterstitial = new PublisherInterstitialAd(context);
+            googleInterstitial.setAdUnitId(adServerSettings.getAdUnitId());
+            googleInterstitial.setAdListener(googleInterstitialListener);
         }
 
         PublisherAdRequest.Builder adRequestBuilder = new PublisherAdRequest.Builder();
 
-        for (String key : mKeywords.keySet()) {
-            if (mKeywords.containsKey(key)) {
-                adRequestBuilder.addCustomTargeting(key, mKeywords.get(key));
+        for (String key : keywords.keySet()) {
+            if (keywords.containsKey(key)) {
+                adRequestBuilder.addCustomTargeting(key, keywords.get(key));
             }
         }
 
         adRequest = adRequestBuilder.build();
 
         if (generalSettings.getAdFormat() == AdFormat.BANNER) {
-            mGoogleAd.loadAd(adRequest);
+            googleAd.loadAd(adRequest);
         } else if (generalSettings.getAdFormat() == AdFormat.INTERSTITIAL) {
-            mGoogleInterstitial.loadAd(adRequest);
+            googleInterstitial.loadAd(adRequest);
         }
 
         checkRequestForKeywordsAM(adRequest);
@@ -130,12 +112,12 @@ public class AdServerTest {
     private String createStringKeywords() {
         StringBuilder stringBuilder = new StringBuilder();
 
-        for (String key : mKeywords.keySet()) {
+        for (String key : keywords.keySet()) {
             if (stringBuilder.length() > 0) {
                 stringBuilder.append(LineItemKeywordManager.KEYWORD_COMMA);
             }
 
-            String keyword = String.format(Locale.ENGLISH, "%s:%s", key, mKeywords.get(key));
+            String keyword = String.format(Locale.ENGLISH, "%s:%s", key, keywords.get(key));
             stringBuilder.append(keyword);
         }
 
@@ -145,24 +127,24 @@ public class AdServerTest {
     private Map<String, String> createMapKeywords(float bidPrice, AdSize adSize, AdFormat adFormat, PrebidServer prebidServer) {
         Map<String, String> keywords = new HashMap<>(LineItemKeywordManager.getInstance().getMapKeywords(bidPrice, adSize, adFormat, prebidServer));
 
-        mRequestId = UUID.randomUUID().toString();
+        requestId = UUID.randomUUID().toString();
 
-        keywords.put(KEYWORD_REQUEST_ID, mRequestId);
+        keywords.put(KEYWORD_REQUEST_ID, requestId);
 
         return keywords;
     }
 
     //--------------------------------- Google Banner Listener -------------------------------------
 
-    private AdListener mGoogleBannerListener = new AdListener() {
+    private AdListener googleBannerListener = new AdListener() {
         @Override
         public void onAdLoaded() {
             super.onAdLoaded();
 
-            AdViewUtils.findHtml(mGoogleAd, new OnWebViewListener() {
+            AdViewUtils.findHtml(googleAd, new OnWebViewListener() {
                 @Override
                 public void success(String html) {
-                    mAdServerResponse = html;
+                    adServerResponse = html;
                     checkResponseForPrebidCreative();
                 }
 
@@ -183,7 +165,7 @@ public class AdServerTest {
 
     //------------------------------- Google Interstitial Listener ---------------------------------
 
-    private AdListener mGoogleInterstitialListener = new AdListener() {
+    private AdListener googleInterstitialListener = new AdListener() {
         @Override
         public void onAdLoaded() {
             super.onAdLoaded();
@@ -204,7 +186,7 @@ public class AdServerTest {
 
     //Check PublisherAdRequest
     private void checkRequestForKeywordsAM(@Nullable PublisherAdRequest adRequest) {
-        if (adRequest != null && mListener != null) {
+        if (adRequest != null && listener != null) {
 
             Map<String, String> map = new HashMap<>();
 
@@ -215,39 +197,40 @@ public class AdServerTest {
                 map.put(key, adRequest.getCustomTargeting().getString(key));
             }
 
-            if (map.get(KEYWORD_REQUEST_ID).equals(mRequestId)) {
-                if (mKeywords.equals(map)) {
-                    mListener.onPrebidKeywordsFoundOnRequest();
+            if (map.get(KEYWORD_REQUEST_ID).equals(requestId)) {
+                if (keywords.equals(map)) {
+                    listener.onPrebidKeywordsFoundOnRequest();
                 } else {
-                    mListener.onPrebidKeywordsNotFoundOnRequest();
+                    listener.onPrebidKeywordsNotFoundOnRequest();
                 }
             }
         }
     }
 
     private void checkRequestForKeywords(String url, String postBody) {
-        if (url.contains(mRequestId) || postBody.contains(mRequestId)) {
+        if (url.contains(requestId) || postBody.contains(requestId)) {
             boolean containsKeyValues = true;
 
-            for (String key : mKeywords.keySet()) {
-                String keyValuePair = String.format(Locale.ENGLISH, "%s:%s", key, mKeywords.get(key));
+            for (String key : keywords.keySet()) {
+                String keyValuePair = String.format(Locale.ENGLISH, "%s:%s", key, keywords.get(key));
                 if (!postBody.contains(keyValuePair)) {
                     containsKeyValues = false;
                 }
             }
 
-            if (mListener != null) {
+            if (listener != null) {
                 if (containsKeyValues) {
-                    mListener.onPrebidKeywordsFoundOnRequest();
+                    listener.onPrebidKeywordsFoundOnRequest();
                 } else {
-                    mListener.onPrebidKeywordsNotFoundOnRequest();
+                    listener.onPrebidKeywordsNotFoundOnRequest();
                 }
             }
         }
     }
 
     private void checkResponseForPrebidCreative() {
-        if (!TextUtils.isEmpty(mAdServerResponse) && (mAdServerResponse.contains("pbm.js") || mAdServerResponse.contains("creative.js"))) {
+        if (!TextUtils.isEmpty(adServerResponse) && (adServerResponse.contains("pbm.js") || adServerResponse.contains(
+                "creative.js"))) {
             invokeContainsPrebidCreative(true);
         } else {
             invokeContainsPrebidCreative(false);
@@ -255,9 +238,9 @@ public class AdServerTest {
     }
 
     private void invokeContainsPrebidCreative(@Nullable Boolean contains) {
-        mContext.runOnUiThread(() -> {
-            if (mListener != null) {
-                mListener.adServerResponseContainsPrebidCreative(contains);
+        context.runOnUiThread(() -> {
+            if (listener != null) {
+                listener.adServerResponseContainsPrebidCreative(contains);
             }
 
             invokeTestFinished();
@@ -265,12 +248,12 @@ public class AdServerTest {
     }
 
     private void invokeTestFinished() {
-        if (mGoogleAd != null) {
-            mGoogleAd.destroy();
+        if (googleAd != null) {
+            googleAd.destroy();
         }
 
-        if (mListener != null) {
-            mListener.onTestFinished();
+        if (listener != null) {
+            listener.onTestFinished();
         }
     }
 }

--- a/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/validation/RealTimeDemandTest.java
+++ b/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/validation/RealTimeDemandTest.java
@@ -4,55 +4,47 @@ import android.content.Context;
 import android.net.Uri;
 import android.text.TextUtils;
 import android.util.Log;
-
 import org.json.JSONArray;
 import org.json.JSONObject;
-import org.prebid.mobile.AdUnit;
-import org.prebid.mobile.BannerAdUnit;
-import org.prebid.mobile.Host;
-import org.prebid.mobile.InterstitialAdUnit;
-import org.prebid.mobile.PrebidMobile;
+import org.prebid.mobile.*;
 import org.prebid.mobile.drprebid.Constants;
 import org.prebid.mobile.drprebid.async.DemandTestResultTask;
 import org.prebid.mobile.drprebid.async.DemandTestTask;
 import org.prebid.mobile.drprebid.managers.DemandTestManager;
 import org.prebid.mobile.drprebid.managers.SettingsManager;
-import org.prebid.mobile.drprebid.model.AdFormat;
 import org.prebid.mobile.drprebid.model.AdSize;
-import org.prebid.mobile.drprebid.model.Bidder;
-import org.prebid.mobile.drprebid.model.DemandTestResults;
-import org.prebid.mobile.drprebid.model.GeneralSettings;
-import org.prebid.mobile.drprebid.model.PrebidServer;
-import org.prebid.mobile.drprebid.model.PrebidServerSettings;
+import org.prebid.mobile.drprebid.model.*;
 
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.Iterator;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 public class RealTimeDemandTest {
+
     private static final String TAG = RealTimeDemandTest.class.getSimpleName();
     private static final int REQUEST_MAX = 100;
 
     public interface Listener {
+
         void onTestFinished(DemandTestResults results);
+
     }
 
-    private Listener mListener;
-    private Context mContext;
+    private Listener listener;
+    private Context context;
 
     private int testResponseCount = 0;
     private DemandTestResults testResults;
 
-    public RealTimeDemandTest(Context context, Listener listener) {
-        mContext = context;
-        mListener = listener;
+    public RealTimeDemandTest(
+            Context context,
+            Listener listener
+    ) {
+        this.context = context;
+        this.listener = listener;
     }
 
     public void startTest() {
-        GeneralSettings generalSettings = SettingsManager.getInstance(mContext).getGeneralSettings();
-        PrebidServerSettings prebidServerSettings = SettingsManager.getInstance(mContext).getPrebidServerSettings();
+        GeneralSettings generalSettings = SettingsManager.getInstance(context).getGeneralSettings();
+        PrebidServerSettings prebidServerSettings = SettingsManager.getInstance(context).getPrebidServerSettings();
 
         AdUnit adUnit = null;
         if (generalSettings.getAdFormat() == AdFormat.BANNER) {
@@ -84,7 +76,11 @@ public class RealTimeDemandTest {
                 hostUrl = Constants.EndpointUrls.APPNEXUS_PREBID_SERVER;
         }
 
-        DemandRequestBuilder builder = new DemandRequestBuilder(mContext, prebidServerSettings.getConfigId(), generalSettings.getAdSize());
+        DemandRequestBuilder builder = new DemandRequestBuilder(
+                context,
+                prebidServerSettings.getConfigId(),
+                generalSettings.getAdSize()
+        );
         String request = builder.buildRequest(adUnits, prebidServerSettings.getAccountId(), true);
 
         testResponseCount = 0;
@@ -190,7 +186,9 @@ public class RealTimeDemandTest {
                 if (ext.has("errors")) {
                     JSONObject bidderErrors = ext.getJSONObject("errors");
                     if (bidderErrors != null) {
-                        if (SettingsManager.getInstance(mContext).getPrebidServerSettings().getPrebidServer() == PrebidServer.RUBICON) {
+                        if (SettingsManager.getInstance(context)
+                                           .getPrebidServerSettings()
+                                           .getPrebidServer() == PrebidServer.RUBICON) {
                             Iterator<String> keyIterator = bidderErrors.keys();
                             while (keyIterator.hasNext()) {
                                 String key = keyIterator.next();
@@ -268,8 +266,8 @@ public class RealTimeDemandTest {
             }
 
             testResults.setAvgResponseTime(averageResponseTime);
-            if (mListener != null) {
-                mListener.onTestFinished(testResults);
+            if (listener != null) {
+                listener.onTestFinished(testResults);
             }
         }
     };


### PR DESCRIPTION
Rendering SDK uses m- prefixes for class fields, but the original doesn't. So we need to unify the code style. Fix tests that use reflection.