### PR TITLE
Remove configuration properties from examples in the Internal app

### DIFF
--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/gam/original/GamOriginalInterstitialFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/gam/original/GamOriginalInterstitialFragment.kt
@@ -25,7 +25,9 @@ import com.google.android.gms.ads.admanager.AdManagerInterstitialAd
 import com.google.android.gms.ads.admanager.AdManagerInterstitialAdLoadCallback
 import kotlinx.android.synthetic.main.events_bids.*
 import kotlinx.android.synthetic.main.fragment_bidding_interstitial.*
-import org.prebid.mobile.*
+import org.prebid.mobile.AdUnit
+import org.prebid.mobile.InterstitialAdUnit
+import org.prebid.mobile.VideoInterstitialAdUnit
 import org.prebid.mobile.api.data.AdUnitFormat
 import org.prebid.mobile.renderingtestapp.R
 import org.prebid.mobile.renderingtestapp.plugplay.bidding.base.BaseBidInterstitialFragment
@@ -52,9 +54,7 @@ class GamOriginalInterstitialFragment : BaseBidInterstitialFragment() {
         height: Int
     ) {
         adUnit = if (adUnitFormat == AdUnitFormat.VIDEO) {
-            VideoInterstitialAdUnit(configId!!).apply {
-                parameters = configureVideoParameters()
-            }
+            VideoInterstitialAdUnit(configId!!)
         } else {
             InterstitialAdUnit(configId!!, 30, 30)
         }
@@ -110,22 +110,4 @@ class GamOriginalInterstitialFragment : BaseBidInterstitialFragment() {
         }
     }
 
-    private fun configureVideoParameters(): VideoBaseAdUnit.Parameters {
-        return VideoBaseAdUnit.Parameters().apply {
-            placement = Signals.Placement.Interstitial
-            api = listOf(
-                Signals.Api.VPAID_1,
-                Signals.Api.VPAID_2
-            )
-            maxBitrate = 1500
-            minBitrate = 300
-            maxDuration = 30
-            minDuration = 5
-            mimes = listOf("video/x-flv", "video/mp4")
-            playbackMethod = listOf(Signals.PlaybackMethod.AutoPlaySoundOn)
-            protocols = listOf(
-                Signals.Protocols.VAST_2_0
-            )
-        }
-    }
 }

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/gam/original/GamOriginalOutstreamFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/gam/original/GamOriginalOutstreamFragment.kt
@@ -24,9 +24,7 @@ import com.google.android.gms.ads.admanager.AdManagerAdRequest
 import com.google.android.gms.ads.admanager.AdManagerAdView
 import kotlinx.android.synthetic.main.events_bids.*
 import kotlinx.android.synthetic.main.fragment_bidding_banner.*
-import org.prebid.mobile.Signals
 import org.prebid.mobile.VideoAdUnit
-import org.prebid.mobile.VideoBaseAdUnit
 import org.prebid.mobile.addendum.AdViewUtils
 import org.prebid.mobile.addendum.PbFindSizeError
 import org.prebid.mobile.renderingtestapp.AdFragment
