### PR TITLE
Replace GAD application id with new format

### DIFF
--- a/Example/PrebidDemoJava/src/main/AndroidManifest.xml
+++ b/Example/PrebidDemoJava/src/main/AndroidManifest.xml
@@ -23,6 +23,10 @@
         android:theme="@style/AppTheme"
         android:usesCleartextTraffic="true">
 
+        <meta-data
+            android:name="com.google.android.gms.ads.APPLICATION_ID"
+            android:value="ca-app-pub-3940256099942544~3347511713" />
+
         <activity
             android:name=".activities.MainActivity"
             android:exported="true">
@@ -35,11 +39,6 @@
         <activity
             android:name=".activities.SettingsActivity"
             android:exported="true" />
-
-        <meta-data
-            android:name="com.google.android.gms.ads.AD_MANAGER_APP"
-            android:value="true" />
-
 
         <activity
             android:name=".activities.ads.gam.original.GamOriginalApiDisplayBanner320x50"


### PR DESCRIPTION
The Java demo app used the old format of the GAD application id. So after an automatic GAM update, the app throws a runtime exception. 
```
java.lang.RuntimeException: Unable to get provider com.google.android.gms.ads.MobileAdsInitProvider.
```