### PR TITLE
fix: hb_cache_id_local is not added to targetingKeywords if adObject is null

### DIFF
--- a/Example/PrebidDemoJava/src/main/java/org/prebid/mobile/javademo/activities/ads/gam/original/GamOriginalApiNativeInApp.java
+++ b/Example/PrebidDemoJava/src/main/java/org/prebid/mobile/javademo/activities/ads/gam/original/GamOriginalApiNativeInApp.java
@@ -36,7 +36,6 @@ import org.prebid.mobile.javademo.activities.BaseAdActivity;
 import org.prebid.mobile.javademo.utils.ImageUtils;
 
 import java.util.ArrayList;
-import java.util.Map;
 
 public class GamOriginalApiNativeInApp extends BaseAdActivity {
 
@@ -61,17 +60,9 @@ public class GamOriginalApiNativeInApp extends BaseAdActivity {
         adUnit = new NativeAdUnit(CONFIG_ID);
         configureNativeAdUnit(adUnit);
 
-        final AdManagerAdRequest.Builder builder = new AdManagerAdRequest.Builder();
+        final AdManagerAdRequest adRequest = new AdManagerAdRequest.Builder().build();
         adLoader = createAdLoader(getAdWrapperView());
-        adUnit.fetchDemand((bidInfo) -> {
-            final Map<String, String> targetingKeywords = bidInfo.getTargetingKeywords();
-            if (targetingKeywords == null) return;
-            for (var entry : targetingKeywords.entrySet()) {
-                builder.addCustomTargeting(entry.getKey(), entry.getValue());
-            }
-            AdManagerAdRequest request = builder.build();
-            adLoader.loadAd(request);
-        });
+        adUnit.fetchDemand(adRequest, resultCode -> adLoader.loadAd(adRequest));
     }
 
     private void inflatePrebidNativeAd(

--- a/Example/PrebidDemoJava/src/main/java/org/prebid/mobile/javademo/activities/ads/gam/original/GamOriginalApiNativeInApp.java
+++ b/Example/PrebidDemoJava/src/main/java/org/prebid/mobile/javademo/activities/ads/gam/original/GamOriginalApiNativeInApp.java
@@ -36,6 +36,7 @@ import org.prebid.mobile.javademo.activities.BaseAdActivity;
 import org.prebid.mobile.javademo.utils.ImageUtils;
 
 import java.util.ArrayList;
+import java.util.Map;
 
 public class GamOriginalApiNativeInApp extends BaseAdActivity {
 
@@ -60,9 +61,17 @@ public class GamOriginalApiNativeInApp extends BaseAdActivity {
         adUnit = new NativeAdUnit(CONFIG_ID);
         configureNativeAdUnit(adUnit);
 
-        final AdManagerAdRequest adRequest = new AdManagerAdRequest.Builder().build();
+        final AdManagerAdRequest.Builder builder = new AdManagerAdRequest.Builder();
         adLoader = createAdLoader(getAdWrapperView());
-        adUnit.fetchDemand(adRequest, resultCode -> adLoader.loadAd(adRequest));
+        adUnit.fetchDemand((bidInfo) -> {
+            final Map<String, String> targetingKeywords = bidInfo.getTargetingKeywords();
+            if (targetingKeywords == null) return;
+            for (var entry : targetingKeywords.entrySet()) {
+                builder.addCustomTargeting(entry.getKey(), entry.getValue());
+            }
+            AdManagerAdRequest request = builder.build();
+            adLoader.loadAd(request);
+        });
     }
 
     private void inflatePrebidNativeAd(

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/Util.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/Util.java
@@ -26,6 +26,7 @@ import androidx.annotation.Nullable;
 import org.json.JSONArray;
 import org.json.JSONException;
 import org.json.JSONObject;
+import org.prebid.mobile.rendering.bidding.data.bid.BidResponse;
 
 import java.lang.reflect.Method;
 import java.util.ArrayList;
@@ -376,7 +377,7 @@ public class Util {
         try {
             Bundle bundle = (Bundle) Util.callMethodOnObject(object, "getCustomTargeting");
             if (bundle != null) {
-                String key = "hb_cache_id_local";
+                String key = BidResponse.KEY_CACHE_ID;
                 bundle.putString(key, cacheId);
                 addReservedKeys(key);
             }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/addendum/AdViewUtils.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/addendum/AdViewUtils.java
@@ -33,6 +33,7 @@ import org.prebid.mobile.LogUtil;
 import org.prebid.mobile.PrebidMobile.LogLevel;
 import org.prebid.mobile.PrebidNativeAd;
 import org.prebid.mobile.PrebidNativeAdListener;
+import org.prebid.mobile.rendering.bidding.data.bid.BidResponse;
 
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
@@ -465,7 +466,7 @@ public final class AdViewUtils {
     private static void findNativeInGAMCustomTemplateAd(@NonNull Object object, @NonNull PrebidNativeAdListener listener) {
         String isPrebid = (String) callMethodOnObject(object, "getText", "isPrebid");
         if ("1".equals(isPrebid)) {
-            String cacheId = (String) callMethodOnObject(object, "getText", "hb_cache_id_local");
+            String cacheId = (String) callMethodOnObject(object, "getText", BidResponse.KEY_CACHE_ID);
             PrebidNativeAd ad = createPrebidNativeAd(cacheId, listener);
             if (ad != null) {
                 listener.onPrebidNativeLoaded(ad);

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/data/BidInfo.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/data/BidInfo.java
@@ -89,7 +89,11 @@ public class BidInfo {
 
         boolean isNative = configuration != null && configuration.getNativeConfiguration() != null;
         if (isNative && bidInfo.resultCode == ResultCode.SUCCESS) {
-            bidInfo.nativeCacheId = CacheManager.save(bidResponse.getWinningBidJson());
+            final @Nullable String cacheId = CacheManager.save(bidResponse.getWinningBidJson());
+            bidInfo.nativeCacheId = cacheId;
+            if (cacheId != null) {
+                bidInfo.targetingKeywords.put(BidResponse.KEY_CACHE_ID, cacheId);
+            }
         }
 
         return bidInfo;


### PR DESCRIPTION
### Summary
`GamOriginalApiNativeInApp` will fail to show the ad on 1bbd1da0bab74e878b4df4c5d34360c082222579 because `nativeAdUnit.fetchDemand((bidInfo) -> { …})` is used and `adObject` is `null`.

#### Why `adObject = null` fails

`NativeAdUnit` will need to propagate the `String cacheId` from `CacheManager.save(response.getWinningBidJson())` downstream so `AdViewUtils.findNative` can later find it inside one of Google Ad Manager classes (`NativeCustomTemplateAd`, `NativeCustomFormatAd`, etc). This propagation does not happen when `fetchDemand`'s `adObject` is `null` 
- `Utils.saveCacheId` returns early and does nothing
- Google Ad Manager instance does not have `hb_cache_id_local`
- `AdViewUtils.findNative` calls `PrebidNativeAdListener.onPrebidNativeNotValid`.

#### Why `adObject = AdManagerAdRequest` succeeds

The `Util.saveCacheId` with an instance of `AdManagerAdRequest` as `adObject` will add `hb_cache_id_local` into its `customTargeting` https://github.com/prebid/prebid-mobile-android/blob/8e431b6c15fe647de47d1f78e3952b3215ca388a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/Util.java#L380

That targeting is propagated into `NativeCustomFormatAd` so `AdViewUtils.findNative` can successfully get the saved ad from `CacheManager.get(cacheId)`.

### Solution

Add the `hb_cache_id_local` into `bidInfo.targetingKeywords` if it's native to be similar with `AdManagerAdRequest` code path.