### PR TITLE
fixed mraid.fireEvent() in mraid.js

### DIFF
--- a/scripts/js/mraid.js
+++ b/scripts/js/mraid.js
@@ -419,22 +419,26 @@ var printDebug = function(messageBuilder) {};
             return;
         }
 
+        //make a copy of original listeners
+        var orgHandlers = [];
+        for (var handler in handlers)
+            orgHandlers[handler] = handlers[handler];
 
-        for(var handler = 0; handler < handlers.length; handler++) {
+        for(var handler = 0; handler < orgHandlers.length; handler++) {
             if(event == 'ready') {
-                handlers[handler]();
+                orgHandlers[handler]();
             } else if(event == 'error') {
-                handlers[handler](args[0], args[1]);
+                orgHandlers[handler](args[0], args[1]);
             } else if(event == 'stateChange') {
-                handlers[handler](args);
+                orgHandlers[handler](args);
             } else if(event == 'viewableChange') {
-                handlers[handler](args);
+                orgHandlers[handler](args);
             } else if(event == 'sizeChange') {
-                handlers[handler](args[0], args[1]);
+                orgHandlers[handler](args[0], args[1]);
             } else if(event == 'audioVolumeChange') {
-                handlers[handler](args);
+                orgHandlers[handler](args);
             } else if(event == 'exposureChange') {
-                handlers[handler](mraid.lastExposure.exposedPercentage,
+                orgHandlers[handler](mraid.lastExposure.exposedPercentage,
                  mraid.lastExposure.visibleRectangle,
                  mraid.lastExposure.occlusionRectangles);
             }


### PR DESCRIPTION
we found some ads contents with mraid may remove EventListener in listeners function. for example:
function addVchange(){	
	mraid.isViewable()?viewChangeCB(true):mraid.addEventListener("viewableChange",viewCB);//add cb
	mraid.addEventListener("viewableChange",viewCB2);//add cb2
}
function viewCB(n){
	console.log('+++++++ viewCB() ++++++++');
	mraid.removeEventListener("viewableChange", viewCB));//remove itself
}
function viewCB2(n){
	console.log('+++++++ viewCB2() ++++++++');
}
so, if use currently mraid.js, in viewCB(), listener itself will be removed and next item will be null, that mean viewCB2() will not be triggered, we already found some ads contains like this usage, so we change the mraid.fireEvent(), we make a copy when events needs to be fired, if listener function remove itself, the fireEvent()'s array will not be cracked and keep its original order, then all of EventListners will be triggered correctly.
the same issue we have committed pull request on ios-sdk #942. but prebid-android-sdk seems use remote url to download mraid.js into PBM library ，so we changed mraid.js in scripts\js, pls review it.
greate thx.