@@ -41,18 +39,11 @@ class GamOriginalOutstreamFragment : AdFragment() {
     private var gamView: AdManagerAdView? = null
 
     override fun initAd(): Any? {
-        val parameters = VideoBaseAdUnit.Parameters()
-        parameters.mimes = listOf("video/mp4")
-        parameters.protocols = listOf(Signals.Protocols.VAST_2_0)
-        parameters.playbackMethod = listOf(Signals.PlaybackMethod.AutoPlaySoundOff)
-        parameters.placement = Signals.Placement.InBanner
-
         adUnit = VideoAdUnit(
             configId,
             width,
             height
         )
-        adUnit?.parameters = parameters
 
         gamView = AdManagerAdView(requireContext())
         gamView?.adUnitId = adUnitId

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/gam/original/GamOriginalRewardedVideoFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/gam/original/GamOriginalRewardedVideoFragment.kt
@@ -26,8 +26,6 @@ import com.google.android.gms.ads.rewarded.RewardedAdLoadCallback
 import kotlinx.android.synthetic.main.events_bids.*
 import kotlinx.android.synthetic.main.fragment_bidding_interstitial.*
 import org.prebid.mobile.RewardedVideoAdUnit
-import org.prebid.mobile.Signals
-import org.prebid.mobile.VideoBaseAdUnit
 import org.prebid.mobile.renderingtestapp.R
 import org.prebid.mobile.renderingtestapp.plugplay.bidding.base.BaseBidRewardedFragment
 
@@ -52,7 +50,6 @@ class GamOriginalRewardedVideoFragment : BaseBidRewardedFragment() {
     private fun createAd() {
         val builder = AdManagerAdRequest.Builder()
         adUnit = RewardedVideoAdUnit(configId)
-        adUnit?.parameters = configureVideoParameters()
         adUnit?.fetchDemand(builder) {
             val request = builder.build()
             RewardedAd.load(
@@ -93,14 +90,6 @@ class GamOriginalRewardedVideoFragment : BaseBidRewardedFragment() {
                 btnLoad?.text = getString(R.string.text_load)
                 displayAdCallback?.invoke()
             }
-        }
-    }
-
-    private fun configureVideoParameters(): VideoBaseAdUnit.Parameters {
-        return VideoBaseAdUnit.Parameters().apply {
-            mimes = listOf("video/mp4")
-            protocols = listOf(Signals.Protocols.VAST_2_0)
-            playbackMethod = listOf(Signals.PlaybackMethod.AutoPlaySoundOff)
         }
     }
 

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/models/openrtb/bidRequests/ImpTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/models/openrtb/bidRequests/ImpTest.java
@@ -16,15 +16,17 @@
 
 package org.prebid.mobile.rendering.models.openrtb.bidRequests;
 
+import static org.junit.Assert.assertEquals;
+
+import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.prebid.mobile.rendering.models.openrtb.bidRequests.imps.Banner;
 import org.prebid.mobile.rendering.models.openrtb.bidRequests.imps.Pmp;
 import org.prebid.mobile.rendering.models.openrtb.bidRequests.imps.Video;
 
-import static org.junit.Assert.assertEquals;
-
 public class ImpTest {
+
     @Test
     public void getJsonObject() throws Exception {
         Imp imp = new Imp();
@@ -45,4 +47,17 @@ public class ImpTest {
         assertEquals("got: " + actualObj.toString(), expectedString, actualObj.toString());
         imp.getJsonObject();
     }
+
+    @Test
+    public void impObjectWithFullVideo() throws JSONException {
+        Imp imp = new Imp();
+
+        imp.video = new Video();
+
+        JSONObject actualObj = imp.getJsonObject();
+        String expectedString = "{\"video\":{}}";
+        assertEquals(expectedString, actualObj.toString());
+        imp.getJsonObject();
+    }
+
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/models/openrtb/bidRequests/imps/VideoTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/models/openrtb/bidRequests/imps/VideoTest.java
@@ -16,18 +16,26 @@
 
 package org.prebid.mobile.rendering.models.openrtb.bidRequests.imps;
 
+import static org.junit.Assert.assertEquals;
+
+import org.json.JSONException;
 import org.json.JSONObject;
 import org.junit.Test;
 import org.prebid.mobile.rendering.networking.parameters.BasicParameterBuilder;
 
-import static org.junit.Assert.assertEquals;
-
 public class VideoTest {
+
+    @Test
+    public void emptyVideoObject() throws JSONException {
+        Video video = new Video();
+        JSONObject json = video.getJsonObject();
+        String expected = "{}";
+        assertEquals(expected, json.toString());
+    }
+
     @Test
     public void getJsonObject() throws Exception {
-
         Video video = new Video();
-
         video.mimes = BasicParameterBuilder.SUPPORTED_VIDEO_MIME_TYPES;
         video.minduration = 1;
         video.maxduration = 100;
@@ -48,4 +56,5 @@ public class VideoTest {
         assertEquals("got: " + actualObj.toString(), expectedString, actualObj.toString());
         video.getJsonObject();
     }
+
 }


### PR DESCRIPTION
Add unit tests for Video parameters. Closes #552.