### PR TITLE
Fix for internal test app crashes

### DIFF
--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/AdFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/AdFragment.kt
@@ -26,6 +26,7 @@ import android.view.ViewGroup
 import android.view.ViewGroup.LayoutParams.MATCH_PARENT
 import android.widget.FrameLayout
 import android.widget.ProgressBar
+import androidx.annotation.CallSuper
 import androidx.preference.PreferenceManager
 import androidx.test.espresso.idling.CountingIdlingResource
 import org.prebid.mobile.*
@@ -58,6 +59,7 @@ abstract class AdFragment : BaseFragment() {
 
     private var adView: Any? = null
 
+    @CallSuper
     override fun initUi(view: View, savedInstanceState: Bundle?) {
         arguments?.let {
             configId = it.getString(getString(R.string.key_bid_config_id), "")

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/admob/AdMobBannerFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/admob/AdMobBannerFragment.kt
@@ -16,7 +16,6 @@ import org.prebid.mobile.renderingtestapp.R
 import org.prebid.mobile.renderingtestapp.databinding.FragmentBiddingBannerAdmobBinding
 import org.prebid.mobile.renderingtestapp.plugplay.config.AdConfiguratorDialogFragment
 import org.prebid.mobile.renderingtestapp.utils.BaseEvents
-import org.prebid.mobile.renderingtestapp.utils.CommandLineArgumentParser
 
 open class AdMobBannerFragment : AdFragment() {
 
@@ -31,12 +30,11 @@ open class AdMobBannerFragment : AdFragment() {
 
     protected val binding: FragmentBiddingBannerAdmobBinding
         get() = getBinding()
-    private lateinit var events: Events
+
+    protected val events by lazy { Events(binding.root) }
 
     override fun initUi(view: View, savedInstanceState: Bundle?) {
         super.initUi(view, savedInstanceState)
-
-        events = Events(view)
 
         binding.adIdLabel.text = getString(R.string.label_auid, configId)
         binding.btnLoad.setOnClickListener {
@@ -139,7 +137,7 @@ open class AdMobBannerFragment : AdFragment() {
 
     }
 
-    private class Events(parentView: View) : BaseEvents(parentView) {
+    protected class Events(parentView: View) : BaseEvents(parentView) {
 
         fun loaded(b: Boolean) = enable(R.id.btnAdLoaded, b)
         fun impression(b: Boolean) = enable(R.id.btnAdImpression, b)

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/admob/AdMobInterstitialFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/admob/AdMobInterstitialFragment.kt
@@ -18,7 +18,6 @@ import org.prebid.mobile.renderingtestapp.R
 import org.prebid.mobile.renderingtestapp.databinding.FragmentAdmobRewardedBinding
 import org.prebid.mobile.renderingtestapp.plugplay.config.AdConfiguratorDialogFragment
 import org.prebid.mobile.renderingtestapp.utils.BaseEvents
-import org.prebid.mobile.renderingtestapp.utils.CommandLineArgumentParser
 import java.util.*
 
 open class AdMobInterstitialFragment : AdFragment() {
@@ -35,14 +34,12 @@ open class AdMobInterstitialFragment : AdFragment() {
 
     protected val binding: FragmentAdmobRewardedBinding
         get() = getBinding()
-    protected lateinit var events: Events
+    protected val events by lazy { Events(binding.root) }
 
     override val layoutRes = R.layout.fragment_admob_rewarded
 
     override fun initUi(view: View, savedInstanceState: Bundle?) {
         super.initUi(view, savedInstanceState)
-
-        events = Events(view)
 
         binding.adIdLabel.text = getString(R.string.label_auid, configId)
         binding.btnLoad.setOnClickListener {

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/admob/AdMobNativeFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/admob/AdMobNativeFragment.kt
@@ -19,7 +19,6 @@ import org.prebid.mobile.renderingtestapp.databinding.FragmentAdmobNativeBinding
 import org.prebid.mobile.renderingtestapp.databinding.ViewNativeAdBinding
 import org.prebid.mobile.renderingtestapp.plugplay.config.AdConfiguratorDialogFragment
 import org.prebid.mobile.renderingtestapp.utils.BaseEvents
-import org.prebid.mobile.renderingtestapp.utils.CommandLineArgumentParser
 
 class AdMobNativeFragment : AdFragment() {
 
@@ -34,14 +33,12 @@ class AdMobNativeFragment : AdFragment() {
 
     private val binding: FragmentAdmobNativeBinding
         get() = getBinding()
-    private lateinit var events: Events
+    protected val events by lazy { Events(binding.root) }
 
     override val layoutRes = R.layout.fragment_admob_native
 
     override fun initUi(view: View, savedInstanceState: Bundle?) {
         super.initUi(view, savedInstanceState)
-
-        events = Events(view)
 
         binding.adIdLabel.text = getString(R.string.label_auid, configId)
         binding.btnLoad.setOnClickListener {
@@ -149,7 +146,7 @@ class AdMobNativeFragment : AdFragment() {
         wrapper.addView(binding.root)
     }
 
-    private class Events(parentView: View) : BaseEvents(parentView) {
+    protected class Events(parentView: View) : BaseEvents(parentView) {
 
         fun loaded(b: Boolean) = enable(R.id.btnAdLoaded, b)
         fun opened(b: Boolean) = enable(R.id.btnAdOpened, b)

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/admob/AdMobRewardedFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/admob/AdMobRewardedFragment.kt
@@ -30,14 +30,12 @@ open class AdMobRewardedFragment : AdFragment() {
 
     protected val binding: FragmentAdmobRewardedBinding
         get() = getBinding()
-    protected lateinit var events: Events
+    protected val events by lazy { Events(binding.root) }
 
     override val layoutRes = R.layout.fragment_admob_rewarded
 
     override fun initUi(view: View, savedInstanceState: Bundle?) {
         super.initUi(view, savedInstanceState)
-
-        events = Events(view)
 
         binding.adIdLabel.text = getString(R.string.label_auid, configId)
         binding.btnLoad.setOnClickListener {

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/base/BaseBidInterstitialFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/base/BaseBidInterstitialFragment.kt
@@ -39,12 +39,11 @@ abstract class BaseBidInterstitialFragment : AdFragment(),
 
     protected val binding: FragmentBiddingInterstitialBinding
         get() = getBinding()
-    protected lateinit var events: Events
+    protected val events by lazy { Events(binding.root) }
 
     override fun initUi(view: View, savedInstanceState: Bundle?) {
         super.initUi(view, savedInstanceState)
 
-        events = Events(view)
         binding.btnLoad.setOnClickListener {
             handleLoadInterstitialClick()
         }

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/base/BaseBidRewardedFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/base/BaseBidRewardedFragment.kt
@@ -38,11 +38,11 @@ abstract class BaseBidRewardedFragment : AdFragment() {
 
     protected val binding: FragmentBiddingRewardedBinding
         get() = getBinding()
-    protected lateinit var events: Events
+    protected val events by lazy { Events(binding.root) }
 
     override fun initUi(view: View, savedInstanceState: Bundle?) {
         super.initUi(view, savedInstanceState)
-        events = Events(view)
+
         binding.btnLoad.setOnClickListener {
             handleLoadInterstitialClick()
         }

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/gam/original/GamOriginalBannerFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/gam/original/GamOriginalBannerFragment.kt
@@ -32,7 +32,6 @@ import org.prebid.mobile.renderingtestapp.R
 import org.prebid.mobile.renderingtestapp.databinding.FragmentBiddingBannerBinding
 import org.prebid.mobile.renderingtestapp.plugplay.config.AdConfiguratorDialogFragment
 import org.prebid.mobile.renderingtestapp.utils.BaseEvents
-import org.prebid.mobile.renderingtestapp.utils.CommandLineArgumentParser
 
 open class GamOriginalBannerFragment : AdFragment() {
     companion object {
@@ -46,7 +45,7 @@ open class GamOriginalBannerFragment : AdFragment() {
 
     private val binding: FragmentBiddingBannerBinding
         get() = getBinding()
-    private lateinit var events: Events
+    protected val events by lazy { Events(binding.root) }
 
     open fun createAdUnit(): BannerAdUnit {
         val adUnit = BannerAdUnit(configId, width, height)
@@ -58,7 +57,7 @@ open class GamOriginalBannerFragment : AdFragment() {
 
     override fun initUi(view: View, savedInstanceState: Bundle?) {
         super.initUi(view, savedInstanceState)
-        events = Events(view)
+
         binding.adIdLabel.text = getString(R.string.label_auid, configId)
         binding.btnLoad.setOnClickListener {
             resetEventButtons()
@@ -127,7 +126,7 @@ open class GamOriginalBannerFragment : AdFragment() {
         adUnit?.destroy()
     }
 
-    private class Events(parentView: View) : BaseEvents(parentView) {
+    protected class Events(parentView: View) : BaseEvents(parentView) {
 
         fun loaded(b: Boolean) = enable(R.id.btnAdLoaded, b)
         fun clicked(b: Boolean) = enable(R.id.btnAdClicked, b)

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/gam/original/GamOriginalMultiformatBannerVideoNativeFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/gam/original/GamOriginalMultiformatBannerVideoNativeFragment.kt
@@ -60,7 +60,7 @@ open class GamOriginalMultiformatBannerVideoNativeFragment : AdFragment() {
 
     override val layoutRes = R.layout.fragment_bidding_multiformat
 
-    private lateinit var events: Events
+    protected val events by lazy { Events(binding.root) }
     private var prebidAdUnit: PrebidAdUnit? = null
     private val params = arrayOf(Params.BANNER, Params.VIDEO, Params.NATIVE)
     private val binding: FragmentBiddingMultiformatBinding get() = getBinding()
@@ -72,7 +72,6 @@ open class GamOriginalMultiformatBannerVideoNativeFragment : AdFragment() {
 
     override fun initUi(view: View, savedInstanceState: Bundle?) {
         super.initUi(view, savedInstanceState)
-        events = Events(view)
         initButtons()
     }
 
@@ -301,7 +300,7 @@ open class GamOriginalMultiformatBannerVideoNativeFragment : AdFragment() {
         prebidAdUnit?.destroy()
     }
 
-    private class Events(parentView: View) : BaseEvents(parentView) {
+    protected class Events(parentView: View) : BaseEvents(parentView) {
 
         fun loaded(b: Boolean) = enable(R.id.btnAdLoaded, b)
         fun impression(b: Boolean) = enable(R.id.btnAdImpression, b)

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/gam/original/GamOriginalMultiformatBannerVideoNativeStylesFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/gam/original/GamOriginalMultiformatBannerVideoNativeStylesFragment.kt
@@ -46,7 +46,7 @@ open class GamOriginalMultiformatBannerVideoNativeStylesFragment : AdFragment() 
 
     override val layoutRes = R.layout.fragment_bidding_multiformat
 
-    private lateinit var events: Events
+    protected val events by lazy { Events(binding.root) }
     private var prebidAdUnit: PrebidAdUnit? = null
     private val params = arrayOf(Params.BANNER, Params.VIDEO, Params.NATIVE)
     private val binding: FragmentBiddingMultiformatBinding get() = getBinding()
@@ -58,7 +58,6 @@ open class GamOriginalMultiformatBannerVideoNativeStylesFragment : AdFragment() 
 
     override fun initUi(view: View, savedInstanceState: Bundle?) {
         super.initUi(view, savedInstanceState)
-        events = Events(view)
         initButtons()
     }
 
@@ -198,7 +197,7 @@ open class GamOriginalMultiformatBannerVideoNativeStylesFragment : AdFragment() 
         prebidAdUnit?.destroy()
     }
 
-    private class Events(parentView: View) : BaseEvents(parentView) {
+    protected class Events(parentView: View) : BaseEvents(parentView) {
 
         fun loaded(b: Boolean) = enable(R.id.btnAdLoaded, b)
         fun impression(b: Boolean) = enable(R.id.btnAdImpression, b)

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/gam/original/GamOriginalNativeBannerFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/gam/original/GamOriginalNativeBannerFragment.kt
@@ -3,8 +3,6 @@ package org.prebid.mobile.renderingtestapp.plugplay.bidding.gam.original
 import android.os.Bundle
 import android.util.Log
 import android.view.View
-import android.widget.Button
-import android.widget.RelativeLayout
 import com.google.android.gms.ads.AdListener
 import com.google.android.gms.ads.AdSize
 import com.google.android.gms.ads.LoadAdError
@@ -18,7 +16,6 @@ import org.prebid.mobile.renderingtestapp.R
 import org.prebid.mobile.renderingtestapp.databinding.FragmentBiddingBannerBinding
 import org.prebid.mobile.renderingtestapp.plugplay.config.AdConfiguratorDialogFragment
 import org.prebid.mobile.renderingtestapp.utils.BaseEvents
-import org.prebid.mobile.renderingtestapp.widgets.EventCounterView
 
 class GamOriginalNativeBannerFragment : AdFragment() {
 
@@ -31,11 +28,10 @@ class GamOriginalNativeBannerFragment : AdFragment() {
 
     private val binding: FragmentBiddingBannerBinding
         get() = getBinding()
-    private lateinit var events: Events
+    protected val events by lazy { Events(binding.root) }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        events = Events(view)
         binding.btnLoad.setOnClickListener {
             resetEventButtons()
             loadAd()
@@ -147,7 +143,7 @@ class GamOriginalNativeBannerFragment : AdFragment() {
         nativeAdUnit?.destroy()
     }
 
-    private class Events(parentView: View) : BaseEvents(parentView) {
+    class Events(parentView: View) : BaseEvents(parentView) {
 
         fun loaded(b: Boolean) = enable(R.id.btnAdLoaded, b)
         fun clicked(b: Boolean) = enable(R.id.btnAdClicked, b)

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/gam/original/GamOriginalOutstreamFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/gam/original/GamOriginalOutstreamFragment.kt
@@ -44,10 +44,9 @@ class GamOriginalOutstreamFragment : AdFragment() {
 
     private val binding: FragmentBiddingBannerVideoBinding
         get() = getBinding()
-    private lateinit var events: Events
+    protected val events by lazy { Events(binding.root) }
 
     override fun initAd(): Any? {
-        events = Events(view!!)
         adUnit = BannerAdUnit(
             configId,
             width,
@@ -111,7 +110,7 @@ class GamOriginalOutstreamFragment : AdFragment() {
     override val layoutRes: Int = R.layout.fragment_bidding_banner_video
 
 
-    private class Events(parentView: View) : BaseEvents(parentView) {
+    protected class Events(parentView: View) : BaseEvents(parentView) {
 
         fun loaded(b: Boolean) = enable(R.id.btnAdLoaded, b)
         fun clicked(b: Boolean) = enable(R.id.btnAdClicked, b)

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/gam/original/GamOriginalOutstreamNewApiFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/gam/original/GamOriginalOutstreamNewApiFragment.kt
@@ -44,10 +44,9 @@ class GamOriginalOutstreamNewApiFragment : AdFragment() {
 
     private val binding: FragmentBiddingBannerVideoBinding
         get() = getBinding()
-    private lateinit var events: Events
+    protected val events by lazy { Events(binding.root) }
 
     override fun initAd(): Any? {
-        events = Events(view!!)
         adUnit = BannerAdUnit(
             configId,
             width,
@@ -111,7 +110,7 @@ class GamOriginalOutstreamNewApiFragment : AdFragment() {
     override val layoutRes: Int = R.layout.fragment_bidding_banner_video
 
 
-    private class Events(parentView: View) : BaseEvents(parentView) {
+    protected class Events(parentView: View) : BaseEvents(parentView) {
 
         fun loaded(b: Boolean) = enable(R.id.btnAdLoaded, b)
         fun clicked(b: Boolean) = enable(R.id.btnAdClicked, b)

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/gam/rendering/GamBannerFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/gam/rendering/GamBannerFragment.kt
@@ -29,7 +29,6 @@ import org.prebid.mobile.renderingtestapp.R
 import org.prebid.mobile.renderingtestapp.databinding.FragmentBiddingBannerBinding
 import org.prebid.mobile.renderingtestapp.plugplay.config.AdConfiguratorDialogFragment
 import org.prebid.mobile.renderingtestapp.utils.BaseEvents
-import org.prebid.mobile.renderingtestapp.utils.CommandLineArgumentParser
 
 open class GamBannerFragment : AdFragment(),
     BannerViewListener {
@@ -40,11 +39,10 @@ open class GamBannerFragment : AdFragment(),
     protected var bannerView: BannerView? = null
     protected val binding: FragmentBiddingBannerBinding
         get() = getBinding()
-    protected lateinit var events: Events
+    protected val events by lazy { Events(binding.root) }
 
     override fun initUi(view: View, savedInstanceState: Bundle?) {
         super.initUi(view, savedInstanceState)
-        events = Events(view)
         binding.adIdLabel.text = getString(R.string.label_auid, configId)
         binding.btnLoad.setOnClickListener {
             resetEventButtons()

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/gam/rendering/GamOutstreamFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/gam/rendering/GamOutstreamFragment.kt
@@ -38,7 +38,7 @@ class GamOutstreamFragment : AdFragment(), BannerViewListener {
     override val layoutRes: Int = R.layout.fragment_bidding_banner_video
 
     protected var bannerView: BannerView? = null
-    protected lateinit var events: Events
+    protected val events by lazy { Events(binding.root) }
     protected val binding: FragmentBiddingBannerVideoBinding
         get() = getBinding()
 
@@ -51,7 +51,6 @@ class GamOutstreamFragment : AdFragment(), BannerViewListener {
 
     override fun initUi(view: View, savedInstanceState: Bundle?) {
         super.initUi(view, savedInstanceState)
-        events = Events(view)
         binding.adIdLabel.text = getString(R.string.label_auid, configId)
         binding.btnLoad.setOnClickListener {
             resetEventButtons()

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/max/MaxBannerFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/max/MaxBannerFragment.kt
@@ -32,13 +32,12 @@ open class MaxBannerFragment : AdFragment() {
 
     protected val binding: FragmentBiddingBannerApplovinMaxBinding
         get() = getBinding()
-    protected lateinit var events: Events
+    protected val events by lazy { Events(binding.root) }
 
     override fun configuratorMode() = AdConfiguratorDialogFragment.AdConfiguratorMode.BANNER
 
     override fun initUi(view: View, savedInstanceState: Bundle?) {
         super.initUi(view, savedInstanceState)
-        events = Events(view)
         binding.adIdLabel.text = getString(R.string.label_auid, configId)
         binding.btnLoad.setOnClickListener {
             resetAdEvents()

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/max/MaxInterstitialFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/max/MaxInterstitialFragment.kt
@@ -35,11 +35,10 @@ open class MaxInterstitialFragment : AdFragment() {
 
     private val binding: FragmentBiddingInterstitialApplovinMaxBinding
         get() = getBinding()
-    private lateinit var events: Events
+    protected val events by lazy { Events(binding.root) }
 
     override fun initUi(view: View, savedInstanceState: Bundle?) {
         super.initUi(view, savedInstanceState)
-        events = Events(view)
         binding.adIdLabel.text = getString(R.string.label_auid, configId)
         binding.btnLoad.setOnClickListener {
             handleLoadButtonClick()

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/max/MaxNativeFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/max/MaxNativeFragment.kt
@@ -34,12 +34,11 @@ open class MaxNativeFragment : AdFragment() {
 
     private val binding: FragmentBiddingNativeApplovinMaxBinding
         get() = getBinding()
-    private lateinit var events: Events
+    protected val events by lazy { Events(binding.root) }
 
     override fun initUi(view: View, savedInstanceState: Bundle?) {
         super.initUi(view, savedInstanceState)
 
-        events = Events(view)
         binding.adIdLabel.text = getString(R.string.label_auid, configId)
         binding.btnLoad.setOnClickListener {
             resetAdEvents()

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/max/MaxRewardedFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/max/MaxRewardedFragment.kt
@@ -31,11 +31,11 @@ open class MaxRewardedFragment : AdFragment() {
 
     private val binding: FragmentBiddingRewardedApplovinMaxBinding
         get() = getBinding()
-    private lateinit var events: Events
+    protected val events by lazy { Events(binding.root) }
 
     override fun initUi(view: View, savedInstanceState: Bundle?) {
         super.initUi(view, savedInstanceState)
-        events = Events(view)
+
         binding.adIdLabel.text = getString(R.string.label_auid, configId)
         binding.btnLoad.setOnClickListener {
             handleLoadButtonClick()

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/pluginrenderer/PpmBannerPluginEventListenerFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/pluginrenderer/PpmBannerPluginEventListenerFragment.kt
@@ -29,7 +29,6 @@ import org.prebid.mobile.renderingtestapp.R
 import org.prebid.mobile.renderingtestapp.databinding.FragmentBiddingBannerBinding
 import org.prebid.mobile.renderingtestapp.plugplay.config.AdConfiguratorDialogFragment
 import org.prebid.mobile.renderingtestapp.utils.BaseEvents
-import org.prebid.mobile.renderingtestapp.utils.CommandLineArgumentParser
 import org.prebid.mobile.renderingtestapp.utils.SampleCustomRenderer
 import org.prebid.mobile.renderingtestapp.utils.SampleCustomRendererEventListener
 
@@ -44,7 +43,7 @@ open class PpmBannerPluginEventListenerFragment : AdFragment(), BannerViewListen
     protected val binding: FragmentBiddingBannerBinding
         get() = getBinding()
 
-    protected lateinit var events: Events
+    protected val events by lazy { Events(binding.root) }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -53,7 +52,7 @@ open class PpmBannerPluginEventListenerFragment : AdFragment(), BannerViewListen
 
     override fun initUi(view: View, savedInstanceState: Bundle?) {
         super.initUi(view, savedInstanceState)
-        events = Events(view)
+
         binding.adIdLabel.text = getString(R.string.label_auid, configId)
         binding.btnLoad.setOnClickListener {
             resetEventButtons()

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/pluginrenderer/PpmBannerPluginRendererFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/pluginrenderer/PpmBannerPluginRendererFragment.kt
@@ -28,7 +28,6 @@ import org.prebid.mobile.renderingtestapp.R
 import org.prebid.mobile.renderingtestapp.databinding.FragmentBiddingBannerBinding
 import org.prebid.mobile.renderingtestapp.plugplay.config.AdConfiguratorDialogFragment
 import org.prebid.mobile.renderingtestapp.utils.BaseEvents
-import org.prebid.mobile.renderingtestapp.utils.CommandLineArgumentParser
 import org.prebid.mobile.renderingtestapp.utils.SampleCustomRenderer
 
 open class PpmBannerPluginRendererFragment : AdFragment(), BannerViewListener {
@@ -42,7 +41,7 @@ open class PpmBannerPluginRendererFragment : AdFragment(), BannerViewListener {
     protected val binding: FragmentBiddingBannerBinding
         get() = getBinding()
 
-    protected lateinit var events: Events
+    protected val events by lazy { Events(binding.root) }
 
     override fun onCreate(savedInstanceState: Bundle?) {
         super.onCreate(savedInstanceState)
@@ -51,7 +50,7 @@ open class PpmBannerPluginRendererFragment : AdFragment(), BannerViewListener {
 
     override fun initUi(view: View, savedInstanceState: Bundle?) {
         super.initUi(view, savedInstanceState)
-        events = Events(view)
+
         binding.adIdLabel.text = getString(R.string.label_auid, configId)
         binding.btnLoad.setOnClickListener {
             resetEventButtons()

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/ppm/PpmBannerFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/ppm/PpmBannerFragment.kt
@@ -27,7 +27,6 @@ import org.prebid.mobile.renderingtestapp.R
 import org.prebid.mobile.renderingtestapp.databinding.FragmentBiddingBannerBinding
 import org.prebid.mobile.renderingtestapp.plugplay.config.AdConfiguratorDialogFragment
 import org.prebid.mobile.renderingtestapp.utils.BaseEvents
-import org.prebid.mobile.renderingtestapp.utils.CommandLineArgumentParser
 
 open class PpmBannerFragment : AdFragment(), BannerViewListener {
     private val TAG = PpmBannerFragment::class.java.simpleName
@@ -39,11 +38,11 @@ open class PpmBannerFragment : AdFragment(), BannerViewListener {
     protected val binding: FragmentBiddingBannerBinding
         get() = getBinding()
 
-    protected lateinit var events: Events
+    protected val events by lazy { Events(binding.root) }
 
     override fun initUi(view: View, savedInstanceState: Bundle?) {
         super.initUi(view, savedInstanceState)
-        events = Events(view)
+
         binding.adIdLabel.text = getString(R.string.label_auid, configId)
         binding.btnLoad.setOnClickListener {
             resetEventButtons()

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/ppm/PpmNativeFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/ppm/PpmNativeFragment.kt
@@ -43,11 +43,10 @@ open class PpmNativeFragment : AdFragment() {
 
     protected val binding: FragmentNativeBinding
         get() = getBinding()
-    protected lateinit var events: Events
+    protected val events by lazy { Events(binding.root) }
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
-        events = Events(view)
 
         if (layoutRes == R.layout.fragment_native) {
             layoutInflater.inflate(

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/ppm/PpmVideoFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/ppm/PpmVideoFragment.kt
@@ -42,12 +42,12 @@ open class PpmVideoFragment : AdFragment(), BannerViewListener, BannerVideoListe
     protected val binding: FragmentBiddingBannerVideoBinding
         get() = getBinding()
 
-    protected lateinit var events: Events
+    protected val events by lazy { Events(binding.root) }
 
 
     override fun initUi(view: View, savedInstanceState: Bundle?) {
         super.initUi(view, savedInstanceState)
-        events = Events(view)
+
         binding.adIdLabel.text = getString(R.string.label_auid, configId)
         binding.btnLoad.setOnClickListener {
             resetEventButtons()


### PR DESCRIPTION
In some cases in the internal test app crashes when there is ad failed callback (f.e. when network is disabled). 
```
                       E  FATAL EXCEPTION: main
                          Process: org.prebid.mobile.renderingtestapp, PID: 21150
                          kotlin.UninitializedPropertyAccessException: lateinit property events has not been initialized
                          	at org.prebid.mobile.renderingtestapp.plugplay.bidding.ppm.PpmVideoFragment.getEvents(PpmVideoFragment.kt:45)
                          	at org.prebid.mobile.renderingtestapp.plugplay.bidding.ppm.PpmVideoFragment.onAdFailed(PpmVideoFragment.kt:89)
                          	at org.prebid.mobile.api.rendering.BannerView.notifyErrorListener(BannerView.java:521)
                          	at org.prebid.mobile.api.rendering.BannerView.-$$Nest$mnotifyErrorListener(Unknown Source:0)
                          	at org.prebid.mobile.api.rendering.BannerView$4.onPrebidSdkWin(BannerView.java:191)
                          	at org.prebid.mobile.rendering.bidding.interfaces.StandaloneBannerEventHandler.requestAdWithBid(StandaloneBannerEventHandler.java:38)
                          	at org.prebid.mobile.api.rendering.BannerView$3.onError(BannerView.java:181)
                          	at org.prebid.mobile.rendering.bidding.loader.BidLoader.failedToLoadBid(BidLoader.java:207)
                          	at org.prebid.mobile.rendering.bidding.loader.BidLoader.-$$Nest$mfailedToLoadBid(Unknown Source:0)
                          	at org.prebid.mobile.rendering.bidding.loader.BidLoader$1.onErrorWithException(BidLoader.java:88)
                          	at org.prebid.mobile.rendering.networking.modelcontrollers.Requester.sendAdException(Requester.java:143)
                          	at org.prebid.mobile.rendering.networking.modelcontrollers.Requester.makeAdRequest(Requester.java:161)
                          	at org.prebid.mobile.rendering.networking.modelcontrollers.Requester.getAdId(Requester.java:133)
                          	at org.prebid.mobile.rendering.networking.modelcontrollers.BidRequester.startAdRequest(BidRequester.java:45)
                          	at org.prebid.mobile.rendering.bidding.loader.BidLoader.sendBidRequest(BidLoader.java:193)
                          	at org.prebid.mobile.rendering.bidding.loader.BidLoader.load(BidLoader.java:144)
                          	at org.prebid.mobile.api.rendering.BannerView.loadAd(BannerView.java:304)
                          	at org.prebid.mobile.renderingtestapp.plugplay.bidding.ppm.PpmVideoFragment.loadAd(PpmVideoFragment.kt:79)
                          	at org.prebid.mobile.renderingtestapp.AdFragment.startAd(AdFragment.kt:171)
                          	at org.prebid.mobile.renderingtestapp.AdFragment.initUi(AdFragment.kt:81)
                          	at org.prebid.mobile.renderingtestapp.plugplay.bidding.ppm.PpmVideoFragment.initUi(PpmVideoFragment.kt:49)
                          	at org.prebid.mobile.renderingtestapp.utils.BaseFragment.onViewCreated(BaseFragment.kt:49)
                          	at org.prebid.mobile.renderingtestapp.AdFragment.onViewCreated(AdFragment.kt:86)
```