### PR TITLE
Clicktrackers implementation for Native ads

### DIFF
--- a/PrebidMobile/PrebidMobile-core/build.gradle
+++ b/PrebidMobile/PrebidMobile-core/build.gradle
@@ -22,12 +22,12 @@ android {
 dependencies {
     implementation project(":omsdk-android")
 
-    implementation 'androidx.annotation:annotation:1.5.0'
-
-    implementation 'com.google.android.gms:play-services-base:18.1.0'
+    implementation 'androidx.annotation:annotation:1.3.0'
+    implementation 'com.google.android.gms:play-services-base:18.0.1'
     implementation 'com.google.android.gms:play-services-ads-identifier:18.0.1'
-    implementation 'com.google.android.exoplayer:exoplayer-core:2.15.1'
-    implementation 'com.google.android.exoplayer:exoplayer-ui:2.15.1'
+    implementation 'com.google.android.exoplayer:exoplayer-core:2.13.3'
+    implementation 'com.google.android.exoplayer:exoplayer-ui:2.13.3'
 
-    implementation "androidx.localbroadcastmanager:localbroadcastmanager:1.0.0"
+    implementation 'com.huawei.hms:base:6.4.0.303'
+    implementation 'com.huawei.hms:ads-identifier:3.4.39.302'
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/ClickTracker.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/ClickTracker.java
@@ -1,0 +1,75 @@
+/*
+ *    Copyright 2020-2021 Prebid.org, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.prebid.mobile;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+
+import org.prebid.mobile.http.HTTPGet;
+import org.prebid.mobile.http.HTTPResponse;
+
+class ClickTracker {
+    private String url;
+    private boolean fired = false;
+    private Context context;
+    private ClickTrackerListener clickTrackerListener;
+
+    static ClickTracker createAndFire(String url, Context context, ClickTrackerListener clickTrackerListener) {
+        ClickTracker clickTracker = new ClickTracker(url, context, clickTrackerListener);
+        clickTracker.fire();
+        return clickTracker;
+    }
+
+    private ClickTracker(String url, Context context, ClickTrackerListener clickTrackerListener) {
+        this.url = url;
+        this.context = context;
+        this.clickTrackerListener = clickTrackerListener;
+    }
+
+    private synchronized void fire() {
+        // check if impression has already fired
+        if (!fired) {
+            SharedNetworkManager nm = SharedNetworkManager.getInstance(context);
+            if (nm.isConnected(context)) {
+                @SuppressLint("StaticFieldLeak") HTTPGet asyncTask = new HTTPGet() {
+                    @Override
+                    protected void onPostExecute(HTTPResponse response) {
+                        if (clickTrackerListener != null) {
+                            clickTrackerListener.onClickTrackerFired();
+                        }
+                    }
+
+                    @Override
+                    protected String getUrl() {
+                        return url;
+                    }
+                };
+                asyncTask.execute();
+            } else {
+                nm.addClickTrackerURL(url, context, new ClickTrackerListener() {
+                    @Override
+                    public void onClickTrackerFired() {
+                        if (clickTrackerListener != null) {
+                            clickTrackerListener.onClickTrackerFired();
+                        }
+                    }
+                });
+            }
+            fired = true;
+        }
+    }
+}

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/ClickTrackerListener.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/ClickTrackerListener.java
@@ -1,0 +1,22 @@
+/*
+ *    Copyright 2020-2021 Prebid.org, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.prebid.mobile;
+
+public interface ClickTrackerListener {
+    public void onClickTrackerFired();
+
+}

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/SharedNetworkManager.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/SharedNetworkManager.java
@@ -48,6 +48,7 @@ public class SharedNetworkManager {
     private static final String permission = "android.permission.ACCESS_NETWORK_STATE";
     private boolean permitted;
     private ImpressionTrackerListener impressionTrackerListener;
+    private ClickTrackerListener clickTrackerListener;
 
     private SharedNetworkManager(Context context) {
         int permissionStatus = context.getPackageManager().checkPermission(
@@ -78,6 +79,13 @@ public class SharedNetworkManager {
         startTimer(context);
     }
 
+    synchronized void addClickTrackerURL(String url, Context context, ClickTrackerListener clickTrackerListener) {
+        LogUtil.debug("SharedNetworkManager adding URL for Network Retry");
+        this.clickTrackerListener = clickTrackerListener;
+        urls.add(new UrlObject(url));
+        startTimer(context);
+    }
+
     private void startTimer(Context context) {
         if (retryTimer == null) {
             // check Network Connectivity after a certain period
@@ -104,6 +112,10 @@ public class SharedNetworkManager {
                                                     // Nothing more to do just print logs and exit.
                                                     if (impressionTrackerListener != null) {
                                                         impressionTrackerListener.onImpressionTrackerFired();
+                                                    }
+
+                                                    if (clickTrackerListener != null) {
+                                                        clickTrackerListener.onClickTrackerFired();
                                                     }
                                                 }
 

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/networking/parameters/DeviceInfoParameterBuilder.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/networking/parameters/DeviceInfoParameterBuilder.java
@@ -17,6 +17,8 @@
 package org.prebid.mobile.rendering.networking.parameters;
 
 import android.os.Build;
+
+import org.json.JSONObject;
 import org.prebid.mobile.AdSize;
 import org.prebid.mobile.configuration.AdUnitConfiguration;
 import org.prebid.mobile.rendering.bidding.data.bid.Prebid;
@@ -74,6 +76,14 @@ public class DeviceInfoParameterBuilder extends ParameterBuilder {
             final AdSize minSizePercentage = adConfiguration.getMinSizePercentage();
             if (minSizePercentage != null) {
                 device.getExt().put("prebid", Prebid.getJsonObjectForDeviceMinSizePerc(minSizePercentage));
+            }
+
+            String oaid = AdIdManager.getOaId();
+            if (Utils.isNotBlank(oaid)) {
+                JSONObject jsonOAID = new JSONObject();
+                Utils.addValue(jsonOAID, "oaid", oaid);
+                Utils.addValue(jsonOAID, "limitTracking", AdIdManager.isOaidLimitAdTrackingEnabled()? 1 : 0);
+                device.getExt().put("data",jsonOAID);
             }
         }
     }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/helpers/ExternalViewerUtils.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/helpers/ExternalViewerUtils.java
@@ -146,6 +146,9 @@ public class ExternalViewerUtils {
             return;
         }
         Intent intent = new Intent(Intent.ACTION_VIEW);
+        if (!(context instanceof Activity)) {
+            intent.addFlags(FLAG_ACTIVITY_NEW_TASK);
+        }
         intent.setData(Uri.parse(url));
         if (URLUtil.isValidUrl(url) || isActivityCallable(context, intent)) {
             startActivity(context, intent);

--- a/build.gradle
+++ b/build.gradle
@@ -1,25 +1,26 @@
 ext {
-    prebidSdkVersionName = "2.1.1"
-    prebidSdkMinVersion = 16
-    prebidSdkTargetVersion = 32
-    prebidSdkCompileVersion = 32
-    prebidSdkBuildToolsVersion = "30.0.3"
+    prebidVersionName = "2.0.0"
+    prebidVersionCode = 1
+    minSDKVersion = 17
+    targetSDKVersion = 28
+    compileSdkVersion = 30
+    buildToolsVersion = "28.0.3"
 
     artifactGroupId = "org.prebid"
     artifactFolder = "${buildDir}/generated-artifacts"
-    omSdkVersion = "1.4.1"
+    omSdkVersion = "1.3.17"
     omSdkModuleName = "omsdk-android"
 }
 
 buildscript {
-    ext.kotlin_version = '1.6.21'
+    ext.kotlin_version = '1.5.32'
     repositories {
         google()
         mavenCentral()
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:7.3.1'
+        classpath 'com.android.tools.build:gradle:4.1.3'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
@@ -30,6 +31,7 @@ allprojects {
         mavenCentral()
         maven { url 'https://maven.google.com' }
         maven { url 'https://jitpack.io' }
-        maven { url "https://oss.sonatype.org/content/repositories/orgprebid-1079" }
+        maven { url "https://oss.sonatype.org/content/repositories/orgprebid-1070" }
+        maven { url 'https://developer.huawei.com/repo/' }
     }
 }


### PR DESCRIPTION
Motivation: Feature request #649 

Currently, the Prebid Mobile SDK is not making use of the link.clicktrackers of the standard OpenRTB protocol. This pull request is to implement that feature.

Whenever a native ad is tapped (or, "clicked"), it should send HTTP GET requests to all the urls in the `link.clicktrackers` array.