### PR TITLE
Change VIDEO_INTERSTITIAL_PLAYBACK_END default from 2 → 1 for interstitial video ads

### DIFF
--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/networking/parameters/BasicParameterBuilder.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/networking/parameters/BasicParameterBuilder.java
@@ -76,8 +76,8 @@ public class BasicParameterBuilder extends ParameterBuilder {
     // 5 - VAST 2.0 Wrapper
     static final int[] SUPPORTED_VIDEO_PROTOCOLS = new int[]{2, 5};
 
-    // 2 - On Leaving Viewport or when Terminated by User
-    static final int VIDEO_INTERSTITIAL_PLAYBACK_END = 2;
+    // 1 - On Video Completion or when Terminated by User
+    static final int VIDEO_INTERSTITIAL_PLAYBACK_END = 1;
     //term to say cached locally as per Mopub & dfp - approved by product
     static final int VIDEO_DELIVERY_DOWNLOAD = 3;
     static final int VIDEO_LINEARITY_LINEAR = 1;
@@ -303,7 +303,7 @@ public class BasicParameterBuilder extends ParameterBuilder {
             video.linearity = VIDEO_LINEARITY_LINEAR;
 
             //Interstitial video specific values
-            video.playbackend = VIDEO_INTERSTITIAL_PLAYBACK_END;//On Leaving Viewport or when Terminated by User
+            video.playbackend = VIDEO_INTERSTITIAL_PLAYBACK_END;//On Video Completion or when Terminated by User
 
             if (adConfiguration.isAdType(AdFormat.INTERSTITIAL)) {
                 video.plcmt = Signals.Plcmt.Interstitial.getValue();

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/models/openrtb/bidRequests/imps/VideoTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/models/openrtb/bidRequests/imps/VideoTest.java
@@ -50,11 +50,11 @@ public class VideoTest {
         video.pos = 7;
         video.placement = 5;
         video.plcmt = 3;
-        video.playbackend = 2;
+        video.playbackend = 1;
         video.battr = new int[]{10, 15};
 
         JSONObject actualObj = video.getJsonObject();
-        String expectedString = "{\"delivery\":[3],\"battr\":[10,15],\"linearity\":1,\"minbitrate\":1,\"h\":250,\"playbackmethod\":[1,2],\"minduration\":1,\"mimes\":[\"video/mp4\",\"video/3gpp\",\"video/webm\",\"video/mkv\"],\"maxbitrate\":20,\"plcmt\":3,\"maxduration\":100,\"playbackend\":2,\"pos\":7,\"w\":300,\"placement\":5,\"protocols\":[2,5]}";
+        String expectedString = "{\"delivery\":[3],\"battr\":[10,15],\"linearity\":1,\"minbitrate\":1,\"h\":250,\"playbackmethod\":[1,2],\"minduration\":1,\"mimes\":[\"video/mp4\",\"video/3gpp\",\"video/webm\",\"video/mkv\"],\"maxbitrate\":20,\"plcmt\":3,\"maxduration\":100,\"playbackend\":1,\"pos\":7,\"w\":300,\"placement\":5,\"protocols\":[2,5]}";
         assertEquals("got: " + actualObj.toString(), expectedString, actualObj.toString());
         video.getJsonObject();
     }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/networking/parameters/BasicParameterBuilderTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/networking/parameters/BasicParameterBuilderTest.java
@@ -759,7 +759,7 @@ public class BasicParameterBuilderTest {
         assertNull(video.h);
         assertEquals(new Integer(5), video.placement);
         assertEquals(new Integer(1), video.linearity);
-        assertEquals(new Integer(2), video.playbackend);
+        assertEquals(new Integer(1), video.playbackend);
         assertArrayEquals(new String[]{"video/mp4", "video/3gpp", "video/webm", "video/mkv"}, video.mimes);
         assertArrayEquals(new int[]{2, 5}, video.protocols);
         assertArrayEquals(new int[]{3}, video.delivery);
@@ -799,7 +799,7 @@ public class BasicParameterBuilderTest {
         assertEquals(new Integer(5), video.placement);
 
         assertEquals(new Integer(1), video.linearity);
-        assertEquals(new Integer(2), video.playbackend);
+        assertEquals(new Integer(1), video.playbackend);
         assertArrayEquals(new int[]{3}, video.delivery);
         assertArrayEquals(new String[]{"video/mp4", "video/3gpp", "video/webm", "video/mkv"}, video.mimes);
         assertArrayEquals(new int[]{2, 5}, video.protocols);
@@ -1183,7 +1183,7 @@ public class BasicParameterBuilderTest {
         video.linearity = BasicParameterBuilder.VIDEO_LINEARITY_LINEAR;
 
         //Interstitial video specific values
-        video.playbackend = VIDEO_INTERSTITIAL_PLAYBACK_END;//On Leaving Viewport or when Terminated by User
+        video.playbackend = VIDEO_INTERSTITIAL_PLAYBACK_END;//On Video Completion or when Terminated by User
         video.delivery = new int[]{BasicParameterBuilder.VIDEO_DELIVERY_DOWNLOAD};
         video.pos = AdPosition.FULLSCREEN.getValue();
 


### PR DESCRIPTION
## Summary
Change the value of the `VIDEO_INTERSTITIAL_PLAYBACK_END` from 2 → 1 for interstitial video ads.

## Current Behavior
- VIDEO_INTERSTITIAL_PLAYBACK_END is sent as 2.
- All videos are interstitials, so "On Leaving Viewport" never occurs.
- Video end always happens as "On Video Completion or when Terminated by User".
- Sending `VIDEO_INTERSTITIAL_PLAYBACK_END = 2` may cause DSPs / advertisers to undervalue the ad request, leading to lower bids than the actual inventory performance would justify.

## Change
- Update value of `VIDEO_INTERSTITIAL_PLAYBACK_END` to `1` to reflect actual behavior.

## Impact
- This change is backward-compatible and only adjusts the default setting to better reflect real playback behavior, without impacting other features.

## Related Issue
- Closes prebid/prebid-mobile-android#1199