### PR TITLE
Fix renderers key node on bid request

### DIFF
--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/openrtb/BidRequest.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/openrtb/BidRequest.java
@@ -37,7 +37,6 @@ public class BidRequest extends BaseBid {
     private Regs regs = null;
     private User user = null;
     private Source source = null;
-    private PluginRendererList pluginRendererList = null;
 
     private Ext ext = null;
 
@@ -156,13 +155,5 @@ public class BidRequest extends BaseBid {
             ext = new Ext();
         }
         return ext;
-    }
-
-    public void setPluginRendererList(PluginRendererList pluginRendererList) {
-        this.pluginRendererList = pluginRendererList;
-    }
-
-    public PluginRendererList getPluginRenderers() {
-        return pluginRendererList;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/openrtb/bidRequests/PluginRendererList.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/openrtb/bidRequests/PluginRendererList.java
@@ -24,14 +24,14 @@ import java.util.List;
 
 public class PluginRendererList extends BaseBid {
 
+    public static String RENDERERS_KEY = "renderers";
+
     private List<PluginRenderer> renderers;
 
 
     public JSONObject getJsonObject() throws JSONException {
         JSONObject jsonObject = new JSONObject();
-        JSONObject sdkObject = new JSONObject();
-        toJSON(sdkObject, "renderers", this.renderers);
-        jsonObject.put("sdk", sdkObject);
+        toJSON(jsonObject, RENDERERS_KEY, this.renderers);
         return jsonObject;
     }
 
@@ -39,7 +39,7 @@ public class PluginRendererList extends BaseBid {
         this.renderers = renderers;
     }
 
-    public List<PluginRenderer> getList() {
+    public List<PluginRenderer> get() {
         return this.renderers;
     }
 

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/networking/parameters/BasicParameterBuilder.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/networking/parameters/BasicParameterBuilder.java
@@ -23,35 +23,26 @@ import android.content.res.Resources;
 import android.text.TextUtils;
 import android.util.Pair;
 
-import androidx.annotation.VisibleForTesting;
-
 import org.json.JSONArray;
-import org.json.JSONException;
 import org.json.JSONObject;
 import org.prebid.mobile.AdSize;
 import org.prebid.mobile.BannerParameters;
 import org.prebid.mobile.DataObject;
 import org.prebid.mobile.ExternalUserId;
-import org.prebid.mobile.LogUtil;
 import org.prebid.mobile.PrebidMobile;
 import org.prebid.mobile.Signals;
 import org.prebid.mobile.TargetingParams;
 import org.prebid.mobile.VideoParameters;
 import org.prebid.mobile.api.data.AdFormat;
-import org.prebid.mobile.api.rendering.pluginrenderer.PrebidMobilePluginRegister;
-import org.prebid.mobile.api.rendering.pluginrenderer.PrebidMobilePluginRenderer;
 import org.prebid.mobile.configuration.AdUnitConfiguration;
 import org.prebid.mobile.rendering.bidding.data.bid.Prebid;
 import org.prebid.mobile.rendering.models.PlacementType;
 import org.prebid.mobile.rendering.models.openrtb.BidRequest;
 import org.prebid.mobile.rendering.models.openrtb.bidRequests.Imp;
-import org.prebid.mobile.rendering.models.openrtb.bidRequests.PluginRenderer;
-import org.prebid.mobile.rendering.models.openrtb.bidRequests.PluginRendererList;
 import org.prebid.mobile.rendering.models.openrtb.bidRequests.User;
 import org.prebid.mobile.rendering.models.openrtb.bidRequests.devices.Geo;
 import org.prebid.mobile.rendering.models.openrtb.bidRequests.imps.Banner;
 import org.prebid.mobile.rendering.models.openrtb.bidRequests.imps.Video;
-import org.prebid.mobile.rendering.models.openrtb.bidRequests.mapper.PluginRendererListMapper;
 import org.prebid.mobile.rendering.models.openrtb.bidRequests.source.Source;
 import org.prebid.mobile.rendering.session.manager.OmAdSessionManager;
 import org.prebid.mobile.rendering.utils.helpers.Utils;
@@ -153,7 +144,6 @@ public class BasicParameterBuilder extends ParameterBuilder {
         if (PrebidMobile.isCoppaEnabled) {
             bidRequest.getRegs().coppa = 1;
         }
-        setPluginRendererList(bidRequest);
     }
 
     private void configureSource(Source source, String uuid) {
@@ -428,30 +418,5 @@ public class BasicParameterBuilder extends ParameterBuilder {
         else {
             return null;
         }
-    }
-
-    @VisibleForTesting
-    public void setPluginRendererList(BidRequest bidRequest) {
-        if (!adConfiguration.isOriginalAdUnit() && !isDefaultPluginRenderer()) {
-            bidRequest.setPluginRendererList(getPluginRendererList());
-            try {
-                bidRequest.getExt().put(bidRequest.getPluginRenderers().getJsonObject());
-            } catch (JSONException e) {
-                LogUtil.error("setPluginRendererList", e.getMessage());
-            }
-        }
-    }
-
-    private boolean isDefaultPluginRenderer() {
-        List<PluginRenderer> renderers = getPluginRendererList().getList();
-        return renderers.size() == 1 && renderers.get(0).getName().equals(PrebidMobilePluginRegister.PREBID_MOBILE_RENDERER_NAME);
-    }
-
-    private PluginRendererList getPluginRendererList() {
-        List<PrebidMobilePluginRenderer> plugins = PrebidMobilePluginRegister.getInstance().getRTBListOfRenderersFor(adConfiguration);
-        PluginRendererListMapper mapper = new PluginRendererListMapper();
-        PluginRendererList rendererList = new PluginRendererList();
-        rendererList.setList(mapper.map(plugins));
-        return rendererList;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/models/openrtb/bidRequests/PluginRendererListTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/models/openrtb/bidRequests/PluginRendererListTest.java
@@ -17,10 +17,9 @@ public class PluginRendererListTest {
         List<PluginRenderer> emptyList = Arrays.asList();
 
         pluginRendererList.setList(emptyList);
-        JSONObject jsonObject = (JSONObject) pluginRendererList.getJsonObject().get("sdk");
 
-        Assert.assertTrue(jsonObject.has("renderers"));
-        JSONArray jsonArray = jsonObject.getJSONArray("renderers");
+        Assert.assertTrue(pluginRendererList.getJsonObject().has(PluginRendererList.RENDERERS_KEY));
+        JSONArray jsonArray = pluginRendererList.getJsonObject().getJSONArray(PluginRendererList.RENDERERS_KEY);
         Assert.assertEquals(0, jsonArray.length());
     }
 
@@ -33,10 +32,9 @@ public class PluginRendererListTest {
         );
 
         pluginRendererList.setList(pluginList);
-        JSONObject jsonObject = (JSONObject) pluginRendererList.getJsonObject().get("sdk");
 
-        Assert.assertTrue(jsonObject.has("renderers"));
-        JSONArray jsonArray = jsonObject.getJSONArray("renderers");
+        Assert.assertTrue(pluginRendererList.getJsonObject().has(PluginRendererList.RENDERERS_KEY));
+        JSONArray jsonArray = pluginRendererList.getJsonObject().getJSONArray(PluginRendererList.RENDERERS_KEY);
         Assert.assertEquals(pluginList.size(), jsonArray.length());
 
         for (int i = 0; i < pluginList.size(); i++) {
@@ -58,10 +56,9 @@ public class PluginRendererListTest {
         );
 
         pluginRendererList.setList(pluginList);
-        JSONObject jsonObject = (JSONObject) pluginRendererList.getJsonObject().get("sdk");
 
-        Assert.assertTrue(jsonObject.has("renderers"));
-        JSONArray jsonArray = jsonObject.getJSONArray("renderers");
+        Assert.assertTrue(pluginRendererList.getJsonObject().has(PluginRendererList.RENDERERS_KEY));
+        JSONArray jsonArray = pluginRendererList.getJsonObject().getJSONArray(PluginRendererList.RENDERERS_KEY);
         Assert.assertEquals(pluginList.size(), jsonArray.length());
 
         for (int i = 0; i < pluginList.size(); i++) {


### PR DESCRIPTION
This pull request is to solve the following issue:

[This pull request](https://github.com/prebid/prebid-mobile-android/pull/648) intended to insert renderers on the following node path from the bid request:
`.ext.prebid.sdk.renderers`

But the implementation did not match the expectation [as you can see here](https://github.com/prebid/prebid-mobile-android/blob/0f5a3d8a9cd36b095da96f9ee0e29007a17e849b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/networking/parameters/BasicParameterBuilder.java#L438), so the current state is
`.ext.sdk.renderers`