### PR TITLE
Fix documentation URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,8 @@
 
 # Prebid Mobile Android SDK
 
-To work with Prebid Mobile, you will need access to a Prebid Server. See [this page](http://prebid.org/prebid-mobile/prebid-mobile-pbs.html) for options.
+To work with Prebid Mobile, you will need access to a Prebid Server.
+See [this page](https://docs.prebid.org/prebid-server/overview/prebid-server-overview.html) for options.
 
 ## Use Maven?
 


### PR DESCRIPTION
The URL in the README.md file goes to 404. 