### PR TITLE
Initialization improvements

### DIFF
--- a/Example/PrebidDemoJava/src/main/java/org/prebid/mobile/javademo/CustomApplication.java
+++ b/Example/PrebidDemoJava/src/main/java/org/prebid/mobile/javademo/CustomApplication.java
@@ -19,6 +19,7 @@ package org.prebid.mobile.javademo;
 import android.app.Application;
 import android.os.Build;
 import android.webkit.WebView;
+import org.prebid.mobile.Host;
 import org.prebid.mobile.PrebidMobile;
 import org.prebid.mobile.javademo.utils.ScreenUtils;
 
@@ -29,7 +30,12 @@ public class CustomApplication extends Application {
         super.onCreate();
 
         PrebidMobile.setShareGeoLocation(true);
-        PrebidMobile.setApplicationContext(getApplicationContext());
+
+        PrebidMobile.setPrebidServerAccountId("0689a263-318d-448b-a3d4-b02e8a709d9d");
+        PrebidMobile.setPrebidServerHost(
+            Host.createCustomHost("https://prebid-server-test-j.prebid.org/openrtb2/auction")
+        );
+        PrebidMobile.initializeSdk(getApplicationContext(), null);
 
         ScreenUtils.closeSystemWindowsAndKeepScreenOn(this);
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.KITKAT) {

--- a/Example/PrebidDemoKotlin/src/main/java/org/prebid/mobile/prebidkotlindemo/CustomApplication.kt
+++ b/Example/PrebidDemoKotlin/src/main/java/org/prebid/mobile/prebidkotlindemo/CustomApplication.kt
@@ -49,8 +49,8 @@ class CustomApplication : Application() {
 
 
     private fun initPrebidSDK() {
-//        PrebidMobile.setPbsDebug(true)
-        PrebidMobile.setApplicationContext(applicationContext)
+        AdTypesRepository.usePrebidServer()
+        PrebidMobile.initializeSdk(applicationContext, null)
         PrebidMobile.setShareGeoLocation(true)
     }
 

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/AdFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/AdFragment.kt
@@ -222,9 +222,9 @@ abstract class AdFragment : BaseFragment() {
         val hostUrl = PrebidMobile.getPrebidServerHost().hostUrl
         val host = Host.CUSTOM
         host.hostUrl = hostUrl
-        PrebidMobile.setApplicationContext(requireContext())
         PrebidMobile.setPrebidServerHost(host)
         PrebidMobile.setPrebidServerAccountId(PrebidMobile.getPrebidServerAccountId())
+        PrebidMobile.initializeSdk(requireContext(), null)
     }
 
 }

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/InternalTestApplication.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/InternalTestApplication.kt
@@ -25,6 +25,7 @@ import androidx.multidex.MultiDex
 import androidx.multidex.MultiDexApplication
 import com.applovin.sdk.AppLovinSdk
 import com.applovin.sdk.AppLovinSdkConfiguration
+import org.prebid.mobile.Host
 import org.prebid.mobile.PrebidMobile
 import org.prebid.mobile.renderingtestapp.utils.DemoItemProvider
 import org.prebid.mobile.renderingtestapp.utils.SourcePicker
@@ -42,7 +43,8 @@ class InternalTestApplication : MultiDexApplication() {
         super.onCreate()
         instance = this
 
-        PrebidMobile.setApplicationContext(this)
+        PrebidMobile.setPrebidServerHost(Host.createCustomHost("https://prebid-server-test-j.prebid.org/openrtb2/auction"))
+        PrebidMobile.initializeSdk(this, null)
         PrebidMobile.setPrebidServerAccountId(getString(R.string.prebid_account_id_prod))
         PrebidMobile.logLevel = PrebidMobile.LogLevel.DEBUG
         SourcePicker.setBidServerHost(SourcePicker.PBS_SERVER_DOMAIN)

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/PrebidMobile.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/PrebidMobile.java
@@ -20,16 +20,33 @@ import android.content.Context;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 import org.prebid.mobile.core.BuildConfig;
+import org.prebid.mobile.rendering.listeners.SdkInitializationListener;
 import org.prebid.mobile.rendering.mraid.MraidEnv;
 import org.prebid.mobile.rendering.sdk.ManagersResolver;
+import org.prebid.mobile.rendering.sdk.SdkInitializer;
 import org.prebid.mobile.rendering.sdk.deviceData.listeners.SdkInitListener;
-import org.prebid.mobile.rendering.session.manager.OmAdSessionManager;
-import org.prebid.mobile.rendering.utils.helpers.AppInfoManager;
 
 import java.util.*;
-import java.util.concurrent.atomic.AtomicInteger;
 
 public class PrebidMobile {
+
+    public static boolean isCoppaEnabled = false;
+    public static boolean useExternalBrowser = false;
+
+    /**
+     * If true, the SDK sends "af=3,5", indicating support for MRAID
+     */
+    public static boolean sendMraidSupportParams = true;
+
+    /**
+     * Minimum refresh interval allowed. 30 seconds
+     */
+    public static final int AUTO_REFRESH_DELAY_MIN = 30_000;
+
+    /**
+     * Maximum refresh interval allowed. 120 seconds
+     */
+    public static final int AUTO_REFRESH_DELAY_MAX = 120_000;
 
     public static final String SCHEME_HTTPS = "https";
     public static final String SCHEME_HTTP = "http";
@@ -54,34 +71,20 @@ public class PrebidMobile {
     public static final String NATIVE_VERSION = "1.2";
 
     /**
-     * Maximum refresh interval allowed. 120 seconds
-     */
-    public static final int AUTO_REFRESH_DELAY_MAX = 120_000;
-
-    /**
-     * Minimum refresh interval allowed. 30 seconds
-     */
-    public static final int AUTO_REFRESH_DELAY_MIN = 30_000;
-
-    /**
      * Open measurement SDK version
      */
     public static final String OMSDK_VERSION = BuildConfig.OMSDK_VERSION;
 
-    private static final AtomicInteger INIT_SDK_TASK_COUNT = new AtomicInteger();
-    private static final int MANDATORY_TASK_COUNT = 3;
-
     /**
-     * Log levels for easy development
-     * Default - No sdks logs
-     * Refer - LogLevel
+     * Please use {@link PrebidMobile#setLogLevel(LogLevel)}, this field will become private in next releases.
      */
+    @Deprecated
     public static LogLevel logLevel = LogLevel.NONE;
 
-    /**
-     * If true, the SDK sends "af=3,5", indicating support for MRAID
-     */
-    public static boolean sendMraidSupportParams = true;
+
+    private static boolean pbsDebug = false;
+    private static boolean shareGeoLocation = false;
+    private static boolean assignNativeAssetID = false;
 
     /**
      * Indicates whether the PBS should cache the bid for the rendering API.
@@ -90,33 +93,20 @@ public class PrebidMobile {
      */
     private static boolean useCacheForReportingWithRenderingApi = false;
 
-    public static boolean isCoppaEnabled = false;
-    public static boolean useExternalBrowser = false;
-
-    private static SdkInitListener sdkInitListener;
-
-    private static boolean isSdkInitialized = false;
-    private static boolean useHttps = false;
-
+    private static int timeoutMillis = 2_000;
 
     private static final String TAG = PrebidMobile.class.getSimpleName();
-
-    static boolean timeoutMillisUpdated = false;
-    private static boolean pbsDebug = false;
-    private static boolean shareGeoLocation = false;
-    private static boolean assignNativeAssetID = false;
-    private static int timeoutMillis = 2_000;
 
     private static String accountId = "";
     private static String storedAuctionResponse = "";
 
     private static Host host = Host.CUSTOM;
+
     private static final Map<String, String> storedBidResponses = new LinkedHashMap<>();
     private static List<ExternalUserId> externalUserIds = new ArrayList<>();
     private static HashMap<String, String> customHeaders = new HashMap<>();
 
-    private PrebidMobile() {
-    }
+    private PrebidMobile() {}
 
     public static boolean isUseCacheForReportingWithRenderingApi() {
         return useCacheForReportingWithRenderingApi;
@@ -197,30 +187,42 @@ public class PrebidMobile {
         return PrebidMobile.customHeaders;
     }
 
-    public static void setApplicationContext(@Nullable Context context) {
-        setApplicationContext(context, null);
+    public static void initializeSdk(
+        @Nullable Context context,
+        @Nullable SdkInitializationListener listener
+    ) {
+        SdkInitializer.init(context, listener);
     }
 
-    public static void setApplicationContext(@Nullable Context context, @Nullable SdkInitListener listener) {
-        if (context == null) {
-            LogUtil.error("Context must be not null!");
-            return;
-        }
+    /**
+     * Please use {@link PrebidMobile#initializeSdk(Context, SdkInitializationListener)}.
+     */
+    @Deprecated
+    public static void setApplicationContext(@Nullable Context context) {
+        SdkInitializer.init(context, null);
+    }
 
-        if (isSdkInitialized) {
-            return;
-        }
-        LogUtil.debug(TAG, "Initializing Prebid Rendering SDK");
+    /**
+     * Please use {@link PrebidMobile#initializeSdk(Context, SdkInitializationListener)}.
+     */
+    @Deprecated
+    public static void setApplicationContext(
+        @Nullable Context context,
+        @Nullable SdkInitListener listener
+    ) {
+        SdkInitializer.init(context, new SdkInitializationListener() {
+            @Override
+            public void onSdkInit() {
+                if (listener != null) {
+                    listener.onSDKInit();
+                }
+            }
 
-        sdkInitListener = listener;
-        INIT_SDK_TASK_COUNT.set(0);
-
-        if (logLevel != null) {
-            initializeLogging();
-        }
-        AppInfoManager.init(context);
-        initOpenMeasurementSDK(context);
-        ManagersResolver.getInstance().prepare(context);
+            @Override
+            public void onSdkFailedToInit(InitError error) {
+                LogUtil.error(TAG, error.getError());
+            }
+        });
     }
 
     public static Context getApplicationContext() {
@@ -236,7 +238,10 @@ public class PrebidMobile {
         return storedAuctionResponse;
     }
 
-    public static void addStoredBidResponse(String bidder, String responseId) {
+    public static void addStoredBidResponse(
+        String bidder,
+        String responseId
+    ) {
         storedBidResponses.put(bidder, responseId);
     }
 
@@ -276,32 +281,15 @@ public class PrebidMobile {
      * Return 'true' if Prebid Rendering SDK is initialized completely
      */
     public static boolean isSdkInitialized() {
-        return isSdkInitialized;
+        return SdkInitializer.isIsSdkInitialized();
     }
 
-    private static void initOpenMeasurementSDK(Context context) {
-        OmAdSessionManager.activateOmSdk(context.getApplicationContext());
-        increaseTaskCount();
+    public static LogLevel getLogLevel() {
+        return PrebidMobile.logLevel;
     }
 
-    private static void initializeLogging() {
-        LogUtil.setLogLevel(logLevel.getValue());//set to the publisher set value
-        increaseTaskCount();
-    }
-
-    /**
-     * Notifies SDK initializer that one task was completed.
-     * Only for internal use!
-     */
-    public static void increaseTaskCount() {
-        if (INIT_SDK_TASK_COUNT.incrementAndGet() >= MANDATORY_TASK_COUNT) {
-            isSdkInitialized = true;
-            LogUtil.debug(TAG, "Prebid Rendering SDK " + SDK_VERSION + " Initialized");
-
-            if (sdkInitListener != null) {
-                sdkInitListener.onSDKInit();
-            }
-        }
+    public static void setLogLevel(LogLevel logLevel) {
+        PrebidMobile.logLevel = logLevel;
     }
 
 
@@ -313,7 +301,10 @@ public class PrebidMobile {
      * DEBUG - sdk logs with debug level only. Noisy level.
      */
     public enum LogLevel {
-        NONE(-1), DEBUG(3), WARN(5), ERROR(6);
+        NONE(-1),
+        DEBUG(3),
+        WARN(5),
+        ERROR(6);
 
         private final int value;
 

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/PrebidMobile.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/PrebidMobile.java
@@ -19,6 +19,7 @@ package org.prebid.mobile;
 import android.content.Context;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+import org.prebid.mobile.api.exceptions.InitError;
 import org.prebid.mobile.core.BuildConfig;
 import org.prebid.mobile.rendering.listeners.SdkInitializationListener;
 import org.prebid.mobile.rendering.mraid.MraidEnv;

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/PrebidMobile.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/PrebidMobile.java
@@ -187,6 +187,15 @@ public class PrebidMobile {
         return PrebidMobile.customHeaders;
     }
 
+
+    /**
+     * Initializes the main SDK classes. Makes request to Prebid server to check its status.
+     * You have to set host url ({@link PrebidMobile#setPrebidServerHost(Host)}) before calling this method.
+     *
+     * @param context  any context (must be not null)
+     * @param listener initialization listener (can be null)
+     * @see <a href="https://docs.prebid.org/prebid-server/endpoints/pbs-endpoint-status.html">GET /status</a>
+     */
     public static void initializeSdk(
         @Nullable Context context,
         @Nullable SdkInitializationListener listener

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/exceptions/InitError.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/exceptions/InitError.java
@@ -1,0 +1,15 @@
+package org.prebid.mobile.api.exceptions;
+
+public class InitError {
+
+    private String error;
+
+    public InitError(String error) {
+        this.error = error;
+    }
+
+    public String getError() {
+        return error;
+    }
+
+}

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/mediation/MediationBaseAdUnit.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/mediation/MediationBaseAdUnit.java
@@ -212,8 +212,7 @@ public abstract class MediationBaseAdUnit {
     }
 
     private void initSdk(Context context) {
-        PrebidMobile.setApplicationContext(context, () -> {
-        });
+        PrebidMobile.initializeSdk(context, null);
     }
 
     private void cancelRefresh() {

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/BannerView.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/BannerView.java
@@ -430,7 +430,7 @@ public class BannerView extends FrameLayout {
     }
 
     private void initPrebidRenderingSdk() {
-        PrebidMobile.setApplicationContext(getContext());
+        PrebidMobile.initializeSdk(getContext(), null);
     }
 
     private void initBidLoader() {

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/BaseInterstitialAdUnit.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/BaseInterstitialAdUnit.java
@@ -271,7 +271,7 @@ public abstract class BaseInterstitialAdUnit {
     }
 
     private void initPrebidRenderingSdk() {
-        PrebidMobile.setApplicationContext(getContext(), () -> {});
+        PrebidMobile.initializeSdk(getContext(), null);
     }
 
     private void initBidLoader() {

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/listeners/SdkInitializationListener.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/listeners/SdkInitializationListener.java
@@ -1,23 +1,11 @@
 package org.prebid.mobile.rendering.listeners;
 
+import org.prebid.mobile.api.exceptions.InitError;
+
 public interface SdkInitializationListener {
 
     void onSdkInit();
 
     void onSdkFailedToInit(InitError error);
-
-    class InitError {
-
-        private String error;
-
-        public InitError(String error) {
-            this.error = error;
-        }
-
-        public String getError() {
-            return error;
-        }
-
-    }
 
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/listeners/SdkInitializationListener.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/listeners/SdkInitializationListener.java
@@ -1,0 +1,23 @@
+package org.prebid.mobile.rendering.listeners;
+
+public interface SdkInitializationListener {
+
+    void onSdkInit();
+
+    void onSdkFailedToInit(InitError error);
+
+    class InitError {
+
+        private String error;
+
+        public InitError(String error) {
+            this.error = error;
+        }
+
+        public String getError() {
+            return error;
+        }
+
+    }
+
+}

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/ManagersResolver.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/ManagersResolver.java
@@ -19,7 +19,6 @@ package org.prebid.mobile.rendering.sdk;
 import android.content.Context;
 import android.util.Log;
 import org.prebid.mobile.LogUtil;
-import org.prebid.mobile.PrebidMobile;
 import org.prebid.mobile.rendering.sdk.deviceData.managers.*;
 import org.prebid.mobile.rendering.utils.helpers.Utils;
 
@@ -183,7 +182,7 @@ public class ManagersResolver {
             LogUtil.error(TAG, "Failed to register managers: " + Log.getStackTraceString(e));
         }
         finally {
-            PrebidMobile.increaseTaskCount();
+            SdkInitializer.increaseTaskCount();
         }
     }
 

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/SdkInitializer.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/SdkInitializer.java
@@ -5,6 +5,7 @@ import android.content.Context;
 import androidx.annotation.Nullable;
 import org.prebid.mobile.LogUtil;
 import org.prebid.mobile.PrebidMobile;
+import org.prebid.mobile.api.exceptions.InitError;
 import org.prebid.mobile.rendering.listeners.SdkInitializationListener;
 import org.prebid.mobile.rendering.session.manager.OmAdSessionManager;
 import org.prebid.mobile.rendering.utils.helpers.AppInfoManager;
@@ -30,7 +31,7 @@ public class SdkInitializer {
             String error = "Context must be not null!";
             LogUtil.error(error);
             if (listener != null) {
-                listener.onSdkFailedToInit(new SdkInitializationListener.InitError(error));
+                listener.onSdkFailedToInit(new InitError(error));
             }
             return;
         }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/SdkInitializer.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/SdkInitializer.java
@@ -1,0 +1,78 @@
+package org.prebid.mobile.rendering.sdk;
+
+import android.content.Context;
+import androidx.annotation.Nullable;
+import org.prebid.mobile.LogUtil;
+import org.prebid.mobile.PrebidMobile;
+import org.prebid.mobile.rendering.listeners.SdkInitializationListener;
+import org.prebid.mobile.rendering.session.manager.OmAdSessionManager;
+import org.prebid.mobile.rendering.utils.helpers.AppInfoManager;
+
+import java.util.concurrent.atomic.AtomicInteger;
+
+public class SdkInitializer {
+
+    private static final String TAG = SdkInitializer.class.getSimpleName();
+
+    private static boolean isSdkInitialized = false;
+
+    private static final AtomicInteger INIT_SDK_TASK_COUNT = new AtomicInteger();
+    private static final int MANDATORY_TASK_COUNT = 3;
+
+    private static SdkInitializationListener sdkInitListener;
+
+    public static void init(
+        @Nullable Context context,
+        @Nullable SdkInitializationListener listener
+    ) {
+        if (context == null) {
+            LogUtil.error("Context must be not null!");
+            return;
+        }
+
+        if (isSdkInitialized) {
+            return;
+        }
+        LogUtil.debug(TAG, "Initializing Prebid Rendering SDK");
+
+        sdkInitListener = listener;
+        INIT_SDK_TASK_COUNT.set(0);
+
+        if (PrebidMobile.logLevel != null) {
+            initializeLogging();
+        }
+        AppInfoManager.init(context);
+        initOpenMeasurementSDK(context);
+        ManagersResolver.getInstance().prepare(context);
+    }
+
+    private static void initializeLogging() {
+        LogUtil.setLogLevel(PrebidMobile.getLogLevel().getValue());
+        increaseTaskCount();
+    }
+
+    private static void initOpenMeasurementSDK(Context context) {
+        OmAdSessionManager.activateOmSdk(context.getApplicationContext());
+        increaseTaskCount();
+    }
+
+    /**
+     * Notifies SDK initializer that one task was completed.
+     * Only for internal use!
+     */
+    public static void increaseTaskCount() {
+        if (INIT_SDK_TASK_COUNT.incrementAndGet() >= MANDATORY_TASK_COUNT) {
+            isSdkInitialized = true;
+            LogUtil.debug(TAG, "Prebid Rendering SDK " + PrebidMobile.SDK_VERSION + " Initialized");
+
+            if (sdkInitListener != null) {
+                sdkInitListener.onSdkInit();
+            }
+        }
+    }
+
+    public static boolean isIsSdkInitialized() {
+        return isSdkInitialized;
+    }
+
+}

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/SdkInitializer.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/SdkInitializer.java
@@ -21,7 +21,7 @@ public class SdkInitializer {
     private static final AtomicInteger INIT_SDK_TASK_COUNT = new AtomicInteger();
     private static final int MANDATORY_TASK_COUNT = 4;
 
-    private static SdkInitializationListener sdkInitListener;
+    protected static SdkInitializationListener sdkInitListener;
 
     public static void init(
         @Nullable Context context,

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/SdkInitializer.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/SdkInitializer.java
@@ -1,6 +1,6 @@
 package org.prebid.mobile.rendering.sdk;
 
-import android.app.Activity;
+import android.app.Application;
 import android.content.Context;
 import androidx.annotation.Nullable;
 import org.prebid.mobile.LogUtil;
@@ -31,7 +31,7 @@ public class SdkInitializer {
             return;
         }
 
-        if (context instanceof Activity) {
+        if (!(context instanceof Application)) {
             Context applicationContext = context.getApplicationContext();
             if (applicationContext != null) {
                 context = applicationContext;

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/SdkInitializer.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/SdkInitializer.java
@@ -27,7 +27,11 @@ public class SdkInitializer {
         @Nullable SdkInitializationListener listener
     ) {
         if (context == null) {
-            LogUtil.error("Context must be not null!");
+            String error = "Context must be not null!";
+            LogUtil.error(error);
+            if (listener != null) {
+                listener.onSdkFailedToInit(new SdkInitializationListener.InitError(error));
+            }
             return;
         }
 

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/SdkInitializer.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/SdkInitializer.java
@@ -16,7 +16,7 @@ public class SdkInitializer {
 
     private static final String TAG = SdkInitializer.class.getSimpleName();
 
-    private static boolean isSdkInitialized = false;
+    protected static boolean isSdkInitialized = false;
 
     private static final AtomicInteger INIT_SDK_TASK_COUNT = new AtomicInteger();
     private static final int MANDATORY_TASK_COUNT = 4;
@@ -27,6 +27,7 @@ public class SdkInitializer {
         @Nullable Context context,
         @Nullable SdkInitializationListener listener
     ) {
+        sdkInitListener = listener;
         if (context == null) {
             String error = "Context must be not null!";
             LogUtil.error(error);
@@ -40,6 +41,8 @@ public class SdkInitializer {
             Context applicationContext = context.getApplicationContext();
             if (applicationContext != null) {
                 context = applicationContext;
+            } else {
+                LogUtil.warning(TAG, "Can't get application context, SDK will use context: " + context.getClass());
             }
         }
 
@@ -50,7 +53,6 @@ public class SdkInitializer {
 
         LogUtil.debug(TAG, "Initializing Prebid Rendering SDK");
 
-        sdkInitListener = listener;
         INIT_SDK_TASK_COUNT.set(0);
 
         if (PrebidMobile.logLevel != null) {

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/StatusRequester.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/StatusRequester.java
@@ -1,0 +1,88 @@
+package org.prebid.mobile.rendering.sdk;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.prebid.mobile.LogUtil;
+import org.prebid.mobile.PrebidMobile;
+import org.prebid.mobile.rendering.listeners.SdkInitializationListener;
+import org.prebid.mobile.rendering.networking.BaseNetworkTask;
+import org.prebid.mobile.rendering.networking.ResponseHandler;
+import org.prebid.mobile.rendering.networking.tracking.ServerConnection;
+
+public class StatusRequester {
+
+    private static final String TAG = StatusRequester.class.getSimpleName();
+
+    public static void makeRequest(@Nullable SdkInitializationListener listener) {
+        String url = PrebidMobile.getPrebidServerHost().getHostUrl();
+        if (url.contains("/openrtb2/auction")) {
+            String statusUrl = url.replace("/openrtb2/auction", "/status");
+            ServerConnection.fireWithResult(
+                statusUrl,
+                getResponseHandler(listener)
+            );
+        } else if (url.isEmpty()) {
+            onInitError("Please set host url (PrebidMobile.setPrebidServerHost) and only then run SDK initialization.", listener);
+        } else {
+            onInitError("Error, url doesn't contain /openrtb2/auction part", listener);
+        }
+    }
+
+    private static ResponseHandler getResponseHandler(@Nullable SdkInitializationListener listener) {
+        return new ResponseHandler() {
+            @Override
+            public void onResponse(BaseNetworkTask.GetUrlResult response) {
+                if (response.statusCode == 200) {
+                    try {
+                        JSONObject responseJson = new JSONObject(response.responseString);
+                        JSONObject applicationJson = responseJson.optJSONObject("application");
+                        if (applicationJson != null) {
+                            String status = applicationJson.optString("status");
+                            if (status.equalsIgnoreCase("ok")) {
+                                onSuccess();
+                                return;
+                            }
+                        }
+                    } catch (JSONException exception) {
+                        onInitError("JsonException: " + exception.getMessage(), listener);
+                        return;
+                    }
+                }
+                onInitError("Server status is not ok!", listener);
+            }
+
+            @Override
+            public void onError(
+                String msg,
+                long responseTime
+            ) {
+                onInitError("Exception: " + msg, listener);
+            }
+
+            @Override
+            public void onErrorWithException(
+                Exception exception,
+                long responseTime
+            ) {
+                onInitError("Exception: " + exception.getMessage(), listener);
+            }
+        };
+    }
+
+    private static void onSuccess() {
+        SdkInitializer.increaseTaskCount();
+    }
+
+    private static void onInitError(
+        @NonNull String message,
+        @Nullable SdkInitializationListener listener
+    ) {
+        LogUtil.error(TAG, message);
+        if (listener != null) {
+            listener.onSdkFailedToInit(new SdkInitializationListener.InitError(message));
+        }
+    }
+
+}

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/StatusRequester.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/StatusRequester.java
@@ -6,6 +6,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.prebid.mobile.LogUtil;
 import org.prebid.mobile.PrebidMobile;
+import org.prebid.mobile.api.exceptions.InitError;
 import org.prebid.mobile.rendering.listeners.SdkInitializationListener;
 import org.prebid.mobile.rendering.networking.BaseNetworkTask;
 import org.prebid.mobile.rendering.networking.ResponseHandler;
@@ -81,7 +82,7 @@ public class StatusRequester {
     ) {
         LogUtil.error(TAG, message);
         if (listener != null) {
-            listener.onSdkFailedToInit(new SdkInitializationListener.InitError(message));
+            listener.onSdkFailedToInit(new InitError(message));
         }
     }
 

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/deviceData/listeners/SdkInitListener.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/deviceData/listeners/SdkInitListener.java
@@ -16,6 +16,8 @@
 
 package org.prebid.mobile.rendering.sdk.deviceData.listeners;
 
+@Deprecated
 public interface SdkInitListener {
+
     void onSDKInit();
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/views/base/BaseAdView.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/views/base/BaseAdView.java
@@ -95,7 +95,7 @@ public abstract class BaseAdView extends FrameLayout {
         int visibility = getVisibility();
 
         setScreenVisibility(visibility);
-        PrebidMobile.setApplicationContext(getContext(), null);
+        PrebidMobile.initializeSdk(getContext(), null);
     }
 
     protected void registerEventBroadcast() {

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/sdk/PrebidMobileTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/sdk/PrebidMobileTest.java
@@ -77,7 +77,7 @@ public class PrebidMobileTest {
     @Test
     public void testOnSDKInitWithoutVideoPreCache() throws Exception {
         //test if sdkinit is sent even if precache fails for any reason, as it is optional & should not avoid further sdk actions
-        WhiteBox.field(PrebidMobile.class, "isSdkInitialized").set(null, false);
+        WhiteBox.field(SdkInitializer.class, "isSdkInitialized").set(null, false);
         Context context = Robolectric.buildActivity(Activity.class).create().get();
         SdkInitListener mockSdkInitListener = mock(SdkInitListener.class);
 

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/sdk/SdkInitializerTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/sdk/SdkInitializerTest.java
@@ -37,16 +37,17 @@ public class SdkInitializerTest {
     public void setUp() throws Exception {
         server = new MockWebServer();
         context = Robolectric.buildActivity(Activity.class).create().get();
-        calledAlready = false;
-        isSuccessful = null;
-        error = null;
-        PrebidMobile.setPrebidServerHost(Host.createCustomHost(""));
-        SdkInitializer.isSdkInitialized = false;
     }
 
     @After
     public void tearDown() throws IOException {
         server.shutdown();
+        calledAlready = false;
+        isSuccessful = null;
+        error = null;
+        PrebidMobile.setPrebidServerHost(Host.createCustomHost(""));
+        SdkInitializer.isSdkInitialized = false;
+        SdkInitializer.sdkInitListener = null;
     }
 
 

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/sdk/SdkInitializerTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/sdk/SdkInitializerTest.java
@@ -1,0 +1,145 @@
+package org.prebid.mobile.rendering.sdk;
+
+import android.app.Activity;
+import android.content.Context;
+import okhttp3.HttpUrl;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.prebid.mobile.Host;
+import org.prebid.mobile.PrebidMobile;
+import org.prebid.mobile.api.exceptions.InitError;
+import org.prebid.mobile.rendering.listeners.SdkInitializationListener;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+
+import java.io.IOException;
+
+import static android.os.Looper.getMainLooper;
+import static java.lang.Thread.sleep;
+import static org.junit.Assert.*;
+import static org.robolectric.Shadows.shadowOf;
+
+@RunWith(RobolectricTestRunner.class)
+public class SdkInitializerTest {
+
+    private boolean calledAlready = false;
+    private Boolean isSuccessful;
+    private String error;
+
+    private MockWebServer server;
+    private Context context;
+
+    @Before
+    public void setUp() throws Exception {
+        server = new MockWebServer();
+        context = Robolectric.buildActivity(Activity.class).create().get();
+    }
+
+    @After
+    public void tearDown() throws IOException {
+        server.shutdown();
+        isSuccessful = null;
+        error = null;
+        PrebidMobile.setPrebidServerHost(Host.createCustomHost(""));
+    }
+
+
+    @Test
+    public void init_putNullContextAndNullListener_initializationFail() {
+        SdkInitializer.init(null, null);
+
+        assertFalse(PrebidMobile.isSdkInitialized());
+    }
+
+    @Test
+    public void init_putNullContext_initializationFail() {
+        SdkInitializer.init(null, createListener());
+
+        assertFalse(isSuccessful);
+        assertFalse(PrebidMobile.isSdkInitialized());
+        assertEquals(error, "Context must be not null!");
+    }
+
+    @Test
+    public void init_withoutHost_initializationFail() {
+        SdkInitializer.init(context, createListener());
+
+        assertFalse(isSuccessful);
+        assertFalse(PrebidMobile.isSdkInitialized());
+        assertEquals(error, "Please set host url (PrebidMobile.setPrebidServerHost) and only then run SDK initialization.");
+    }
+
+    @Test
+    public void init_statusResponseNotOk_initializationFail() throws IOException, InterruptedException {
+        String host = setResponseStatusAndGetMockServerHostUrl("fail");
+        PrebidMobile.setPrebidServerHost(Host.createCustomHost(host));
+
+        SdkInitializer.init(context, createListener());
+
+        sleep(300);
+        shadowOf(getMainLooper()).idle();
+        sleep(200);
+
+        assertFalse(isSuccessful);
+        assertFalse(PrebidMobile.isSdkInitialized());
+        assertEquals(error, "Server status is not ok!");
+    }
+
+    @Test
+    public void init_statusResponseIsOk_initializationIsSuccessful() throws IOException, InterruptedException {
+        String host = setResponseStatusAndGetMockServerHostUrl("ok");
+        PrebidMobile.setPrebidServerHost(Host.createCustomHost(host));
+
+        SdkInitializer.init(context, createListener());
+
+        sleep(300);
+        shadowOf(getMainLooper()).idle();
+        sleep(200);
+
+        assertTrue(isSuccessful);
+        assertTrue(PrebidMobile.isSdkInitialized());
+        assertNull(error);
+    }
+
+
+    private SdkInitializationListener createListener() {
+        return new SdkInitializationListener() {
+
+            @Override
+            public void onSdkInit() {
+                if (calledAlready) fail();
+
+                isSuccessful = true;
+
+                calledAlready = true;
+            }
+
+            @Override
+            public void onSdkFailedToInit(InitError initError) {
+                if (calledAlready) fail();
+
+                isSuccessful = false;
+                error = initError.getError();
+
+                calledAlready = true;
+            }
+        };
+    }
+
+    private String setResponseStatusAndGetMockServerHostUrl(String status) throws IOException {
+        MockResponse mockResponse = new MockResponse();
+        mockResponse.setResponseCode(200);
+        mockResponse.setBody("{\n    \"application\": {\n        \"status\": \"" + status + "\"\n    }\n}");
+        server.enqueue(mockResponse);
+        server.start();
+        HttpUrl url = server.url("/status");
+        server.setProtocolNegotiationEnabled(false);
+
+        return url.toString().replace("/status", "/openrtb2/auction");
+    }
+
+}

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/sdk/SdkInitializerTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/sdk/SdkInitializerTest.java
@@ -38,14 +38,15 @@ public class SdkInitializerTest {
         server = new MockWebServer();
         context = Robolectric.buildActivity(Activity.class).create().get();
         calledAlready = false;
+        isSuccessful = null;
+        error = null;
+        PrebidMobile.setPrebidServerHost(Host.createCustomHost(""));
+        SdkInitializer.isSdkInitialized = false;
     }
 
     @After
     public void tearDown() throws IOException {
         server.shutdown();
-        isSuccessful = null;
-        error = null;
-        PrebidMobile.setPrebidServerHost(Host.createCustomHost(""));
     }
 
 

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/sdk/SdkInitializerTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/sdk/SdkInitializerTest.java
@@ -37,11 +37,16 @@ public class SdkInitializerTest {
     public void setUp() throws Exception {
         server = new MockWebServer();
         context = Robolectric.buildActivity(Activity.class).create().get();
+        reset();
     }
 
     @After
     public void tearDown() throws IOException {
         server.shutdown();
+        reset();
+    }
+
+    private void reset() {
         calledAlready = false;
         isSuccessful = null;
         error = null;

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/sdk/SdkInitializerTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/sdk/SdkInitializerTest.java
@@ -37,6 +37,7 @@ public class SdkInitializerTest {
     public void setUp() throws Exception {
         server = new MockWebServer();
         context = Robolectric.buildActivity(Activity.class).create().get();
+        calledAlready = false;
     }
 
     @After

--- a/PrebidMobile/PrebidMobile-maxAdapters/src/main/java/com/applovin/mediation/adapters/PrebidMaxMediationAdapter.java
+++ b/PrebidMobile/PrebidMobile-maxAdapters/src/main/java/com/applovin/mediation/adapters/PrebidMaxMediationAdapter.java
@@ -18,6 +18,7 @@ import com.applovin.mediation.adapters.prebid.managers.MaxInterstitialManager;
 import com.applovin.mediation.adapters.prebid.managers.MaxNativeManager;
 import com.applovin.sdk.AppLovinSdk;
 import org.prebid.mobile.PrebidMobile;
+import org.prebid.mobile.api.exceptions.InitError;
 import org.prebid.mobile.rendering.listeners.SdkInitializationListener;
 
 @Keep

--- a/PrebidMobile/PrebidMobile-maxAdapters/src/main/java/com/applovin/mediation/adapters/PrebidMaxMediationAdapter.java
+++ b/PrebidMobile/PrebidMobile-maxAdapters/src/main/java/com/applovin/mediation/adapters/PrebidMaxMediationAdapter.java
@@ -18,6 +18,7 @@ import com.applovin.mediation.adapters.prebid.managers.MaxInterstitialManager;
 import com.applovin.mediation.adapters.prebid.managers.MaxNativeManager;
 import com.applovin.sdk.AppLovinSdk;
 import org.prebid.mobile.PrebidMobile;
+import org.prebid.mobile.rendering.listeners.SdkInitializationListener;
 
 @Keep
 public class PrebidMaxMediationAdapter extends MediationAdapterBase implements MaxAdViewAdapter, MaxInterstitialAdapter, MaxRewardedAdapter, MaxNativeAdAdapter {
@@ -44,8 +45,14 @@ public class PrebidMaxMediationAdapter extends MediationAdapterBase implements M
             onCompletionListener.onCompletion(InitializationStatus.INITIALIZED_SUCCESS, null);
         } else {
             onCompletionListener.onCompletion(InitializationStatus.INITIALIZING, null);
-            PrebidMobile.setApplicationContext(activity.getApplicationContext(), () -> {
-                onCompletionListener.onCompletion(InitializationStatus.INITIALIZED_SUCCESS, null);
+            PrebidMobile.initializeSdk(activity.getApplicationContext(), new SdkInitializationListener() {
+                @Override
+                public void onSdkInit() {
+                    onCompletionListener.onCompletion(InitializationStatus.INITIALIZED_SUCCESS, null);
+                }
+
+                @Override
+                public void onSdkFailedToInit(InitError error) {}
             });
         }
     }

--- a/PrebidMobile/tests.gradle
+++ b/PrebidMobile/tests.gradle
@@ -13,7 +13,8 @@ dependencies {
 
     testImplementation 'org.assertj:assertj-core:1.7.0'
     testImplementation 'org.skyscreamer:jsonassert:1.5.0'
-    testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.0'
+    testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.3'
+    testImplementation 'com.squareup.okhttp3:okhttp:4.9.3'
 
     testImplementation 'org.apache.commons:commons-lang3:3.7'
     testImplementation 'com.google.android.gms:play-services-ads:20.0.0'

--- a/scripts/testPrebidMobile.sh
+++ b/scripts/testPrebidMobile.sh
@@ -18,7 +18,7 @@ echoX "clean previous build"
 ./gradlew clean
 
 echoX "start unit tests"
-./gradlew -q PrebidMobile-core:testReleaseUnitTest
-./gradlew -q PrebidMobile-gamEventHandlers:testReleaseUnitTest
-./gradlew -q PrebidMobile-admobAdapters:testReleaseUnitTest
-./gradlew -q PrebidMobile-maxAdapters:testReleaseUnitTest
+./gradlew -i PrebidMobile-core:testReleaseUnitTest
+./gradlew -i PrebidMobile-gamEventHandlers:testReleaseUnitTest
+./gradlew -i PrebidMobile-admobAdapters:testReleaseUnitTest
+./gradlew -i PrebidMobile-maxAdapters:testReleaseUnitTest

--- a/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/DrPrebidApplication.java
+++ b/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/DrPrebidApplication.java
@@ -1,7 +1,6 @@
 package org.prebid.mobile.drprebid;
 
 import androidx.multidex.MultiDexApplication;
-import org.prebid.mobile.PrebidMobile;
 import org.prebid.mobile.ServerRequestSettings;
 import org.prebid.mobile.drprebid.managers.LineItemKeywordManager;
 
@@ -9,7 +8,6 @@ public class DrPrebidApplication extends MultiDexApplication {
     @Override
     public void onCreate() {
         super.onCreate();
-        PrebidMobile.setApplicationContext(this);
         try {
             ServerRequestSettings.update(this);
         } catch (Exception e) {

--- a/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/validation/RealTimeDemandTest.java
+++ b/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/validation/RealTimeDemandTest.java
@@ -75,6 +75,7 @@ public class RealTimeDemandTest {
                 PrebidMobile.setPrebidServerHost(Host.APPNEXUS);
                 hostUrl = Constants.EndpointUrls.APPNEXUS_PREBID_SERVER;
         }
+        PrebidMobile.initializeSdk(context, null);
 
         DemandRequestBuilder builder = new DemandRequestBuilder(
                 context,

--- a/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/validation/SdkTest.java
+++ b/tools/drprebid/src/main/java/org/prebid/mobile/drprebid/validation/SdkTest.java
@@ -91,6 +91,7 @@ public class SdkTest {
                 Host.CUSTOM.setHostUrl(buildCustomServerEndpoint(prebidServerSettings.getCustomPrebidServerUrl()));
                 break;
         }
+        PrebidMobile.initializeSdk(context, null);
 
         if (listener != null) {
             listener.onAdUnitRegistered();


### PR DESCRIPTION
Save application context even if activity context was placed. Add request to the status endpoint when init SDK. Check if the previous init context is null when calling init SDK, to have the ability to make reinitialization. Replace all setApplicationContext SDK calls with new ones. Closes #447.

Other: Move all initialization methods to SdkInitializer. Refactor PrebidMobile. Create a new SDK initialization listener. Deprecate the LogLevel field and create a setter.