### PR TITLE
Add support for privacy url

### DIFF
--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/PrebidNativeAd.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/PrebidNativeAd.java
@@ -59,6 +59,8 @@ public class PrebidNativeAd {
     private ArrayList<ClickTracker> clickTrackers;
     private String winEvent;
     private String impEvent;
+    @Nullable
+    private String privacyUrl;
 
 
     public static PrebidNativeAd create(String cacheId) {
@@ -154,6 +156,11 @@ public class PrebidNativeAd {
                             }
                         }
                     }
+                }
+
+                if (adm.has("privacy")) {
+                    String url = adm.getString("privacy");
+                    ad.setPrivacyUrl(url);
                 }
                 parseEvents(details, ad);
                 return ad;
@@ -281,6 +288,15 @@ public class PrebidNativeAd {
             }
         }
         return "";
+    }
+
+    @Nullable
+    public String getPrivacyUrl() {
+        return privacyUrl;
+    }
+
+    private void setPrivacyUrl(@Nullable String url) {
+        privacyUrl = url;
     }
 
     /**


### PR DESCRIPTION
As one of [Native Markup Response Object](https://www.iab.com/wp-content/uploads/2018/03/OpenRTB-Native-Ads-Specification-Final-1.2.pdf), If support is indicated in the request, the privacy URL of the informing page users about buyers targeting activity.