### PR TITLE
Do not include NativeImageAsset exact dimensions in JSON if not specified

### DIFF
--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/NativeImageAsset.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/NativeImageAsset.java
@@ -20,6 +20,12 @@ public class NativeImageAsset extends NativeAsset {
         hmin = minHeight;
     }
 
+    public NativeImageAsset(int minWidth, int minHeight) {
+        super(REQUEST_ASSET.IMAGE);
+        wmin = minWidth;
+        hmin = minHeight;
+    }
+
     public enum IMAGE_TYPE {
         ICON(1),
         MAIN(3),
@@ -161,9 +167,13 @@ public class NativeImageAsset extends NativeAsset {
             JSONObject imageObject = new JSONObject();
             imageObject.putOpt("type", type != null ? type.getID() : null);
 
-            imageObject.put("w", w);
+            if (w > 0) {
+                imageObject.put("w", w);
+            }
             imageObject.put("wmin", wmin);
-            imageObject.put("h", h);
+            if (h > 0) {
+                imageObject.put("h", h);
+            }
             imageObject.put("hmin", hmin);
             imageObject.putOpt("ext", imageExt);
 


### PR DESCRIPTION
Based on [OpenRTB Native ads specification](https://www.iab.com/wp-content/uploads/2018/03/OpenRTB-Native-Ads-Specification-Final-1.2.pdf) width and height for image request are optional so that client can only specify minimum required dimensions.

<img width="400" alt="image" src="https://github.com/prebid/prebid-mobile-android/assets/17886739/e9abd8f5-3286-4be5-97e2-741f407451d9"><br>

In the current implementation this is **not allowed** and width and height are always included in the image request JSON. This bug prevents us from displaying more ads. I would be very grateful for a quick review and including it in the next version.

 