### PR TITLE
fix(Render): Add get query params on url request builder

### DIFF
--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/networking/BaseNetworkTask.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/networking/BaseNetworkTask.java
@@ -236,7 +236,11 @@ public class BaseNetworkTask
     }
 
     private URLConnection setHttpURLConnectionProperty(GetUrlParams param) throws Exception {
-        URL url = new URL(param.url);
+        String queryParams = "";
+        if (param.requestType.equals("GET") && param.queryParams != null) {
+            queryParams = "?" + param.queryParams;
+        }
+        URL url = new URL(param.url + queryParams);
         connection = url.openConnection();
         if (connection instanceof HttpURLConnection) {
             ((HttpURLConnection) connection).setRequestMethod(param.requestType);


### PR DESCRIPTION
There is an issue when the `vastadtaguri` element in the VAST XML contains an URL with query params.