### PR TITLE
Remove optional permissions from SDK

### DIFF
--- a/Example/PrebidInternalTestApp/src/main/AndroidManifest.xml
+++ b/Example/PrebidInternalTestApp/src/main/AndroidManifest.xml
@@ -16,11 +16,17 @@
   -->
 
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-          xmlns:tools="http://schemas.android.com/tools"
-          package="org.prebid.mobile.renderingtestapp">
+    xmlns:tools="http://schemas.android.com/tools"
+    package="org.prebid.mobile.renderingtestapp">
 
-    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
-    <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
+    <uses-permission android:name="android.permission.INTERNET" />
+
+    <!-- Optional permissions. Will pass Lat/Lon values when available. Choose either Coarse or Fine -->
+    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
+
+    <!-- Optional permissions. Used for MRAID 2.0 storePicture ads -->
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <application
         android:name=".InternalTestApplication"

--- a/PrebidMobile/PrebidMobile-core/src/main/AndroidManifest.xml
+++ b/PrebidMobile/PrebidMobile-core/src/main/AndroidManifest.xml
@@ -5,8 +5,6 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 
     <!-- Android P changes -->
     <application>

--- a/PrebidMobile/PrebidMobile-gamEventHandlers/src/main/AndroidManifest.xml
+++ b/PrebidMobile/PrebidMobile-gamEventHandlers/src/main/AndroidManifest.xml
@@ -19,6 +19,4 @@
 
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE" />
-    <uses-permission android:name="android.permission.ACCESS_FINE_LOCATION" />
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE" />
 </manifest>


### PR DESCRIPTION
Make permissions ACCESS_FINE_LOCATION and WRITE_EXTERNAL_STORAGE optional for publishers.  