### PR TITLE
Fix smoke tests 

### DIFF
--- a/Example/PrebidDemoKotlin/src/main/java/org/prebid/mobile/prebidkotlindemo/activities/ads/admob/AdMobVideoRewardedActivity.kt
+++ b/Example/PrebidDemoKotlin/src/main/java/org/prebid/mobile/prebidkotlindemo/activities/ads/admob/AdMobVideoRewardedActivity.kt
@@ -30,7 +30,7 @@ class AdMobVideoRewardedActivity : BaseAdActivity() {
 
     companion object {
         const val AD_UNIT_ID = "ca-app-pub-1875909575462531/1908212572"
-        const val CONFIG_ID = "prebid-demo-video-rewarded-320-480"
+        const val CONFIG_ID = "prebid-demo-video-rewarded-endcard-time-close-button"
     }
 
     private var rewardedAd: RewardedAd? = null

--- a/Example/PrebidDemoKotlin/src/main/java/org/prebid/mobile/prebidkotlindemo/activities/ads/applovin/AppLovinMaxVideoRewardedActivity.kt
+++ b/Example/PrebidDemoKotlin/src/main/java/org/prebid/mobile/prebidkotlindemo/activities/ads/applovin/AppLovinMaxVideoRewardedActivity.kt
@@ -30,7 +30,7 @@ class AppLovinMaxVideoRewardedActivity : BaseAdActivity() {
 
     companion object {
         const val AD_UNIT_ID = "897f2fc59d617715"
-        const val CONFIG_ID = "prebid-demo-video-rewarded-320-480"
+        const val CONFIG_ID = "prebid-demo-video-rewarded-endcard-time-close-button"
     }
 
     private var maxRewardedAd: MaxRewardedAd? = null

--- a/Example/PrebidDemoKotlin/src/main/java/org/prebid/mobile/prebidkotlindemo/activities/ads/gam/rendering/GamRenderingApiVideoRewardedActivity.kt
+++ b/Example/PrebidDemoKotlin/src/main/java/org/prebid/mobile/prebidkotlindemo/activities/ads/gam/rendering/GamRenderingApiVideoRewardedActivity.kt
@@ -28,7 +28,7 @@ class GamRenderingApiVideoRewardedActivity : BaseAdActivity() {
 
     companion object {
         const val AD_UNIT_ID = "/21808260008/prebid-demo-app-original-api-video-interstitial"
-        const val CONFIG_ID = "prebid-demo-video-rewarded-320-480"
+        const val CONFIG_ID = "prebid-demo-video-rewarded-endcard-time-close-button"
     }
 
     private var adUnit: RewardedAdUnit? = null

--- a/Example/PrebidDemoKotlin/src/main/java/org/prebid/mobile/prebidkotlindemo/activities/ads/inapp/InAppVideoRewardedActivity.kt
+++ b/Example/PrebidDemoKotlin/src/main/java/org/prebid/mobile/prebidkotlindemo/activities/ads/inapp/InAppVideoRewardedActivity.kt
@@ -26,7 +26,7 @@ import org.prebid.mobile.rendering.interstitial.rewarded.Reward
 class InAppVideoRewardedActivity : BaseAdActivity() {
 
     companion object {
-        const val CONFIG_ID = "prebid-demo-video-rewarded-320-480"
+        const val CONFIG_ID = "prebid-demo-video-rewarded-endcard-time-close-button"
     }
 
     private var adUnit: RewardedAdUnit? = null


### PR DESCRIPTION
After implementing the rewarded ad unit functionality, our test app's rewarded examples wait for the close button to trigger the default timeout, which is 120 seconds. To complete smoke tests faster, we replaced the rewarded config IDs. 