### PR TITLE
fix(Render): replace vast regex validator to include other valid formats

### DIFF
--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/loading/VastParserExtractor.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/loading/VastParserExtractor.java
@@ -29,6 +29,7 @@ import org.prebid.mobile.rendering.networking.ResponseHandler;
 import org.prebid.mobile.rendering.networking.modelcontrollers.AsyncVastLoader;
 import org.prebid.mobile.rendering.parser.AdResponseParserBase;
 import org.prebid.mobile.rendering.parser.AdResponseParserVast;
+import org.prebid.mobile.rendering.utils.helpers.Utils;
 import org.prebid.mobile.rendering.video.vast.VASTErrorCodes;
 
 public class VastParserExtractor {
@@ -82,7 +83,7 @@ public class VastParserExtractor {
     }
 
     private void performVastUnwrap(String vast) {
-        if (!vast.contains("VAST version")) {
+        if (!Utils.isVast(vast)) {
             final AdException adException = new AdException(AdException.INTERNAL_ERROR, VASTErrorCodes.VAST_SCHEMA_ERROR.toString());
             listener.onResult(createExtractorFailureResult(adException));
             return;

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/helpers/Utils.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/helpers/Utils.java
@@ -62,7 +62,7 @@ import static org.prebid.mobile.PrebidMobile.AUTO_REFRESH_DELAY_MIN;
 
 public final class Utils {
     private static final String TAG = Utils.class.getSimpleName();
-    private static final String VAST_REGEX = "<VAST version=\"[\\d\\D]*.[\\d\\D]*\">";
+    private static final String VAST_REGEX = "<VAST\\s.*version=\".*\"(\\s.*|)?>";
 
     public static float DENSITY;
 


### PR DESCRIPTION
Replace vast regex validator to include other valid formats and unified validation criteria on vast parser extractor