### PR TITLE
Fix for 683 ShareGeoLocation not working without precise location

### DIFF
--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/networking/parameters/GeoLocationParameterBuilder.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/networking/parameters/GeoLocationParameterBuilder.java
@@ -46,7 +46,8 @@ public class GeoLocationParameterBuilder extends ParameterBuilder {
         adRequestInput.getBidRequest().getDevice().setGeo(null);
 
         if (locationInfoManager != null && PrebidMobile.isShareGeoLocation()) {
-            if (deviceManager != null && deviceManager.isPermissionGranted("android.permission.ACCESS_FINE_LOCATION")) {
+            if (deviceManager != null && (deviceManager.isPermissionGranted("android.permission.ACCESS_FINE_LOCATION")
+                    || deviceManager.isPermissionGranted("android.permission.ACCESS_COARSE_LOCATION"))) {
                 setLocation(adRequestInput, locationInfoManager);
             }
         }


### PR DESCRIPTION
Location wasn't being set because when "use precise location" isn't checked, the app uses the Coarse location permission which was not being checked. Closes #683 