### PR TITLE
PrebidMobile-core: `ExternalUserId` must serialize `atype` as `atype` not `adtype`.

### DIFF
--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/ExternalUserId.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/ExternalUserId.java
@@ -99,7 +99,7 @@ public class ExternalUserId {
         try {
             JSONObject uidObject = new JSONObject();
             uidObject.putOpt("id", getIdentifier());
-            uidObject.putOpt("adtype", getAtype());
+            uidObject.putOpt("atype", getAtype());
             if (getExt() != null) {
                 uidObject.putOpt("ext", new JSONObject(getExt()));
             }


### PR DESCRIPTION
`UID.adtype` does not exist as a property. This is a typo and is causing issues for us. See [1] for more information.

[1] https://github.com/InteractiveAdvertisingBureau/openrtb2.x/blob/main/2.6.md#3228---object-uid-