### PR TITLE
MS-5342 Fix for Prebid Asset id missing even after enabling assignNativeAssetID

### DIFF
--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/NativeAsset.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/NativeAsset.java
@@ -20,6 +20,6 @@ public abstract class NativeAsset {
         return type;
     }
 
-    public abstract JSONObject getJsonObject();
+    public abstract JSONObject getJsonObject(int idCount);
 
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/NativeDataAsset.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/NativeDataAsset.java
@@ -103,10 +103,14 @@ public class NativeDataAsset extends NativeAsset {
     }
 
     @Override
-    public JSONObject getJsonObject() {
+    public JSONObject getJsonObject(int idCount) {
         JSONObject result = new JSONObject();
 
         try {
+            if (PrebidMobile.shouldAssignNativeAssetID()) {
+                result.putOpt("id", idCount);
+            }
+
             result.putOpt("required", required ? 1 : 0);
             result.putOpt("ext", assetExt);
 

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/NativeImageAsset.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/NativeImageAsset.java
@@ -147,10 +147,14 @@ public class NativeImageAsset extends NativeAsset {
 
 
     @Override
-    public JSONObject getJsonObject() {
+    public JSONObject getJsonObject(int idCount) {
         JSONObject result = new JSONObject();
 
         try {
+            if (PrebidMobile.shouldAssignNativeAssetID()) {
+                result.putOpt("id", idCount);
+            }
+
             result.putOpt("required", required ? 1 : 0);
             result.putOpt("ext", assetExt);
 

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/NativeTitleAsset.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/NativeTitleAsset.java
@@ -51,10 +51,14 @@ public class NativeTitleAsset extends NativeAsset {
     }
 
     @Override
-    public JSONObject getJsonObject() {
+    public JSONObject getJsonObject(int idCount) {
         JSONObject result = new JSONObject();
 
         try {
+            if (PrebidMobile.shouldAssignNativeAssetID()) {
+                result.putOpt("id", idCount);
+            }
+
             result.putOpt("required", required ? 1 : 0);
             result.putOpt("ext", assetExt);
 

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/openrtb/bidRequests/Native.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/openrtb/bidRequests/Native.java
@@ -66,8 +66,9 @@ public class Native extends BaseBid {
 
     private JSONArray getAssetsJsonArray(List<NativeAsset> assetList) throws JSONException {
         JSONArray assetJsonArray = new JSONArray();
+        int idCount = 0;
         for (NativeAsset asset : assetList) {
-            assetJsonArray.put(asset.getJsonObject());
+            assetJsonArray.put(asset.getJsonObject(++idCount));
         }
         return assetJsonArray;
     }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/NativeAssetTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/NativeAssetTest.java
@@ -2,6 +2,7 @@ package org.prebid.mobile;
 
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.prebid.mobile.testutils.BaseSetup;
@@ -13,6 +14,11 @@ import static org.junit.Assert.*;
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = BaseSetup.testSDK, manifest = Config.NONE)
 public class NativeAssetTest {
+
+    @Before
+    public void setup() {
+        PrebidMobile.assignNativeAssetID(false);
+    }
 
     @Test
     public void testNativeAssetTitle() {
@@ -60,6 +66,65 @@ public class NativeAssetTest {
             e.printStackTrace();
         }
         assertEquals("value2", value2);
+    }
+
+    @Test
+    public void testNativeAssetTitleAssignNativeAssetID() {
+        NativeTitleAsset title = new NativeTitleAsset();
+        assertEquals(0, title.getLen());
+        assertEquals(false, title.isRequired());
+        assertNull(title.getTitleExt());
+        assertNull(title.getAssetExt());
+
+        title.setLength(25);
+        title.setRequired(true);
+        JSONObject assetExt = new JSONObject();
+        try {
+            assetExt.put("key1", "value1");
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+        title.setAssetExt(assetExt);
+
+        JSONObject titleExt = new JSONObject();
+        try {
+            titleExt.put("key2", "value2");
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+        title.setTitleExt(titleExt);
+
+
+        assertEquals(25, title.getLen());
+        assertEquals(true, title.isRequired());
+        String value1 = "";
+        try {
+            JSONObject data = (JSONObject) title.getAssetExt();
+            value1 = data.getString("key1");
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+        assertEquals("value1", value1);
+
+        String value2 = "";
+        try {
+            JSONObject data = (JSONObject) title.getTitleExt();
+            value2 = data.getString("key2");
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+        assertEquals("value2", value2);
+
+        JSONObject titleJsonObject = title.getJsonObject(1);
+        int id = titleJsonObject.optInt("id");
+        assertEquals(0, id); // Since the optInt returns 0 if a key does not exist
+
+        PrebidMobile.assignNativeAssetID(true);
+
+        titleJsonObject = title.getJsonObject(1);
+        id = titleJsonObject.optInt("id");
+        assertEquals(1, id); // 1 is the idCount that we have set while getting the JSON Object
+
     }
 
     @Test
@@ -127,6 +192,83 @@ public class NativeAssetTest {
         NativeImageAsset.IMAGE_TYPE.CUSTOM.setID(1);
         assertEquals(600, image.getImageType().getID());
         assertFalse("Invalid CustomId", 1 == image.getImageType().getID());
+    }
+
+    @Test
+    public void testNativeAssetImageAssignNativeAssetID() {
+        NativeImageAsset image = new NativeImageAsset();
+        image.setWMin(20);
+        image.setHMin(30);
+        image.setW(100);
+        image.setH(200);
+        image.setRequired(true);
+        image.addMime("png");
+        JSONObject assetExt = new JSONObject();
+        try {
+            assetExt.put("key1", "value1");
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+        image.setAssetExt(assetExt);
+
+        JSONObject imageExt = new JSONObject();
+        try {
+            imageExt.put("key2", "value2");
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+        image.setImageExt(imageExt);
+
+        assertEquals(20, image.getWMin());
+        assertEquals(30, image.getHMin());
+        assertEquals(100, image.getW());
+        assertEquals(200, image.getH());
+        assertEquals(true, image.isRequired());
+        assertEquals("png", image.getMimes().get(0));
+
+        String value1 = "";
+        try {
+            JSONObject data = (JSONObject) image.getAssetExt();
+            value1 = data.getString("key1");
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+        assertEquals("value1", value1);
+
+        String value2 = "";
+        try {
+            JSONObject data = (JSONObject) image.getImageExt();
+            value2 = data.getString("key2");
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+        assertEquals("value2", value2);
+
+        image.setImageType(NativeImageAsset.IMAGE_TYPE.ICON);
+        assertEquals(NativeImageAsset.IMAGE_TYPE.ICON, image.getImageType());
+        assertEquals(1, image.getImageType().getID());
+        image.setImageType(NativeImageAsset.IMAGE_TYPE.MAIN);
+        assertEquals(NativeImageAsset.IMAGE_TYPE.MAIN, image.getImageType());
+        assertEquals(3, image.getImageType().getID());
+        image.setImageType(NativeImageAsset.IMAGE_TYPE.CUSTOM);
+        assertEquals(NativeImageAsset.IMAGE_TYPE.CUSTOM, image.getImageType());
+        NativeImageAsset.IMAGE_TYPE.CUSTOM.setID(500);
+        assertEquals(500, image.getImageType().getID());
+        NativeImageAsset.IMAGE_TYPE.CUSTOM.setID(600);
+        assertEquals(600, image.getImageType().getID());
+        NativeImageAsset.IMAGE_TYPE.CUSTOM.setID(1);
+        assertEquals(600, image.getImageType().getID());
+        assertFalse("Invalid CustomId", 1 == image.getImageType().getID());
+
+        JSONObject imageJsonObject = image.getJsonObject(1);
+        int id = imageJsonObject.optInt("id");
+        assertEquals(0, id); // Since the optInt returns 0 if a key does not exist
+
+        PrebidMobile.assignNativeAssetID(true);
+
+        imageJsonObject = image.getJsonObject(1);
+        id = imageJsonObject.optInt("id");
+        assertEquals(1, id); // 1 is the idCount that we have set while getting the JSON Object
     }
 
     @Test
@@ -216,6 +358,104 @@ public class NativeAssetTest {
         assertEquals(600, dataAsset.getDataType().getID());
         assertFalse("Invalid CustomId", 1 == dataAsset.getDataType().getID());
 
+    }
+
+    @Test
+    public void testNativeAssetDataAssignNativeAssetID() {
+        NativeDataAsset dataAsset = new NativeDataAsset();
+        dataAsset.setLen(25);
+        dataAsset.setRequired(true);
+        JSONObject assetExt = new JSONObject();
+        try {
+            assetExt.put("key1", "value1");
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+        dataAsset.setAssetExt(assetExt);
+        JSONObject dataExt = new JSONObject();
+        try {
+            dataExt.put("key2", "value2");
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+        dataAsset.setDataExt(dataExt);
+
+        assertEquals(25, dataAsset.getLen());
+        assertEquals(true, dataAsset.isRequired());
+
+        String value1 = "";
+        try {
+            JSONObject data = (JSONObject) dataAsset.getAssetExt();
+            value1 = data.getString("key1");
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+        assertEquals("value1", value1);
+
+        String value2 = "";
+        try {
+            JSONObject data = (JSONObject) dataAsset.getDataExt();
+            value2 = data.getString("key2");
+        } catch (JSONException e) {
+            e.printStackTrace();
+        }
+        assertEquals("value2", value2);
+
+        dataAsset.setDataType(NativeDataAsset.DATA_TYPE.SPONSORED);
+        assertEquals(NativeDataAsset.DATA_TYPE.SPONSORED, dataAsset.getDataType());
+        assertEquals(1, dataAsset.getDataType().getID());
+        dataAsset.setDataType(NativeDataAsset.DATA_TYPE.DESC);
+        assertEquals(NativeDataAsset.DATA_TYPE.DESC, dataAsset.getDataType());
+        assertEquals(2, dataAsset.getDataType().getID());
+        dataAsset.setDataType(NativeDataAsset.DATA_TYPE.RATING);
+        assertEquals(NativeDataAsset.DATA_TYPE.RATING, dataAsset.getDataType());
+        assertEquals(3, dataAsset.getDataType().getID());
+        dataAsset.setDataType(NativeDataAsset.DATA_TYPE.LIKES);
+        assertEquals(NativeDataAsset.DATA_TYPE.LIKES, dataAsset.getDataType());
+        assertEquals(4, dataAsset.getDataType().getID());
+        dataAsset.setDataType(NativeDataAsset.DATA_TYPE.DOWNLOADS);
+        assertEquals(NativeDataAsset.DATA_TYPE.DOWNLOADS, dataAsset.getDataType());
+        assertEquals(5, dataAsset.getDataType().getID());
+        dataAsset.setDataType(NativeDataAsset.DATA_TYPE.PRICE);
+        assertEquals(NativeDataAsset.DATA_TYPE.PRICE, dataAsset.getDataType());
+        assertEquals(6, dataAsset.getDataType().getID());
+        dataAsset.setDataType(NativeDataAsset.DATA_TYPE.SALEPRICE);
+        assertEquals(NativeDataAsset.DATA_TYPE.SALEPRICE, dataAsset.getDataType());
+        assertEquals(7, dataAsset.getDataType().getID());
+        dataAsset.setDataType(NativeDataAsset.DATA_TYPE.PHONE);
+        assertEquals(NativeDataAsset.DATA_TYPE.PHONE, dataAsset.getDataType());
+        assertEquals(8, dataAsset.getDataType().getID());
+        dataAsset.setDataType(NativeDataAsset.DATA_TYPE.ADDRESS);
+        assertEquals(NativeDataAsset.DATA_TYPE.ADDRESS, dataAsset.getDataType());
+        assertEquals(9, dataAsset.getDataType().getID());
+        dataAsset.setDataType(NativeDataAsset.DATA_TYPE.DESC2);
+        assertEquals(NativeDataAsset.DATA_TYPE.DESC2, dataAsset.getDataType());
+        assertEquals(10, dataAsset.getDataType().getID());
+        dataAsset.setDataType(NativeDataAsset.DATA_TYPE.DESPLAYURL);
+        assertEquals(NativeDataAsset.DATA_TYPE.DESPLAYURL, dataAsset.getDataType());
+        assertEquals(11, dataAsset.getDataType().getID());
+        dataAsset.setDataType(NativeDataAsset.DATA_TYPE.CTATEXT);
+        assertEquals(NativeDataAsset.DATA_TYPE.CTATEXT, dataAsset.getDataType());
+        assertEquals(12, dataAsset.getDataType().getID());
+        dataAsset.setDataType(NativeDataAsset.DATA_TYPE.CUSTOM);
+        assertEquals(NativeDataAsset.DATA_TYPE.CUSTOM, dataAsset.getDataType());
+        NativeDataAsset.DATA_TYPE.CUSTOM.setID(500);
+        assertEquals(500, dataAsset.getDataType().getID());
+        NativeDataAsset.DATA_TYPE.CUSTOM.setID(600);
+        assertEquals(600, dataAsset.getDataType().getID());
+        NativeDataAsset.DATA_TYPE.CUSTOM.setID(1);
+        assertEquals(600, dataAsset.getDataType().getID());
+        assertFalse("Invalid CustomId", 1 == dataAsset.getDataType().getID());
+
+        JSONObject dataAssetJsonObject = dataAsset.getJsonObject(1);
+        int id = dataAssetJsonObject.optInt("id");
+        assertEquals(0, id); // Since the optInt returns 0 if a key does not exist
+
+        PrebidMobile.assignNativeAssetID(true);
+
+        dataAssetJsonObject = dataAsset.getJsonObject(1);
+        id = dataAssetJsonObject.optInt("id");
+        assertEquals(1, id); // 1 is the idCount that we have set while getting the JSON Object
     }
 
 


### PR DESCRIPTION
* There were changes made for assigning Native asset ids in [this PR](https://github.com/prebid/prebid-mobile-android/pull/273/files).
* But after some refactoring, these changes were reverted, I am not sure why.
* I have made this fix, please feel free to share your feedback / approve the PR.
* This is a solution to issue #640 reported on github.