### PR TITLE
Disable plugin register to be used from PrebidMobile class

### DIFF
--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/HeaderBiddingFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/HeaderBiddingFragment.kt
@@ -173,6 +173,8 @@ class HeaderBiddingFragment : BaseFragment() {
                 defaultAccountId =  defaultAccountId
             )
         }
+        // TODO not ready, wait for rendering delegation full release
+        switch.isEnabled = false
     }
 
     private fun initCacheSwitch() {

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/HeaderBiddingViewModel.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/HeaderBiddingViewModel.kt
@@ -90,7 +90,9 @@ class HeaderBiddingViewModel(
     }
 
     fun isCustomRendererEnabled(): Boolean {
-        return PrebidMobile.containsPluginRenderer(sampleCustomRenderer);
+        // TODO not ready, wait for rendering delegation full release
+//        return PrebidMobile.containsPluginRenderer(sampleCustomRenderer);
+        return false
     }
 
     fun onCustomRendererStateChanged(
@@ -98,13 +100,14 @@ class HeaderBiddingViewModel(
         defaultAccountId: String,
         customRendererAccountId: String
     ) {
-        if (isChecked) {
-            PrebidMobile.registerPluginRenderer(sampleCustomRenderer)
-            PrebidMobile.setPrebidServerAccountId(customRendererAccountId)
-        } else {
-            PrebidMobile.unregisterPluginRenderer(sampleCustomRenderer)
-            PrebidMobile.setPrebidServerAccountId(defaultAccountId)
-        }
+        // TODO not ready, wait for rendering delegation full release
+//        if (isChecked) {
+//            PrebidMobile.registerPluginRenderer(sampleCustomRenderer)
+//            PrebidMobile.setPrebidServerAccountId(customRendererAccountId)
+//        } else {
+//            PrebidMobile.unregisterPluginRenderer(sampleCustomRenderer)
+//            PrebidMobile.setPrebidServerAccountId(defaultAccountId)
+//        }
     }
 
     fun onDemoItemClicked(item: DemoItem) {

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/PrebidMobile.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/PrebidMobile.java
@@ -359,15 +359,16 @@ public class PrebidMobile {
         return customStatusEndpoint;
     }
 
-    public static void registerPluginRenderer(PrebidMobilePluginRenderer prebidMobilePluginRenderer) {
+    // TODO not ready, wait for rendering delegation full release
+    private static void registerPluginRenderer(PrebidMobilePluginRenderer prebidMobilePluginRenderer) {
         PrebidMobilePluginRegister.getInstance().registerPlugin(prebidMobilePluginRenderer);
     }
 
-    public static void unregisterPluginRenderer(PrebidMobilePluginRenderer prebidMobilePluginRenderer) {
+    private static void unregisterPluginRenderer(PrebidMobilePluginRenderer prebidMobilePluginRenderer) {
         PrebidMobilePluginRegister.getInstance().unregisterPlugin(prebidMobilePluginRenderer);
     }
 
-    public static Boolean containsPluginRenderer(PrebidMobilePluginRenderer prebidMobilePluginRenderer) {
+    private static Boolean containsPluginRenderer(PrebidMobilePluginRenderer prebidMobilePluginRenderer) {
         return PrebidMobilePluginRegister.getInstance().containsPlugin(prebidMobilePluginRenderer);
     }
 

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/SdkInitializer.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/SdkInitializer.java
@@ -13,6 +13,7 @@ import org.prebid.mobile.PrebidMobile;
 import org.prebid.mobile.api.data.InitializationStatus;
 import org.prebid.mobile.api.exceptions.InitError;
 import org.prebid.mobile.api.rendering.PrebidRenderer;
+import org.prebid.mobile.api.rendering.pluginrenderer.PrebidMobilePluginRegister;
 import org.prebid.mobile.rendering.listeners.SdkInitializationListener;
 import org.prebid.mobile.rendering.session.manager.OmAdSessionManager;
 import org.prebid.mobile.rendering.utils.helpers.AppInfoManager;
@@ -42,7 +43,8 @@ public class SdkInitializer {
             LogUtil.setLogLevel(PrebidMobile.getLogLevel().getValue());
         }
 
-        PrebidMobile.registerPluginRenderer(new PrebidRenderer());
+//        PrebidMobile.registerPluginRenderer(new PrebidRenderer());
+        PrebidMobilePluginRegister.getInstance().registerPlugin(new PrebidRenderer());
 
         try {
             AppInfoManager.init(applicationContext);

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/PrebidMobileTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/PrebidMobileTest.java
@@ -25,6 +25,7 @@ import static org.junit.Assert.assertTrue;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.prebid.mobile.api.rendering.pluginrenderer.PrebidMobilePluginRegister;
 import org.prebid.mobile.api.rendering.pluginrenderer.PrebidMobilePluginRenderer;
 import org.prebid.mobile.reflection.Reflection;
 import org.prebid.mobile.reflection.sdk.PrebidMobileReflection;
@@ -142,10 +143,12 @@ public class PrebidMobileTest extends BaseSetup {
         );
 
         // When
-        PrebidMobile.registerPluginRenderer(fakePrebidMobilePluginRenderer);
+//        PrebidMobile.registerPluginRenderer(fakePrebidMobilePluginRenderer);
+        PrebidMobilePluginRegister.getInstance().registerPlugin(fakePrebidMobilePluginRenderer);
 
         // Then
-        assertTrue(PrebidMobile.containsPluginRenderer(fakePrebidMobilePluginRenderer));
+//        assertTrue(PrebidMobile.containsPluginRenderer(fakePrebidMobilePluginRenderer));
+        assertTrue(PrebidMobilePluginRegister.getInstance().containsPlugin(fakePrebidMobilePluginRenderer));
     }
 
     @Test
@@ -158,15 +161,19 @@ public class PrebidMobileTest extends BaseSetup {
         );
 
         // When
-        PrebidMobile.registerPluginRenderer(fakePrebidMobilePluginRenderer);
+//        PrebidMobile.registerPluginRenderer(fakePrebidMobilePluginRenderer);
+        PrebidMobilePluginRegister.getInstance().registerPlugin(fakePrebidMobilePluginRenderer);
 
         // Then
-        assertTrue(PrebidMobile.containsPluginRenderer(fakePrebidMobilePluginRenderer));
+//        assertTrue(PrebidMobile.containsPluginRenderer(fakePrebidMobilePluginRenderer));
+        assertTrue(PrebidMobilePluginRegister.getInstance().containsPlugin(fakePrebidMobilePluginRenderer));
 
         // When
-        PrebidMobile.unregisterPluginRenderer(fakePrebidMobilePluginRenderer);
+//        PrebidMobile.unregisterPluginRenderer(fakePrebidMobilePluginRenderer);
+        PrebidMobilePluginRegister.getInstance().unregisterPlugin(fakePrebidMobilePluginRenderer);
 
         // Then
-        assertFalse(PrebidMobile.containsPluginRenderer(fakePrebidMobilePluginRenderer));
+//        assertFalse(PrebidMobile.containsPluginRenderer(fakePrebidMobilePluginRenderer));
+        assertFalse(PrebidMobilePluginRegister.getInstance().containsPlugin(fakePrebidMobilePluginRenderer));
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/DisplayViewTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/DisplayViewTest.java
@@ -17,8 +17,8 @@ import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
-import org.prebid.mobile.PrebidMobile;
 import org.prebid.mobile.api.data.AdFormat;
+import org.prebid.mobile.api.rendering.pluginrenderer.PrebidMobilePluginRegister;
 import org.prebid.mobile.api.rendering.pluginrenderer.PrebidMobilePluginRenderer;
 import org.prebid.mobile.configuration.AdUnitConfiguration;
 import org.prebid.mobile.rendering.bidding.data.bid.Bid;
@@ -54,7 +54,8 @@ public class DisplayViewTest {
         adUnitConfiguration.setAdFormat(AdFormat.BANNER);
 
         fakePrebidMobilePluginRenderer = Mockito.spy(FakePrebidMobilePluginRenderer.getFakePrebidRenderer(null, mockBannerView, true));
-        PrebidMobile.registerPluginRenderer(fakePrebidMobilePluginRenderer);
+//        PrebidMobile.registerPluginRenderer(fakePrebidMobilePluginRenderer);
+        PrebidMobilePluginRegister.getInstance().registerPlugin(fakePrebidMobilePluginRenderer);
 
         mockResponse = mock(BidResponse.class);
         Bid mockBid = mock(Bid.class);

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/InterstitialAdUnitTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/InterstitialAdUnitTest.java
@@ -24,9 +24,9 @@ import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.prebid.mobile.AdSize;
-import org.prebid.mobile.PrebidMobile;
 import org.prebid.mobile.api.data.AdUnitFormat;
 import org.prebid.mobile.api.exceptions.AdException;
+import org.prebid.mobile.api.rendering.pluginrenderer.PrebidMobilePluginRegister;
 import org.prebid.mobile.api.rendering.pluginrenderer.PrebidMobilePluginRenderer;
 import org.prebid.mobile.api.rendering.listeners.InterstitialAdUnitListener;
 import org.prebid.mobile.configuration.AdUnitConfiguration;
@@ -256,7 +256,8 @@ public class InterstitialAdUnitTest {
         final InterstitialEventListener spyEventListener = spy(getEventListener());
         when(mockBidResponse.getWinningBid()).thenReturn(mockBid);
         PrebidMobilePluginRenderer fakePrebidRenderer = FakePrebidMobilePluginRenderer.getFakePrebidRenderer(mockInterstitialController, null, true);
-        PrebidMobile.registerPluginRenderer(fakePrebidRenderer);
+//        PrebidMobile.registerPluginRenderer(fakePrebidRenderer);
+        PrebidMobilePluginRegister.getInstance().registerPlugin(fakePrebidRenderer);
 
         WhiteBox.setInternalState(interstitialAdUnit, "bidResponse", mockBidResponse);
         WhiteBox.setInternalState(interstitialAdUnit, "interstitialController", mockInterstitialController);

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/RewardedAdUnitTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/RewardedAdUnitTest.java
@@ -23,8 +23,8 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
-import org.prebid.mobile.PrebidMobile;
 import org.prebid.mobile.api.exceptions.AdException;
+import org.prebid.mobile.api.rendering.pluginrenderer.PrebidMobilePluginRegister;
 import org.prebid.mobile.api.rendering.pluginrenderer.PrebidMobilePluginRenderer;
 import org.prebid.mobile.api.rendering.listeners.RewardedAdUnitListener;
 import org.prebid.mobile.configuration.AdUnitConfiguration;
@@ -248,7 +248,8 @@ public class RewardedAdUnitTest {
         final RewardedVideoEventListener spyEventListener = spy(getEventListener());
         when(mockBidResponse.getWinningBid()).thenReturn(mockBid);
         PrebidMobilePluginRenderer fakePrebidRenderer = FakePrebidMobilePluginRenderer.getFakePrebidRenderer(mockInterstitialController, null, true);
-        PrebidMobile.registerPluginRenderer(fakePrebidRenderer);
+//        PrebidMobile.registerPluginRenderer(fakePrebidRenderer);
+        PrebidMobilePluginRegister.getInstance().registerPlugin(fakePrebidRenderer);
 
         WhiteBox.setInternalState(rewardedAdUnit, "bidResponse", mockBidResponse);
         WhiteBox.setInternalState(rewardedAdUnit, "interstitialController", mockInterstitialController);


### PR DESCRIPTION
This is to disable the ability to register plugin renderers from PrebidMobile class. Anyway internal classes can and must still use the internal singleton register, since prebid render its ads now under the new rendering interfaces