### PR TITLE
fix: Pin Google Play Services Ads to 22.6.0

### DIFF
--- a/Example/PrebidDemoJava/build.gradle
+++ b/Example/PrebidDemoJava/build.gradle
@@ -38,7 +38,7 @@ dependencies {
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
 
     // Ads
-    implementation 'com.google.android.gms:play-services-ads:+'
+    implementation libs.google.play.services.ads
 
     // Video Player
     implementation 'com.google.android.exoplayer:exoplayer:2.15.1'

--- a/Example/PrebidDemoKotlin/build.gradle
+++ b/Example/PrebidDemoKotlin/build.gradle
@@ -46,7 +46,7 @@ dependencies {
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1'
 
     // Advertisement
-    implementation 'com.google.android.gms:play-services-ads:+'
+    implementation libs.google.play.services.ads
     implementation "com.applovin:applovin-sdk:11.5.3"
     implementation "com.google.android.gms:play-services-ads-identifier:18.0.1" // For Applovin Max
 

--- a/Example/PrebidInternalTestApp/build.gradle
+++ b/Example/PrebidInternalTestApp/build.gradle
@@ -84,7 +84,7 @@ dependencies {
 
     // Ad dependencies
     implementation 'com.google.android.gms:play-services-base:18.1.0'
-    implementation 'com.google.android.gms:play-services-ads:+'
+    implementation libs.google.play.services.ads
     implementation "com.applovin:applovin-sdk:11.3.2"
     implementation "com.google.android.gms:play-services-ads-identifier:18.0.1" // For Applovin Max
 

--- a/PrebidMobile/PrebidMobile-admobAdapters/build.gradle
+++ b/PrebidMobile/PrebidMobile-admobAdapters/build.gradle
@@ -10,5 +10,5 @@ android {
 
 dependencies {
     implementation project(":PrebidMobile")
-    implementation 'com.google.android.gms:play-services-ads:+'
+    implementation libs.google.play.services.ads
 }

--- a/PrebidMobile/PrebidMobile-gamEventHandlers/build.gradle
+++ b/PrebidMobile/PrebidMobile-gamEventHandlers/build.gradle
@@ -10,5 +10,5 @@ android {
 
 dependencies {
     implementation project(":PrebidMobile")
-    implementation 'com.google.android.gms:play-services-ads:+'
+    implementation libs.google.play.services.ads
 }

--- a/PrebidMobile/PrebidMobile-gamEventHandlers/src/test/java/org/prebid/mobile/eventhandlers/global/GoogleAdVersionTest.java
+++ b/PrebidMobile/PrebidMobile-gamEventHandlers/src/test/java/org/prebid/mobile/eventhandlers/global/GoogleAdVersionTest.java
@@ -20,7 +20,8 @@ public class GoogleAdVersionTest {
         assertEquals(
                 "Google Ad SDK was updated to " + currentVersion + "! " +
                         "Please test Prebid SDK with the new version, resolve compilation problems, rewrite deprecated code. " +
-                        "After testing you must update PrebidMobile.TESTED_GOOGLE_SDK_VERSION" +
+                        "After testing you must update PrebidMobile.TESTED_GOOGLE_SDK_VERSION," +
+                        "update google-play-services-ads version on the libs.versions.toml " +
                         "and also must update version in publishing XML files (scripts/Maven/*.xml.",
                 currentVersion,
                 PrebidMobile.TESTED_GOOGLE_SDK_VERSION

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,0 +1,5 @@
+[versions]
+google-play-services-ads = "22.6.0"
+
+[libraries]
+google-play-services-ads = { group = "com.google.android.gms", name = "play-services-ads", version.ref = "google-play-services-ads" }


### PR DESCRIPTION
### Summary

This fixes the build failure when building `PrebidDemoKotlin` for example. Below is the failure log
```
Manifest merger failed : uses-sdk:minSdkVersion 19 cannot be smaller than version 21 declared in library [com.google.android.gms:play-services-ads:23.0.0] /Users/shinwan2/.gradle/caches/transforms-3/81f307a4ec7ff1c69519d0f953072760/transformed/jetified-play-services-ads-23.0.0/AndroidManifest.xml as the library might be using APIs not available in 19
  Suggestion: use a compatible library with a minSdk of at most 19,
    or increase this project's minSdk version to at least 21,
    or use tools:overrideLibrary="com.google.android.gms.ads.impl" to force usage (may lead to runtime failures)
```

This is because the version was not pinned
```
implementation 'com.google.android.gms:play-services-ads:+'
```
and Google has released version `23.0.0` on [2024-03-07](https://developers.google.com/admob/android/rel-notes) which changes the minimum Android API level to 21 while Prebid still requires minimum API level 19.

I use [version catalog](https://developer.android.com/build/migrate-to-catalogs#groovy) to centralize the constant. Let me know if a naming convention for that exists.

### Test

Run the demo app.