### PR TITLE
Update compile and target version to 33; Update Kotlin plugin to 1.8.22; Update Google SDK version to 22.4.0

### DIFF
--- a/Example/PrebidDemoJava/build.gradle
+++ b/Example/PrebidDemoJava/build.gradle
@@ -1,11 +1,11 @@
 apply plugin: 'com.android.application'
 
 android {
-    setCompileSdkVersion(32)
+    setCompileSdkVersion(33)
     setBuildToolsVersion("30.0.3")
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 32
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0.0"
         applicationId "org.prebid.mobile.javademo"

--- a/Example/PrebidDemoKotlin/build.gradle
+++ b/Example/PrebidDemoKotlin/build.gradle
@@ -2,11 +2,11 @@ apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
 
 android {
-    setCompileSdkVersion(32)
+    setCompileSdkVersion(33)
     setBuildToolsVersion("30.0.3")
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 32
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0.0"
         applicationId "org.prebid.mobile.prebidkotlindemo"

--- a/Example/PrebidDemoKotlin/src/androidTest/java/org/prebid/mobile/prebidkotlindemo/ui/VideoAdsTest.kt
+++ b/Example/PrebidDemoKotlin/src/androidTest/java/org/prebid/mobile/prebidkotlindemo/ui/VideoAdsTest.kt
@@ -49,6 +49,7 @@ class VideoAdsTest(
             AdFormat.VIDEO_BANNER -> checkVideoBannerAd()
             AdFormat.VIDEO_REWARDED -> checkVideoRewardedAd(testCase)
             AdFormat.VIDEO_INTERSTITIAL -> checkVideoInterstitialAd()
+            else -> { throw IllegalArgumentException("TestCase not supported for ${testCase.adFormat.description}") }
         }
     }
 

--- a/Example/PrebidInternalTestApp/build.gradle
+++ b/Example/PrebidInternalTestApp/build.gradle
@@ -19,11 +19,11 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-kapt'
 
 android {
-    setCompileSdkVersion(32)
+    setCompileSdkVersion(33)
     setBuildToolsVersion("30.0.3")
     defaultConfig {
         minSdkVersion 19
-        targetSdkVersion 32
+        targetSdkVersion 33
         versionCode 1
         versionName "1.0.0"
         applicationId "org.prebid.mobile.renderingtestapp"

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/PrebidMobile.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/PrebidMobile.java
@@ -92,7 +92,7 @@ public class PrebidMobile {
     /**
      * Tested Google SDK version.
      */
-    public static final String TESTED_GOOGLE_SDK_VERSION = "22.3.0";
+    public static final String TESTED_GOOGLE_SDK_VERSION = "22.4.0";
 
     /**
      * Please use {@link PrebidMobile#setLogLevel(LogLevel)}, this field will become private in next releases.

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,7 @@ ext {
 }
 
 buildscript {
-    ext.kotlin_version = '1.9.0'
+    ext.kotlin_version = '1.8.22'
     repositories {
         google()
         mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -1,8 +1,8 @@
 ext {
     prebidSdkVersionName = "2.1.4"
     prebidSdkMinVersion = 16
-    prebidSdkTargetVersion = 32
-    prebidSdkCompileVersion = 32
+    prebidSdkTargetVersion = 33
+    prebidSdkCompileVersion = 33
     prebidSdkBuildToolsVersion = "30.0.3"
 
     artifactGroupId = "org.prebid"
@@ -12,7 +12,7 @@ ext {
 }
 
 buildscript {
-    ext.kotlin_version = '1.6.21'
+    ext.kotlin_version = '1.9.0'
     repositories {
         google()
         mavenCentral()

--- a/scripts/Maven/PrebidMobile-admobAdapters-pom.xml
+++ b/scripts/Maven/PrebidMobile-admobAdapters-pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>com.google.android.gms</groupId>
             <artifactId>play-services-ads</artifactId>
-            <version>22.3.0</version>
+            <version>22.4.0</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/scripts/Maven/PrebidMobile-gamEventHandlers-pom.xml
+++ b/scripts/Maven/PrebidMobile-gamEventHandlers-pom.xml
@@ -58,7 +58,7 @@
         <dependency>
             <groupId>com.google.android.gms</groupId>
             <artifactId>play-services-ads</artifactId>
-            <version>22.3.0</version>
+            <version>22.4.0</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Currently `PrebidInternalTestApp` project run is failing due to the error below.

This sub-dependency `androidx.privacysandbox.ads:ads-adservices*` requires to compile against version `33`, current value on this project is `32`. As consequence Kotlin plugin needed to be update to >= `1.8`.

I was not able to track which commit brought this breaking change, so apparently we have a dependency that was updated without version increment on the maven repo.

⚠️ Plus Google SDK version was updated, so this is blocking the CI, so I am taking the chance to update it as well.


to-do
---

- [x] Update compile and target version from 32 to 33
- [x] Update kotlin version from 1.6.21 to 1.8.22
- [x] Update google sdk version from 22.3.0 to 22.4.0

Error
---
```
  2 issues were found when checking AAR metadata:

  1.  Dependency 'androidx.privacysandbox.ads:ads-adservices-java:1.0.0-beta05' requires libraries and applications that
      depend on it to compile against version 33 or later of the
      Android APIs.

      :PrebidInternalTestApp is currently compiled against android-32.

      Recommended action: Update this project to use a newer compileSdkVersion
      of at least 33, for example 33.

      Note that updating a library or application's compileSdkVersion (which
      allows newer APIs to be used) can be done separately from updating
      targetSdkVersion (which opts the app in to new runtime behavior) and
      minSdkVersion (which determines which devices the app can be installed
      on).

  2.  Dependency 'androidx.privacysandbox.ads:ads-adservices:1.0.0-beta05' requires libraries and applications that
      depend on it to compile against version 33 or later of the
      Android APIs.

      :PrebidInternalTestApp is currently compiled against android-32.

      Recommended action: Update this project to use a newer compileSdkVersion
      of at least 33, for example 33.

      Note that updating a library or application's compileSdkVersion (which
      allows newer APIs to be used) can be done separately from updating
      targetSdkVersion (which opts the app in to new runtime behavior) and
      minSdkVersion (which determines which devices the app can be installed
      on).
```
