### PR TITLE
Update exoplayer to version 2.15.1 and replace deprecated code (#482)

### DIFF
--- a/PrebidMobile/PrebidMobile-core/build.gradle
+++ b/PrebidMobile/PrebidMobile-core/build.gradle
@@ -26,6 +26,6 @@ dependencies {
 
     implementation 'com.google.android.gms:play-services-base:18.0.1'
     implementation 'com.google.android.gms:play-services-ads-identifier:18.0.1'
-    implementation 'com.google.android.exoplayer:exoplayer-core:2.13.3'
-    implementation 'com.google.android.exoplayer:exoplayer-ui:2.13.3'
+    implementation 'com.google.android.exoplayer:exoplayer-core:2.15.1'
+    implementation 'com.google.android.exoplayer:exoplayer-ui:2.15.1'
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/loading/VastParserExtractor.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/loading/VastParserExtractor.java
@@ -29,6 +29,7 @@ import org.prebid.mobile.rendering.networking.ResponseHandler;
 import org.prebid.mobile.rendering.networking.modelcontrollers.AsyncVastLoader;
 import org.prebid.mobile.rendering.parser.AdResponseParserBase;
 import org.prebid.mobile.rendering.parser.AdResponseParserVast;
+import org.prebid.mobile.rendering.utils.helpers.Utils;
 import org.prebid.mobile.rendering.video.vast.VASTErrorCodes;
 
 public class VastParserExtractor {
@@ -82,7 +83,7 @@ public class VastParserExtractor {
     }
 
     private void performVastUnwrap(String vast) {
-        if (!vast.contains("VAST version")) {
+        if (!Utils.isVast(vast)) {
             final AdException adException = new AdException(AdException.INTERNAL_ERROR, VASTErrorCodes.VAST_SCHEMA_ERROR.toString());
             listener.onResult(createExtractorFailureResult(adException));
             return;

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/helpers/Utils.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/helpers/Utils.java
@@ -62,7 +62,7 @@ import static org.prebid.mobile.PrebidMobile.AUTO_REFRESH_DELAY_MIN;
 
 public final class Utils {
     private static final String TAG = Utils.class.getSimpleName();
-    private static final String VAST_REGEX = "<VAST version=\"[\\d\\D]*.[\\d\\D]*\">";
+    private static final String VAST_REGEX = "<VAST\\s.*version=\".*\"(\\s.*|)?>";
 
     public static float DENSITY;
 

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/VideoCreative.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/VideoCreative.java
@@ -336,7 +336,7 @@ public class VideoCreative extends VideoCreativeProtocol
             videoCreativeView.setBroadcastId(adConfiguration.getBroadcastId());
 
             // Get the preloaded video from device file storage
-            videoUri = Uri.parse(context.getFilesDir() + (model.getMediaUrl()));
+            videoUri = Uri.fromFile(new File(context.getFilesDir() + (model.getMediaUrl())));
         }
 
         // Show call-to-action overlay right away if click through url is available & end card is not available
@@ -393,7 +393,6 @@ public class VideoCreative extends VideoCreativeProtocol
     protected void showCallToAction() {
         if (!model.getAdConfiguration().isBuiltInVideo()
             && Utils.isNotBlank(model.getVastClickthroughUrl())
-            && !model.getAdConfiguration().isRewarded()
         ) {
             videoCreativeView.showCallToAction();
         }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/VideoCreative.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/VideoCreative.java
@@ -21,8 +21,10 @@ import android.net.Uri;
 import android.os.AsyncTask;
 import android.text.TextUtils;
 import android.view.View;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.VisibleForTesting;
+
 import org.prebid.mobile.ContentObject;
 import org.prebid.mobile.LogUtil;
 import org.prebid.mobile.api.exceptions.AdException;
@@ -392,7 +394,8 @@ public class VideoCreative extends VideoCreativeProtocol
 
     protected void showCallToAction() {
         if (!model.getAdConfiguration().isBuiltInVideo()
-            && Utils.isNotBlank(model.getVastClickthroughUrl())
+                && Utils.isNotBlank(model.getVastClickthroughUrl())
+                && !model.getAdConfiguration().isRewarded()
         ) {
             videoCreativeView.showCallToAction();
         }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/views/AdViewManager.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/views/AdViewManager.java
@@ -378,7 +378,8 @@ public class AdViewManager implements CreativeViewListener, TransactionManagerLi
     private void handleVideoCreativeComplete(AbstractCreative creative) {
         Transaction transaction = transactionManager.getCurrentTransaction();
         boolean isBuiltInVideo = creative.isBuiltInVideo();
-        closeInterstitial();
+        if(hasEndCard())
+            closeInterstitial();
 
         if (transactionManager.hasNextCreative() && adView != null) {
 

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/views/AdViewManager.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/views/AdViewManager.java
@@ -21,6 +21,7 @@ import android.os.Build;
 import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
+
 import org.prebid.mobile.LogUtil;
 import org.prebid.mobile.api.data.AdFormat;
 import org.prebid.mobile.api.exceptions.AdException;
@@ -378,8 +379,7 @@ public class AdViewManager implements CreativeViewListener, TransactionManagerLi
     private void handleVideoCreativeComplete(AbstractCreative creative) {
         Transaction transaction = transactionManager.getCurrentTransaction();
         boolean isBuiltInVideo = creative.isBuiltInVideo();
-        if(hasEndCard())
-            closeInterstitial();
+        closeInterstitial();
 
         if (transactionManager.hasNextCreative() && adView != null) {
 

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/utils/url/action/MraidInternalBrowserActionTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/utils/url/action/MraidInternalBrowserActionTest.java
@@ -29,6 +29,7 @@ import org.junit.runner.RunWith;
 import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
+import org.prebid.mobile.core.BuildConfig;
 import org.prebid.mobile.rendering.models.internal.MraidVariableContainer;
 import org.prebid.mobile.rendering.mraid.methods.network.RedirectUrlListener;
 import org.prebid.mobile.rendering.utils.url.ActionNotResolvedException;
@@ -133,7 +134,7 @@ public class MraidInternalBrowserActionTest {
         Intent intentArgument = intentArgumentCaptor.getValue();
 
         assertEquals(intentArgument.getAction(), Intent.ACTION_VIEW);
-        assertEquals(intentArgument.getFlags(), Intent.FLAG_ACTIVITY_NEW_TASK);
+        assertEquals(intentArgument.getFlags(), BuildConfig.DEBUG ? 0 : Intent.FLAG_ACTIVITY_NEW_TASK);
     }
 
     @Test

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/video/ExoPlayerViewTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/video/ExoPlayerViewTest.java
@@ -112,13 +112,14 @@ public class ExoPlayerViewTest {
 
         verify(mockVideoCreative).onEvent(VideoAdEvent.Event.AD_CREATIVEVIEW);
         verify(mockVideoCreative).onEvent(VideoAdEvent.Event.AD_START);
-        verify(mockSimpleExoPlayer).prepare(any(MediaSource.class), anyBoolean(), anyBoolean());
+        verify(mockSimpleExoPlayer).setMediaSource(any(MediaSource.class), anyBoolean());
+        verify(mockSimpleExoPlayer).prepare();
     }
 
     @Test
     public void setVastVideoDuration() {
-        exoPlayerView.setVastVideoDuration(1000l);
-        verify(exoPlayerView).setVastVideoDuration(1000l);
+        exoPlayerView.setVastVideoDuration(1000L);
+        verify(exoPlayerView).setVastVideoDuration(1000L);
     }
 
     @Test
@@ -163,7 +164,7 @@ public class ExoPlayerViewTest {
         exoPlayerView.destroy();
         verify(mockAdViewProgressUpdateTask).cancel(true);
         verify(exoPlayerView, times(1)).destroy();
-        verify(mockSimpleExoPlayer).removeListener(any(Player.EventListener.class));
+        verify(mockSimpleExoPlayer).removeListener(any(Player.Listener.class));
         verify(exoPlayerView).setPlayer(null);
         verify(mockSimpleExoPlayer).release();
     }
@@ -181,7 +182,8 @@ public class ExoPlayerViewTest {
         exoPlayerView.setVideoUri(Uri.EMPTY);
         exoPlayerView.resume();
 
-        verify(mockSimpleExoPlayer).prepare(any(MediaSource.class), anyBoolean(), anyBoolean());
+        verify(mockSimpleExoPlayer).setMediaSource(any(MediaSource.class), anyBoolean());
+        verify(mockSimpleExoPlayer).prepare();
     }
 
     @Test

--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 ext {
-    prebidVersionName = "2.0.2-yl"
+    prebidVersionName = "2.0.2"
     prebidVersionCode = 1
     minSDKVersion = 16
     targetSDKVersion = 28


### PR DESCRIPTION
Resolve conflicts. Returned consistent behavior with iOS (according to [issue](https://github.com/prebid/prebid-mobile-android/issues/462))

* Update exoplayer to version 2.15.1 and replace deprecated code

* Fix internal browser action test

* fix(Render): Add get query params on url request builder

* fix(Render): replace vast regex validator to include other valid formats and unified validation criteria on vast parser extractor

* fix(Render): fix exo player issue by changing video uri builder

* fix(Render): close interstitial video only when it is an end card

* fix(render): show call to action on rewarded video

* fix(Render): fix NPE in ad response parser vast on get vast url method

* Update release version to 2.0.2.1

Co-authored-by: German Gonzalez <german.gonzalez@etermax.com>
Co-authored-by: gerzalez-etermax <110118032+gerzalez-etermax@users.noreply.github.com>