### PR TITLE
Fix bar layout params is null #905

### DIFF
--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/views/browser/AdBrowserActivity.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/views/browser/AdBrowserActivity.java
@@ -166,7 +166,6 @@ public final class AdBrowserActivity extends Activity
         initBrowserControls();
 
         RelativeLayout contentLayout = new RelativeLayout(this);
-        RelativeLayout.LayoutParams barLayoutParams = null;
         RelativeLayout.LayoutParams webViewLayoutParams = new RelativeLayout.LayoutParams(LayoutParams.MATCH_PARENT,
                 LayoutParams.MATCH_PARENT
         );
@@ -178,7 +177,6 @@ public final class AdBrowserActivity extends Activity
             webView.setWebViewClient(new AdBrowserActivityWebViewClient(AdBrowserActivity.this));
             webView.loadUrl(url);
 
-            barLayoutParams = new RelativeLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT);
             if (browserControls != null) {
                 browserControls.showNavigationControls();
             }
@@ -191,6 +189,7 @@ public final class AdBrowserActivity extends Activity
         }
 
         if (browserControls != null) {
+            RelativeLayout.LayoutParams barLayoutParams = new RelativeLayout.LayoutParams(LayoutParams.MATCH_PARENT, LayoutParams.WRAP_CONTENT);
             contentLayout.addView(browserControls, barLayoutParams);
         }
 


### PR DESCRIPTION
In rare situations where a user clicks on an advertisement but the click‑URL is missing, the bar layout parameters may remain uninitialised, which causes the application to crash.

#905.