### PR TITLE
Proposal: Getter ApiFramework from renderers

### DIFF
--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/utils/SampleCustomRenderer.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/utils/SampleCustomRenderer.kt
@@ -29,6 +29,7 @@ import android.view.ViewTreeObserver
 import android.webkit.WebView
 import android.widget.FrameLayout
 import android.widget.ImageButton
+import com.google.common.collect.ImmutableList
 import org.json.JSONObject
 import org.prebid.mobile.LogUtil
 import org.prebid.mobile.api.data.AdFormat
@@ -41,6 +42,7 @@ import org.prebid.mobile.configuration.AdUnitConfiguration
 import org.prebid.mobile.rendering.bidding.data.bid.BidResponse
 import org.prebid.mobile.rendering.bidding.interfaces.InterstitialControllerListener
 import org.prebid.mobile.rendering.bidding.listeners.DisplayViewListener
+import java.util.Arrays
 
 class SampleCustomRenderer : PrebidMobilePluginRenderer {
 
@@ -51,6 +53,8 @@ class SampleCustomRenderer : PrebidMobilePluginRenderer {
     override fun getVersion(): String = "1.0.0"
 
     override fun getData(): JSONObject? = null
+
+    override fun getApiFrameworks(): List<Int> = listOf(1, 2, 7)
 
     override fun registerEventListener(
         pluginEventListener: PluginEventListener,

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/PrebidRenderer.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/PrebidRenderer.java
@@ -38,6 +38,10 @@ import org.prebid.mobile.rendering.bidding.display.InterstitialController;
 import org.prebid.mobile.rendering.bidding.interfaces.InterstitialControllerListener;
 import org.prebid.mobile.rendering.bidding.listeners.DisplayViewListener;
 
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
 public class PrebidRenderer implements PrebidMobilePluginRenderer {
 
     @Override
@@ -54,6 +58,11 @@ public class PrebidRenderer implements PrebidMobilePluginRenderer {
     @Override
     public JSONObject getData() {
         return null;
+    }
+
+    @Override
+    public List<Integer> getApiFrameworks() {
+        return Collections.emptyList();
     }
 
     @Override

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/pluginrenderer/PrebidMobilePluginRenderer.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/pluginrenderer/PrebidMobilePluginRenderer.java
@@ -30,6 +30,8 @@ import org.prebid.mobile.rendering.bidding.data.bid.BidResponse;
 import org.prebid.mobile.rendering.bidding.interfaces.InterstitialControllerListener;
 import org.prebid.mobile.rendering.bidding.listeners.DisplayViewListener;
 
+import java.util.List;
+
 public interface PrebidMobilePluginRenderer {
 
     String getName();
@@ -38,6 +40,8 @@ public interface PrebidMobilePluginRenderer {
 
     @Nullable
     JSONObject getData();
+
+    List<Integer> getApiFrameworks();
 
     /**
      * Register a listener related to a specific ad unit config fingerprint in order to dispatch specific ad events

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/PrebidMobileTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/PrebidMobileTest.java
@@ -35,6 +35,7 @@ import org.prebid.mobile.testutils.FakePrebidMobilePluginRenderer;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
+import java.util.Arrays;
 import java.util.HashMap;
 
 @RunWith(RobolectricTestRunner.class)
@@ -146,7 +147,8 @@ public class PrebidMobileTest extends BaseSetup {
                 null,
                 true,
                 PREBID_MOBILE_RENDERER_NAME,
-                "1.0"
+                "1.0",
+                Arrays.asList(1, 2, 7)
         );
 
         // When
@@ -164,7 +166,8 @@ public class PrebidMobileTest extends BaseSetup {
                 null,
                 true,
                 PREBID_MOBILE_RENDERER_NAME,
-                "1.0"
+                "1.0",
+                Arrays.asList(1, 2, 7)
         );
 
         // When

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/DisplayViewTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/DisplayViewTest.java
@@ -30,6 +30,8 @@ import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
+import java.util.Arrays;
+
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 19)
 public class DisplayViewTest {
@@ -56,7 +58,7 @@ public class DisplayViewTest {
 
         adUnitConfiguration.setAdFormat(AdFormat.BANNER);
 
-        fakePrebidMobilePluginRenderer = Mockito.spy(FakePrebidMobilePluginRenderer.getFakePrebidRenderer(null, mockBannerView, true, PREBID_MOBILE_RENDERER_NAME, "1.0"));
+        fakePrebidMobilePluginRenderer = Mockito.spy(FakePrebidMobilePluginRenderer.getFakePrebidRenderer(null, mockBannerView, true, PREBID_MOBILE_RENDERER_NAME, "1.0", Arrays.asList(1, 2, 7)));
         PrebidMobile.registerPluginRenderer(fakePrebidMobilePluginRenderer);
 
         mockResponse = mock(BidResponse.class);

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/InterstitialAdUnitTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/InterstitialAdUnitTest.java
@@ -65,6 +65,7 @@ import org.prebid.mobile.testutils.FakePrebidMobilePluginRenderer;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 
+import java.util.Arrays;
 import java.util.EnumSet;
 
 @RunWith(RobolectricTestRunner.class)
@@ -307,7 +308,7 @@ public class InterstitialAdUnitTest {
         final Bid mockBid = mock(Bid.class);
         final InterstitialEventListener spyEventListener = spy(getEventListener());
         when(mockBidResponse.getWinningBid()).thenReturn(mockBid);
-        PrebidMobilePluginRenderer fakePrebidRenderer = FakePrebidMobilePluginRenderer.getFakePrebidRenderer(mockInterstitialController, null, true, PREBID_MOBILE_RENDERER_NAME, "1.0");
+        PrebidMobilePluginRenderer fakePrebidRenderer = FakePrebidMobilePluginRenderer.getFakePrebidRenderer(mockInterstitialController, null, true, PREBID_MOBILE_RENDERER_NAME, "1.0", Arrays.asList(1, 2, 7));
         PrebidMobile.registerPluginRenderer(fakePrebidRenderer);
 
         WhiteBox.setInternalState(interstitialAdUnit, "bidResponse", mockBidResponse);

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/RewardedAdUnitTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/RewardedAdUnitTest.java
@@ -47,6 +47,8 @@ import static org.mockito.Mockito.*;
 import static org.prebid.mobile.api.rendering.BaseInterstitialAdUnit.InterstitialAdUnitState.*;
 import static org.prebid.mobile.api.rendering.pluginrenderer.PrebidMobilePluginRegister.PREBID_MOBILE_RENDERER_NAME;
 
+import java.util.Arrays;
+
 @RunWith(RobolectricTestRunner.class)
 public class RewardedAdUnitTest {
 
@@ -248,7 +250,7 @@ public class RewardedAdUnitTest {
         final Bid mockBid = mock(Bid.class);
         final RewardedVideoEventListener spyEventListener = spy(getEventListener());
         when(mockBidResponse.getWinningBid()).thenReturn(mockBid);
-        PrebidMobilePluginRenderer fakePrebidRenderer = FakePrebidMobilePluginRenderer.getFakePrebidRenderer(mockInterstitialController, null, true, PREBID_MOBILE_RENDERER_NAME, "1.0");
+        PrebidMobilePluginRenderer fakePrebidRenderer = FakePrebidMobilePluginRenderer.getFakePrebidRenderer(mockInterstitialController, null, true, PREBID_MOBILE_RENDERER_NAME, "1.0", Arrays.asList(1, 2, 7));
         PrebidMobile.registerPluginRenderer(fakePrebidRenderer);
 
         WhiteBox.setInternalState(rewardedAdUnit, "bidResponse", mockBidResponse);

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/models/openrtb/bidRequests/mapper/PluginRendererListMapperTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/models/openrtb/bidRequests/mapper/PluginRendererListMapperTest.java
@@ -22,6 +22,8 @@ import org.prebid.mobile.rendering.bidding.listeners.DisplayViewListener;
 import org.prebid.mobile.rendering.models.openrtb.bidRequests.PluginRenderer;
 
 import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 
 public class PluginRendererListMapperTest {
@@ -45,6 +47,12 @@ public class PluginRendererListMapperTest {
         @Override
         public JSONObject getData() {
             return pluginData;
+        }
+
+        @NonNull
+        @Override
+        public List<Integer> getApiFrameworks() {
+            return Collections.emptyList();
         }
 
         @Override

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/networking/parameters/BasicParameterBuilderTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/networking/parameters/BasicParameterBuilderTest.java
@@ -99,7 +99,7 @@ public class BasicParameterBuilderTest {
     private static final String USER_CUSTOM = "custom";
     private static final String USER_GENDER = "M";
     private static final String USER_BUYER_ID = "bid";
-    private PrebidMobilePluginRenderer otherPlugin = FakePrebidMobilePluginRenderer.getFakePrebidRenderer(null, null, true, "FakePlugin", "1.0");
+    private PrebidMobilePluginRenderer otherPlugin = FakePrebidMobilePluginRenderer.getFakePrebidRenderer(null, null, true, "FakePlugin", "1.0", Arrays.asList(1, 2, 7));
 
     private Context context;
 
@@ -300,6 +300,26 @@ public class BasicParameterBuilderTest {
         assertNull(actualImp.video);
         assertEquals(1, actualImp.secure.intValue());
         assertEquals(0, actualImp.instl.intValue());
+    }
+
+    @Test
+    public void whenPluginRendererPresent_ImpWithValidBannerApiObject() {
+        AdUnitConfiguration adConfiguration = new AdUnitConfiguration();
+        adConfiguration.setAdFormat(AdFormat.BANNER);
+        adConfiguration.setPbAdSlot("12345");
+        PrebidMobile.addStoredBidResponse("bidderTest", "123456");
+        PrebidMobile.setStoredAuctionResponse("storedResponse");
+        PrebidMobile.registerPluginRenderer(otherPlugin);
+
+        BasicParameterBuilder builder = new BasicParameterBuilder(adConfiguration,
+                context.getResources(),
+                browserActivityAvailable
+        );
+        AdRequestInput adRequestInput = new AdRequestInput();
+        builder.appendBuilderParameters(adRequestInput);
+        BidRequest actualBidRequest = adRequestInput.getBidRequest();
+
+        assertArrayEquals(new int[]{1, 2, 3, 5, 6, 7}, actualBidRequest.getImp().get(0).banner.api);
     }
 
     @Test

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/testutils/FakePrebidMobilePluginRenderer.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/testutils/FakePrebidMobilePluginRenderer.java
@@ -17,13 +17,16 @@ import org.prebid.mobile.rendering.bidding.interfaces.InterstitialControllerList
 import org.prebid.mobile.rendering.bidding.listeners.DisplayVideoListener;
 import org.prebid.mobile.rendering.bidding.listeners.DisplayViewListener;
 
+import java.util.List;
+
 public class FakePrebidMobilePluginRenderer {
     public static PrebidMobilePluginRenderer getFakePrebidRenderer(
             InterstitialController mockInterstitialController,
             View mockBannerAdView,
             Boolean isSupportRenderingFor,
             String rendererName,
-            String rendererVersion
+            String rendererVersion,
+            List<Integer> apiFrameworks
     ) {
         return new PrebidMobilePluginRenderer() {
             @Override
@@ -35,6 +38,11 @@ public class FakePrebidMobilePluginRenderer {
             @Nullable
             @Override
             public JSONObject getData() { return null; }
+
+            @Override
+            public List<Integer> getApiFrameworks() {
+                return apiFrameworks;
+            }
 
             @Override
             public void registerEventListener(PluginEventListener pluginEventListener, String listenerKey) { }


### PR DESCRIPTION
### Context

Using the new feature **Prebid PluginRenderer**, while doing some test, i encountered a problem where the delivery were not filled because of the incorrect api frameworks provided

Indeed, by default, Prebid Renderer does not offert the 2 api frameworks 1 and 2 which refers to VPAID 1.0 and VPAID 2.0

### Proposal

Adding a new method to the PluginRenderer contract by allowing the SDKs to provide their ApiFramework inside the bid request, it will concat everything into the banner bid request.

### Remaining Problem

Every provided APIs remains on the same level for every renderers, which is a problem if a SDK win but not compatible with an API used on the winning ad.

### Question

Should it be on the adapter level on Prebid Server in the end ? knowing that this value is a pure rendering value and should normally be kept by the SDK that will render.