### PR TITLE
Update GMA SDK to 25.2.0

### DIFF
--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/HeaderBiddingViewModel.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/HeaderBiddingViewModel.kt
@@ -41,8 +41,8 @@ class HeaderBiddingViewModel(
     val demoItems: LiveData<List<DemoItem>>
         get() = _demoItems
 
-    private val _navigateToDemoExample = MutableLiveData<DemoItem>()
-    val navigateToDemoExample: LiveData<DemoItem>
+    private val _navigateToDemoExample = MutableLiveData<DemoItem?>()
+    val navigateToDemoExample: LiveData<DemoItem?>
         get() = _navigateToDemoExample
 
     private val _configurationState = MutableLiveData<Boolean>()

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/PrebidMobile.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/PrebidMobile.java
@@ -87,7 +87,7 @@ public class PrebidMobile {
     /**
      * Tested Google SDK version.
      */
-    public static final String TESTED_GOOGLE_SDK_VERSION = "25.1.0";
+    public static final String TESTED_GOOGLE_SDK_VERSION = "25.2.0";
 
     /**
      * Tested Google Next-Gen SDK version.

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/networking/BaseNetworkTask.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/networking/BaseNetworkTask.java
@@ -297,7 +297,7 @@ public class BaseNetworkTask
 
     @VisibleForTesting
     protected static void sendRequest(@NotNull String requestBody, @NotNull OutputStream requestStream) throws IOException {
-        byte[] bytes = requestBody.getBytes();
+        byte[] bytes = requestBody.getBytes("UTF-8");
         for (byte b : bytes) {
             requestStream.write(b);
         }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/networking/BaseNetworkTaskTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/networking/BaseNetworkTaskTest.java
@@ -313,7 +313,7 @@ public class BaseNetworkTaskTest {
 
         BaseNetworkTask.sendRequest("{\"app\":\"天気\"}", request);
 
-        Assert.assertEquals("{\"app\":\"天気\"}", request.toString());
+        Assert.assertEquals("{\"app\":\"天気\"}", request.toString("UTF-8"));
     }
 
 }

--- a/scripts/Maven/PrebidMobile-admobAdapters-pom.xml
+++ b/scripts/Maven/PrebidMobile-admobAdapters-pom.xml
@@ -60,7 +60,7 @@
         <dependency>
             <groupId>com.google.android.gms</groupId>
             <artifactId>play-services-ads</artifactId>
-            <version>25.1.0</version>
+            <version>25.2.0</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>

--- a/scripts/Maven/PrebidMobile-gamEventHandlers-pom.xml
+++ b/scripts/Maven/PrebidMobile-gamEventHandlers-pom.xml
@@ -59,7 +59,7 @@
         <dependency>
             <groupId>com.google.android.gms</groupId>
             <artifactId>play-services-ads</artifactId>
-            <version>25.1.0</version>
+            <version>25.2.0</version>
             <scope>compile</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
- Update GMA SDK to 25.2.0

 - Fix build (nullable type check)
```
/builds/id5-sync/prebid-mobile-android/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/HeaderBiddingViewModel.kt:94: Error: Cannot set non-nullable LiveData value to null [NullSafeMutableLiveData from androidx.lifecycle]
        _navigateToDemoExample.value = null
                                       ~~~~
   Explanation for issues of type "NullSafeMutableLiveData":
   This check ensures that LiveData values are not null when explicitly       
            declared as non-nullable.
                   Kotlin interoperability does not support enforcing explicit
   null-safety when using                 generic Java type parameters. Since
   LiveData is a Java class its value can always                 be null even
   when its type is explicitly declared as non-nullable. This can lead        
           to runtime exceptions from reading a null LiveData value that is
   assumed to be                 non-nullable.
   Vendor: Android Open Source Project
   Identifier: androidx.lifecycle
   Feedback: https://issuetracker.google.com/issues/new?component=413132
1 errors, 0 warnings
> Task :PrebidMobile-nextGenEventHandlers:verifyReleaseResources
```
- Fix encoding issue in `BaseNetworkTask`: explicitly use `UTF-8` charset instead of platform default to prevent test failures with multibyte characters on CI environments with `non-UTF-8` locale