### PR TITLE
chore: Centralize dependencies to version catalog

### DIFF
--- a/Example/PrebidDemoJava/build.gradle
+++ b/Example/PrebidDemoJava/build.gradle
@@ -35,7 +35,7 @@ dependencies {
 //    implementation "org.prebid:prebid-mobile-sdk:$prebidSdkVersionName"
 
     // Base
-    implementation 'androidx.appcompat:appcompat:1.2.0'
+    implementation libs.androidx.appcompat
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
 
     // Ads

--- a/Example/PrebidDemoJava/build.gradle
+++ b/Example/PrebidDemoJava/build.gradle
@@ -48,7 +48,7 @@ dependencies {
     implementation libs.extension.ima
 
     // Multidex
-    implementation 'androidx.multidex:multidex:2.0.0'
+    implementation libs.androidx.multidex
 
     // Image Downloader
     implementation "com.github.bumptech.glide:glide:4.14.2"

--- a/Example/PrebidDemoJava/build.gradle
+++ b/Example/PrebidDemoJava/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 
     // Base
     implementation libs.androidx.appcompat
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation libs.androidx.constraintlayout
 
     // Ads
     implementation libs.google.play.services.ads

--- a/Example/PrebidDemoJava/build.gradle
+++ b/Example/PrebidDemoJava/build.gradle
@@ -51,5 +51,5 @@ dependencies {
     implementation libs.androidx.multidex
 
     // Image Downloader
-    implementation "com.github.bumptech.glide:glide:4.14.2"
+    implementation libs.glide
 }

--- a/Example/PrebidDemoJava/build.gradle
+++ b/Example/PrebidDemoJava/build.gradle
@@ -42,10 +42,10 @@ dependencies {
     implementation libs.google.play.services.ads
 
     // Video Player
-    implementation 'com.google.android.exoplayer:exoplayer:2.15.1'
-    implementation 'com.google.android.exoplayer:exoplayer-core:2.15.1'
-    implementation 'com.google.android.exoplayer:exoplayer-ui:2.15.1'
-    implementation 'com.google.android.exoplayer:extension-ima:2.15.1'
+    implementation libs.exoplayer
+    implementation libs.exoplayer.core
+    implementation libs.exoplayer.ui
+    implementation libs.extension.ima
 
     // Multidex
     implementation 'androidx.multidex:multidex:2.0.0'

--- a/Example/PrebidDemoKotlin/build.gradle
+++ b/Example/PrebidDemoKotlin/build.gradle
@@ -48,7 +48,7 @@ dependencies {
 
     // Advertisement
     implementation libs.google.play.services.ads
-    implementation "com.applovin:applovin-sdk:13.1.0"
+    implementation libs.applovin.sdk
     implementation "com.google.android.gms:play-services-ads-identifier:18.0.1" // For Applovin Max
 
     // Image Downloader

--- a/Example/PrebidDemoKotlin/build.gradle
+++ b/Example/PrebidDemoKotlin/build.gradle
@@ -55,7 +55,7 @@ dependencies {
     implementation "com.github.bumptech.glide:glide:4.14.2"
 
     // Multidex
-    implementation 'androidx.multidex:multidex:2.0.1'
+    implementation libs.androidx.multidex
 
     // Video Player
     implementation libs.exoplayer

--- a/Example/PrebidDemoKotlin/build.gradle
+++ b/Example/PrebidDemoKotlin/build.gradle
@@ -58,10 +58,10 @@ dependencies {
     implementation 'androidx.multidex:multidex:2.0.1'
 
     // Video Player
-    implementation 'com.google.android.exoplayer:exoplayer:2.15.1'
-    implementation 'com.google.android.exoplayer:exoplayer-core:2.15.1'
-    implementation 'com.google.android.exoplayer:exoplayer-ui:2.15.1'
-    implementation 'com.google.android.exoplayer:extension-ima:2.15.1'
+    implementation libs.exoplayer
+    implementation libs.exoplayer.core
+    implementation libs.exoplayer.ui
+    implementation libs.extension.ima
 
     // Tests
     testImplementation 'junit:junit:4.13.2'

--- a/Example/PrebidDemoKotlin/build.gradle
+++ b/Example/PrebidDemoKotlin/build.gradle
@@ -52,7 +52,7 @@ dependencies {
     implementation "com.google.android.gms:play-services-ads-identifier:18.0.1" // For Applovin Max
 
     // Image Downloader
-    implementation "com.github.bumptech.glide:glide:4.14.2"
+    implementation libs.glide
 
     // Multidex
     implementation libs.androidx.multidex

--- a/Example/PrebidDemoKotlin/build.gradle
+++ b/Example/PrebidDemoKotlin/build.gradle
@@ -67,5 +67,5 @@ dependencies {
     testImplementation libs.junit
     androidTestImplementation libs.androidx.junit
     androidTestImplementation libs.androidx.espresso.core
-    androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
+    androidTestImplementation libs.androidx.uiautomator
 }

--- a/Example/PrebidDemoKotlin/build.gradle
+++ b/Example/PrebidDemoKotlin/build.gradle
@@ -65,7 +65,7 @@ dependencies {
 
     // Tests
     testImplementation libs.junit
-    androidTestImplementation 'androidx.test.ext:junit:1.1.3'
+    androidTestImplementation libs.androidx.junit
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
 }

--- a/Example/PrebidDemoKotlin/build.gradle
+++ b/Example/PrebidDemoKotlin/build.gradle
@@ -44,7 +44,7 @@ dependencies {
     implementation libs.androidx.appcompat
     implementation libs.androidx.preference.ktx
     implementation libs.androidx.constraintlayout
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1'
+    implementation libs.androidx.lifecycle.viewmodel.ktx
 
     // Advertisement
     implementation libs.google.play.services.ads

--- a/Example/PrebidDemoKotlin/build.gradle
+++ b/Example/PrebidDemoKotlin/build.gradle
@@ -40,7 +40,7 @@ dependencies {
 //    implementation "org.prebid:prebid-mobile-sdk-max-adapters:$prebidSdkVersionName"
 
     // Standard libraries
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation libs.kotlin.stdlib
     implementation libs.androidx.appcompat
     implementation 'androidx.preference:preference-ktx:1.2.0'
     implementation libs.androidx.constraintlayout

--- a/Example/PrebidDemoKotlin/build.gradle
+++ b/Example/PrebidDemoKotlin/build.gradle
@@ -66,6 +66,6 @@ dependencies {
     // Tests
     testImplementation libs.junit
     androidTestImplementation libs.androidx.junit
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    androidTestImplementation libs.androidx.espresso.core
     androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
 }

--- a/Example/PrebidDemoKotlin/build.gradle
+++ b/Example/PrebidDemoKotlin/build.gradle
@@ -42,7 +42,7 @@ dependencies {
     // Standard libraries
     implementation libs.kotlin.stdlib
     implementation libs.androidx.appcompat
-    implementation 'androidx.preference:preference-ktx:1.2.0'
+    implementation libs.androidx.preference.ktx
     implementation libs.androidx.constraintlayout
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1'
 

--- a/Example/PrebidDemoKotlin/build.gradle
+++ b/Example/PrebidDemoKotlin/build.gradle
@@ -64,7 +64,7 @@ dependencies {
     implementation libs.extension.ima
 
     // Tests
-    testImplementation 'junit:junit:4.13.2'
+    testImplementation libs.junit
     androidTestImplementation 'androidx.test.ext:junit:1.1.3'
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'

--- a/Example/PrebidDemoKotlin/build.gradle
+++ b/Example/PrebidDemoKotlin/build.gradle
@@ -41,7 +41,7 @@ dependencies {
 
     // Standard libraries
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'androidx.appcompat:appcompat:1.3.0'
+    implementation libs.androidx.appcompat
     implementation 'androidx.preference:preference-ktx:1.2.0'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1'

--- a/Example/PrebidDemoKotlin/build.gradle
+++ b/Example/PrebidDemoKotlin/build.gradle
@@ -49,7 +49,7 @@ dependencies {
     // Advertisement
     implementation libs.google.play.services.ads
     implementation libs.applovin.sdk
-    implementation "com.google.android.gms:play-services-ads-identifier:18.0.1" // For Applovin Max
+    implementation libs.google.play.services.ads.identifier // For Applovin Max
 
     // Image Downloader
     implementation libs.glide

--- a/Example/PrebidDemoKotlin/build.gradle
+++ b/Example/PrebidDemoKotlin/build.gradle
@@ -43,7 +43,7 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation libs.androidx.appcompat
     implementation 'androidx.preference:preference-ktx:1.2.0'
-    implementation 'androidx.constraintlayout:constraintlayout:2.1.4'
+    implementation libs.androidx.constraintlayout
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1'
 
     // Advertisement

--- a/Example/PrebidInternalTestApp/build.gradle
+++ b/Example/PrebidInternalTestApp/build.gradle
@@ -60,7 +60,6 @@ android {
 
 dependencies {
     def nav_version = "2.3.1"
-    def lifecycle_version = "2.2.0"
 
     implementation project(':PrebidMobile')
     implementation project(':PrebidMobile-gamEventHandlers')
@@ -78,7 +77,7 @@ dependencies {
     implementation libs.androidx.annotation
     implementation libs.androidx.constraintlayout
     implementation libs.androidx.recyclerview
-    implementation "androidx.lifecycle:lifecycle-extensions:$lifecycle_version"
+    implementation libs.androidx.lifecycle.extensions
     implementation libs.androidx.preference.ktx
     implementation 'androidx.vectordrawable:vectordrawable-animated:1.1.0'
     implementation libs.androidx.lifecycle.viewmodel.ktx

--- a/Example/PrebidInternalTestApp/build.gradle
+++ b/Example/PrebidInternalTestApp/build.gradle
@@ -84,7 +84,7 @@ dependencies {
     implementation libs.androidx.lifecycle.viewmodel.ktx
 
     // Ad dependencies
-    implementation 'com.google.android.gms:play-services-base:18.1.0'
+    implementation libs.google.play.services.base
     implementation libs.google.play.services.ads
     implementation libs.applovin.sdk
     implementation libs.google.play.services.ads.identifier // For Applovin Max

--- a/Example/PrebidInternalTestApp/build.gradle
+++ b/Example/PrebidInternalTestApp/build.gradle
@@ -59,8 +59,6 @@ android {
 }
 
 dependencies {
-    def nav_version = "2.3.1"
-
     implementation project(':PrebidMobile')
     implementation project(':PrebidMobile-gamEventHandlers')
     implementation project(':PrebidMobile-admobAdapters')
@@ -90,8 +88,8 @@ dependencies {
 
 
     // Navigation component
-    implementation "androidx.navigation:navigation-fragment-ktx:$nav_version"
-    implementation "androidx.navigation:navigation-ui-ktx:$nav_version"
+    implementation libs.androidx.navigation.fragment.ktx
+    implementation libs.androidx.navigation.ui.ktx
 
     // Mock server
     implementation('com.squareup.okhttp3:mockwebserver:4.9.2') {

--- a/Example/PrebidInternalTestApp/build.gradle
+++ b/Example/PrebidInternalTestApp/build.gradle
@@ -87,7 +87,7 @@ dependencies {
     implementation 'com.google.android.gms:play-services-base:18.1.0'
     implementation libs.google.play.services.ads
     implementation libs.applovin.sdk
-    implementation "com.google.android.gms:play-services-ads-identifier:18.0.1" // For Applovin Max
+    implementation libs.google.play.services.ads.identifier // For Applovin Max
 
 
     // Navigation component

--- a/Example/PrebidInternalTestApp/build.gradle
+++ b/Example/PrebidInternalTestApp/build.gradle
@@ -102,7 +102,7 @@ dependencies {
 
     // Helper
     implementation 'com.google.code.gson:gson:2.8.6'
-    implementation 'com.github.bumptech.glide:glide:4.11.0'
+    implementation libs.glide
     implementation libs.androidx.multidex
     implementation 'com.github.RobertApikyan:SegmentedControl:1.1.3'
 

--- a/Example/PrebidInternalTestApp/build.gradle
+++ b/Example/PrebidInternalTestApp/build.gradle
@@ -110,7 +110,7 @@ dependencies {
     androidTestImplementation 'com.jayway.android.robotium:robotium-solo:5.5.4'
     androidTestImplementation 'androidx.test:runner:1.4.0'
     androidTestImplementation 'androidx.test:rules:1.4.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
+    androidTestImplementation libs.androidx.espresso.core
     androidTestImplementation 'androidx.test.espresso:espresso-intents:3.4.0'
     androidTestImplementation 'androidx.test.espresso:espresso-web:3.4.0'
     androidTestImplementation libs.androidx.annotation

--- a/Example/PrebidInternalTestApp/build.gradle
+++ b/Example/PrebidInternalTestApp/build.gradle
@@ -95,7 +95,7 @@ dependencies {
     implementation(libs.okhttp.mockwebserver) {
         exclude group: 'junit'
     }
-    implementation 'androidx.test.espresso:espresso-idling-resource:3.4.0'
+    implementation libs.androidx.espresso.idling.resource
 
     // Helper
     implementation 'com.google.code.gson:gson:2.8.6'
@@ -108,8 +108,8 @@ dependencies {
     androidTestImplementation 'androidx.test:runner:1.4.0'
     androidTestImplementation 'androidx.test:rules:1.4.0'
     androidTestImplementation libs.androidx.espresso.core
-    androidTestImplementation 'androidx.test.espresso:espresso-intents:3.4.0'
-    androidTestImplementation 'androidx.test.espresso:espresso-web:3.4.0'
+    androidTestImplementation libs.androidx.espresso.intents
+    androidTestImplementation libs.androidx.espresso.web
     androidTestImplementation libs.androidx.annotation
     androidTestImplementation libs.androidx.uiautomator
 

--- a/Example/PrebidInternalTestApp/build.gradle
+++ b/Example/PrebidInternalTestApp/build.gradle
@@ -79,7 +79,7 @@ dependencies {
     implementation libs.androidx.constraintlayout
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
     implementation "androidx.lifecycle:lifecycle-extensions:$lifecycle_version"
-    implementation 'androidx.preference:preference-ktx:1.1.1'
+    implementation libs.androidx.preference.ktx
     implementation 'androidx.vectordrawable:vectordrawable-animated:1.1.0'
     implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1'
 

--- a/Example/PrebidInternalTestApp/build.gradle
+++ b/Example/PrebidInternalTestApp/build.gradle
@@ -86,7 +86,7 @@ dependencies {
     // Ad dependencies
     implementation 'com.google.android.gms:play-services-base:18.1.0'
     implementation libs.google.play.services.ads
-    implementation "com.applovin:applovin-sdk:13.1.0"
+    implementation libs.applovin.sdk
     implementation "com.google.android.gms:play-services-ads-identifier:18.0.1" // For Applovin Max
 
 

--- a/Example/PrebidInternalTestApp/build.gradle
+++ b/Example/PrebidInternalTestApp/build.gradle
@@ -103,7 +103,7 @@ dependencies {
     // Helper
     implementation 'com.google.code.gson:gson:2.8.6'
     implementation 'com.github.bumptech.glide:glide:4.11.0'
-    implementation 'androidx.multidex:multidex:2.0.1'
+    implementation libs.androidx.multidex
     implementation 'com.github.RobertApikyan:SegmentedControl:1.1.3'
 
     // Android tests

--- a/Example/PrebidInternalTestApp/build.gradle
+++ b/Example/PrebidInternalTestApp/build.gradle
@@ -105,7 +105,7 @@ dependencies {
 
     // Android tests
     androidTestImplementation libs.robotium.solo
-    androidTestImplementation 'androidx.test:runner:1.4.0'
+    androidTestImplementation libs.androidx.test.runner
     androidTestImplementation 'androidx.test:rules:1.4.0'
     androidTestImplementation libs.androidx.espresso.core
     androidTestImplementation libs.androidx.espresso.intents

--- a/Example/PrebidInternalTestApp/build.gradle
+++ b/Example/PrebidInternalTestApp/build.gradle
@@ -77,7 +77,7 @@ dependencies {
     implementation libs.kotlin.stdlib
     implementation libs.androidx.annotation
     implementation libs.androidx.constraintlayout
-    implementation 'androidx.recyclerview:recyclerview:1.1.0'
+    implementation libs.androidx.recyclerview
     implementation "androidx.lifecycle:lifecycle-extensions:$lifecycle_version"
     implementation libs.androidx.preference.ktx
     implementation 'androidx.vectordrawable:vectordrawable-animated:1.1.0'

--- a/Example/PrebidInternalTestApp/build.gradle
+++ b/Example/PrebidInternalTestApp/build.gradle
@@ -92,7 +92,7 @@ dependencies {
     implementation libs.androidx.navigation.ui.ktx
 
     // Mock server
-    implementation('com.squareup.okhttp3:mockwebserver:4.9.2') {
+    implementation(libs.okhttp.mockwebserver) {
         exclude group: 'junit'
     }
     implementation 'androidx.test.espresso:espresso-idling-resource:3.4.0'

--- a/Example/PrebidInternalTestApp/build.gradle
+++ b/Example/PrebidInternalTestApp/build.gradle
@@ -98,7 +98,7 @@ dependencies {
     implementation libs.androidx.espresso.idling.resource
 
     // Helper
-    implementation 'com.google.code.gson:gson:2.8.6'
+    implementation libs.gson
     implementation libs.glide
     implementation libs.androidx.multidex
     implementation 'com.github.RobertApikyan:SegmentedControl:1.1.3'

--- a/Example/PrebidInternalTestApp/build.gradle
+++ b/Example/PrebidInternalTestApp/build.gradle
@@ -81,7 +81,7 @@ dependencies {
     implementation "androidx.lifecycle:lifecycle-extensions:$lifecycle_version"
     implementation libs.androidx.preference.ktx
     implementation 'androidx.vectordrawable:vectordrawable-animated:1.1.0'
-    implementation 'androidx.lifecycle:lifecycle-viewmodel-ktx:2.5.1'
+    implementation libs.androidx.lifecycle.viewmodel.ktx
 
     // Ad dependencies
     implementation 'com.google.android.gms:play-services-base:18.1.0'

--- a/Example/PrebidInternalTestApp/build.gradle
+++ b/Example/PrebidInternalTestApp/build.gradle
@@ -75,7 +75,7 @@ dependencies {
 
     // Base dependencies
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
-    implementation 'androidx.annotation:annotation:1.1.0'
+    implementation libs.androidx.annotation
     implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
     implementation "androidx.lifecycle:lifecycle-extensions:$lifecycle_version"
@@ -113,7 +113,7 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-core:3.4.0'
     androidTestImplementation 'androidx.test.espresso:espresso-intents:3.4.0'
     androidTestImplementation 'androidx.test.espresso:espresso-web:3.4.0'
-    androidTestImplementation 'androidx.annotation:annotation:1.1.0'
+    androidTestImplementation libs.androidx.annotation
     androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
 
     // Video player

--- a/Example/PrebidInternalTestApp/build.gradle
+++ b/Example/PrebidInternalTestApp/build.gradle
@@ -106,7 +106,7 @@ dependencies {
     // Android tests
     androidTestImplementation libs.robotium.solo
     androidTestImplementation libs.androidx.test.runner
-    androidTestImplementation 'androidx.test:rules:1.4.0'
+    androidTestImplementation libs.androidx.test.rules
     androidTestImplementation libs.androidx.espresso.core
     androidTestImplementation libs.androidx.espresso.intents
     androidTestImplementation libs.androidx.espresso.web

--- a/Example/PrebidInternalTestApp/build.gradle
+++ b/Example/PrebidInternalTestApp/build.gradle
@@ -114,7 +114,7 @@ dependencies {
     androidTestImplementation 'androidx.test.espresso:espresso-intents:3.4.0'
     androidTestImplementation 'androidx.test.espresso:espresso-web:3.4.0'
     androidTestImplementation libs.androidx.annotation
-    androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
+    androidTestImplementation libs.androidx.uiautomator
 
     // Video player
     implementation libs.exoplayer

--- a/Example/PrebidInternalTestApp/build.gradle
+++ b/Example/PrebidInternalTestApp/build.gradle
@@ -101,7 +101,7 @@ dependencies {
     implementation libs.gson
     implementation libs.glide
     implementation libs.androidx.multidex
-    implementation 'com.github.RobertApikyan:SegmentedControl:1.1.3'
+    implementation libs.segmentedcontrol
 
     // Android tests
     androidTestImplementation 'com.jayway.android.robotium:robotium-solo:5.5.4'

--- a/Example/PrebidInternalTestApp/build.gradle
+++ b/Example/PrebidInternalTestApp/build.gradle
@@ -117,8 +117,8 @@ dependencies {
     androidTestImplementation 'androidx.test.uiautomator:uiautomator:2.2.0'
 
     // Video player
-    implementation 'com.google.android.exoplayer:exoplayer:2.15.1'
-    implementation 'com.google.android.exoplayer:exoplayer-core:2.15.1'
-    implementation 'com.google.android.exoplayer:exoplayer-ui:2.15.1'
-    implementation 'com.google.android.exoplayer:extension-ima:2.15.1'
+    implementation libs.exoplayer
+    implementation libs.exoplayer.core
+    implementation libs.exoplayer.ui
+    implementation libs.extension.ima
 }

--- a/Example/PrebidInternalTestApp/build.gradle
+++ b/Example/PrebidInternalTestApp/build.gradle
@@ -76,7 +76,7 @@ dependencies {
     // Base dependencies
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
     implementation libs.androidx.annotation
-    implementation 'androidx.constraintlayout:constraintlayout:2.0.4'
+    implementation libs.androidx.constraintlayout
     implementation 'androidx.recyclerview:recyclerview:1.1.0'
     implementation "androidx.lifecycle:lifecycle-extensions:$lifecycle_version"
     implementation 'androidx.preference:preference-ktx:1.1.1'

--- a/Example/PrebidInternalTestApp/build.gradle
+++ b/Example/PrebidInternalTestApp/build.gradle
@@ -74,7 +74,7 @@ dependencies {
 //    implementation "org.prebid:prebid-mobile-sdk-max-adapters:$prebidSdkVersionName"
 
     // Base dependencies
-    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+    implementation libs.kotlin.stdlib
     implementation libs.androidx.annotation
     implementation libs.androidx.constraintlayout
     implementation 'androidx.recyclerview:recyclerview:1.1.0'

--- a/Example/PrebidInternalTestApp/build.gradle
+++ b/Example/PrebidInternalTestApp/build.gradle
@@ -79,7 +79,7 @@ dependencies {
     implementation libs.androidx.recyclerview
     implementation libs.androidx.lifecycle.extensions
     implementation libs.androidx.preference.ktx
-    implementation 'androidx.vectordrawable:vectordrawable-animated:1.1.0'
+    implementation libs.androidx.vectordrawable.animated
     implementation libs.androidx.lifecycle.viewmodel.ktx
 
     // Ad dependencies

--- a/Example/PrebidInternalTestApp/build.gradle
+++ b/Example/PrebidInternalTestApp/build.gradle
@@ -104,7 +104,7 @@ dependencies {
     implementation libs.segmentedcontrol
 
     // Android tests
-    androidTestImplementation 'com.jayway.android.robotium:robotium-solo:5.5.4'
+    androidTestImplementation libs.robotium.solo
     androidTestImplementation 'androidx.test:runner:1.4.0'
     androidTestImplementation 'androidx.test:rules:1.4.0'
     androidTestImplementation libs.androidx.espresso.core

--- a/PrebidMobile/PrebidMobile-core/build.gradle
+++ b/PrebidMobile/PrebidMobile-core/build.gradle
@@ -31,7 +31,7 @@ android {
 dependencies {
     implementation project(":omsdk-android")
 
-    implementation 'androidx.annotation:annotation:1.5.0'
+    implementation libs.androidx.annotation
 
     implementation 'com.google.android.gms:play-services-base:18.1.0'
     implementation 'com.google.android.gms:play-services-ads-identifier:18.0.1'

--- a/PrebidMobile/PrebidMobile-core/build.gradle
+++ b/PrebidMobile/PrebidMobile-core/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     implementation libs.androidx.annotation
 
     implementation 'com.google.android.gms:play-services-base:18.1.0'
-    implementation 'com.google.android.gms:play-services-ads-identifier:18.0.1'
+    implementation libs.google.play.services.ads.identifier
     implementation libs.exoplayer.core
     implementation libs.exoplayer.ui
 

--- a/PrebidMobile/PrebidMobile-core/build.gradle
+++ b/PrebidMobile/PrebidMobile-core/build.gradle
@@ -38,5 +38,5 @@ dependencies {
     implementation libs.exoplayer.core
     implementation libs.exoplayer.ui
 
-    implementation "androidx.localbroadcastmanager:localbroadcastmanager:1.0.0"
+    implementation libs.androidx.localbroadcastmanager
 }

--- a/PrebidMobile/PrebidMobile-core/build.gradle
+++ b/PrebidMobile/PrebidMobile-core/build.gradle
@@ -35,8 +35,8 @@ dependencies {
 
     implementation 'com.google.android.gms:play-services-base:18.1.0'
     implementation 'com.google.android.gms:play-services-ads-identifier:18.0.1'
-    implementation 'com.google.android.exoplayer:exoplayer-core:2.15.1'
-    implementation 'com.google.android.exoplayer:exoplayer-ui:2.15.1'
+    implementation libs.exoplayer.core
+    implementation libs.exoplayer.ui
 
     implementation "androidx.localbroadcastmanager:localbroadcastmanager:1.0.0"
 }

--- a/PrebidMobile/PrebidMobile-core/build.gradle
+++ b/PrebidMobile/PrebidMobile-core/build.gradle
@@ -33,7 +33,7 @@ dependencies {
 
     implementation libs.androidx.annotation
 
-    implementation 'com.google.android.gms:play-services-base:18.1.0'
+    implementation libs.google.play.services.base
     implementation libs.google.play.services.ads.identifier
     implementation libs.exoplayer.core
     implementation libs.exoplayer.ui

--- a/PrebidMobile/PrebidMobile-maxAdapters/build.gradle
+++ b/PrebidMobile/PrebidMobile-maxAdapters/build.gradle
@@ -4,7 +4,7 @@ apply from: '../tests.gradle'
 
 dependencies {
     implementation project(":PrebidMobile")
-    implementation "com.applovin:applovin-sdk:13.1.0"
+    implementation libs.applovin.sdk
 }
 android {
     namespace "org.prebid.mobile.max.adapters"

--- a/PrebidMobile/test-utils/build.gradle
+++ b/PrebidMobile/test-utils/build.gradle
@@ -4,6 +4,6 @@ plugins {
 
 dependencies {
     implementation libs.junit
-    implementation 'org.json:json:20180813'
+    implementation libs.json
     implementation libs.gson
 }

--- a/PrebidMobile/test-utils/build.gradle
+++ b/PrebidMobile/test-utils/build.gradle
@@ -5,5 +5,5 @@ plugins {
 dependencies {
     implementation libs.junit
     implementation 'org.json:json:20180813'
-    implementation 'com.google.code.gson:gson:2.8.6'
+    implementation libs.gson
 }

--- a/PrebidMobile/test-utils/build.gradle
+++ b/PrebidMobile/test-utils/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 dependencies {
-    implementation 'junit:junit:4.12'
+    implementation libs.junit
     implementation 'org.json:json:20180813'
     implementation 'com.google.code.gson:gson:2.8.6'
 }

--- a/PrebidMobile/tests.gradle
+++ b/PrebidMobile/tests.gradle
@@ -20,7 +20,7 @@ dependencies {
     testImplementation libs.okhttp.mockwebserver
     testImplementation libs.okhttp
 
-    testImplementation 'org.apache.commons:commons-lang3:3.7'
+    testImplementation libs.apache.commons.lang3
     testImplementation libs.json
     testImplementation libs.gson
 }

--- a/PrebidMobile/tests.gradle
+++ b/PrebidMobile/tests.gradle
@@ -16,7 +16,7 @@ dependencies {
     testImplementation libs.shadows.httpclient
 
     testImplementation libs.assertj.core
-    testImplementation 'org.skyscreamer:jsonassert:1.5.0'
+    testImplementation libs.jsonassert
     testImplementation libs.okhttp.mockwebserver
     testImplementation libs.okhttp
 

--- a/PrebidMobile/tests.gradle
+++ b/PrebidMobile/tests.gradle
@@ -15,7 +15,7 @@ dependencies {
     testImplementation libs.robolectric
     testImplementation libs.shadows.httpclient
 
-    testImplementation 'org.assertj:assertj-core:1.7.0'
+    testImplementation libs.assertj.core
     testImplementation 'org.skyscreamer:jsonassert:1.5.0'
     testImplementation libs.okhttp.mockwebserver
     testImplementation libs.okhttp

--- a/PrebidMobile/tests.gradle
+++ b/PrebidMobile/tests.gradle
@@ -9,7 +9,7 @@ dependencies {
     testImplementation libs.androidx.test.rules
 
     // JSON comparators
-    testImplementation "com.fasterxml.jackson.core:jackson-databind:2.14.3"
+    testImplementation libs.jackson.databind
     testImplementation "org.apache.camel:camel-json-patch:3.22.2"
 
     testImplementation libs.robolectric

--- a/PrebidMobile/tests.gradle
+++ b/PrebidMobile/tests.gradle
@@ -22,5 +22,5 @@ dependencies {
 
     testImplementation 'org.apache.commons:commons-lang3:3.7'
     testImplementation 'org.json:json:20180813'
-    testImplementation 'com.google.code.gson:gson:2.8.6'
+    testImplementation libs.gson
 }

--- a/PrebidMobile/tests.gradle
+++ b/PrebidMobile/tests.gradle
@@ -21,6 +21,6 @@ dependencies {
     testImplementation libs.okhttp
 
     testImplementation 'org.apache.commons:commons-lang3:3.7'
-    testImplementation 'org.json:json:20180813'
+    testImplementation libs.json
     testImplementation libs.gson
 }

--- a/PrebidMobile/tests.gradle
+++ b/PrebidMobile/tests.gradle
@@ -10,7 +10,7 @@ dependencies {
 
     // JSON comparators
     testImplementation libs.jackson.databind
-    testImplementation "org.apache.camel:camel-json-patch:3.22.2"
+    testImplementation libs.apache.camel.json.patch
 
     testImplementation libs.robolectric
     testImplementation libs.shadows.httpclient

--- a/PrebidMobile/tests.gradle
+++ b/PrebidMobile/tests.gradle
@@ -17,8 +17,8 @@ dependencies {
 
     testImplementation 'org.assertj:assertj-core:1.7.0'
     testImplementation 'org.skyscreamer:jsonassert:1.5.0'
-    testImplementation 'com.squareup.okhttp3:mockwebserver:4.9.3'
-    testImplementation 'com.squareup.okhttp3:okhttp:4.9.3'
+    testImplementation libs.okhttp.mockwebserver
+    testImplementation libs.okhttp
 
     testImplementation 'org.apache.commons:commons-lang3:3.7'
     testImplementation 'org.json:json:20180813'

--- a/PrebidMobile/tests.gradle
+++ b/PrebidMobile/tests.gradle
@@ -5,7 +5,7 @@ dependencies {
     testImplementation 'org.hamcrest:hamcrest-core:2.2'
     testImplementation 'org.hamcrest:hamcrest-library:2.2'
     testImplementation 'org.mockito:mockito-core:4.5.1'
-    testImplementation 'androidx.test:runner:1.4.0'
+    testImplementation libs.androidx.test.runner
     testImplementation 'androidx.test:rules:1.4.0'
 
     // JSON comparators

--- a/PrebidMobile/tests.gradle
+++ b/PrebidMobile/tests.gradle
@@ -6,7 +6,7 @@ dependencies {
     testImplementation 'org.hamcrest:hamcrest-library:2.2'
     testImplementation 'org.mockito:mockito-core:4.5.1'
     testImplementation libs.androidx.test.runner
-    testImplementation 'androidx.test:rules:1.4.0'
+    testImplementation libs.androidx.test.rules
 
     // JSON comparators
     testImplementation "com.fasterxml.jackson.core:jackson-databind:2.14.3"

--- a/PrebidMobile/tests.gradle
+++ b/PrebidMobile/tests.gradle
@@ -4,7 +4,7 @@ dependencies {
     testImplementation libs.junit
     testImplementation libs.hamcrest.core
     testImplementation libs.hamcrest.library
-    testImplementation 'org.mockito:mockito-core:4.5.1'
+    testImplementation libs.mockito.core
     testImplementation libs.androidx.test.runner
     testImplementation libs.androidx.test.rules
 

--- a/PrebidMobile/tests.gradle
+++ b/PrebidMobile/tests.gradle
@@ -1,7 +1,7 @@
 dependencies {
     testImplementation project(':test-utils')
 
-    testImplementation 'junit:junit:4.13.2'
+    testImplementation libs.junit
     testImplementation 'org.hamcrest:hamcrest-core:2.2'
     testImplementation 'org.hamcrest:hamcrest-library:2.2'
     testImplementation 'org.mockito:mockito-core:4.5.1'

--- a/PrebidMobile/tests.gradle
+++ b/PrebidMobile/tests.gradle
@@ -2,8 +2,8 @@ dependencies {
     testImplementation project(':test-utils')
 
     testImplementation libs.junit
-    testImplementation 'org.hamcrest:hamcrest-core:2.2'
-    testImplementation 'org.hamcrest:hamcrest-library:2.2'
+    testImplementation libs.hamcrest.core
+    testImplementation libs.hamcrest.library
     testImplementation 'org.mockito:mockito-core:4.5.1'
     testImplementation libs.androidx.test.runner
     testImplementation libs.androidx.test.rules

--- a/build.gradle
+++ b/build.gradle
@@ -19,7 +19,7 @@ buildscript {
     }
 
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.7.3'
+        classpath libs.gradle
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -12,7 +12,6 @@ ext {
 }
 
 buildscript {
-    ext.kotlin_version = '2.1.0'
     repositories {
         google()
         mavenCentral()
@@ -20,7 +19,7 @@ buildscript {
 
     dependencies {
         classpath libs.gradle
-        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
+        classpath libs.kotlin.gradle.plugin
     }
 }
 

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ androidx-espresso-core = "3.4.0"
 androidx-lifecycle-viewmodel-ktx = "2.5.1"
 androidx-lifecycle-extensions = "2.2.0"
 androidx-multidex = "2.0.1"
+androidx-navigation = "2.3.1"
 androidx-preference-ktx = "1.2.0"
 androidx-recyclerview = "1.1.0"
 androidx-uiautomator = "2.2.0"
@@ -31,6 +32,8 @@ androidx-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-j
 androidx-lifecycle-extensions = { module = "androidx.lifecycle:lifecycle-extensions", version.ref = "androidx-lifecycle-extensions" }
 androidx-lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidx-lifecycle-viewmodel-ktx" }
 androidx-multidex = { module = "androidx.multidex:multidex", version.ref = "androidx-multidex" }
+androidx-navigation-fragment-ktx = { module = "androidx.navigation:navigation-fragment-ktx", version.ref = "androidx-navigation" }
+androidx-navigation-ui-ktx = { module = "androidx.navigation:navigation-ui-ktx", version.ref = "androidx-navigation" }
 androidx-preference-ktx = { module = "androidx.preference:preference-ktx", version.ref = "androidx-preference-ktx" }
 androidx-recyclerview = { module = "androidx.recyclerview:recyclerview", version.ref = "androidx-recyclerview" }
 androidx-uiautomator = { module = "androidx.test.uiautomator:uiautomator", version.ref = "androidx-uiautomator" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ androidx-espresso-core = "3.4.0"
 androidx-lifecycle-viewmodel-ktx = "2.5.1"
 androidx-multidex = "2.0.1"
 androidx-preference-ktx = "1.2.0"
+androidx-uiautomator = "2.2.0"
 applovin-sdk = "13.1.0"
 exoplayer = "2.15.1"
 glide = "4.14.2"
@@ -26,6 +27,7 @@ androidx-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-j
 androidx-lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidx-lifecycle-viewmodel-ktx" }
 androidx-multidex = { module = "androidx.multidex:multidex", version.ref = "androidx-multidex" }
 androidx-preference-ktx = { module = "androidx.preference:preference-ktx", version.ref = "androidx-preference-ktx" }
+androidx-uiautomator = { module = "androidx.test.uiautomator:uiautomator", version.ref = "androidx-uiautomator" }
 applovin-sdk = { module = "com.applovin:applovin-sdk", version.ref = "applovin-sdk" }
 exoplayer = { module = "com.google.android.exoplayer:exoplayer", version.ref = "exoplayer" }
 exoplayer-core = { module = "com.google.android.exoplayer:exoplayer-core", version.ref = "exoplayer" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,19 +1,23 @@
 [versions]
+androidx-appcompat = "1.3.0"
+androidx-annotation = "1.5.0"
+androidx-constraintlayout = "2.1.4"
+androidx-lifecycle-viewmodel-ktx = "2.5.1"
+androidx-multidex = "2.0.1"
+androidx-preference-ktx = "1.2.0"
 exoplayer = "2.15.1"
 glide = "4.14.2"
 google-play-services-ads = "+"
 gradle = "8.7.3"
 kotlin-stdlib = "2.1.0"
-androidx-lifecycle-viewmodel-ktx = "2.5.1"
-androidx-preference-ktx = "1.2.0"
 robolectric = "4.12.2"
-androidx-appcompat = "1.3.0"
-androidx-annotation = "1.5.0"
-androidx-constraintlayout = "2.1.4"
-androidx-multidex = "2.0.1"
 
 [libraries]
+androidx-annotation = { module = 'androidx.annotation:annotation', version.ref = "androidx-annotation" }
+androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
+androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidx-constraintlayout" }
 androidx-lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidx-lifecycle-viewmodel-ktx" }
+androidx-multidex = { module = "androidx.multidex:multidex", version.ref = "androidx-multidex" }
 androidx-preference-ktx = { module = "androidx.preference:preference-ktx", version.ref = "androidx-preference-ktx" }
 exoplayer = { module = "com.google.android.exoplayer:exoplayer", version.ref = "exoplayer" }
 exoplayer-core = { module = "com.google.android.exoplayer:exoplayer-core", version.ref = "exoplayer" }
@@ -25,7 +29,3 @@ gradle = { module = "com.android.tools.build:gradle", version.ref = "gradle" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin-stdlib" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 shadows-httpclient = { module = "org.robolectric:shadows-httpclient", version.ref = "robolectric" }
-androidx-annotation = { module = 'androidx.annotation:annotation', version.ref = "androidx-annotation" }
-androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
-androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidx-constraintlayout" }
-androidx-multidex = { module = "androidx.multidex:multidex", version.ref = "androidx-multidex" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 androidx-appcompat = "1.3.0"
 androidx-annotation = "1.5.0"
 androidx-constraintlayout = "2.1.4"
+androidx-espresso-core = "3.4.0"
 androidx-lifecycle-viewmodel-ktx = "2.5.1"
 androidx-multidex = "2.0.1"
 androidx-preference-ktx = "1.2.0"
@@ -20,6 +21,7 @@ robolectric = "4.12.2"
 androidx-annotation = { module = 'androidx.annotation:annotation', version.ref = "androidx-annotation" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidx-constraintlayout" }
+androidx-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "androidx-espresso-core" }
 androidx-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-junit" }
 androidx-lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidx-lifecycle-viewmodel-ktx" }
 androidx-multidex = { module = "androidx.multidex:multidex", version.ref = "androidx-multidex" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,6 +23,7 @@ google-play-services-base = "18.1.0"
 gradle = "8.7.3"
 gson = "2.8.6"
 hamcrest = "2.2"
+jackson-databind = "2.14.3"
 json = "20180813"
 junit = "4.13.2"
 androidx-junit = "1.1.3"
@@ -67,6 +68,7 @@ gradle = { module = "com.android.tools.build:gradle", version.ref = "gradle" }
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 hamcrest-core = { module = "org.hamcrest:hamcrest-core", version.ref = "hamcrest" }
 hamcrest-library = { module = "org.hamcrest:hamcrest-library", version.ref = "hamcrest" }
+jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson-databind" }
 json = { module = "org.json:json", version.ref = "json" }
 junit = { module = "junit:junit", version.ref = "junit" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin-stdlib" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -15,6 +15,7 @@ androidx-test-runner = "1.4.0"
 androidx-uiautomator = "2.2.0"
 androidx-vectordrawable-animated = "1.1.0"
 apache-camel-json-patch = "3.22.2"
+apache-commons-lang3 = "3.7"
 applovin-sdk = "13.1.0"
 assertj-core = "1.7.0"
 exoplayer = "2.15.1"
@@ -59,6 +60,7 @@ androidx-test-runner = { module = "androidx.test:runner", version.ref = "android
 androidx-uiautomator = { module = "androidx.test.uiautomator:uiautomator", version.ref = "androidx-uiautomator" }
 androidx-vectordrawable-animated = { module = "androidx.vectordrawable:vectordrawable-animated", version.ref = "androidx-vectordrawable-animated" }
 apache-camel-json-patch = { module = "org.apache.camel:camel-json-patch", version.ref = "apache-camel-json-patch" }
+apache-commons-lang3 = { module = "org.apache.commons:commons-lang3", version.ref = "apache-commons-lang3" }
 applovin-sdk = { module = "com.applovin:applovin-sdk", version.ref = "applovin-sdk" }
 assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj-core" }
 exoplayer = { module = "com.google.android.exoplayer:exoplayer", version.ref = "exoplayer" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -16,6 +16,7 @@ androidx-uiautomator = "2.2.0"
 androidx-vectordrawable-animated = "1.1.0"
 apache-camel-json-patch = "3.22.2"
 applovin-sdk = "13.1.0"
+assertj-core = "1.7.0"
 exoplayer = "2.15.1"
 glide = "4.14.2"
 google-play-services-ads = "+"
@@ -58,6 +59,7 @@ androidx-uiautomator = { module = "androidx.test.uiautomator:uiautomator", versi
 androidx-vectordrawable-animated = { module = "androidx.vectordrawable:vectordrawable-animated", version.ref = "androidx-vectordrawable-animated" }
 apache-camel-json-patch = { module = "org.apache.camel:camel-json-patch", version.ref = "apache-camel-json-patch" }
 applovin-sdk = { module = "com.applovin:applovin-sdk", version.ref = "applovin-sdk" }
+assertj-core = { module = "org.assertj:assertj-core", version.ref = "assertj-core" }
 exoplayer = { module = "com.google.android.exoplayer:exoplayer", version.ref = "exoplayer" }
 exoplayer-core = { module = "com.google.android.exoplayer:exoplayer-core", version.ref = "exoplayer" }
 extension-ima = { module = "com.google.android.exoplayer:extension-ima", version.ref = "exoplayer" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ google-play-services-ads-identifier = "18.0.1"
 google-play-services-base = "18.1.0"
 gradle = "8.7.3"
 gson = "2.8.6"
+json = "20180813"
 junit = "4.13.2"
 androidx-junit = "1.1.3"
 kotlin-stdlib = "2.1.0"
@@ -62,6 +63,7 @@ google-play-services-ads-identifier = { module = "com.google.android.gms:play-se
 google-play-services-base = { module = "com.google.android.gms:play-services-base", version.ref = "google-play-services-base" }
 gradle = { module = "com.android.tools.build:gradle", version.ref = "gradle" }
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
+json = { module = "org.json:json", version.ref = "json" }
 junit = { module = "junit:junit", version.ref = "junit" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin-stdlib" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp3" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ androidx-junit = "1.1.3"
 kotlin-stdlib = "2.1.0"
 okhttp3 = "4.9.3"
 robolectric = "4.12.2"
+segmentedcontrol = "1.1.3"
 
 [libraries]
 androidx-annotation = { module = 'androidx.annotation:annotation', version.ref = "androidx-annotation" }
@@ -59,4 +60,5 @@ kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp3" }
 okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp3" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
+segmentedcontrol = { module = "com.github.RobertApikyan:SegmentedControl", version.ref = "segmentedcontrol" }
 shadows-httpclient = { module = "org.robolectric:shadows-httpclient", version.ref = "robolectric" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -18,6 +18,7 @@ google-play-services-ads = "+"
 google-play-services-ads-identifier = "18.0.1"
 google-play-services-base = "18.1.0"
 gradle = "8.7.3"
+gson = "2.8.6"
 junit = "4.13.2"
 androidx-junit = "1.1.3"
 kotlin-stdlib = "2.1.0"
@@ -52,6 +53,7 @@ google-play-services-ads = { group = "com.google.android.gms", name = "play-serv
 google-play-services-ads-identifier = { module = "com.google.android.gms:play-services-ads-identifier", version.ref = "google-play-services-ads-identifier" }
 google-play-services-base = { module = "com.google.android.gms:play-services-base", version.ref = "google-play-services-base" }
 gradle = { module = "com.android.tools.build:gradle", version.ref = "gradle" }
+gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 junit = { module = "junit:junit", version.ref = "junit" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin-stdlib" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp3" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,6 +11,7 @@ glide = "4.14.2"
 google-play-services-ads = "+"
 google-play-services-ads-identifier = "18.0.1"
 gradle = "8.7.3"
+junit = "4.13.2"
 kotlin-stdlib = "2.1.0"
 robolectric = "4.12.2"
 
@@ -30,6 +31,7 @@ glide = { module = "com.github.bumptech.glide:glide", version.ref = "glide" }
 google-play-services-ads = { group = "com.google.android.gms", name = "play-services-ads", version.ref = "google-play-services-ads" }
 google-play-services-ads-identifier = { module = "com.google.android.gms:play-services-ads-identifier", version.ref = "google-play-services-ads-identifier" }
 gradle = { module = "com.android.tools.build:gradle", version.ref = "gradle" }
+junit = { module = "junit:junit", version.ref = "junit" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin-stdlib" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 shadows-httpclient = { module = "org.robolectric:shadows-httpclient", version.ref = "robolectric" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,8 +1,10 @@
 [versions]
 google-play-services-ads = "+"
 robolectric = "4.12.2"
+androidx-annotation = "1.5.0"
 
 [libraries]
 google-play-services-ads = { group = "com.google.android.gms", name = "play-services-ads", version.ref = "google-play-services-ads" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 shadows-httpclient = { module = "org.robolectric:shadows-httpclient", version.ref = "robolectric" }
+androidx-annotation = { module = 'androidx.annotation:annotation', version.ref = "androidx-annotation" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ exoplayer = "2.15.1"
 glide = "4.14.2"
 google-play-services-ads = "+"
 gradle = "8.7.3"
+kotlin-stdlib = "2.1.0"
 robolectric = "4.12.2"
 androidx-appcompat = "1.3.0"
 androidx-annotation = "1.5.0"
@@ -17,6 +18,7 @@ exoplayer-ui = { module = "com.google.android.exoplayer:exoplayer-ui", version.r
 glide = { module = "com.github.bumptech.glide:glide", version.ref = "glide" }
 google-play-services-ads = { group = "com.google.android.gms", name = "play-services-ads", version.ref = "google-play-services-ads" }
 gradle = { module = "com.android.tools.build:gradle", version.ref = "gradle" }
+kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin-stdlib" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 shadows-httpclient = { module = "org.robolectric:shadows-httpclient", version.ref = "robolectric" }
 androidx-annotation = { module = 'androidx.annotation:annotation', version.ref = "androidx-annotation" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,7 @@ robolectric = "4.12.2"
 androidx-appcompat = "1.3.0"
 androidx-annotation = "1.5.0"
 androidx-constraintlayout = "2.1.4"
+androidx-multidex = "2.0.1"
 
 [libraries]
 exoplayer = { module = "com.google.android.exoplayer:exoplayer", version.ref = "exoplayer" }
@@ -17,3 +18,4 @@ shadows-httpclient = { module = "org.robolectric:shadows-httpclient", version.re
 androidx-annotation = { module = 'androidx.annotation:annotation', version.ref = "androidx-annotation" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidx-constraintlayout" }
+androidx-multidex = { module = "androidx.multidex:multidex", version.ref = "androidx-multidex" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,6 +2,7 @@
 exoplayer = "2.15.1"
 glide = "4.14.2"
 google-play-services-ads = "+"
+gradle = "8.7.3"
 robolectric = "4.12.2"
 androidx-appcompat = "1.3.0"
 androidx-annotation = "1.5.0"
@@ -15,6 +16,7 @@ extension-ima = { module = "com.google.android.exoplayer:extension-ima", version
 exoplayer-ui = { module = "com.google.android.exoplayer:exoplayer-ui", version.ref = "exoplayer" }
 glide = { module = "com.github.bumptech.glide:glide", version.ref = "glide" }
 google-play-services-ads = { group = "com.google.android.gms", name = "play-services-ads", version.ref = "google-play-services-ads" }
+gradle = { module = "com.android.tools.build:gradle", version.ref = "gradle" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 shadows-httpclient = { module = "org.robolectric:shadows-httpclient", version.ref = "robolectric" }
 androidx-annotation = { module = 'androidx.annotation:annotation', version.ref = "androidx-annotation" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,7 @@ androidx-constraintlayout = "2.1.4"
 androidx-lifecycle-viewmodel-ktx = "2.5.1"
 androidx-multidex = "2.0.1"
 androidx-preference-ktx = "1.2.0"
+applovin-sdk = "13.1.0"
 exoplayer = "2.15.1"
 glide = "4.14.2"
 google-play-services-ads = "+"
@@ -19,6 +20,7 @@ androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayo
 androidx-lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidx-lifecycle-viewmodel-ktx" }
 androidx-multidex = { module = "androidx.multidex:multidex", version.ref = "androidx-multidex" }
 androidx-preference-ktx = { module = "androidx.preference:preference-ktx", version.ref = "androidx-preference-ktx" }
+applovin-sdk = { module = "com.applovin:applovin-sdk", version.ref = "applovin-sdk" }
 exoplayer = { module = "com.google.android.exoplayer:exoplayer", version.ref = "exoplayer" }
 exoplayer-core = { module = "com.google.android.exoplayer:exoplayer-core", version.ref = "exoplayer" }
 extension-ima = { module = "com.google.android.exoplayer:extension-ima", version.ref = "exoplayer" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -22,6 +22,7 @@ google-play-services-ads-identifier = "18.0.1"
 google-play-services-base = "18.1.0"
 gradle = "8.7.3"
 gson = "2.8.6"
+hamcrest = "2.2"
 json = "20180813"
 junit = "4.13.2"
 androidx-junit = "1.1.3"
@@ -63,6 +64,8 @@ google-play-services-ads-identifier = { module = "com.google.android.gms:play-se
 google-play-services-base = { module = "com.google.android.gms:play-services-base", version.ref = "google-play-services-base" }
 gradle = { module = "com.android.tools.build:gradle", version.ref = "gradle" }
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
+hamcrest-core = { module = "org.hamcrest:hamcrest-core", version.ref = "hamcrest" }
+hamcrest-library = { module = "org.hamcrest:hamcrest-library", version.ref = "hamcrest" }
 json = { module = "org.json:json", version.ref = "json" }
 junit = { module = "junit:junit", version.ref = "junit" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin-stdlib" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -5,6 +5,7 @@ androidx-constraintlayout = "2.1.4"
 androidx-espresso = "3.4.0"
 androidx-lifecycle-viewmodel-ktx = "2.5.1"
 androidx-lifecycle-extensions = "2.2.0"
+androidx-localbroadcastmanager = "1.0.0"
 androidx-multidex = "2.0.1"
 androidx-navigation = "2.3.1"
 androidx-preference-ktx = "1.2.0"
@@ -40,6 +41,7 @@ androidx-espresso-web = { module = "androidx.test.espresso:espresso-web", versio
 androidx-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-junit" }
 androidx-lifecycle-extensions = { module = "androidx.lifecycle:lifecycle-extensions", version.ref = "androidx-lifecycle-extensions" }
 androidx-lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidx-lifecycle-viewmodel-ktx" }
+androidx-localbroadcastmanager = { module = "androidx.localbroadcastmanager:localbroadcastmanager", version.ref = "androidx-localbroadcastmanager" }
 androidx-multidex = { module = "androidx.multidex:multidex", version.ref = "androidx-multidex" }
 androidx-navigation-fragment-ktx = { module = "androidx.navigation:navigation-fragment-ktx", version.ref = "androidx-navigation" }
 androidx-navigation-ui-ktx = { module = "androidx.navigation:navigation-ui-ktx", version.ref = "androidx-navigation" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,7 @@
 [versions]
 google-play-services-ads = "+"
 robolectric = "4.12.2"
+androidx-appcompat = "1.3.0"
 androidx-annotation = "1.5.0"
 
 [libraries]
@@ -8,3 +9,4 @@ google-play-services-ads = { group = "com.google.android.gms", name = "play-serv
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 shadows-httpclient = { module = "org.robolectric:shadows-httpclient", version.ref = "robolectric" }
 androidx-annotation = { module = 'androidx.annotation:annotation', version.ref = "androidx-annotation" }
+androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ androidx-multidex = "2.0.1"
 androidx-navigation = "2.3.1"
 androidx-preference-ktx = "1.2.0"
 androidx-recyclerview = "1.1.0"
+androidx-test-runner = "1.4.0"
 androidx-uiautomator = "2.2.0"
 androidx-vectordrawable-animated = "1.1.0"
 applovin-sdk = "13.1.0"
@@ -43,6 +44,7 @@ androidx-navigation-fragment-ktx = { module = "androidx.navigation:navigation-fr
 androidx-navigation-ui-ktx = { module = "androidx.navigation:navigation-ui-ktx", version.ref = "androidx-navigation" }
 androidx-preference-ktx = { module = "androidx.preference:preference-ktx", version.ref = "androidx-preference-ktx" }
 androidx-recyclerview = { module = "androidx.recyclerview:recyclerview", version.ref = "androidx-recyclerview" }
+androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidx-test-runner" }
 androidx-uiautomator = { module = "androidx.test.uiautomator:uiautomator", version.ref = "androidx-uiautomator" }
 androidx-vectordrawable-animated = { module = "androidx.vectordrawable:vectordrawable-animated", version.ref = "androidx-vectordrawable-animated" }
 applovin-sdk = { module = "com.applovin:applovin-sdk", version.ref = "applovin-sdk" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ exoplayer = "2.15.1"
 glide = "4.14.2"
 google-play-services-ads = "+"
 google-play-services-ads-identifier = "18.0.1"
+google-play-services-base = "18.1.0"
 gradle = "8.7.3"
 junit = "4.13.2"
 androidx-junit = "1.1.3"
@@ -36,6 +37,7 @@ exoplayer-ui = { module = "com.google.android.exoplayer:exoplayer-ui", version.r
 glide = { module = "com.github.bumptech.glide:glide", version.ref = "glide" }
 google-play-services-ads = { group = "com.google.android.gms", name = "play-services-ads", version.ref = "google-play-services-ads" }
 google-play-services-ads-identifier = { module = "com.google.android.gms:play-services-ads-identifier", version.ref = "google-play-services-ads-identifier" }
+google-play-services-base = { module = "com.google.android.gms:play-services-base", version.ref = "google-play-services-base" }
 gradle = { module = "com.android.tools.build:gradle", version.ref = "gradle" }
 junit = { module = "junit:junit", version.ref = "junit" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin-stdlib" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ applovin-sdk = "13.1.0"
 exoplayer = "2.15.1"
 glide = "4.14.2"
 google-play-services-ads = "+"
+google-play-services-ads-identifier = "18.0.1"
 gradle = "8.7.3"
 kotlin-stdlib = "2.1.0"
 robolectric = "4.12.2"
@@ -27,6 +28,7 @@ extension-ima = { module = "com.google.android.exoplayer:extension-ima", version
 exoplayer-ui = { module = "com.google.android.exoplayer:exoplayer-ui", version.ref = "exoplayer" }
 glide = { module = "com.github.bumptech.glide:glide", version.ref = "glide" }
 google-play-services-ads = { group = "com.google.android.gms", name = "play-services-ads", version.ref = "google-play-services-ads" }
+google-play-services-ads-identifier = { module = "com.google.android.gms:play-services-ads-identifier", version.ref = "google-play-services-ads-identifier" }
 gradle = { module = "com.android.tools.build:gradle", version.ref = "gradle" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin-stdlib" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -3,6 +3,7 @@ google-play-services-ads = "+"
 robolectric = "4.12.2"
 androidx-appcompat = "1.3.0"
 androidx-annotation = "1.5.0"
+androidx-constraintlayout = "2.1.4"
 
 [libraries]
 google-play-services-ads = { group = "com.google.android.gms", name = "play-services-ads", version.ref = "google-play-services-ads" }
@@ -10,3 +11,4 @@ robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectr
 shadows-httpclient = { module = "org.robolectric:shadows-httpclient", version.ref = "robolectric" }
 androidx-annotation = { module = 'androidx.annotation:annotation', version.ref = "androidx-annotation" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
+androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidx-constraintlayout" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 androidx-appcompat = "1.3.0"
 androidx-annotation = "1.5.0"
 androidx-constraintlayout = "2.1.4"
-androidx-espresso-core = "3.4.0"
+androidx-espresso = "3.4.0"
 androidx-lifecycle-viewmodel-ktx = "2.5.1"
 androidx-lifecycle-extensions = "2.2.0"
 androidx-multidex = "2.0.1"
@@ -28,7 +28,10 @@ robolectric = "4.12.2"
 androidx-annotation = { module = 'androidx.annotation:annotation', version.ref = "androidx-annotation" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidx-constraintlayout" }
-androidx-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "androidx-espresso-core" }
+androidx-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "androidx-espresso" }
+androidx-espresso-idling-resource = { module = "androidx.test.espresso:espresso-idling-resource", version.ref = "androidx-espresso" }
+androidx-espresso-intents = { module = "androidx.test.espresso:espresso-intents", version.ref = "androidx-espresso" }
+androidx-espresso-web = { module = "androidx.test.espresso:espresso-web", version.ref = "androidx-espresso" }
 androidx-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-junit" }
 androidx-lifecycle-extensions = { module = "androidx.lifecycle:lifecycle-extensions", version.ref = "androidx-lifecycle-extensions" }
 androidx-lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidx-lifecycle-viewmodel-ktx" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -6,6 +6,7 @@ androidx-espresso-core = "3.4.0"
 androidx-lifecycle-viewmodel-ktx = "2.5.1"
 androidx-multidex = "2.0.1"
 androidx-preference-ktx = "1.2.0"
+androidx-recyclerview = "1.1.0"
 androidx-uiautomator = "2.2.0"
 applovin-sdk = "13.1.0"
 exoplayer = "2.15.1"
@@ -28,6 +29,7 @@ androidx-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-j
 androidx-lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidx-lifecycle-viewmodel-ktx" }
 androidx-multidex = { module = "androidx.multidex:multidex", version.ref = "androidx-multidex" }
 androidx-preference-ktx = { module = "androidx.preference:preference-ktx", version.ref = "androidx-preference-ktx" }
+androidx-recyclerview = { module = "androidx.recyclerview:recyclerview", version.ref = "androidx-recyclerview" }
 androidx-uiautomator = { module = "androidx.test.uiautomator:uiautomator", version.ref = "androidx-uiautomator" }
 applovin-sdk = { module = "com.applovin:applovin-sdk", version.ref = "applovin-sdk" }
 exoplayer = { module = "com.google.android.exoplayer:exoplayer", version.ref = "exoplayer" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ androidx-multidex = "2.0.1"
 androidx-navigation = "2.3.1"
 androidx-preference-ktx = "1.2.0"
 androidx-recyclerview = "1.1.0"
+androidx-test-rules = "1.4.0"
 androidx-test-runner = "1.4.0"
 androidx-uiautomator = "2.2.0"
 androidx-vectordrawable-animated = "1.1.0"
@@ -44,6 +45,7 @@ androidx-navigation-fragment-ktx = { module = "androidx.navigation:navigation-fr
 androidx-navigation-ui-ktx = { module = "androidx.navigation:navigation-ui-ktx", version.ref = "androidx-navigation" }
 androidx-preference-ktx = { module = "androidx.preference:preference-ktx", version.ref = "androidx-preference-ktx" }
 androidx-recyclerview = { module = "androidx.recyclerview:recyclerview", version.ref = "androidx-recyclerview" }
+androidx-test-rules = { module = "androidx.test:rules", version.ref = "androidx-test-rules" }
 androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidx-test-runner" }
 androidx-uiautomator = { module = "androidx.test.uiautomator:uiautomator", version.ref = "androidx-uiautomator" }
 androidx-vectordrawable-animated = { module = "androidx.vectordrawable:vectordrawable-animated", version.ref = "androidx-vectordrawable-animated" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -14,6 +14,7 @@ androidx-test-rules = "1.4.0"
 androidx-test-runner = "1.4.0"
 androidx-uiautomator = "2.2.0"
 androidx-vectordrawable-animated = "1.1.0"
+apache-camel-json-patch = "3.22.2"
 applovin-sdk = "13.1.0"
 exoplayer = "2.15.1"
 glide = "4.14.2"
@@ -55,6 +56,7 @@ androidx-test-rules = { module = "androidx.test:rules", version.ref = "androidx-
 androidx-test-runner = { module = "androidx.test:runner", version.ref = "androidx-test-runner" }
 androidx-uiautomator = { module = "androidx.test.uiautomator:uiautomator", version.ref = "androidx-uiautomator" }
 androidx-vectordrawable-animated = { module = "androidx.vectordrawable:vectordrawable-animated", version.ref = "androidx-vectordrawable-animated" }
+apache-camel-json-patch = { module = "org.apache.camel:camel-json-patch", version.ref = "apache-camel-json-patch" }
 applovin-sdk = { module = "com.applovin:applovin-sdk", version.ref = "applovin-sdk" }
 exoplayer = { module = "com.google.android.exoplayer:exoplayer", version.ref = "exoplayer" }
 exoplayer-core = { module = "com.google.android.exoplayer:exoplayer-core", version.ref = "exoplayer" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ glide = "4.14.2"
 google-play-services-ads = "+"
 gradle = "8.7.3"
 kotlin-stdlib = "2.1.0"
+androidx-preference-ktx = "1.2.0"
 robolectric = "4.12.2"
 androidx-appcompat = "1.3.0"
 androidx-annotation = "1.5.0"
@@ -11,6 +12,7 @@ androidx-constraintlayout = "2.1.4"
 androidx-multidex = "2.0.1"
 
 [libraries]
+androidx-preference-ktx = { module = "androidx.preference:preference-ktx", version.ref = "androidx-preference-ktx" }
 exoplayer = { module = "com.google.android.exoplayer:exoplayer", version.ref = "exoplayer" }
 exoplayer-core = { module = "com.google.android.exoplayer:exoplayer-core", version.ref = "exoplayer" }
 extension-ima = { module = "com.google.android.exoplayer:extension-ima", version.ref = "exoplayer" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ androidx-annotation = "1.5.0"
 androidx-constraintlayout = "2.1.4"
 androidx-espresso-core = "3.4.0"
 androidx-lifecycle-viewmodel-ktx = "2.5.1"
+androidx-lifecycle-extensions = "2.2.0"
 androidx-multidex = "2.0.1"
 androidx-preference-ktx = "1.2.0"
 androidx-recyclerview = "1.1.0"
@@ -26,6 +27,7 @@ androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "a
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidx-constraintlayout" }
 androidx-espresso-core = { module = "androidx.test.espresso:espresso-core", version.ref = "androidx-espresso-core" }
 androidx-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-junit" }
+androidx-lifecycle-extensions = { module = "androidx.lifecycle:lifecycle-extensions", version.ref = "androidx-lifecycle-extensions" }
 androidx-lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidx-lifecycle-viewmodel-ktx" }
 androidx-multidex = { module = "androidx.multidex:multidex", version.ref = "androidx-multidex" }
 androidx-preference-ktx = { module = "androidx.preference:preference-ktx", version.ref = "androidx-preference-ktx" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -9,6 +9,7 @@ androidx-multidex = "2.0.1"
 androidx-preference-ktx = "1.2.0"
 androidx-recyclerview = "1.1.0"
 androidx-uiautomator = "2.2.0"
+androidx-vectordrawable-animated = "1.1.0"
 applovin-sdk = "13.1.0"
 exoplayer = "2.15.1"
 glide = "4.14.2"
@@ -33,6 +34,7 @@ androidx-multidex = { module = "androidx.multidex:multidex", version.ref = "andr
 androidx-preference-ktx = { module = "androidx.preference:preference-ktx", version.ref = "androidx-preference-ktx" }
 androidx-recyclerview = { module = "androidx.recyclerview:recyclerview", version.ref = "androidx-recyclerview" }
 androidx-uiautomator = { module = "androidx.test.uiautomator:uiautomator", version.ref = "androidx-uiautomator" }
+androidx-vectordrawable-animated = { module = "androidx.vectordrawable:vectordrawable-animated", version.ref = "androidx-vectordrawable-animated" }
 applovin-sdk = { module = "com.applovin:applovin-sdk", version.ref = "applovin-sdk" }
 exoplayer = { module = "com.google.android.exoplayer:exoplayer", version.ref = "exoplayer" }
 exoplayer-core = { module = "com.google.android.exoplayer:exoplayer-core", version.ref = "exoplayer" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -21,6 +21,7 @@ gradle = "8.7.3"
 junit = "4.13.2"
 androidx-junit = "1.1.3"
 kotlin-stdlib = "2.1.0"
+okhttp3 = "4.9.3"
 robolectric = "4.12.2"
 
 [libraries]
@@ -50,5 +51,7 @@ google-play-services-base = { module = "com.google.android.gms:play-services-bas
 gradle = { module = "com.android.tools.build:gradle", version.ref = "gradle" }
 junit = { module = "junit:junit", version.ref = "junit" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin-stdlib" }
+okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp3" }
+okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp3" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 shadows-httpclient = { module = "org.robolectric:shadows-httpclient", version.ref = "robolectric" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -79,6 +79,7 @@ jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", ver
 json = { module = "org.json:json", version.ref = "json" }
 jsonassert = { module = "org.skyscreamer:jsonassert", version.ref = "jsonassert" }
 junit = { module = "junit:junit", version.ref = "junit" }
+kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin-stdlib" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin-stdlib" }
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito-core" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp3" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,4 +1,5 @@
 [versions]
+exoplayer = "2.15.1"
 google-play-services-ads = "+"
 robolectric = "4.12.2"
 androidx-appcompat = "1.3.0"
@@ -6,6 +7,10 @@ androidx-annotation = "1.5.0"
 androidx-constraintlayout = "2.1.4"
 
 [libraries]
+exoplayer = { module = "com.google.android.exoplayer:exoplayer", version.ref = "exoplayer" }
+exoplayer-core = { module = "com.google.android.exoplayer:exoplayer-core", version.ref = "exoplayer" }
+extension-ima = { module = "com.google.android.exoplayer:extension-ima", version.ref = "exoplayer" }
+exoplayer-ui = { module = "com.google.android.exoplayer:exoplayer-ui", version.ref = "exoplayer" }
 google-play-services-ads = { group = "com.google.android.gms", name = "play-services-ads", version.ref = "google-play-services-ads" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 shadows-httpclient = { module = "org.robolectric:shadows-httpclient", version.ref = "robolectric" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -12,6 +12,7 @@ google-play-services-ads = "+"
 google-play-services-ads-identifier = "18.0.1"
 gradle = "8.7.3"
 junit = "4.13.2"
+androidx-junit = "1.1.3"
 kotlin-stdlib = "2.1.0"
 robolectric = "4.12.2"
 
@@ -19,6 +20,7 @@ robolectric = "4.12.2"
 androidx-annotation = { module = 'androidx.annotation:annotation', version.ref = "androidx-annotation" }
 androidx-appcompat = { module = "androidx.appcompat:appcompat", version.ref = "androidx-appcompat" }
 androidx-constraintlayout = { module = "androidx.constraintlayout:constraintlayout", version.ref = "androidx-constraintlayout" }
+androidx-junit = { module = "androidx.test.ext:junit", version.ref = "androidx-junit" }
 androidx-lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidx-lifecycle-viewmodel-ktx" }
 androidx-multidex = { module = "androidx.multidex:multidex", version.ref = "androidx-multidex" }
 androidx-preference-ktx = { module = "androidx.preference:preference-ktx", version.ref = "androidx-preference-ktx" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -24,6 +24,7 @@ androidx-junit = "1.1.3"
 kotlin-stdlib = "2.1.0"
 okhttp3 = "4.9.3"
 robolectric = "4.12.2"
+robotium-solo = "5.5.4"
 segmentedcontrol = "1.1.3"
 
 [libraries]
@@ -60,5 +61,6 @@ kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp3" }
 okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp3" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
+robotium-solo = { module = "com.jayway.android.robotium:robotium-solo", version.ref = "robotium-solo" }
 segmentedcontrol = { module = "com.github.RobertApikyan:SegmentedControl", version.ref = "segmentedcontrol" }
 shadows-httpclient = { module = "org.robolectric:shadows-httpclient", version.ref = "robolectric" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,5 +1,6 @@
 [versions]
 exoplayer = "2.15.1"
+glide = "4.14.2"
 google-play-services-ads = "+"
 robolectric = "4.12.2"
 androidx-appcompat = "1.3.0"
@@ -12,6 +13,7 @@ exoplayer = { module = "com.google.android.exoplayer:exoplayer", version.ref = "
 exoplayer-core = { module = "com.google.android.exoplayer:exoplayer-core", version.ref = "exoplayer" }
 extension-ima = { module = "com.google.android.exoplayer:extension-ima", version.ref = "exoplayer" }
 exoplayer-ui = { module = "com.google.android.exoplayer:exoplayer-ui", version.ref = "exoplayer" }
+glide = { module = "com.github.bumptech.glide:glide", version.ref = "glide" }
 google-play-services-ads = { group = "com.google.android.gms", name = "play-services-ads", version.ref = "google-play-services-ads" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }
 shadows-httpclient = { module = "org.robolectric:shadows-httpclient", version.ref = "robolectric" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,7 @@ gson = "2.8.6"
 hamcrest = "2.2"
 jackson-databind = "2.14.3"
 json = "20180813"
+jsonassert = "1.5.0"
 junit = "4.13.2"
 androidx-junit = "1.1.3"
 kotlin-stdlib = "2.1.0"
@@ -74,6 +75,7 @@ hamcrest-core = { module = "org.hamcrest:hamcrest-core", version.ref = "hamcrest
 hamcrest-library = { module = "org.hamcrest:hamcrest-library", version.ref = "hamcrest" }
 jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", version.ref = "jackson-databind" }
 json = { module = "org.json:json", version.ref = "json" }
+jsonassert = { module = "org.skyscreamer:jsonassert", version.ref = "jsonassert" }
 junit = { module = "junit:junit", version.ref = "junit" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin-stdlib" }
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito-core" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,6 +4,7 @@ glide = "4.14.2"
 google-play-services-ads = "+"
 gradle = "8.7.3"
 kotlin-stdlib = "2.1.0"
+androidx-lifecycle-viewmodel-ktx = "2.5.1"
 androidx-preference-ktx = "1.2.0"
 robolectric = "4.12.2"
 androidx-appcompat = "1.3.0"
@@ -12,6 +13,7 @@ androidx-constraintlayout = "2.1.4"
 androidx-multidex = "2.0.1"
 
 [libraries]
+androidx-lifecycle-viewmodel-ktx = { module = "androidx.lifecycle:lifecycle-viewmodel-ktx", version.ref = "androidx-lifecycle-viewmodel-ktx" }
 androidx-preference-ktx = { module = "androidx.preference:preference-ktx", version.ref = "androidx-preference-ktx" }
 exoplayer = { module = "com.google.android.exoplayer:exoplayer", version.ref = "exoplayer" }
 exoplayer-core = { module = "com.google.android.exoplayer:exoplayer-core", version.ref = "exoplayer" }

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -27,6 +27,7 @@ json = "20180813"
 junit = "4.13.2"
 androidx-junit = "1.1.3"
 kotlin-stdlib = "2.1.0"
+mockito-core = "4.5.1"
 okhttp3 = "4.9.3"
 robolectric = "4.12.2"
 robotium-solo = "5.5.4"
@@ -69,6 +70,7 @@ hamcrest-library = { module = "org.hamcrest:hamcrest-library", version.ref = "ha
 json = { module = "org.json:json", version.ref = "json" }
 junit = { module = "junit:junit", version.ref = "junit" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin-stdlib" }
+mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito-core" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp3" }
 okhttp-mockwebserver = { module = "com.squareup.okhttp3:mockwebserver", version.ref = "okhttp3" }
 robolectric = { module = "org.robolectric:robolectric", version.ref = "robolectric" }

--- a/tools/drprebid/build.gradle
+++ b/tools/drprebid/build.gradle
@@ -35,7 +35,7 @@ dependencies {
     implementation project(':PrebidMobile')
 
     implementation libs.androidx.appcompat
-    implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
+    implementation libs.androidx.constraintlayout
     implementation 'com.google.android.material:material:1.0.0'
     implementation 'androidx.recyclerview:recyclerview:1.0.0'
 

--- a/tools/drprebid/build.gradle
+++ b/tools/drprebid/build.gradle
@@ -47,7 +47,5 @@ dependencies {
 
     implementation 'com.squareup.okhttp3:okhttp:3.14.2'
 
-    implementation 'androidx.multidex:multidex:2.0.1'
-
-
+    implementation libs.androidx.multidex
 }

--- a/tools/drprebid/build.gradle
+++ b/tools/drprebid/build.gradle
@@ -45,7 +45,7 @@ dependencies {
     implementation 'com.google.android.gms:play-services-vision:17.0.2'
     implementation 'com.google.android.gms:play-services-ads:17.1.3'
 
-    implementation 'com.squareup.okhttp3:okhttp:3.14.2'
+    implementation libs.okhttp
 
     implementation libs.androidx.multidex
 }

--- a/tools/drprebid/build.gradle
+++ b/tools/drprebid/build.gradle
@@ -37,7 +37,7 @@ dependencies {
     implementation libs.androidx.appcompat
     implementation libs.androidx.constraintlayout
     implementation 'com.google.android.material:material:1.0.0'
-    implementation 'androidx.recyclerview:recyclerview:1.0.0'
+    implementation libs.androidx.recyclerview
 
     implementation 'androidx.lifecycle:lifecycle-extensions:2.0.0'
     implementation 'androidx.lifecycle:lifecycle-common-java8:2.0.0'

--- a/tools/drprebid/build.gradle
+++ b/tools/drprebid/build.gradle
@@ -39,7 +39,7 @@ dependencies {
     implementation 'com.google.android.material:material:1.0.0'
     implementation libs.androidx.recyclerview
 
-    implementation 'androidx.lifecycle:lifecycle-extensions:2.0.0'
+    implementation libs.androidx.lifecycle.extensions
     implementation 'androidx.lifecycle:lifecycle-common-java8:2.0.0'
 
     implementation 'com.google.android.gms:play-services-vision:17.0.2'

--- a/tools/drprebid/build.gradle
+++ b/tools/drprebid/build.gradle
@@ -34,7 +34,7 @@ dependencies {
 
     implementation project(':PrebidMobile')
 
-    implementation 'androidx.appcompat:appcompat:1.0.0'
+    implementation libs.androidx.appcompat
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'com.google.android.material:material:1.0.0'
     implementation 'androidx.recyclerview:recyclerview:1.0.0'


### PR DESCRIPTION
No versions are changed for PrebidMobile core modules. This can be verified by running `./gradlew :PrebidMobile:dependencies` for both this branch & master branch. 

[Before](https://github.com/user-attachments/files/19514201/DependenciesBeforeVersionCatalog20250329.txt)
[After](https://github.com/user-attachments/files/19514196/DependenciesAfterVersionCatalog20250329.txt)

Notable version changes from internal test app, drPrebid, demo project:
1. `androidx.annotation:1.5.0` is consistently used 78bbf80d366080a7cb4caf42103d457265928508
2. `androidx.appcompat:1.3.0` is consistently used dbbd6a69d9279275a4d774ec74ad51eaef78ea73
3. `constraintlayout:2.1.4` is consistently used 4da2ec958fe662745418943f6fa43c5d78a7da3f
4. `multidex:2.0.1` is consistently used 1c36ec4ac432ca9773d1b662b7fda16a6f13ac9f
5. `glide:4.14.2` is consistently used e3ded313e6104f36940a910ad83643c3cfd876f0
6. `preference-ktx:1.2.0` is consistently used 23e9fafc1f3907be19570e2c02cde217b069311c
7. `junit:4.13.2` is consistently used 467707f11cbab95c5c940b4e6831a8f7ba1f6f78
8. `recyclerview:1.1.0` is consistently used 3c7788860a1ed528622f0029f4fcec5b2423546e
9. `lifecycle-extensions:2.2.0` is consistently used 6ca2f4dcbccc32fe038491e46f4df96c14e20d46
10. `okhttp3:4.9.3` is consistently used ebc5f3e11f2bd15ec7535fb870842d92d95217be