### PR TITLE
Add didInjectView callback to PrebidMobilePluginRenderer

### DIFF
--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/BannerView.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/BannerView.java
@@ -19,8 +19,6 @@ package org.prebid.mobile.api.rendering;
 import android.content.Context;
 import android.content.res.TypedArray;
 import android.util.AttributeSet;
-import android.util.Pair;
-import android.view.Gravity;
 import android.view.View;
 import android.widget.FrameLayout;
 import androidx.annotation.NonNull;
@@ -488,12 +486,7 @@ public class BannerView extends FrameLayout {
         removeAllViews();
 
         displayView = new DisplayView(getContext(), displayViewListener, displayVideoListener, adUnitConfig, bidResponse);
-        if (bidResponse.getPreferredPluginRendererName().equals(PrebidMobilePluginRegister.PREBID_MOBILE_RENDERER_NAME)) {
-            final Pair<Integer, Integer> sizePair = bidResponse.getWinningBidWidthHeightPairDips(getContext());
-            addView(displayView, new FrameLayout.LayoutParams(sizePair.first, sizePair.second, Gravity.CENTER));
-        } else {
-            addView(displayView, new FrameLayout.LayoutParams(MATCH_PARENT, MATCH_PARENT));
-        }
+        addView(displayView, new FrameLayout.LayoutParams(MATCH_PARENT, MATCH_PARENT));
 
         // Give the PluginRenderer the final layout pass
         PrebidMobilePluginRenderer plugin = PrebidMobilePluginRegister.getInstance().getPluginForPreferredRenderer(bidResponse);

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/BannerView.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/BannerView.java
@@ -20,6 +20,7 @@ import android.content.Context;
 import android.content.res.TypedArray;
 import android.util.AttributeSet;
 import android.util.Pair;
+import android.view.Gravity;
 import android.view.View;
 import android.widget.FrameLayout;
 import androidx.annotation.NonNull;
@@ -35,6 +36,7 @@ import org.prebid.mobile.api.rendering.listeners.BannerVideoListener;
 import org.prebid.mobile.api.rendering.listeners.BannerViewListener;
 import org.prebid.mobile.api.rendering.pluginrenderer.PluginEventListener;
 import org.prebid.mobile.api.rendering.pluginrenderer.PrebidMobilePluginRegister;
+import org.prebid.mobile.api.rendering.pluginrenderer.PrebidMobilePluginRenderer;
 import org.prebid.mobile.configuration.AdUnitConfiguration;
 import org.prebid.mobile.core.R;
 import org.prebid.mobile.rendering.bidding.data.bid.Bid;
@@ -486,11 +488,17 @@ public class BannerView extends FrameLayout {
         removeAllViews();
 
         displayView = new DisplayView(getContext(), displayViewListener, displayVideoListener, adUnitConfig, bidResponse);
-        if (bidResponse.getPreferredPluginRendererName() == PrebidMobilePluginRegister.PREBID_MOBILE_RENDERER_NAME) {
+        if (bidResponse.getPreferredPluginRendererName().equals(PrebidMobilePluginRegister.PREBID_MOBILE_RENDERER_NAME)) {
             final Pair<Integer, Integer> sizePair = bidResponse.getWinningBidWidthHeightPairDips(getContext());
-            addView(displayView, sizePair.first, sizePair.second);
+            addView(displayView, new FrameLayout.LayoutParams(sizePair.first, sizePair.second, Gravity.CENTER));
         } else {
             addView(displayView, new FrameLayout.LayoutParams(MATCH_PARENT, MATCH_PARENT));
+        }
+
+        // Give the PluginRenderer the final layout pass
+        PrebidMobilePluginRenderer plugin = PrebidMobilePluginRegister.getInstance().getPluginForPreferredRenderer(bidResponse);
+        if (plugin != null) {
+            plugin.didInjectView(displayView, this, bidResponse);
         }
     }
 

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/PrebidRenderer.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/PrebidRenderer.java
@@ -19,7 +19,9 @@ package org.prebid.mobile.api.rendering;
 import static org.prebid.mobile.api.rendering.pluginrenderer.PrebidMobilePluginRegister.PREBID_MOBILE_RENDERER_NAME;
 
 import android.content.Context;
+import android.view.Gravity;
 import android.view.View;
+import android.widget.FrameLayout;
 
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
@@ -97,5 +99,10 @@ public class PrebidRenderer implements PrebidMobilePluginRenderer {
                 adUnitConfiguration.isAdType(AdFormat.INTERSTITIAL) ||
                 adUnitConfiguration.isAdType(AdFormat.NATIVE) ||
                 adUnitConfiguration.isAdType(AdFormat.VAST);
+    }
+
+    @Override
+    public void didInjectView(@NonNull View view, @NonNull View inBannerView, @NonNull BidResponse bidResponse) {
+        view.setLayoutParams(new FrameLayout.LayoutParams(FrameLayout.LayoutParams.WRAP_CONTENT, FrameLayout.LayoutParams.WRAP_CONTENT, Gravity.CENTER));
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/pluginrenderer/PrebidMobilePluginRenderer.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/pluginrenderer/PrebidMobilePluginRenderer.java
@@ -81,4 +81,14 @@ public interface PrebidMobilePluginRenderer {
      * Returns true only if the given ad unit could be renderer by the plugin
      */
     boolean isSupportRenderingFor(AdUnitConfiguration adUnitConfiguration);
+
+    /**
+     * Optional callback invoked after a view has been injected into a BannerView container
+     * to ensure that the renderer has the final layout pass.
+     * Default implementation is a no-op to preserve backward compatibility for existing plugins.
+     *
+     * @param view The view that was injected (typically a DisplayView or plugin-created ad view).
+     * @param inBannerView The BannerView container where the view was added.
+     */
+    default void didInjectView(@NonNull View view, @NonNull View inBannerView, @NonNull BidResponse bidResponse) { }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/bidding/data/bid/BidResponse.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/bidding/data/bid/BidResponse.java
@@ -25,6 +25,7 @@ import org.json.JSONException;
 import org.json.JSONObject;
 import org.prebid.mobile.LogUtil;
 import org.prebid.mobile.PrebidMobile;
+import org.prebid.mobile.api.rendering.pluginrenderer.PrebidMobilePluginRegister;
 import org.prebid.mobile.configuration.AdUnitConfiguration;
 import org.prebid.mobile.rendering.models.openrtb.bidRequests.Ext;
 import org.prebid.mobile.rendering.models.openrtb.bidRequests.MobileSdkPassThrough;
@@ -237,11 +238,16 @@ public class BidResponse {
     }
 
     public String getPreferredPluginRendererName() {
+        String renderer = null;
         Bid bid = getWinningBid();
         if (bid != null) {
-            return bid.getPrebid().getMeta().get(KEY_RENDERER_NAME);
+            renderer = bid.getPrebid().getMeta().get(KEY_RENDERER_NAME);
         }
-        return null;
+        // Return Prebid Mobile Renderer as default
+        if (renderer == null) {
+            renderer = PrebidMobilePluginRegister.PREBID_MOBILE_RENDERER_NAME;
+        }
+        return renderer;
     }
 
     public String getPreferredPluginRendererVersion() {


### PR DESCRIPTION
### Summary
This PR addresses a few issues I ran into while working with the plugin renderer system. 

**1. getPreferredPluginRendererName() returns null by default**
When a bid response doesn't include a renderer key in its meta, `getPreferredPluginRendererName()` is returning null. This  leads to a live production bug where the `if` condition in [BannerView.displayPrebidView](https://github.com/prebid/prebid-mobile-android/blob/f1fd15afc10a3685a643de85e1b8052cdcc9c94f/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/BannerView.java#L489-L494) that can never be hit, since by default it will always evaluate to false. 

**Fix:** Set PrebidRenderer as the default for `getPreferredPluginRendererName()`

**2. Final layout responsibility should be given to chosen PluginRenderer**
Layout parameters for the injected ad view are being set directly inside BannerView. Since BannerView doesn't have visibility into how a given renderer intends to display its content, this feels like the wrong place for this logic. The renderer itself is best positioned to own those decisions — it knows the ad format, creative dimensions, and any renderer-specific requirements.

**Fix:** Add new callback to the `PrebidMobilePluginRenderer` to notify it once the ad has been injected so it can manage the final layout.

**3. MATCH_PARENT is the wrong default for fixed-size banner ads**
Due to the bug from issue#1, MATCH_PARENT is always being set on the injected view. This is a potential source of issues since ideally the `PrebidRenderer` wants the size to be controlled by logic in `PrebidWebView`, and the outer `DisplayView` should simply WRAP_CONTENT.  

**Fix:** Use the new `didInjectView` method on PrebidRenderer to set WRAP_CONTENT with center gravity.

### Testing

I've tested these fixes on the PrebidInternalTestApp using every "Banner" "In-app" variant, and each one looks and behaves as expected.

Parallel PR for iOS [PR 1261](https://github.com/prebid/prebid-mobile-ios/pull/1261)