### PR TITLE
clicktrackers implementation for native ads

### DIFF
--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/ClickTracker.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/ClickTracker.java
@@ -1,0 +1,75 @@
+/*
+ *    Copyright 2020-2021 Prebid.org, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.prebid.mobile;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+
+import org.prebid.mobile.http.HTTPGet;
+import org.prebid.mobile.http.HTTPResponse;
+
+class ClickTracker {
+    private String url;
+    private boolean fired = false;
+    private Context context;
+    private ClickTrackerListener clickTrackerListener;
+
+    static ClickTracker createAndFire(String url, Context context, ClickTrackerListener clickTrackerListener) {
+        ClickTracker clickTracker = new ClickTracker(url, context, clickTrackerListener);
+        clickTracker.fire();
+        return clickTracker;
+    }
+
+    private ClickTracker(String url, Context context, ClickTrackerListener clickTrackerListener) {
+        this.url = url;
+        this.context = context;
+        this.clickTrackerListener = clickTrackerListener;
+    }
+
+    private synchronized void fire() {
+        // check if impression has already fired
+        if (!fired) {
+            SharedNetworkManager nm = SharedNetworkManager.getInstance(context);
+            if (nm.isConnected(context)) {
+                @SuppressLint("StaticFieldLeak") HTTPGet asyncTask = new HTTPGet() {
+                    @Override
+                    protected void onPostExecute(HTTPResponse response) {
+                        if (clickTrackerListener != null) {
+                            clickTrackerListener.onClickTrackerFired();
+                        }
+                    }
+
+                    @Override
+                    protected String getUrl() {
+                        return url;
+                    }
+                };
+                asyncTask.execute();
+            } else {
+                nm.addClickTrackerURL(url, context, new ClickTrackerListener() {
+                    @Override
+                    public void onClickTrackerFired() {
+                        if (clickTrackerListener != null) {
+                            clickTrackerListener.onClickTrackerFired();
+                        }
+                    }
+                });
+            }
+            fired = true;
+        }
+    }
+}

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/ClickTrackerListener.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/ClickTrackerListener.java
@@ -1,0 +1,22 @@
+/*
+ *    Copyright 2020-2021 Prebid.org, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.prebid.mobile;
+
+public interface ClickTrackerListener {
+    public void onClickTrackerFired();
+
+}

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/SharedNetworkManager.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/SharedNetworkManager.java
@@ -48,6 +48,7 @@ public class SharedNetworkManager {
     private static final String permission = "android.permission.ACCESS_NETWORK_STATE";
     private boolean permitted;
     private ImpressionTrackerListener impressionTrackerListener;
+    private ClickTrackerListener clickTrackerListener;
 
     private SharedNetworkManager(Context context) {
         int permissionStatus = context.getPackageManager().checkPermission(
@@ -78,6 +79,13 @@ public class SharedNetworkManager {
         startTimer(context);
     }
 
+    synchronized void addClickTrackerURL(String url, Context context, ClickTrackerListener clickTrackerListener) {
+        LogUtil.debug("SharedNetworkManager adding URL for Network Retry");
+        this.clickTrackerListener = clickTrackerListener;
+        urls.add(new UrlObject(url));
+        startTimer(context);
+    }
+
     private void startTimer(Context context) {
         if (retryTimer == null) {
             // check Network Connectivity after a certain period
@@ -104,6 +112,10 @@ public class SharedNetworkManager {
                                                     // Nothing more to do just print logs and exit.
                                                     if (impressionTrackerListener != null) {
                                                         impressionTrackerListener.onImpressionTrackerFired();
+                                                    }
+
+                                                    if (clickTrackerListener != null) {
+                                                        clickTrackerListener.onClickTrackerFired();
                                                     }
                                                 }
 


### PR DESCRIPTION
Motivation: Feature request https://github.com/prebid/prebid-mobile-android/issues/649

Currently, the Prebid Mobile SDK is not making use of the link.clicktrackers of the standard OpenRTB protocol. This pull request is to implement that feature.

Whenever a native ad is tapped (or, "clicked"), it should send HTTP GET requests to all the urls in the link.clicktrackers array.

(I messed up the previous Pull Request 🙈)