### PR TITLE
add FLAG_ACTIVITY_NEW_TASK for external browser

### DIFF
--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/helpers/ExternalViewerUtils.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/helpers/ExternalViewerUtils.java
@@ -119,6 +119,9 @@ public class ExternalViewerUtils {
             return;
         }
         Intent intent = new Intent(Intent.ACTION_VIEW);
+        if (!(context instanceof Activity)) {
+            intent.addFlags(FLAG_ACTIVITY_NEW_TASK);
+        }
         intent.setData(Uri.parse(url));
         if (URLUtil.isValidUrl(url) || isActivityCallable(context, intent)) {
             context.startActivity(intent);


### PR DESCRIPTION
to fix android.util.AndroidRuntimeException: Calling startActivity() from outside of an Activity  context requires the FLAG_ACTIVITY_NEW_TASK flag.