### PR TITLE
Third-party plugin renderers in adapters

### DIFF
--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/admob/AdMobBannerCustomRendererFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/admob/AdMobBannerCustomRendererFragment.kt
@@ -1,0 +1,19 @@
+package org.prebid.mobile.renderingtestapp.plugplay.bidding.admob
+
+import org.prebid.mobile.PrebidMobile
+import org.prebid.mobile.renderingtestapp.utils.SampleCustomRenderer
+
+class AdMobBannerCustomRendererFragment : AdMobBannerFragment() {
+
+    private val sampleCustomRenderer = SampleCustomRenderer()
+
+    override fun onCreate(savedInstanceState: android.os.Bundle?) {
+        super.onCreate(savedInstanceState)
+        PrebidMobile.registerPluginRenderer(sampleCustomRenderer)
+    }
+
+    override fun onDestroy() {
+        PrebidMobile.unregisterPluginRenderer(sampleCustomRenderer)
+        super.onDestroy()
+    }
+}

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/admob/AdMobInterstitialCustomRendererFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/admob/AdMobInterstitialCustomRendererFragment.kt
@@ -1,0 +1,19 @@
+package org.prebid.mobile.renderingtestapp.plugplay.bidding.admob
+
+import org.prebid.mobile.PrebidMobile
+import org.prebid.mobile.renderingtestapp.utils.SampleCustomRenderer
+
+class AdMobInterstitialCustomRendererFragment : AdMobInterstitialFragment() {
+
+    private val sampleCustomRenderer = SampleCustomRenderer()
+
+    override fun onCreate(savedInstanceState: android.os.Bundle?) {
+        super.onCreate(savedInstanceState)
+        PrebidMobile.registerPluginRenderer(sampleCustomRenderer)
+    }
+
+    override fun onDestroy() {
+        PrebidMobile.unregisterPluginRenderer(sampleCustomRenderer)
+        super.onDestroy()
+    }
+}

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/max/MaxBannerCustomRendererFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/max/MaxBannerCustomRendererFragment.kt
@@ -1,0 +1,19 @@
+package org.prebid.mobile.renderingtestapp.plugplay.bidding.max
+
+import org.prebid.mobile.PrebidMobile
+import org.prebid.mobile.renderingtestapp.utils.SampleCustomRenderer
+
+class MaxBannerCustomRendererFragment : MaxBannerFragment() {
+
+    private val sampleCustomRenderer = SampleCustomRenderer()
+
+    override fun onCreate(savedInstanceState: android.os.Bundle?) {
+        super.onCreate(savedInstanceState)
+        PrebidMobile.registerPluginRenderer(sampleCustomRenderer)
+    }
+
+    override fun onDestroy() {
+        PrebidMobile.unregisterPluginRenderer(sampleCustomRenderer)
+        super.onDestroy()
+    }
+}

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/max/MaxInterstitialCustomRendererFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/max/MaxInterstitialCustomRendererFragment.kt
@@ -1,0 +1,19 @@
+package org.prebid.mobile.renderingtestapp.plugplay.bidding.max
+
+import org.prebid.mobile.PrebidMobile
+import org.prebid.mobile.renderingtestapp.utils.SampleCustomRenderer
+
+class MaxInterstitialCustomRendererFragment : MaxInterstitialFragment() {
+
+    private val sampleCustomRenderer = SampleCustomRenderer()
+
+    override fun onCreate(savedInstanceState: android.os.Bundle?) {
+        super.onCreate(savedInstanceState)
+        PrebidMobile.registerPluginRenderer(sampleCustomRenderer)
+    }
+
+    override fun onDestroy() {
+        PrebidMobile.unregisterPluginRenderer(sampleCustomRenderer)
+        super.onDestroy()
+    }
+}

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/utils/DemoItemProvider.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/utils/DemoItemProvider.kt
@@ -75,11 +75,15 @@ class DemoItemProvider private constructor() {
             R.id.action_header_bidding_to_gam_original_multiformat_rewarded
 
         private const val adMobBannerAction = R.id.action_header_bidding_to_admob_banner
+        private const val adMobBannerCustomRendererAction =
+            R.id.action_header_bidding_to_admob_banner_custom_renderer
         private const val adMobRandomBannerAction =
             R.id.action_header_bidding_to_admob_random_banner
         private const val adMobFlexibleBannerAction =
             R.id.action_header_bidding_to_admob_flexible_banner
         private const val adMobInterstitialAction = R.id.action_header_bidding_to_admob_interstitial
+        private const val adMobInterstitialCustomRendererAction =
+            R.id.action_header_bidding_to_admob_interstitial_custom_renderer
         private const val adMobInterstitialMultiformatAction =
             R.id.action_header_bidding_to_admob_interstitial_multiformat
         private const val adMobInterstitialRandomAction =
@@ -1940,6 +1944,18 @@ class DemoItemProvider private constructor() {
             )
             demoList.add(
                 DemoItem(
+                    getString(R.string.demo_bidding_admob_banner_320_50_custom_renderer),
+                    adMobBannerCustomRendererAction,
+                    adMobBannerTagList,
+                    createBannerBundle(
+                        R.string.imp_prebid_id_banner_320x50_custom_renderer,
+                        R.string.admob_banner_bidding_ad_unit_id_adapter,
+                        320, 50
+                    )
+                )
+            )
+            demoList.add(
+                DemoItem(
                     getString(R.string.demo_bidding_admob_banner_300_250_adapter),
                     adMobBannerAction,
                     adMobBannerTagList,
@@ -1988,6 +2004,18 @@ class DemoItemProvider private constructor() {
                 )
             )
 
+            demoList.add(
+                DemoItem(
+                    getString(R.string.demo_bidding_admob_interstitial_320_480_custom_renderer),
+                    adMobInterstitialCustomRendererAction,
+                    adMobInterstitialTagList,
+                    createBannerBundle(
+                        R.string.imp_prebid_id_interstitial_320_480_custom_renderer,
+                        R.string.admob_interstitial_bidding_ad_unit_id_adapter,
+                        320, 480
+                    )
+                )
+            )
             demoList.add(
                 DemoItem(
                     getString(R.string.demo_bidding_admob_interstitial_admob),
@@ -2192,6 +2220,7 @@ class DemoItemProvider private constructor() {
         private fun addApplovinMaxPbsExamples() {
             val maxBannerTagList = listOf(Tag.ALL, Tag.MAX, Tag.BANNER, Tag.REMOTE)
             val maxBannerAction = R.id.action_header_bidding_to_max_banner
+            val maxBannerCustomRendererAction = R.id.action_header_bidding_to_max_banner_custom_renderer
             val maxBannerRandomAction = R.id.action_header_bidding_to_max_banner_random
             val maxBannerAdaptiveAction = R.id.action_header_bidding_to_max_banner_adaptive
 
@@ -2202,6 +2231,18 @@ class DemoItemProvider private constructor() {
                     maxBannerTagList,
                     createBannerBundle(
                         R.string.imp_prebid_id_banner_320x50,
+                        R.string.max_banner_ad_unit_id,
+                        320, 50
+                    )
+                )
+            )
+            demoList.add(
+                DemoItem(
+                    getString(R.string.demo_bidding_max_banner_320_50_custom_renderer),
+                    maxBannerCustomRendererAction,
+                    maxBannerTagList,
+                    createBannerBundle(
+                        R.string.imp_prebid_id_banner_320x50_custom_renderer,
                         R.string.max_banner_ad_unit_id,
                         320, 50
                     )
@@ -2288,6 +2329,7 @@ class DemoItemProvider private constructor() {
             val maxInterstitialTagList = listOf(Tag.ALL, Tag.MAX, Tag.INTERSTITIAL, Tag.REMOTE)
             val maxVideoInterstitialTagList = listOf(Tag.ALL, Tag.MAX, Tag.VIDEO, Tag.REMOTE)
             val maxInterstitialAction = R.id.action_header_bidding_to_max_interstitial
+            val maxInterstitialCustomRendererAction = R.id.action_header_bidding_to_max_interstitial_custom_renderer
             val maxMultiformatInterstitialAction =
                 R.id.action_header_bidding_to_max_interstitial_multiformat
             val maxRandomInterstitialAction = R.id.action_header_bidding_to_max_interstitial_random
@@ -2300,6 +2342,18 @@ class DemoItemProvider private constructor() {
                     maxInterstitialTagList,
                     createBannerBundle(
                         R.string.imp_prebid_id_interstitial_320_480,
+                        R.string.max_interstitial_ad_unit_id,
+                        320, 480
+                    )
+                )
+            )
+            demoList.add(
+                DemoItem(
+                    getString(R.string.demo_bidding_max_interstitial_320_480_custom_renderer),
+                    maxInterstitialCustomRendererAction,
+                    maxInterstitialTagList,
+                    createBannerBundle(
+                        R.string.imp_prebid_id_interstitial_320_480_custom_renderer,
                         R.string.max_interstitial_ad_unit_id,
                         320, 480
                     )

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/utils/SampleCustomRenderer.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/utils/SampleCustomRenderer.kt
@@ -84,6 +84,8 @@ class SampleCustomRenderer : PrebidMobilePluginRenderer {
             onClick = { displayViewListener.onAdClicked() },
             onClosed = { displayViewListener.onAdClosed() }
         )
+        bannerView.post { displayViewListener.onAdLoaded() }
+
         val visibilityChecker = ViewVisibilityObserver(bannerView) {
             // Dispatch additional event listener based on criteria from ViewVisibilityObserver
             pluginEventListenerMap[adUnitConfiguration.fingerprint]?.onImpression()

--- a/Example/PrebidInternalTestApp/src/main/res/navigation/bidding_navigation.xml
+++ b/Example/PrebidInternalTestApp/src/main/res/navigation/bidding_navigation.xml
@@ -407,6 +407,22 @@
             app:popExitAnim="@anim/nav_default_pop_exit_anim"
             app:popUpTo="@+id/headerBiddingFragment" />
         <action
+            android:id="@+id/action_header_bidding_to_admob_banner_custom_renderer"
+            app:destination="@+id/navigation_admob_banner_custom_renderer"
+            app:enterAnim="@anim/nav_default_enter_anim"
+            app:exitAnim="@anim/nav_default_exit_anim"
+            app:popEnterAnim="@anim/nav_default_pop_enter_anim"
+            app:popExitAnim="@anim/nav_default_pop_exit_anim"
+            app:popUpTo="@+id/headerBiddingFragment" />
+        <action
+            android:id="@+id/action_header_bidding_to_admob_interstitial_custom_renderer"
+            app:destination="@+id/navigation_admob_interstitial_custom_renderer"
+            app:enterAnim="@anim/nav_default_enter_anim"
+            app:exitAnim="@anim/nav_default_exit_anim"
+            app:popEnterAnim="@anim/nav_default_pop_enter_anim"
+            app:popExitAnim="@anim/nav_default_pop_exit_anim"
+            app:popUpTo="@+id/headerBiddingFragment" />
+        <action
             android:id="@+id/action_header_bidding_to_admob_interstitial"
             app:destination="@+id/navigation_admob_interstitial"
             app:enterAnim="@anim/nav_default_enter_anim"
@@ -458,6 +474,24 @@
         <action
             android:id="@+id/action_header_bidding_to_max_banner"
             app:destination="@+id/navigation_max_banner"
+            app:enterAnim="@anim/nav_default_enter_anim"
+            app:exitAnim="@anim/nav_default_exit_anim"
+            app:popEnterAnim="@anim/nav_default_pop_enter_anim"
+            app:popExitAnim="@anim/nav_default_pop_exit_anim"
+            app:popUpTo="@+id/headerBiddingFragment" />
+
+        <action
+            android:id="@+id/action_header_bidding_to_max_banner_custom_renderer"
+            app:destination="@+id/navigation_max_banner_custom_renderer"
+            app:enterAnim="@anim/nav_default_enter_anim"
+            app:exitAnim="@anim/nav_default_exit_anim"
+            app:popEnterAnim="@anim/nav_default_pop_enter_anim"
+            app:popExitAnim="@anim/nav_default_pop_exit_anim"
+            app:popUpTo="@+id/headerBiddingFragment" />
+
+        <action
+            android:id="@+id/action_header_bidding_to_max_interstitial_custom_renderer"
+            app:destination="@+id/navigation_max_interstitial_custom_renderer"
             app:enterAnim="@anim/nav_default_enter_anim"
             app:exitAnim="@anim/nav_default_exit_anim"
             app:popEnterAnim="@anim/nav_default_pop_enter_anim"
@@ -768,6 +802,12 @@
             android:id="@+id/navigation_admob_banner"
         android:name="org.prebid.mobile.renderingtestapp.plugplay.bidding.admob.AdMobBannerFragment" />
     <fragment
+        android:id="@+id/navigation_admob_banner_custom_renderer"
+        android:name="org.prebid.mobile.renderingtestapp.plugplay.bidding.admob.AdMobBannerCustomRendererFragment" />
+    <fragment
+        android:id="@+id/navigation_admob_interstitial_custom_renderer"
+        android:name="org.prebid.mobile.renderingtestapp.plugplay.bidding.admob.AdMobInterstitialCustomRendererFragment" />
+    <fragment
         android:id="@+id/navigation_admob_random_banner"
         android:name="org.prebid.mobile.renderingtestapp.plugplay.bidding.admob.AdMobBannerRandomFragment" />
     <fragment
@@ -796,6 +836,12 @@
     <fragment
         android:id="@+id/navigation_max_banner"
         android:name="org.prebid.mobile.renderingtestapp.plugplay.bidding.max.MaxBannerFragment" />
+    <fragment
+        android:id="@+id/navigation_max_banner_custom_renderer"
+        android:name="org.prebid.mobile.renderingtestapp.plugplay.bidding.max.MaxBannerCustomRendererFragment" />
+    <fragment
+        android:id="@+id/navigation_max_interstitial_custom_renderer"
+        android:name="org.prebid.mobile.renderingtestapp.plugplay.bidding.max.MaxInterstitialCustomRendererFragment" />
 
     <fragment
         android:id="@+id/navigation_max_banner_random"

--- a/Example/PrebidInternalTestApp/src/main/res/values/strings.xml
+++ b/Example/PrebidInternalTestApp/src/main/res/values/strings.xml
@@ -376,6 +376,10 @@
     <string name="imp_prebid_id_banner_multisize">prebid-demo-banner-multisize</string>
     <string name="imp_prebid_id_interstitial_320_480">prebid-demo-display-interstitial-320-480</string>
     <string name="imp_prebid_id_interstitial_320_480_custom_renderer">prebid-ita-display-interstitial-320-480-meta-custom-renderer</string>
+    <string name="demo_bidding_admob_banner_320_50_custom_renderer">Banner 320x50 (AdMob, Custom Renderer)</string>
+    <string name="demo_bidding_admob_interstitial_320_480_custom_renderer">Display Interstitial 320x480 (AdMob, Custom Renderer)</string>
+    <string name="demo_bidding_max_banner_320_50_custom_renderer">Banner 320x50 (MAX, Custom Renderer)</string>
+    <string name="demo_bidding_max_interstitial_320_480_custom_renderer">Display Interstitial 320x480 (MAX, Custom Renderer)</string>
 
     <string name="imp_prebid_id_display_rewarded_default">prebid-demo-banner-rewarded-default</string>
     <string name="imp_prebid_id_display_rewarded_time">prebid-demo-banner-rewarded-time</string>

--- a/PrebidMobile/PrebidMobile-admobAdapters/src/main/java/org/prebid/mobile/admob/PrebidBannerAdapter.java
+++ b/PrebidMobile/PrebidMobile-admobAdapters/src/main/java/org/prebid/mobile/admob/PrebidBannerAdapter.java
@@ -3,6 +3,8 @@ package org.prebid.mobile.admob;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
+import android.view.View;
+
 import com.google.android.gms.ads.mediation.MediationAdLoadCallback;
 import com.google.android.gms.ads.mediation.MediationBannerAd;
 import com.google.android.gms.ads.mediation.MediationBannerAdCallback;
@@ -10,10 +12,10 @@ import com.google.android.gms.ads.mediation.MediationBannerAdConfiguration;
 
 import org.prebid.mobile.api.data.AdFormat;
 import org.prebid.mobile.api.exceptions.AdException;
-import org.prebid.mobile.api.rendering.DisplayView;
 import org.prebid.mobile.configuration.AdUnitConfiguration;
 import org.prebid.mobile.rendering.bidding.data.bid.BidResponse;
 import org.prebid.mobile.rendering.bidding.display.BidResponseCache;
+import org.prebid.mobile.rendering.bidding.display.MediationBannerView;
 import org.prebid.mobile.rendering.bidding.listeners.DisplayViewListener;
 
 /**
@@ -23,7 +25,7 @@ public class PrebidBannerAdapter extends PrebidBaseAdapter {
 
     public static final String EXTRA_RESPONSE_ID = "PrebidBannerAdapterExtraId";
 
-    private DisplayView adView;
+    private View adView;
     @Nullable
     private MediationBannerAdCallback adMobBannerListener;
 
@@ -50,7 +52,7 @@ public class PrebidBannerAdapter extends PrebidBaseAdapter {
         AdUnitConfiguration adConfiguration = new AdUnitConfiguration();
         adConfiguration.setAdFormat(AdFormat.BANNER);
         DisplayViewListener listener = getPrebidListener(adMobLoadListener);
-        adView = new DisplayView(
+        adView = new MediationBannerView(
                 configuration.getContext(),
                 listener,
                 adConfiguration,

--- a/PrebidMobile/PrebidMobile-admobAdapters/src/main/java/org/prebid/mobile/admob/PrebidInterstitialAdapter.java
+++ b/PrebidMobile/PrebidMobile-admobAdapters/src/main/java/org/prebid/mobile/admob/PrebidInterstitialAdapter.java
@@ -1,5 +1,6 @@
 package org.prebid.mobile.admob;
 
+import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
 
@@ -8,19 +9,25 @@ import com.google.android.gms.ads.mediation.MediationInterstitialAd;
 import com.google.android.gms.ads.mediation.MediationInterstitialAdCallback;
 import com.google.android.gms.ads.mediation.MediationInterstitialAdConfiguration;
 
+import org.prebid.mobile.api.data.AdFormat;
 import org.prebid.mobile.api.exceptions.AdException;
-import org.prebid.mobile.rendering.bidding.display.InterstitialController;
+import org.prebid.mobile.api.rendering.PrebidMobileInterstitialControllerInterface;
+import org.prebid.mobile.configuration.AdUnitConfiguration;
+import org.prebid.mobile.rendering.bidding.data.bid.BidResponse;
+import org.prebid.mobile.rendering.bidding.display.BidResponseCache;
+import org.prebid.mobile.rendering.bidding.display.PluginRendererFactory;
 import org.prebid.mobile.rendering.bidding.interfaces.InterstitialControllerListener;
 
 /**
  * Prebid interstitial adapter for AdMob integration.
  */
+@Keep
 public class PrebidInterstitialAdapter extends PrebidBaseAdapter {
 
     public static final String EXTRA_RESPONSE_ID = "PrebidInterstitialAdapterExtraId";
 
     @Nullable
-    private InterstitialController interstitialController;
+    private PrebidMobileInterstitialControllerInterface interstitialController;
     @Nullable
     private MediationInterstitialAdCallback adMobInterstitialListener;
 
@@ -38,13 +45,23 @@ public class PrebidInterstitialAdapter extends PrebidBaseAdapter {
             return;
         }
 
-        try {
-            InterstitialControllerListener listener = getListener(adMobLoadListener);
-            interstitialController = new InterstitialController(configuration.getContext(), listener);
-            interstitialController.loadAd(responseId, false);
-        } catch (AdException e) {
-            adMobLoadListener.onFailure(AdErrors.interstitialControllerError(e.getMessage()));
+        BidResponse bidResponse = BidResponseCache.getInstance().popBidResponse(responseId);
+        if (bidResponse == null) {
+            adMobLoadListener.onFailure(AdErrors.noResponse(responseId));
+            return;
         }
+
+        AdUnitConfiguration config = new AdUnitConfiguration();
+        config.setAdFormat(bidResponse.isVideo() ? AdFormat.VAST : AdFormat.INTERSTITIAL);
+        InterstitialControllerListener listener = getListener(adMobLoadListener);
+        interstitialController = PluginRendererFactory.createInterstitialController(
+                configuration.getContext(), listener, config, bidResponse
+        );
+        if (interstitialController == null) {
+            adMobLoadListener.onFailure(AdErrors.interstitialControllerError("Renderer returned null controller"));
+            return;
+        }
+        interstitialController.loadAd(config, bidResponse);
     }
 
 

--- a/PrebidMobile/PrebidMobile-admobAdapters/src/main/java/org/prebid/mobile/admob/PrebidRewardedAdapter.java
+++ b/PrebidMobile/PrebidMobile-admobAdapters/src/main/java/org/prebid/mobile/admob/PrebidRewardedAdapter.java
@@ -3,16 +3,20 @@ package org.prebid.mobile.admob;
 import androidx.annotation.Keep;
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
 import com.google.android.gms.ads.mediation.MediationAdLoadCallback;
 import com.google.android.gms.ads.mediation.MediationRewardedAd;
 import com.google.android.gms.ads.mediation.MediationRewardedAdCallback;
 import com.google.android.gms.ads.mediation.MediationRewardedAdConfiguration;
-import com.google.android.gms.ads.rewarded.RewardItem;
-import org.jetbrains.annotations.NotNull;
+
+import org.prebid.mobile.api.data.AdFormat;
 import org.prebid.mobile.api.exceptions.AdException;
-import org.prebid.mobile.rendering.bidding.display.InterstitialController;
+import org.prebid.mobile.api.rendering.PrebidMobileInterstitialControllerInterface;
+import org.prebid.mobile.configuration.AdUnitConfiguration;
+import org.prebid.mobile.rendering.bidding.data.bid.BidResponse;
+import org.prebid.mobile.rendering.bidding.display.BidResponseCache;
+import org.prebid.mobile.rendering.bidding.display.PluginRendererFactory;
 import org.prebid.mobile.rendering.bidding.interfaces.InterstitialControllerListener;
-import org.prebid.mobile.rendering.interstitial.rewarded.Reward;
 
 /**
  * Prebid rewarded adapter for AdMob integration.
@@ -23,7 +27,7 @@ public class PrebidRewardedAdapter extends PrebidBaseAdapter {
     public static final String EXTRA_RESPONSE_ID = "PrebidRewardedAdapterExtraId";
 
     @Nullable
-    private InterstitialController interstitialController;
+    private PrebidMobileInterstitialControllerInterface interstitialController;
     @Nullable
     private MediationRewardedAdCallback rewardedAdCallback;
 
@@ -41,14 +45,26 @@ public class PrebidRewardedAdapter extends PrebidBaseAdapter {
             return;
         }
 
-        try {
-            InterstitialControllerListener prebidListener = getListener(adMobLoadListener);
-            interstitialController = new InterstitialController(configuration.getContext(), prebidListener);
-            interstitialController.setRewardListener(prebidListener::onUserEarnedReward);
-            interstitialController.loadAd(responseId, true);
-        } catch (AdException e) {
-            adMobLoadListener.onFailure(AdErrors.interstitialControllerError(e.getMessage()));
+        BidResponse bidResponse = BidResponseCache.getInstance().popBidResponse(responseId);
+        if (bidResponse == null) {
+            adMobLoadListener.onFailure(AdErrors.noResponse(responseId));
+            return;
         }
+
+        InterstitialControllerListener prebidListener = getListener(adMobLoadListener);
+        AdUnitConfiguration config = new AdUnitConfiguration();
+        config.setAdFormat(bidResponse.isVideo() ? AdFormat.VAST : AdFormat.INTERSTITIAL);
+        config.setRewarded(true);
+        config.getRewardManager().setRewardListener(prebidListener::onUserEarnedReward);
+
+        interstitialController = PluginRendererFactory.createInterstitialController(
+                configuration.getContext(), prebidListener, config, bidResponse
+        );
+        if (interstitialController == null) {
+            adMobLoadListener.onFailure(AdErrors.interstitialControllerError("Renderer returned null controller"));
+            return;
+        }
+        interstitialController.loadAd(config, bidResponse);
     }
 
     private InterstitialControllerListener getListener(
@@ -97,7 +113,7 @@ public class PrebidRewardedAdapter extends PrebidBaseAdapter {
 
             @Override
             public void onUserEarnedReward() {
-                if (rewardedAdCallback != null && interstitialController != null) {
+                if (rewardedAdCallback != null) {
                     rewardedAdCallback.onUserEarnedReward();
                 }
             }

--- a/PrebidMobile/PrebidMobile-admobAdapters/src/test/java/org/prebid/mobile/admob/PrebidInterstitialAdapterTest.java
+++ b/PrebidMobile/PrebidMobile-admobAdapters/src/test/java/org/prebid/mobile/admob/PrebidInterstitialAdapterTest.java
@@ -1,0 +1,176 @@
+package org.prebid.mobile.admob;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.prebid.mobile.api.rendering.pluginrenderer.PrebidMobilePluginRegister.PREBID_MOBILE_RENDERER_NAME;
+
+import android.content.Context;
+import android.os.Bundle;
+
+import com.google.android.gms.ads.mediation.MediationAdLoadCallback;
+import com.google.android.gms.ads.mediation.MediationInterstitialAd;
+import com.google.android.gms.ads.mediation.MediationInterstitialAdCallback;
+import com.google.android.gms.ads.mediation.MediationInterstitialAdConfiguration;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.prebid.mobile.api.rendering.PrebidMobileInterstitialControllerInterface;
+import org.prebid.mobile.api.rendering.pluginrenderer.PrebidMobilePluginRegister;
+import org.prebid.mobile.api.rendering.pluginrenderer.PrebidMobilePluginRenderer;
+import org.prebid.mobile.configuration.AdUnitConfiguration;
+import org.prebid.mobile.rendering.bidding.data.bid.BidResponse;
+import org.prebid.mobile.rendering.bidding.display.BidResponseCache;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(minSdk = 29)
+public class PrebidInterstitialAdapterTest {
+
+    private static final String RESPONSE_ID = "test-response-id-interstitial";
+    private static final String CUSTOM_RENDERER = "CustomRenderer";
+    private static final String CUSTOM_VERSION = "2.0";
+
+    // "parameter" is MediationConfiguration.CUSTOM_EVENT_SERVER_PARAMETER_FIELD
+    // "{}" is an empty JSON object — passes doParametersMatch when targeting is also empty
+    private static final String SERVER_PARAM_KEY = "parameter";
+    private static final String SERVER_PARAM_VALUE = "{}";
+
+    @SuppressWarnings("unchecked")
+    private final MediationAdLoadCallback<MediationInterstitialAd, MediationInterstitialAdCallback> mockLoadCallback =
+            mock(MediationAdLoadCallback.class);
+
+    private PrebidInterstitialAdapter adapter;
+    private MediationInterstitialAdConfiguration mockConfig;
+    private Context mockContext;
+    private List<PrebidMobilePluginRenderer> registeredRenderers;
+
+    @Before
+    public void setUp() {
+        adapter = new PrebidInterstitialAdapter();
+        mockContext = mock(Context.class);
+        mockConfig = mock(MediationInterstitialAdConfiguration.class);
+        registeredRenderers = new ArrayList<>();
+        when(mockConfig.getContext()).thenReturn(mockContext);
+
+        // Empty JSON server parameter passes ParametersMatcher when targeting is also empty
+        Bundle serverParameters = new Bundle();
+        serverParameters.putString(SERVER_PARAM_KEY, SERVER_PARAM_VALUE);
+        when(mockConfig.getServerParameters()).thenReturn(serverParameters);
+
+        Bundle extras = new Bundle();
+        extras.putString(PrebidInterstitialAdapter.EXTRA_RESPONSE_ID, RESPONSE_ID);
+        when(mockConfig.getMediationExtras()).thenReturn(extras);
+    }
+
+    @After
+    public void tearDown() {
+        for (PrebidMobilePluginRenderer renderer : registeredRenderers) {
+            PrebidMobilePluginRegister.getInstance().unregisterPlugin(renderer);
+        }
+    }
+
+    @Test
+    public void loadInterstitialAd_noResponseInCache_callsOnFailure() {
+        Bundle extras = new Bundle();
+        extras.putString(PrebidInterstitialAdapter.EXTRA_RESPONSE_ID, "unknown-id-never-cached");
+        when(mockConfig.getMediationExtras()).thenReturn(extras);
+
+        adapter.loadInterstitialAd(mockConfig, mockLoadCallback);
+
+        verify(mockLoadCallback).onFailure(any());
+    }
+
+    @Test
+    public void loadInterstitialAd_defaultRenderer_usesDefaultRenderer() {
+        buildAndCacheBidResponse(null, null);
+
+        PrebidMobileInterstitialControllerInterface mockController =
+                mock(PrebidMobileInterstitialControllerInterface.class);
+        PrebidMobilePluginRenderer defaultRenderer = buildRenderer(
+                PREBID_MOBILE_RENDERER_NAME, "1.0", true, mockController);
+        registerPlugin(defaultRenderer);
+
+        adapter.loadInterstitialAd(mockConfig, mockLoadCallback);
+
+        verify(defaultRenderer).createInterstitialController(any(), any(), any(), any());
+        verify(mockLoadCallback, never()).onFailure(any());
+    }
+
+    @Test
+    public void loadInterstitialAd_customRenderer_delegatesToCustomRenderer() {
+        buildAndCacheBidResponse(CUSTOM_RENDERER, CUSTOM_VERSION);
+
+        PrebidMobileInterstitialControllerInterface customController =
+                mock(PrebidMobileInterstitialControllerInterface.class);
+        PrebidMobilePluginRenderer customRenderer = buildRenderer(
+                CUSTOM_RENDERER, CUSTOM_VERSION, true, customController);
+        registerPlugin(customRenderer);
+
+        PrebidMobileInterstitialControllerInterface defaultController =
+                mock(PrebidMobileInterstitialControllerInterface.class);
+        PrebidMobilePluginRenderer defaultRenderer = buildRenderer(
+                PREBID_MOBILE_RENDERER_NAME, "1.0", true, defaultController);
+        registerPlugin(defaultRenderer);
+
+        adapter.loadInterstitialAd(mockConfig, mockLoadCallback);
+
+        verify(customRenderer).createInterstitialController(any(), any(), any(), any());
+        verify(defaultRenderer, never()).createInterstitialController(any(), any(), any(), any());
+
+    }
+
+    @Test
+    public void loadInterstitialAd_rendererReturnsNull_callsOnFailure() {
+        buildAndCacheBidResponse(null, null);
+
+        PrebidMobilePluginRenderer nullRenderer = buildRenderer(
+                PREBID_MOBILE_RENDERER_NAME, "1.0", true, null);
+        registerPlugin(nullRenderer);
+
+        adapter.loadInterstitialAd(mockConfig, mockLoadCallback);
+
+        verify(mockLoadCallback).onFailure(any());
+    }
+
+
+    private void buildAndCacheBidResponse(String rendererName, String rendererVersion) {
+        BidResponse mockResponse = mock(BidResponse.class);
+        when(mockResponse.getId()).thenReturn(RESPONSE_ID);
+        when(mockResponse.getPreferredPluginRendererName()).thenReturn(rendererName);
+        when(mockResponse.getPreferredPluginRendererVersion()).thenReturn(rendererVersion);
+        when(mockResponse.getTargeting()).thenReturn(new HashMap<>());
+        AdUnitConfiguration config = new AdUnitConfiguration();
+        when(mockResponse.getAdUnitConfiguration()).thenReturn(config);
+        BidResponseCache.getInstance().putBidResponse(RESPONSE_ID, mockResponse);
+    }
+
+    private PrebidMobilePluginRenderer buildRenderer(
+            String name,
+            String version,
+            boolean supports,
+            PrebidMobileInterstitialControllerInterface controller
+    ) {
+        PrebidMobilePluginRenderer renderer = mock(PrebidMobilePluginRenderer.class);
+        when(renderer.getName()).thenReturn(name);
+        when(renderer.getVersion()).thenReturn(version);
+        when(renderer.isSupportRenderingFor(any())).thenReturn(supports);
+        when(renderer.createInterstitialController(any(), any(), any(), any()))
+                .thenReturn(controller);
+        return renderer;
+    }
+
+    private void registerPlugin(PrebidMobilePluginRenderer renderer) {
+        PrebidMobilePluginRegister.getInstance().registerPlugin(renderer);
+        registeredRenderers.add(renderer);
+    }
+}

--- a/PrebidMobile/PrebidMobile-admobAdapters/src/test/java/org/prebid/mobile/admob/PrebidRewardedAdapterTest.java
+++ b/PrebidMobile/PrebidMobile-admobAdapters/src/test/java/org/prebid/mobile/admob/PrebidRewardedAdapterTest.java
@@ -1,0 +1,198 @@
+package org.prebid.mobile.admob;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.prebid.mobile.api.rendering.pluginrenderer.PrebidMobilePluginRegister.PREBID_MOBILE_RENDERER_NAME;
+
+import android.content.Context;
+import android.os.Bundle;
+
+import com.google.android.gms.ads.mediation.MediationAdLoadCallback;
+import com.google.android.gms.ads.mediation.MediationRewardedAd;
+import com.google.android.gms.ads.mediation.MediationRewardedAdCallback;
+import com.google.android.gms.ads.mediation.MediationRewardedAdConfiguration;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.prebid.mobile.api.rendering.PrebidMobileInterstitialControllerInterface;
+import org.prebid.mobile.api.rendering.pluginrenderer.PrebidMobilePluginRegister;
+import org.prebid.mobile.api.rendering.pluginrenderer.PrebidMobilePluginRenderer;
+import org.prebid.mobile.configuration.AdUnitConfiguration;
+import org.prebid.mobile.rendering.bidding.data.bid.BidResponse;
+import org.prebid.mobile.rendering.bidding.display.BidResponseCache;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(minSdk = 29)
+public class PrebidRewardedAdapterTest {
+
+    private static final String RESPONSE_ID = "test-response-id-rewarded";
+    private static final String CUSTOM_RENDERER = "CustomRenderer";
+    private static final String CUSTOM_VERSION = "2.0";
+
+    private static final String SERVER_PARAM_KEY = "parameter";
+    private static final String SERVER_PARAM_VALUE = "{}";
+
+    @SuppressWarnings("unchecked")
+    private final MediationAdLoadCallback<MediationRewardedAd, MediationRewardedAdCallback> mockLoadCallback =
+            mock(MediationAdLoadCallback.class);
+
+    private PrebidRewardedAdapter adapter;
+    private MediationRewardedAdConfiguration mockConfig;
+    private Context mockContext;
+    private List<PrebidMobilePluginRenderer> registeredRenderers;
+
+    @Before
+    public void setUp() {
+        adapter = new PrebidRewardedAdapter();
+        mockContext = mock(Context.class);
+        mockConfig = mock(MediationRewardedAdConfiguration.class);
+        registeredRenderers = new ArrayList<>();
+        when(mockConfig.getContext()).thenReturn(mockContext);
+
+        Bundle serverParameters = new Bundle();
+        serverParameters.putString(SERVER_PARAM_KEY, SERVER_PARAM_VALUE);
+        when(mockConfig.getServerParameters()).thenReturn(serverParameters);
+
+        Bundle extras = new Bundle();
+        extras.putString(PrebidRewardedAdapter.EXTRA_RESPONSE_ID, RESPONSE_ID);
+        when(mockConfig.getMediationExtras()).thenReturn(extras);
+    }
+
+    @After
+    public void tearDown() {
+        for (PrebidMobilePluginRenderer renderer : registeredRenderers) {
+            PrebidMobilePluginRegister.getInstance().unregisterPlugin(renderer);
+        }
+    }
+
+    @Test
+    public void loadRewardedAd_noResponseInCache_callsOnFailure() {
+        Bundle extras = new Bundle();
+        extras.putString(PrebidRewardedAdapter.EXTRA_RESPONSE_ID, "unknown-id-rewarded-never-cached");
+        when(mockConfig.getMediationExtras()).thenReturn(extras);
+
+        adapter.loadRewardedAd(mockConfig, mockLoadCallback);
+
+        verify(mockLoadCallback).onFailure(any());
+    }
+
+    @Test
+    public void loadRewardedAd_defaultRenderer_usesDefaultRenderer() {
+        buildAndCacheBidResponse(null, null);
+
+        PrebidMobileInterstitialControllerInterface mockController =
+                mock(PrebidMobileInterstitialControllerInterface.class);
+        PrebidMobilePluginRenderer defaultRenderer = buildRenderer(
+                PREBID_MOBILE_RENDERER_NAME, "1.0", true, mockController);
+        registerPlugin(defaultRenderer);
+
+        adapter.loadRewardedAd(mockConfig, mockLoadCallback);
+
+        verify(defaultRenderer).createInterstitialController(any(), any(), any(), any());
+        verify(mockLoadCallback, never()).onFailure(any());
+    }
+
+    @Test
+    public void loadRewardedAd_rewardedConfigPassedToRenderer() {
+        buildAndCacheBidResponse(null, null);
+
+        final AdUnitConfiguration[] capturedConfig = {null};
+        PrebidMobilePluginRenderer capturingRenderer = mock(PrebidMobilePluginRenderer.class);
+        when(capturingRenderer.getName()).thenReturn(PREBID_MOBILE_RENDERER_NAME);
+        when(capturingRenderer.getVersion()).thenReturn("1.0");
+        when(capturingRenderer.isSupportRenderingFor(any())).thenReturn(true);
+        when(capturingRenderer.createInterstitialController(any(), any(), any(), any()))
+                .thenAnswer(invocation -> {
+                    capturedConfig[0] = invocation.getArgument(2);
+                    return mock(PrebidMobileInterstitialControllerInterface.class);
+                });
+        registerPlugin(capturingRenderer);
+
+        adapter.loadRewardedAd(mockConfig, mockLoadCallback);
+
+        assertNotNull(capturedConfig[0]);
+        assertEquals(true, capturedConfig[0].isRewarded());
+        assertNotNull(capturedConfig[0].getRewardManager().getRewardListener());
+    }
+
+    @Test
+    public void loadRewardedAd_customRenderer_delegatesToCustomRenderer() {
+        buildAndCacheBidResponse(CUSTOM_RENDERER, CUSTOM_VERSION);
+
+        PrebidMobileInterstitialControllerInterface customController =
+                mock(PrebidMobileInterstitialControllerInterface.class);
+        PrebidMobilePluginRenderer customRenderer = buildRenderer(
+                CUSTOM_RENDERER, CUSTOM_VERSION, true, customController);
+        registerPlugin(customRenderer);
+
+        PrebidMobileInterstitialControllerInterface defaultController =
+                mock(PrebidMobileInterstitialControllerInterface.class);
+        PrebidMobilePluginRenderer defaultRenderer = buildRenderer(
+                PREBID_MOBILE_RENDERER_NAME, "1.0", true, defaultController);
+        registerPlugin(defaultRenderer);
+
+        adapter.loadRewardedAd(mockConfig, mockLoadCallback);
+
+        verify(customRenderer).createInterstitialController(any(), any(), any(), any());
+        verify(defaultRenderer, never()).createInterstitialController(any(), any(), any(), any());
+
+    }
+
+    @Test
+    public void loadRewardedAd_rendererReturnsNull_callsOnFailure() {
+        buildAndCacheBidResponse(null, null);
+
+        PrebidMobilePluginRenderer nullRenderer = buildRenderer(
+                PREBID_MOBILE_RENDERER_NAME, "1.0", true, null);
+        registerPlugin(nullRenderer);
+
+        adapter.loadRewardedAd(mockConfig, mockLoadCallback);
+
+        verify(mockLoadCallback).onFailure(any());
+    }
+
+
+    private void buildAndCacheBidResponse(String rendererName, String rendererVersion) {
+        BidResponse mockResponse = mock(BidResponse.class);
+        when(mockResponse.getId()).thenReturn(RESPONSE_ID);
+        when(mockResponse.getPreferredPluginRendererName()).thenReturn(rendererName);
+        when(mockResponse.getPreferredPluginRendererVersion()).thenReturn(rendererVersion);
+        when(mockResponse.getTargeting()).thenReturn(new HashMap<>());
+        AdUnitConfiguration config = new AdUnitConfiguration();
+        when(mockResponse.getAdUnitConfiguration()).thenReturn(config);
+        BidResponseCache.getInstance().putBidResponse(RESPONSE_ID, mockResponse);
+    }
+
+    private PrebidMobilePluginRenderer buildRenderer(
+            String name,
+            String version,
+            boolean supports,
+            PrebidMobileInterstitialControllerInterface controller
+    ) {
+        PrebidMobilePluginRenderer renderer = mock(PrebidMobilePluginRenderer.class);
+        when(renderer.getName()).thenReturn(name);
+        when(renderer.getVersion()).thenReturn(version);
+        when(renderer.isSupportRenderingFor(any())).thenReturn(supports);
+        when(renderer.createInterstitialController(any(), any(), any(), any()))
+                .thenReturn(controller);
+        return renderer;
+    }
+
+    private void registerPlugin(PrebidMobilePluginRenderer renderer) {
+        PrebidMobilePluginRegister.getInstance().registerPlugin(renderer);
+        registeredRenderers.add(renderer);
+    }
+}

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/pluginrenderer/PrebidMobilePluginRegister.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/pluginrenderer/PrebidMobilePluginRegister.java
@@ -60,6 +60,10 @@ public class PrebidMobilePluginRegister {
         return plugins.containsKey(prebidMobilePluginRendererName);
     }
 
+    public PrebidMobilePluginRenderer getDefaultPluginRenderer() {
+        return plugins.get(PREBID_MOBILE_RENDERER_NAME);
+    }
+
     public void registerEventListener(
             PluginEventListener pluginEventListener,
             String listenerKey
@@ -93,11 +97,20 @@ public class PrebidMobilePluginRegister {
     // Returns the registered renderer according to the preferred renderer data in the bid response
     // If no preferred renderer is found, it returns PrebidRenderer to perform default behavior
     public PrebidMobilePluginRenderer getPluginForPreferredRenderer(BidResponse bidResponse) {
+        return getPluginForPreferredRenderer(bidResponse, bidResponse.getAdUnitConfiguration());
+    }
+
+    // Returns the registered renderer according to the preferred renderer data in the bid response
+    // If no preferred renderer is found, it returns PrebidRenderer to perform default behavior
+    public PrebidMobilePluginRenderer getPluginForPreferredRenderer(
+            BidResponse bidResponse,
+            AdUnitConfiguration adUnitConfiguration
+    ) {
         String preferredRendererName = bidResponse.getPreferredPluginRendererName();
         String preferredRendererVersion = bidResponse.getPreferredPluginRendererVersion();
         PrebidMobilePluginRenderer preferredPlugin = plugins.get(preferredRendererName);
         if (preferredPlugin != null
-                && preferredPlugin.isSupportRenderingFor(bidResponse.getAdUnitConfiguration())
+                && preferredPlugin.isSupportRenderingFor(adUnitConfiguration)
                 && preferredPlugin.getVersion().equals(preferredRendererVersion)) {
             return preferredPlugin;
         } else {

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/pluginrenderer/PrebidMobilePluginRegister.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/pluginrenderer/PrebidMobilePluginRegister.java
@@ -60,6 +60,11 @@ public class PrebidMobilePluginRegister {
         return plugins.containsKey(prebidMobilePluginRendererName);
     }
 
+    @VisibleForTesting
+    public void unregisterAllPlugins() {
+        plugins.clear();
+    }
+
     public PrebidMobilePluginRenderer getDefaultPluginRenderer() {
         return plugins.get(PREBID_MOBILE_RENDERER_NAME);
     }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/bidding/display/MediationBannerView.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/bidding/display/MediationBannerView.java
@@ -1,62 +1,50 @@
-/*
- *    Copyright 2018-2021 Prebid.org, Inc.
- *
- *    Licensed under the Apache License, Version 2.0 (the "License");
- *    you may not use this file except in compliance with the License.
- *    You may obtain a copy of the License at
- *
- *        http://www.apache.org/licenses/LICENSE-2.0
- *
- *    Unless required by applicable law or agreed to in writing, software
- *    distributed under the License is distributed on an "AS IS" BASIS,
- *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- *    See the License for the specific language governing permissions and
- *    limitations under the License.
- */
-
-package org.prebid.mobile.api.rendering;
+package org.prebid.mobile.rendering.bidding.display;
 
 import android.content.Context;
 import android.view.View;
 import android.widget.FrameLayout;
+
 import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
 import org.prebid.mobile.LogUtil;
 import org.prebid.mobile.api.exceptions.AdException;
+import org.prebid.mobile.api.rendering.PrebidDestroyable;
 import org.prebid.mobile.configuration.AdUnitConfiguration;
 import org.prebid.mobile.rendering.bidding.data.bid.BidResponse;
-import org.prebid.mobile.rendering.bidding.display.PluginRendererFactory;
 import org.prebid.mobile.rendering.bidding.listeners.DisplayVideoListener;
 import org.prebid.mobile.rendering.bidding.listeners.DisplayViewListener;
 import org.prebid.mobile.rendering.networking.WinNotifier;
 
 /**
- * Internal view for {@link BannerView}.
+ * Mediation banner container that lets adapters render through the preferred plugin renderer.
  */
-public class DisplayView extends FrameLayout {
+public class MediationBannerView extends FrameLayout implements PrebidDestroyable {
+
+    private static final String TAG = MediationBannerView.class.getSimpleName();
+
+    @Nullable
     private View adView;
+    @Nullable
     private AdUnitConfiguration adUnitConfiguration;
+    @Nullable
     private DisplayViewListener displayViewListener;
+    @Nullable
     private DisplayVideoListener displayVideoListener;
 
-    public DisplayView(
+    public MediationBannerView(
             @NonNull Context context,
-            DisplayViewListener displayViewListener,
+            @NonNull DisplayViewListener displayViewListener,
             @NonNull AdUnitConfiguration adUnitConfiguration,
             @NonNull BidResponse bidResponse
     ) {
-        super(context);
-
-        this.adUnitConfiguration = adUnitConfiguration;
-        this.displayViewListener = displayViewListener;
-
-        createBannerAdView(context, bidResponse);
+        this(context, displayViewListener, null, adUnitConfiguration, bidResponse);
     }
 
-    public DisplayView(
+    public MediationBannerView(
             @NonNull Context context,
-            DisplayViewListener displayViewListener,
-            DisplayVideoListener displayVideoListener,
+            @NonNull DisplayViewListener displayViewListener,
+            @Nullable DisplayVideoListener displayVideoListener,
             @NonNull AdUnitConfiguration adUnitConfiguration,
             @NonNull BidResponse bidResponse
     ) {
@@ -75,6 +63,10 @@ public class DisplayView extends FrameLayout {
     ) {
         WinNotifier winNotifier = new WinNotifier();
         winNotifier.notifyWin(bidResponse, () -> {
+            if (adUnitConfiguration == null || displayViewListener == null) {
+                return;
+            }
+
             adView = PluginRendererFactory.createBannerAdView(
                     context,
                     displayViewListener,
@@ -82,42 +74,29 @@ public class DisplayView extends FrameLayout {
                     adUnitConfiguration,
                     bidResponse
             );
-            if (adView != null) {
-                addView(adView);
-            } else {
+
+            if (adView == null) {
                 displayViewListener.onAdFailed(new AdException(
                         AdException.INTERNAL_ERROR,
                         "Renderer returned null banner view"
                 ));
+                return;
             }
+
+            addView(adView);
         });
     }
 
+    @Override
     public void destroy() {
-        LogUtil.debug("Destroying view");
+        LogUtil.debug(TAG, "Destroying mediation banner view");
+        if (adView instanceof PrebidDestroyable) {
+            ((PrebidDestroyable) adView).destroy();
+        }
+        removeAllViews();
+        adView = null;
         adUnitConfiguration = null;
         displayViewListener = null;
         displayVideoListener = null;
-        if (adView != null && adView instanceof PrebidDestroyable) {
-            ((PrebidDestroyable) adView).destroy();
-        }
-    }
-
-    @Nullable
-    public String getImpOrtbConfig() {
-        return adUnitConfiguration.getImpOrtbConfig();
-    }
-
-    public void setImpOrtbConfig(@Nullable String ortbConfig) {
-        adUnitConfiguration.setImpOrtbConfig(ortbConfig);
-    }
-
-    @Nullable
-    public String getGlobalOrtbConfig() {
-        return adUnitConfiguration.getGlobalOrtbConfig();
-    }
-
-    public void setGlobalOrtbConfig(@Nullable String ortbConfig) {
-        adUnitConfiguration.setGlobalOrtbConfig(ortbConfig);
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/bidding/display/PluginRendererFactory.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/bidding/display/PluginRendererFactory.java
@@ -1,0 +1,109 @@
+package org.prebid.mobile.rendering.bidding.display;
+
+import static org.prebid.mobile.api.rendering.pluginrenderer.PrebidMobilePluginRegister.PREBID_MOBILE_RENDERER_NAME;
+
+import android.content.Context;
+import android.view.View;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import org.prebid.mobile.api.rendering.PrebidRenderer;
+import org.prebid.mobile.api.rendering.PrebidMobileInterstitialControllerInterface;
+import org.prebid.mobile.api.rendering.pluginrenderer.PrebidMobilePluginRegister;
+import org.prebid.mobile.api.rendering.pluginrenderer.PrebidMobilePluginRenderer;
+import org.prebid.mobile.configuration.AdUnitConfiguration;
+import org.prebid.mobile.rendering.bidding.data.bid.BidResponse;
+import org.prebid.mobile.rendering.bidding.interfaces.InterstitialControllerListener;
+import org.prebid.mobile.rendering.bidding.listeners.DisplayVideoListener;
+import org.prebid.mobile.rendering.bidding.listeners.DisplayViewListener;
+
+/**
+ * Resolves the preferred plugin renderer from bid metadata and delegates ad component
+ * creation to it. Falls back to the default Prebid SDK renderer when no custom renderer
+ * matches the bid response or the preferred renderer cannot create an ad component.
+ */
+public class PluginRendererFactory {
+
+    /**
+     * Creates the renderer-owned banner view after the caller has completed win notification.
+     * Mediation banner containers such as {@link MediationBannerView} and legacy DisplayView
+     * call {@link org.prebid.mobile.rendering.networking.WinNotifier} before invoking this method.
+     */
+    @Nullable
+    public static View createBannerAdView(
+            @NonNull Context context,
+            @NonNull DisplayViewListener displayViewListener,
+            @Nullable DisplayVideoListener displayVideoListener,
+            @NonNull AdUnitConfiguration adUnitConfiguration,
+            @NonNull BidResponse bidResponse
+    ) {
+        adUnitConfiguration.modifyUsingBidResponse(bidResponse);
+        PrebidMobilePluginRenderer renderer = getPreferredRenderer(bidResponse, adUnitConfiguration);
+        if (renderer == null) {
+            return null;
+        }
+
+        View adView = renderer.createBannerAdView(context, displayViewListener, displayVideoListener, adUnitConfiguration, bidResponse);
+        if (adView != null) {
+            return adView;
+        }
+
+        if (PREBID_MOBILE_RENDERER_NAME.equals(renderer.getName())) {
+            return null;
+        }
+        return createDefaultRenderer().createBannerAdView(
+                context,
+                displayViewListener,
+                displayVideoListener,
+                adUnitConfiguration,
+                bidResponse
+        );
+    }
+
+    @Nullable
+    public static PrebidMobileInterstitialControllerInterface createInterstitialController(
+            @NonNull Context context,
+            @NonNull InterstitialControllerListener listener,
+            @NonNull AdUnitConfiguration adUnitConfiguration,
+            @NonNull BidResponse bidResponse
+    ) {
+        adUnitConfiguration.modifyUsingBidResponse(bidResponse);
+        PrebidMobilePluginRenderer renderer = getPreferredRenderer(bidResponse, adUnitConfiguration);
+        if (renderer == null) {
+            return null;
+        }
+
+        PrebidMobileInterstitialControllerInterface controller = renderer.createInterstitialController(
+                context,
+                listener,
+                adUnitConfiguration,
+                bidResponse
+        );
+        if (controller != null) {
+            return controller;
+        }
+
+        if (PREBID_MOBILE_RENDERER_NAME.equals(renderer.getName())) {
+            return null;
+        }
+        return createDefaultRenderer().createInterstitialController(context, listener, adUnitConfiguration, bidResponse);
+    }
+
+    @Nullable
+    private static PrebidMobilePluginRenderer getPreferredRenderer(
+            @NonNull BidResponse bidResponse,
+            @NonNull AdUnitConfiguration adUnitConfiguration
+    ) {
+        return PrebidMobilePluginRegister.getInstance().getPluginForPreferredRenderer(bidResponse, adUnitConfiguration);
+    }
+
+    @NonNull
+    private static PrebidMobilePluginRenderer createDefaultRenderer() {
+        PrebidMobilePluginRenderer registeredDefaultRenderer = PrebidMobilePluginRegister.getInstance().getDefaultPluginRenderer();
+        if (registeredDefaultRenderer != null) {
+            return registeredDefaultRenderer;
+        }
+        return new PrebidRenderer();
+    }
+}

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/DisplayViewTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/DisplayViewTest.java
@@ -10,6 +10,7 @@ import android.app.Activity;
 import android.content.Context;
 import android.view.View;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -18,7 +19,9 @@ import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 import org.prebid.mobile.PrebidMobile;
+import org.prebid.mobile.api.exceptions.AdException;
 import org.prebid.mobile.api.data.AdFormat;
+import org.prebid.mobile.api.rendering.pluginrenderer.PrebidMobilePluginRegister;
 import org.prebid.mobile.api.rendering.pluginrenderer.PrebidMobilePluginRenderer;
 import org.prebid.mobile.configuration.AdUnitConfiguration;
 import org.prebid.mobile.rendering.bidding.data.bid.Bid;
@@ -30,6 +33,9 @@ import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
+import java.util.ArrayList;
+import java.util.List;
+
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 19)
 public class DisplayViewTest {
@@ -38,6 +44,7 @@ public class DisplayViewTest {
     private Context context;
     private BidResponse mockResponse;
     private PrebidMobilePluginRenderer fakePrebidMobilePluginRenderer;
+    private List<PrebidMobilePluginRenderer> registeredRenderers;
     @Spy
     private AdUnitConfiguration adUnitConfiguration;
     @Mock
@@ -53,17 +60,25 @@ public class DisplayViewTest {
         MockitoAnnotations.initMocks(DisplayViewTest.this);
 
         context = Robolectric.buildActivity(Activity.class).create().get();
+        registeredRenderers = new ArrayList<>();
 
         adUnitConfiguration.setAdFormat(AdFormat.BANNER);
 
         fakePrebidMobilePluginRenderer = Mockito.spy(FakePrebidMobilePluginRenderer.getFakePrebidRenderer(null, mockBannerView, true, PREBID_MOBILE_RENDERER_NAME, "1.0"));
-        PrebidMobile.registerPluginRenderer(fakePrebidMobilePluginRenderer);
+        registerPlugin(fakePrebidMobilePluginRenderer);
 
         mockResponse = mock(BidResponse.class);
         Bid mockBid = mock(Bid.class);
         when(mockBid.getAdm()).thenReturn("adm");
         when(mockResponse.getWinningBid()).thenReturn(mockBid);
         when(mockResponse.getPreferredPluginRendererName()).thenReturn(PREBID_MOBILE_RENDERER_NAME);
+    }
+
+    @After
+    public void tearDown() {
+        for (PrebidMobilePluginRenderer renderer : registeredRenderers) {
+            PrebidMobilePluginRegister.getInstance().unregisterPlugin(renderer);
+        }
     }
 
     @Test
@@ -78,6 +93,25 @@ public class DisplayViewTest {
     }
 
     @Test
+    public void onDisplayViewWinNotification_nullBannerAdView_reportsAdFailed() {
+        PrebidMobilePluginRenderer nullRenderer = Mockito.spy(
+                FakePrebidMobilePluginRenderer.getFakePrebidRenderer(
+                        null,
+                        null,
+                        true,
+                        PREBID_MOBILE_RENDERER_NAME,
+                        "1.0"
+                )
+        );
+        registerPlugin(nullRenderer);
+
+        displayView = new DisplayView(context, mockDisplayViewListener, adUnitConfiguration, mockResponse);
+
+        verify(mockDisplayViewListener).onAdFailed(Mockito.any(AdException.class));
+        assertEquals(0, displayView.getChildCount());
+    }
+
+    @Test
     public void onDisplayViewWithVideoListenerWinNotification_returnBannerAdView() {
         displayView = new DisplayView(context, mockDisplayViewListener, mockDisplayVideoListener, adUnitConfiguration, mockResponse);
 
@@ -85,5 +119,10 @@ public class DisplayViewTest {
         verify(fakePrebidMobilePluginRenderer).createBannerAdView(context, mockDisplayViewListener, mockDisplayVideoListener, adUnitConfiguration, mockResponse);
         // bannerAdView added to view hierarchy
         assertEquals(1, displayView.getChildCount());
+    }
+
+    private void registerPlugin(PrebidMobilePluginRenderer renderer) {
+        PrebidMobile.registerPluginRenderer(renderer);
+        registeredRenderers.add(renderer);
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/pluginrenderer/PrebidMobilePluginRegisterTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/pluginrenderer/PrebidMobilePluginRegisterTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.prebid.mobile.api.rendering.pluginrenderer.PrebidMobilePluginRegister.PREBID_MOBILE_RENDERER_NAME;
 
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mockito;
@@ -28,6 +29,8 @@ public class PrebidMobilePluginRegisterTest {
     @Before
     public void setUp() {
         instance = PrebidMobilePluginRegister.getInstance();
+        instance.unregisterAllPlugins();
+
         mockPlugin = mock(PrebidMobilePluginRenderer.class);
         mockBidResponse = mock(BidResponse.class);
         mockAdUnitConfiguration = mock(AdUnitConfiguration.class);
@@ -36,6 +39,11 @@ public class PrebidMobilePluginRegisterTest {
         PrebidMobilePluginRenderer mockPrebidPlugin = mock(PrebidMobilePluginRenderer.class);
         when(mockPrebidPlugin.getName()).thenReturn(PREBID_MOBILE_RENDERER_NAME);
         instance.registerPlugin(mockPrebidPlugin);
+    }
+
+    @After
+    public void tearDown() {
+        instance.unregisterAllPlugins();
     }
 
     @Test

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/bidding/display/MediationBannerViewTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/bidding/display/MediationBannerViewTest.java
@@ -1,0 +1,185 @@
+package org.prebid.mobile.rendering.bidding.display;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.prebid.mobile.api.rendering.pluginrenderer.PrebidMobilePluginRegister.PREBID_MOBILE_RENDERER_NAME;
+
+import android.app.Activity;
+import android.content.Context;
+import android.view.View;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.prebid.mobile.api.data.AdFormat;
+import org.prebid.mobile.api.rendering.PrebidDestroyable;
+import org.prebid.mobile.api.rendering.pluginrenderer.PrebidMobilePluginRegister;
+import org.prebid.mobile.api.rendering.pluginrenderer.PrebidMobilePluginRenderer;
+import org.prebid.mobile.configuration.AdUnitConfiguration;
+import org.prebid.mobile.rendering.bidding.data.bid.Bid;
+import org.prebid.mobile.rendering.bidding.data.bid.BidResponse;
+import org.prebid.mobile.rendering.bidding.listeners.DisplayViewListener;
+import org.prebid.mobile.testutils.FakePrebidMobilePluginRenderer;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 19)
+public class MediationBannerViewTest {
+
+    private static final String CUSTOM_RENDERER_NAME = "CustomRenderer";
+    private static final String CUSTOM_RENDERER_VERSION = "2.0";
+
+    private Context context;
+    private AdUnitConfiguration adUnitConfiguration;
+    private BidResponse mockBidResponse;
+    private DisplayViewListener mockDisplayViewListener;
+    private List<PrebidMobilePluginRenderer> registeredRenderers;
+
+    private static class DestroyableView extends View implements PrebidDestroyable {
+        boolean destroyed;
+
+        DestroyableView(Context context) {
+            super(context);
+        }
+
+        @Override
+        public void destroy() {
+            destroyed = true;
+        }
+    }
+
+    @Before
+    public void setUp() {
+        context = Robolectric.buildActivity(Activity.class).create().get();
+        adUnitConfiguration = new AdUnitConfiguration();
+        adUnitConfiguration.setAdFormat(AdFormat.BANNER);
+        mockDisplayViewListener = mock(DisplayViewListener.class);
+        mockBidResponse = mock(BidResponse.class);
+        registeredRenderers = new ArrayList<>();
+
+        Bid mockBid = mock(Bid.class);
+        when(mockBid.getAdm()).thenReturn("adm");
+        when(mockBidResponse.getWinningBid()).thenReturn(mockBid);
+        when(mockBidResponse.getPreferredPluginRendererName()).thenReturn(PREBID_MOBILE_RENDERER_NAME);
+        when(mockBidResponse.getPreferredPluginRendererVersion()).thenReturn("1.0");
+        when(mockBidResponse.getAdUnitConfiguration()).thenReturn(adUnitConfiguration);
+    }
+
+    @After
+    public void tearDown() {
+        for (PrebidMobilePluginRenderer renderer : registeredRenderers) {
+            PrebidMobilePluginRegister.getInstance().unregisterPlugin(renderer);
+        }
+    }
+
+    @Test
+    public void constructor_defaultRenderer_addsViewToHierarchy() {
+        View mockBannerView = mock(View.class);
+        PrebidMobilePluginRenderer defaultRenderer = spy(
+                FakePrebidMobilePluginRenderer.getFakePrebidRenderer(
+                        null, mockBannerView, true,
+                        PREBID_MOBILE_RENDERER_NAME, "1.0"
+                )
+        );
+        registerPlugin(defaultRenderer);
+
+        MediationBannerView bannerView = new MediationBannerView(
+                context, mockDisplayViewListener, adUnitConfiguration, mockBidResponse
+        );
+
+        verify(defaultRenderer).createBannerAdView(any(), any(), any(), any(), any());
+        assertEquals(1, bannerView.getChildCount());
+        verify(mockDisplayViewListener, never()).onAdFailed(any());
+    }
+
+    @Test
+    public void constructor_customRenderer_delegatesToCustomRenderer() {
+        View customView = new View(context);
+        PrebidMobilePluginRenderer customRenderer = spy(
+                FakePrebidMobilePluginRenderer.getFakePrebidRenderer(
+                        null, customView, true,
+                        CUSTOM_RENDERER_NAME, CUSTOM_RENDERER_VERSION
+                )
+        );
+        registerPlugin(customRenderer);
+
+        View defaultView = mock(View.class);
+        PrebidMobilePluginRenderer defaultRenderer = spy(
+                FakePrebidMobilePluginRenderer.getFakePrebidRenderer(
+                        null, defaultView, true,
+                        PREBID_MOBILE_RENDERER_NAME, "1.0"
+                )
+        );
+        registerPlugin(defaultRenderer);
+
+        when(mockBidResponse.getPreferredPluginRendererName()).thenReturn(CUSTOM_RENDERER_NAME);
+        when(mockBidResponse.getPreferredPluginRendererVersion()).thenReturn(CUSTOM_RENDERER_VERSION);
+
+        MediationBannerView bannerView = new MediationBannerView(
+                context, mockDisplayViewListener, adUnitConfiguration, mockBidResponse
+        );
+
+        verify(customRenderer).createBannerAdView(any(), any(), any(), any(), any());
+        verify(defaultRenderer, never()).createBannerAdView(any(), any(), any(), any(), any());
+        assertEquals(1, bannerView.getChildCount());
+
+    }
+
+    @Test
+    public void constructor_rendererReturnsNullView_firesOnAdFailed() {
+        // Custom renderer returns null; factory falls back to default renderer which also returns null
+        PrebidMobilePluginRenderer nullRenderer = spy(
+                FakePrebidMobilePluginRenderer.getFakePrebidRenderer(
+                        null, null, true,
+                        PREBID_MOBILE_RENDERER_NAME, "1.0"
+                )
+        );
+        registerPlugin(nullRenderer);
+
+        MediationBannerView bannerView = new MediationBannerView(
+                context, mockDisplayViewListener, adUnitConfiguration, mockBidResponse
+        );
+
+        verify(mockDisplayViewListener).onAdFailed(any());
+        assertEquals(0, bannerView.getChildCount());
+    }
+
+    @Test
+    public void destroy_clearsChildViewsAndDestroysInnerView() {
+        DestroyableView mockBannerView = new DestroyableView(context);
+        PrebidMobilePluginRenderer defaultRenderer = spy(
+                FakePrebidMobilePluginRenderer.getFakePrebidRenderer(
+                        null, mockBannerView, true,
+                        PREBID_MOBILE_RENDERER_NAME, "1.0"
+                )
+        );
+        registerPlugin(defaultRenderer);
+
+        MediationBannerView bannerView = new MediationBannerView(
+                context, mockDisplayViewListener, adUnitConfiguration, mockBidResponse
+        );
+        assertEquals(1, bannerView.getChildCount());
+
+        bannerView.destroy();
+
+        assertEquals(0, bannerView.getChildCount());
+        assertTrue(mockBannerView.destroyed);
+    }
+
+    private void registerPlugin(PrebidMobilePluginRenderer renderer) {
+        PrebidMobilePluginRegister.getInstance().registerPlugin(renderer);
+        registeredRenderers.add(renderer);
+    }
+}

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/bidding/display/PluginRendererFactoryTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/bidding/display/PluginRendererFactoryTest.java
@@ -1,0 +1,263 @@
+package org.prebid.mobile.rendering.bidding.display;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.spy;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.prebid.mobile.api.rendering.pluginrenderer.PrebidMobilePluginRegister.PREBID_MOBILE_RENDERER_NAME;
+
+import android.app.Activity;
+import android.content.Context;
+import android.view.View;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.prebid.mobile.api.data.AdFormat;
+import org.prebid.mobile.api.rendering.PrebidMobileInterstitialControllerInterface;
+import org.prebid.mobile.api.rendering.pluginrenderer.PrebidMobilePluginRegister;
+import org.prebid.mobile.api.rendering.pluginrenderer.PrebidMobilePluginRenderer;
+import org.prebid.mobile.configuration.AdUnitConfiguration;
+import org.prebid.mobile.rendering.bidding.data.bid.BidResponse;
+import org.prebid.mobile.rendering.bidding.interfaces.InterstitialControllerListener;
+import org.prebid.mobile.testutils.FakePrebidMobilePluginRenderer;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 19)
+public class PluginRendererFactoryTest {
+
+    private static final String CUSTOM_RENDERER_NAME = "CustomRenderer";
+    private static final String CUSTOM_RENDERER_VERSION = "2.0";
+
+    private Context context;
+    private InterstitialControllerListener mockListener;
+    private AdUnitConfiguration config;
+    private BidResponse mockBidResponse;
+    private List<PrebidMobilePluginRenderer> registeredRenderers;
+
+    @Before
+    public void setUp() {
+        context = Robolectric.buildActivity(Activity.class).create().get();
+        mockListener = mock(InterstitialControllerListener.class);
+        config = spy(new AdUnitConfiguration());
+        mockBidResponse = mock(BidResponse.class);
+        registeredRenderers = new ArrayList<>();
+
+        // InterstitialController implements PrebidMobileInterstitialControllerInterface
+        InterstitialController mockDefaultController = mock(InterstitialController.class);
+        PrebidMobilePluginRenderer defaultRenderer = spy(
+                FakePrebidMobilePluginRenderer.getFakePrebidRenderer(
+                        mockDefaultController, new View(context), true,
+                        PREBID_MOBILE_RENDERER_NAME, "1.0"
+                )
+        );
+        registerPlugin(defaultRenderer);
+    }
+
+    @After
+    public void tearDown() {
+        for (PrebidMobilePluginRenderer renderer : registeredRenderers) {
+            PrebidMobilePluginRegister.getInstance().unregisterPlugin(renderer);
+        }
+    }
+
+    @Test
+    public void createInterstitialController_defaultRenderer_returnsController() {
+        when(mockBidResponse.getPreferredPluginRendererName()).thenReturn(null);
+        when(mockBidResponse.getAdUnitConfiguration()).thenReturn(config);
+
+        PrebidMobileInterstitialControllerInterface result =
+                PluginRendererFactory.createInterstitialController(context, mockListener, config, mockBidResponse);
+
+        assertNotNull(result);
+        verify(config).modifyUsingBidResponse(mockBidResponse);
+    }
+
+    @Test
+    public void createInterstitialController_customRendererMatches_usesCustomRenderer() {
+        InterstitialController customController = mock(InterstitialController.class);
+        PrebidMobilePluginRenderer customRenderer = spy(
+                FakePrebidMobilePluginRenderer.getFakePrebidRenderer(
+                        customController, null, true,
+                        CUSTOM_RENDERER_NAME, CUSTOM_RENDERER_VERSION
+                )
+        );
+        registerPlugin(customRenderer);
+
+        when(mockBidResponse.getPreferredPluginRendererName()).thenReturn(CUSTOM_RENDERER_NAME);
+        when(mockBidResponse.getPreferredPluginRendererVersion()).thenReturn(CUSTOM_RENDERER_VERSION);
+        when(mockBidResponse.getAdUnitConfiguration()).thenReturn(config);
+
+        PrebidMobileInterstitialControllerInterface result =
+                PluginRendererFactory.createInterstitialController(context, mockListener, config, mockBidResponse);
+
+        assertNotNull(result);
+        verify(customRenderer).createInterstitialController(any(), any(), any(), any());
+    }
+
+    @Test
+    public void createInterstitialController_customRendererReturnsNull_fallsBackToDefault() {
+        PrebidMobilePluginRenderer customRenderer = spy(
+                FakePrebidMobilePluginRenderer.getFakePrebidRenderer(
+                        null, null, true,
+                        CUSTOM_RENDERER_NAME, CUSTOM_RENDERER_VERSION
+                )
+        );
+        registerPlugin(customRenderer);
+
+        config.setAdFormat(AdFormat.INTERSTITIAL);
+        when(mockBidResponse.getPreferredPluginRendererName()).thenReturn(CUSTOM_RENDERER_NAME);
+        when(mockBidResponse.getPreferredPluginRendererVersion()).thenReturn(CUSTOM_RENDERER_VERSION);
+        when(mockBidResponse.getAdUnitConfiguration()).thenReturn(config);
+
+        PrebidMobileInterstitialControllerInterface result =
+                PluginRendererFactory.createInterstitialController(context, mockListener, config, mockBidResponse);
+
+        assertNotNull(result);
+        verify(customRenderer).createInterstitialController(any(), any(), any(), any());
+    }
+
+    @Test
+    public void createBannerAdView_customRendererMatches_usesCustomRenderer() {
+        View customBannerView = new View(context);
+        PrebidMobilePluginRenderer customRenderer = spy(
+                FakePrebidMobilePluginRenderer.getFakePrebidRenderer(
+                        null, customBannerView, true,
+                        CUSTOM_RENDERER_NAME, CUSTOM_RENDERER_VERSION
+                )
+        );
+        registerPlugin(customRenderer);
+
+        config.setAdFormat(AdFormat.BANNER);
+        when(mockBidResponse.getPreferredPluginRendererName()).thenReturn(CUSTOM_RENDERER_NAME);
+        when(mockBidResponse.getPreferredPluginRendererVersion()).thenReturn(CUSTOM_RENDERER_VERSION);
+        when(mockBidResponse.getAdUnitConfiguration()).thenReturn(config);
+
+        View result = PluginRendererFactory.createBannerAdView(
+                context,
+                mock(org.prebid.mobile.rendering.bidding.listeners.DisplayViewListener.class),
+                null,
+                config,
+                mockBidResponse
+        );
+
+        assertSame(customBannerView, result);
+        verify(customRenderer).createBannerAdView(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    public void createBannerAdView_customRendererReturnsNull_fallsBackToDefault() {
+        PrebidMobilePluginRenderer customRenderer = spy(
+                FakePrebidMobilePluginRenderer.getFakePrebidRenderer(
+                        null, null, true,
+                        CUSTOM_RENDERER_NAME, CUSTOM_RENDERER_VERSION
+                )
+        );
+        registerPlugin(customRenderer);
+
+        config.setAdFormat(AdFormat.BANNER);
+        when(mockBidResponse.getPreferredPluginRendererName()).thenReturn(CUSTOM_RENDERER_NAME);
+        when(mockBidResponse.getPreferredPluginRendererVersion()).thenReturn(CUSTOM_RENDERER_VERSION);
+        when(mockBidResponse.getAdUnitConfiguration()).thenReturn(config);
+
+        View result = PluginRendererFactory.createBannerAdView(
+                context,
+                mock(org.prebid.mobile.rendering.bidding.listeners.DisplayViewListener.class),
+                null,
+                config,
+                mockBidResponse
+        );
+
+        assertNotNull(result);
+        verify(customRenderer).createBannerAdView(any(), any(), any(), any(), any());
+    }
+
+    @Test
+    public void createInterstitialController_versionMismatch_fallsBackToDefault() {
+        PrebidMobilePluginRenderer customRenderer = spy(
+                FakePrebidMobilePluginRenderer.getFakePrebidRenderer(
+                        null, null, true,
+                        CUSTOM_RENDERER_NAME, CUSTOM_RENDERER_VERSION
+                )
+        );
+        registerPlugin(customRenderer);
+
+        when(mockBidResponse.getPreferredPluginRendererName()).thenReturn(CUSTOM_RENDERER_NAME);
+        when(mockBidResponse.getPreferredPluginRendererVersion()).thenReturn("9.9");
+        when(mockBidResponse.getAdUnitConfiguration()).thenReturn(config);
+
+        PrebidMobileInterstitialControllerInterface result =
+                PluginRendererFactory.createInterstitialController(context, mockListener, config, mockBidResponse);
+
+        assertNotNull(result);
+        verify(customRenderer, never()).createInterstitialController(any(), any(), any(), any());
+    }
+
+    @Test
+    public void createInterstitialController_unknownRenderer_fallsBackToDefault() {
+        when(mockBidResponse.getPreferredPluginRendererName()).thenReturn("NoSuchRenderer");
+        when(mockBidResponse.getAdUnitConfiguration()).thenReturn(config);
+
+        PrebidMobileInterstitialControllerInterface result =
+                PluginRendererFactory.createInterstitialController(context, mockListener, config, mockBidResponse);
+
+        assertNotNull(result);
+    }
+
+    @Test
+    public void createInterstitialController_rewardedConfig_rewardListenerPreserved() {
+        when(mockBidResponse.getPreferredPluginRendererName()).thenReturn(null);
+        when(mockBidResponse.getAdUnitConfiguration()).thenReturn(config);
+
+        Runnable rewardCallback = mock(Runnable.class);
+        config.setRewarded(true);
+        config.getRewardManager().setRewardListener(rewardCallback);
+
+        PrebidMobileInterstitialControllerInterface result =
+                PluginRendererFactory.createInterstitialController(context, mockListener, config, mockBidResponse);
+
+        assertNotNull(result);
+        assertEquals(rewardCallback, config.getRewardManager().getRewardListener());
+    }
+
+    @Test
+    public void createInterstitialController_rendererNotSupportingAdUnit_fallsBackToDefault() {
+        AdUnitConfiguration vastConfig = new AdUnitConfiguration();
+        vastConfig.setAdFormat(AdFormat.VAST);
+
+        PrebidMobilePluginRenderer limitedRenderer = spy(
+                FakePrebidMobilePluginRenderer.getFakePrebidRenderer(
+                        null, null, false,
+                        CUSTOM_RENDERER_NAME, CUSTOM_RENDERER_VERSION
+                )
+        );
+        registerPlugin(limitedRenderer);
+
+        when(mockBidResponse.getPreferredPluginRendererName()).thenReturn(CUSTOM_RENDERER_NAME);
+        when(mockBidResponse.getPreferredPluginRendererVersion()).thenReturn(CUSTOM_RENDERER_VERSION);
+        when(mockBidResponse.getAdUnitConfiguration()).thenReturn(vastConfig);
+
+        PrebidMobileInterstitialControllerInterface result =
+                PluginRendererFactory.createInterstitialController(context, mockListener, vastConfig, mockBidResponse);
+
+        assertNotNull(result);
+        verify(limitedRenderer, never()).createInterstitialController(any(), any(), any(), any());
+    }
+
+    private void registerPlugin(PrebidMobilePluginRenderer renderer) {
+        PrebidMobilePluginRegister.getInstance().registerPlugin(renderer);
+        registeredRenderers.add(renderer);
+    }
+}

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/networking/parameters/BasicParameterBuilderTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/networking/parameters/BasicParameterBuilderTest.java
@@ -51,6 +51,7 @@ import org.prebid.mobile.PrebidMobile;
 import org.prebid.mobile.Signals;
 import org.prebid.mobile.TargetingParams;
 import org.prebid.mobile.VideoParameters;
+import org.prebid.mobile.api.rendering.PrebidRenderer;
 import org.prebid.mobile.api.data.AdFormat;
 import org.prebid.mobile.api.data.AdUnitFormat;
 import org.prebid.mobile.api.rendering.pluginrenderer.PrebidMobilePluginRegister;
@@ -82,6 +83,7 @@ import org.robolectric.annotation.Config;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Set;
@@ -108,6 +110,9 @@ public class BasicParameterBuilderTest {
         context = Robolectric.buildActivity(Activity.class).create().get();
         ManagersResolver.getInstance().prepare(context);
         TargetingParams.setExternalUserIds(null);
+
+        PrebidMobilePluginRegister.getInstance().unregisterAllPlugins();
+        PrebidMobile.registerPluginRenderer(new PrebidRenderer());
     }
 
     @After
@@ -125,7 +130,7 @@ public class BasicParameterBuilderTest {
         PrebidMobile.setPrebidServerAccountId("");
         PrebidMobile.setAuctionSettingsId(null);
 
-        PrebidMobile.unregisterPluginRenderer(otherPlugin);
+        PrebidMobilePluginRegister.getInstance().unregisterAllPlugins();
     }
 
     @Test
@@ -1103,9 +1108,14 @@ public class BasicParameterBuilderTest {
         JSONObject sdkObj = prebidObj.getJSONObject("sdk");
         JSONArray renderersObj = sdkObj.getJSONArray(PluginRendererList.RENDERERS_KEY);
         // Default plugin is indexed and additional plugin is indexed
-        assertTrue(renderersObj.length() == 2);
-        assertEquals(((JSONObject)renderersObj.get(0)).get("name"), otherPlugin.getName());
-        assertEquals(((JSONObject)renderersObj.get(1)).get("name"), PrebidMobilePluginRegister.PREBID_MOBILE_RENDERER_NAME);
+        assertEquals(2, renderersObj.length());
+
+        Set<String> rendererNames = new HashSet<>();
+        for (int i = 0; i < renderersObj.length(); i++) {
+            rendererNames.add(renderersObj.getJSONObject(i).getString("name"));
+        }
+        assertTrue(rendererNames.contains(otherPlugin.getName()));
+        assertTrue(rendererNames.contains(PrebidMobilePluginRegister.PREBID_MOBILE_RENDERER_NAME));
     }
 
     @Test

--- a/PrebidMobile/PrebidMobile-maxAdapters/src/main/java/com/applovin/mediation/adapters/prebid/managers/MaxBannerManager.java
+++ b/PrebidMobile/PrebidMobile-maxAdapters/src/main/java/com/applovin/mediation/adapters/prebid/managers/MaxBannerManager.java
@@ -2,6 +2,7 @@ package com.applovin.mediation.adapters.prebid.managers;
 
 import android.app.Activity;
 import android.util.Log;
+import android.view.View;
 
 import androidx.annotation.Nullable;
 
@@ -14,9 +15,10 @@ import com.applovin.mediation.adapters.prebid.ParametersChecker;
 
 import org.prebid.mobile.LogUtil;
 import org.prebid.mobile.api.data.AdFormat;
-import org.prebid.mobile.api.rendering.DisplayView;
+import org.prebid.mobile.api.rendering.PrebidDestroyable;
 import org.prebid.mobile.configuration.AdUnitConfiguration;
 import org.prebid.mobile.rendering.bidding.data.bid.BidResponse;
+import org.prebid.mobile.rendering.bidding.display.MediationBannerView;
 import org.prebid.mobile.rendering.bidding.listeners.DisplayViewListener;
 
 public class MaxBannerManager {
@@ -24,7 +26,7 @@ public class MaxBannerManager {
     private static final String TAG = MaxBannerManager.class.getSimpleName();
 
     @Nullable
-    private DisplayView adView;
+    private View adView;
     @Nullable
     private MaxAdViewAdapterListener maxListener;
 
@@ -55,8 +57,8 @@ public class MaxBannerManager {
     }
 
     public void destroy() {
-        if (adView != null) {
-            adView.destroy();
+        if (adView instanceof PrebidDestroyable) {
+            ((PrebidDestroyable) adView).destroy();
         }
         adView = null;
     }
@@ -81,7 +83,7 @@ public class MaxBannerManager {
         if (activity != null) {
             LogUtil.info(TAG, "Prebid ad won: " + parameters.getThirdPartyAdPlacementId());
             activity.runOnUiThread(() -> {
-                adView = new DisplayView(activity, listener, adConfiguration, response);
+                adView = new MediationBannerView(activity, listener, adConfiguration, response);
             });
         } else {
             onError(1005, "Activity is null");

--- a/PrebidMobile/PrebidMobile-maxAdapters/src/main/java/com/applovin/mediation/adapters/prebid/managers/MaxInterstitialManager.java
+++ b/PrebidMobile/PrebidMobile-maxAdapters/src/main/java/com/applovin/mediation/adapters/prebid/managers/MaxInterstitialManager.java
@@ -2,14 +2,21 @@ package com.applovin.mediation.adapters.prebid.managers;
 
 import android.app.Activity;
 import android.util.Log;
+
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
 import com.applovin.mediation.adapter.MaxAdapterError;
 import com.applovin.mediation.adapter.listeners.MaxInterstitialAdapterListener;
 import com.applovin.mediation.adapter.parameters.MaxAdapterResponseParameters;
 import com.applovin.mediation.adapters.prebid.ListenersCreator;
 import com.applovin.mediation.adapters.prebid.ParametersChecker;
-import org.prebid.mobile.api.exceptions.AdException;
-import org.prebid.mobile.rendering.bidding.display.InterstitialController;
+
+import org.prebid.mobile.api.data.AdFormat;
+import org.prebid.mobile.api.rendering.PrebidMobileInterstitialControllerInterface;
+import org.prebid.mobile.configuration.AdUnitConfiguration;
+import org.prebid.mobile.rendering.bidding.data.bid.BidResponse;
+import org.prebid.mobile.rendering.bidding.display.PluginRendererFactory;
 import org.prebid.mobile.rendering.bidding.interfaces.InterstitialControllerListener;
 
 public class MaxInterstitialManager {
@@ -19,12 +26,12 @@ public class MaxInterstitialManager {
     @Nullable
     private MaxInterstitialAdapterListener maxListener;
     @Nullable
-    private InterstitialController interstitialController;
+    private PrebidMobileInterstitialControllerInterface interstitialController;
 
     public void loadAd(
             MaxAdapterResponseParameters parameters,
             Activity activity,
-            MaxInterstitialAdapterListener maxListener
+            @NonNull MaxInterstitialAdapterListener maxListener
     ) {
         this.maxListener = maxListener;
         loadAd(parameters, activity);
@@ -39,16 +46,25 @@ public class MaxInterstitialManager {
             return;
         }
 
+        BidResponse bidResponse = ParametersChecker.getBidResponse(responseId, this::onError);
+        if (bidResponse == null) {
+            return;
+        }
+
         activity.runOnUiThread(() -> {
-            try {
-                InterstitialControllerListener listener = createPrebidListener();
-                interstitialController = new InterstitialController(activity, listener);
-                interstitialController.loadAd(responseId, false);
-            } catch (AdException e) {
-                String error = "Exception in Prebid interstitial controller (" + e.getMessage() + ")";
+            AdUnitConfiguration config = new AdUnitConfiguration();
+            config.setAdFormat(bidResponse.isVideo() ? AdFormat.VAST : AdFormat.INTERSTITIAL);
+            InterstitialControllerListener listener = createPrebidListener();
+            interstitialController = PluginRendererFactory.createInterstitialController(
+                    activity, listener, config, bidResponse
+            );
+            if (interstitialController == null) {
+                String error = "Renderer returned null interstitial controller";
                 Log.e(TAG, error);
                 onError(1006, error);
+                return;
             }
+            interstitialController.loadAd(config, bidResponse);
         });
     }
 
@@ -71,12 +87,7 @@ public class MaxInterstitialManager {
 
 
     private InterstitialControllerListener createPrebidListener() {
-        if (maxListener != null) {
-            return ListenersCreator.createInterstitialListener(maxListener);
-        } else {
-            Log.e(TAG, "Max interstitial listener must be not null!");
-        }
-        return null;
+        return ListenersCreator.createInterstitialListener(maxListener);
     }
 
     private void onError(

--- a/PrebidMobile/PrebidMobile-maxAdapters/src/main/java/com/applovin/mediation/adapters/prebid/managers/MaxRewardedManager.java
+++ b/PrebidMobile/PrebidMobile-maxAdapters/src/main/java/com/applovin/mediation/adapters/prebid/managers/MaxRewardedManager.java
@@ -2,14 +2,21 @@ package com.applovin.mediation.adapters.prebid.managers;
 
 import android.app.Activity;
 import android.util.Log;
+
+import androidx.annotation.NonNull;
 import androidx.annotation.Nullable;
+
 import com.applovin.mediation.MaxReward;
 import com.applovin.mediation.adapter.MaxAdapterError;
 import com.applovin.mediation.adapter.listeners.MaxRewardedAdapterListener;
 import com.applovin.mediation.adapter.parameters.MaxAdapterResponseParameters;
 import com.applovin.mediation.adapters.prebid.ParametersChecker;
-import org.prebid.mobile.api.exceptions.AdException;
-import org.prebid.mobile.rendering.bidding.display.InterstitialController;
+
+import org.prebid.mobile.api.data.AdFormat;
+import org.prebid.mobile.api.rendering.PrebidMobileInterstitialControllerInterface;
+import org.prebid.mobile.configuration.AdUnitConfiguration;
+import org.prebid.mobile.rendering.bidding.data.bid.BidResponse;
+import org.prebid.mobile.rendering.bidding.display.PluginRendererFactory;
 import org.prebid.mobile.rendering.bidding.interfaces.InterstitialControllerListener;
 import org.prebid.mobile.rendering.interstitial.rewarded.Reward;
 
@@ -20,14 +27,14 @@ public class MaxRewardedManager {
     @Nullable
     private MaxRewardedAdapterListener maxListener;
     @Nullable
-    private InterstitialController interstitialController;
+    private PrebidMobileInterstitialControllerInterface interstitialController;
     @Nullable
-    private InterstitialControllerListener prebidListener;
+    private AdUnitConfiguration adUnitConfiguration;
 
     public void loadAd(
             MaxAdapterResponseParameters parameters,
             Activity activity,
-            MaxRewardedAdapterListener maxListener
+            @NonNull MaxRewardedAdapterListener maxListener
     ) {
         this.maxListener = maxListener;
         loadAd(parameters, activity);
@@ -42,19 +49,28 @@ public class MaxRewardedManager {
             return;
         }
 
+        BidResponse bidResponse = ParametersChecker.getBidResponse(responseId, this::onError);
+        if (bidResponse == null) {
+            return;
+        }
+
         activity.runOnUiThread(() -> {
-            try {
-                prebidListener = createRewardedListener();
-                interstitialController = new InterstitialController(activity, prebidListener);
-                if (prebidListener != null) {
-                    interstitialController.setRewardListener(prebidListener::onUserEarnedReward);
-                }
-                interstitialController.loadAd(responseId, true);
-            } catch (AdException e) {
-                String error = "Exception in Prebid interstitial controller (" + e.getMessage() + ")";
+            InterstitialControllerListener prebidListener = createRewardedListener();
+            adUnitConfiguration = new AdUnitConfiguration();
+            adUnitConfiguration.setAdFormat(bidResponse.isVideo() ? AdFormat.VAST : AdFormat.INTERSTITIAL);
+            adUnitConfiguration.setRewarded(true);
+            adUnitConfiguration.getRewardManager().setRewardListener(prebidListener::onUserEarnedReward);
+
+            interstitialController = PluginRendererFactory.createInterstitialController(
+                    activity, prebidListener, adUnitConfiguration, bidResponse
+            );
+            if (interstitialController == null) {
+                String error = "Renderer returned null rewarded controller";
                 Log.e(TAG, error);
                 onError(1006, error);
+                return;
             }
+            interstitialController.loadAd(adUnitConfiguration, bidResponse);
         });
     }
 
@@ -86,7 +102,7 @@ public class MaxRewardedManager {
     }
 
 
-    public InterstitialControllerListener createRewardedListener() {
+    private InterstitialControllerListener createRewardedListener() {
         return new InterstitialControllerListener() {
             @Override
             public void onInterstitialReadyForDisplay() {
@@ -103,7 +119,7 @@ public class MaxRewardedManager {
             }
 
             @Override
-            public void onInterstitialFailedToLoad(AdException exception) {
+            public void onInterstitialFailedToLoad(org.prebid.mobile.api.exceptions.AdException exception) {
                 if (maxListener != null) {
                     maxListener.onRewardedAdLoadFailed(new MaxAdapterError(2002,
                             "Ad failed: " + exception.getMessage()
@@ -127,23 +143,19 @@ public class MaxRewardedManager {
 
             @Override
             public void onUserEarnedReward() {
-                if (maxListener != null && interstitialController != null) {
-                    Reward reward = interstitialController.getReward();
+                if (maxListener != null) {
+                    Reward reward = adUnitConfiguration != null
+                            ? adUnitConfiguration.getRewardManager().getRewardedExt().getReward()
+                            : null;
                     maxListener.onUserRewarded(new MaxReward() {
                         @Override
                         public String getLabel() {
-                            if (reward != null) {
-                                return reward.getType();
-                            }
-                            return "";
+                            return reward != null ? reward.getType() : "";
                         }
 
                         @Override
                         public int getAmount() {
-                            if (reward != null) {
-                                return reward.getCount();
-                            }
-                            return 0;
+                            return reward != null ? reward.getCount() : 0;
                         }
                     });
                 }

--- a/PrebidMobile/PrebidMobile-maxAdapters/src/test/java/com/applovin/mediation/adapters/prebid/managers/MaxInterstitialManagerTest.java
+++ b/PrebidMobile/PrebidMobile-maxAdapters/src/test/java/com/applovin/mediation/adapters/prebid/managers/MaxInterstitialManagerTest.java
@@ -1,0 +1,176 @@
+package com.applovin.mediation.adapters.prebid.managers;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.prebid.mobile.api.rendering.pluginrenderer.PrebidMobilePluginRegister.PREBID_MOBILE_RENDERER_NAME;
+
+import android.app.Activity;
+import android.os.Bundle;
+
+import com.applovin.mediation.adapter.listeners.MaxInterstitialAdapterListener;
+import com.applovin.mediation.adapter.parameters.MaxAdapterResponseParameters;
+import com.applovin.mediation.adapters.PrebidMaxMediationAdapter;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.prebid.mobile.api.rendering.PrebidMobileInterstitialControllerInterface;
+import org.prebid.mobile.api.rendering.pluginrenderer.PrebidMobilePluginRegister;
+import org.prebid.mobile.api.rendering.pluginrenderer.PrebidMobilePluginRenderer;
+import org.prebid.mobile.configuration.AdUnitConfiguration;
+import org.prebid.mobile.rendering.bidding.data.bid.BidResponse;
+import org.prebid.mobile.rendering.bidding.display.BidResponseCache;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(minSdk = 29)
+public class MaxInterstitialManagerTest {
+
+    private static final String RESPONSE_ID = "test-interstitial-id-max";
+    private static final String CUSTOM_RENDERER = "CustomRenderer";
+    private static final String CUSTOM_VERSION = "2.0";
+    // ParametersMatcher requires keywords and custom params to have matching key-value pairs
+    private static final String KEYWORD_KEY = "hb_pb";
+    private static final String KEYWORD_VALUE = "0.10";
+
+    private MaxInterstitialManager manager;
+    private Activity activity;
+    private MaxInterstitialAdapterListener mockMaxListener;
+    private MaxAdapterResponseParameters mockParams;
+    private List<PrebidMobilePluginRenderer> registeredRenderers;
+
+    @Before
+    public void setUp() {
+        manager = new MaxInterstitialManager();
+        activity = Robolectric.buildActivity(Activity.class).create().get();
+        mockMaxListener = mock(MaxInterstitialAdapterListener.class);
+        mockParams = buildParams(RESPONSE_ID);
+        registeredRenderers = new ArrayList<>();
+    }
+
+    @After
+    public void tearDown() {
+        for (PrebidMobilePluginRenderer renderer : registeredRenderers) {
+            PrebidMobilePluginRegister.getInstance().unregisterPlugin(renderer);
+        }
+    }
+
+    @Test
+    public void loadAd_noResponseInCache_reportsError() {
+        MaxAdapterResponseParameters unknownParams =
+                buildParams("unknown-id-interstitial-never-cached");
+
+        manager.loadAd(unknownParams, activity, mockMaxListener);
+
+        verify(mockMaxListener).onInterstitialAdLoadFailed(any());
+    }
+
+    @Test
+    public void loadAd_defaultRenderer_createsController() {
+        buildAndCacheBidResponse(null, null);
+
+        PrebidMobileInterstitialControllerInterface mockController =
+                mock(PrebidMobileInterstitialControllerInterface.class);
+        PrebidMobilePluginRenderer defaultRenderer = buildRenderer(
+                PREBID_MOBILE_RENDERER_NAME, "1.0", true, mockController);
+        registerPlugin(defaultRenderer);
+
+        manager.loadAd(mockParams, activity, mockMaxListener);
+
+        verify(defaultRenderer).createInterstitialController(any(), any(), any(), any());
+        verify(mockMaxListener, never()).onInterstitialAdLoadFailed(any());
+    }
+
+    @Test
+    public void loadAd_customRenderer_delegatesToCustomRenderer() {
+        buildAndCacheBidResponse(CUSTOM_RENDERER, CUSTOM_VERSION);
+
+        PrebidMobileInterstitialControllerInterface customController =
+                mock(PrebidMobileInterstitialControllerInterface.class);
+        PrebidMobilePluginRenderer customRenderer = buildRenderer(
+                CUSTOM_RENDERER, CUSTOM_VERSION, true, customController);
+        registerPlugin(customRenderer);
+
+        PrebidMobileInterstitialControllerInterface defaultController =
+                mock(PrebidMobileInterstitialControllerInterface.class);
+        PrebidMobilePluginRenderer defaultRenderer = buildRenderer(
+                PREBID_MOBILE_RENDERER_NAME, "1.0", true, defaultController);
+        registerPlugin(defaultRenderer);
+
+        manager.loadAd(mockParams, activity, mockMaxListener);
+
+        verify(customRenderer).createInterstitialController(any(), any(), any(), any());
+        verify(defaultRenderer, never()).createInterstitialController(any(), any(), any(), any());
+
+    }
+
+    @Test
+    public void loadAd_rendererReturnsNull_reportsError() {
+        buildAndCacheBidResponse(null, null);
+
+        PrebidMobilePluginRenderer nullRenderer = buildRenderer(
+                PREBID_MOBILE_RENDERER_NAME, "1.0", true, null);
+        registerPlugin(nullRenderer);
+
+        manager.loadAd(mockParams, activity, mockMaxListener);
+
+        verify(mockMaxListener).onInterstitialAdLoadFailed(any());
+    }
+
+
+    private void buildAndCacheBidResponse(String rendererName, String rendererVersion) {
+        BidResponse mockResponse = mock(BidResponse.class);
+        when(mockResponse.getId()).thenReturn(RESPONSE_ID);
+        when(mockResponse.getPreferredPluginRendererName()).thenReturn(rendererName);
+        when(mockResponse.getPreferredPluginRendererVersion()).thenReturn(rendererVersion);
+        HashMap<String, String> targeting = new HashMap<>();
+        targeting.put(KEYWORD_KEY, KEYWORD_VALUE);
+        when(mockResponse.getTargeting()).thenReturn(targeting);
+        AdUnitConfiguration config = new AdUnitConfiguration();
+        when(mockResponse.getAdUnitConfiguration()).thenReturn(config);
+        BidResponseCache.getInstance().putBidResponse(RESPONSE_ID, mockResponse);
+    }
+
+    // Custom params must match targeting returned by BidResponseCache.getKeywords()
+    private MaxAdapterResponseParameters buildParams(String responseId) {
+        MaxAdapterResponseParameters params = mock(MaxAdapterResponseParameters.class);
+        Map<String, Object> extras = new HashMap<>();
+        extras.put(PrebidMaxMediationAdapter.EXTRA_RESPONSE_ID, responseId);
+        when(params.getLocalExtraParameters()).thenReturn(extras);
+        Bundle customParams = new Bundle();
+        customParams.putString(KEYWORD_KEY, KEYWORD_VALUE);
+        when(params.getCustomParameters()).thenReturn(customParams);
+        return params;
+    }
+
+    private PrebidMobilePluginRenderer buildRenderer(
+            String name,
+            String version,
+            boolean supports,
+            PrebidMobileInterstitialControllerInterface controller
+    ) {
+        PrebidMobilePluginRenderer renderer = mock(PrebidMobilePluginRenderer.class);
+        when(renderer.getName()).thenReturn(name);
+        when(renderer.getVersion()).thenReturn(version);
+        when(renderer.isSupportRenderingFor(any())).thenReturn(supports);
+        when(renderer.createInterstitialController(any(), any(), any(), any()))
+                .thenReturn(controller);
+        return renderer;
+    }
+
+    private void registerPlugin(PrebidMobilePluginRenderer renderer) {
+        PrebidMobilePluginRegister.getInstance().registerPlugin(renderer);
+        registeredRenderers.add(renderer);
+    }
+}

--- a/PrebidMobile/PrebidMobile-maxAdapters/src/test/java/com/applovin/mediation/adapters/prebid/managers/MaxRewardedManagerTest.java
+++ b/PrebidMobile/PrebidMobile-maxAdapters/src/test/java/com/applovin/mediation/adapters/prebid/managers/MaxRewardedManagerTest.java
@@ -1,0 +1,200 @@
+package com.applovin.mediation.adapters.prebid.managers;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.prebid.mobile.api.rendering.pluginrenderer.PrebidMobilePluginRegister.PREBID_MOBILE_RENDERER_NAME;
+
+import android.app.Activity;
+import android.os.Bundle;
+
+import com.applovin.mediation.adapter.listeners.MaxRewardedAdapterListener;
+import com.applovin.mediation.adapter.parameters.MaxAdapterResponseParameters;
+import com.applovin.mediation.adapters.PrebidMaxMediationAdapter;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.prebid.mobile.api.rendering.PrebidMobileInterstitialControllerInterface;
+import org.prebid.mobile.api.rendering.pluginrenderer.PrebidMobilePluginRegister;
+import org.prebid.mobile.api.rendering.pluginrenderer.PrebidMobilePluginRenderer;
+import org.prebid.mobile.configuration.AdUnitConfiguration;
+import org.prebid.mobile.rendering.bidding.data.bid.BidResponse;
+import org.prebid.mobile.rendering.bidding.display.BidResponseCache;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(minSdk = 29)
+public class MaxRewardedManagerTest {
+
+    private static final String RESPONSE_ID = "test-rewarded-id-max";
+    private static final String CUSTOM_RENDERER = "CustomRenderer";
+    private static final String CUSTOM_VERSION = "2.0";
+    private static final String KEYWORD_KEY = "hb_pb";
+    private static final String KEYWORD_VALUE = "0.10";
+
+    private MaxRewardedManager manager;
+    private Activity activity;
+    private MaxRewardedAdapterListener mockMaxListener;
+    private MaxAdapterResponseParameters mockParams;
+    private List<PrebidMobilePluginRenderer> registeredRenderers;
+
+    @Before
+    public void setUp() {
+        manager = new MaxRewardedManager();
+        activity = Robolectric.buildActivity(Activity.class).create().get();
+        mockMaxListener = mock(MaxRewardedAdapterListener.class);
+        mockParams = buildParams(RESPONSE_ID);
+        registeredRenderers = new ArrayList<>();
+    }
+
+    @After
+    public void tearDown() {
+        for (PrebidMobilePluginRenderer renderer : registeredRenderers) {
+            PrebidMobilePluginRegister.getInstance().unregisterPlugin(renderer);
+        }
+    }
+
+    @Test
+    public void loadAd_noResponseInCache_reportsError() {
+        MaxAdapterResponseParameters unknownParams =
+                buildParams("unknown-id-rewarded-never-cached");
+
+        manager.loadAd(unknownParams, activity, mockMaxListener);
+
+        verify(mockMaxListener).onRewardedAdLoadFailed(any());
+    }
+
+    @Test
+    public void loadAd_defaultRenderer_createsController() {
+        buildAndCacheBidResponse(null, null);
+
+        PrebidMobileInterstitialControllerInterface mockController =
+                mock(PrebidMobileInterstitialControllerInterface.class);
+        PrebidMobilePluginRenderer defaultRenderer = buildRenderer(
+                PREBID_MOBILE_RENDERER_NAME, "1.0", true, mockController);
+        registerPlugin(defaultRenderer);
+
+        manager.loadAd(mockParams, activity, mockMaxListener);
+
+        verify(defaultRenderer).createInterstitialController(any(), any(), any(), any());
+        verify(mockMaxListener, never()).onRewardedAdLoadFailed(any());
+    }
+
+    @Test
+    public void loadAd_rewardedConfigPassedToRenderer() {
+        buildAndCacheBidResponse(null, null);
+
+        final AdUnitConfiguration[] capturedConfig = {null};
+        PrebidMobilePluginRenderer capturingRenderer = mock(PrebidMobilePluginRenderer.class);
+        when(capturingRenderer.getName()).thenReturn(PREBID_MOBILE_RENDERER_NAME);
+        when(capturingRenderer.getVersion()).thenReturn("1.0");
+        when(capturingRenderer.isSupportRenderingFor(any())).thenReturn(true);
+        when(capturingRenderer.createInterstitialController(any(), any(), any(), any()))
+                .thenAnswer(invocation -> {
+                    capturedConfig[0] = invocation.getArgument(2);
+                    return mock(PrebidMobileInterstitialControllerInterface.class);
+                });
+        registerPlugin(capturingRenderer);
+
+        manager.loadAd(mockParams, activity, mockMaxListener);
+
+        assertNotNull(capturedConfig[0]);
+        assertEquals(true, capturedConfig[0].isRewarded());
+        assertNotNull(capturedConfig[0].getRewardManager().getRewardListener());
+
+    }
+
+    @Test
+    public void loadAd_customRenderer_delegatesToCustomRenderer() {
+        buildAndCacheBidResponse(CUSTOM_RENDERER, CUSTOM_VERSION);
+
+        PrebidMobileInterstitialControllerInterface customController =
+                mock(PrebidMobileInterstitialControllerInterface.class);
+        PrebidMobilePluginRenderer customRenderer = buildRenderer(
+                CUSTOM_RENDERER, CUSTOM_VERSION, true, customController);
+        registerPlugin(customRenderer);
+
+        PrebidMobileInterstitialControllerInterface defaultController =
+                mock(PrebidMobileInterstitialControllerInterface.class);
+        PrebidMobilePluginRenderer defaultRenderer = buildRenderer(
+                PREBID_MOBILE_RENDERER_NAME, "1.0", true, defaultController);
+        registerPlugin(defaultRenderer);
+
+        manager.loadAd(mockParams, activity, mockMaxListener);
+
+        verify(customRenderer).createInterstitialController(any(), any(), any(), any());
+        verify(defaultRenderer, never()).createInterstitialController(any(), any(), any(), any());
+
+    }
+
+    @Test
+    public void loadAd_rendererReturnsNull_reportsError() {
+        buildAndCacheBidResponse(null, null);
+
+        PrebidMobilePluginRenderer nullRenderer = buildRenderer(
+                PREBID_MOBILE_RENDERER_NAME, "1.0", true, null);
+        registerPlugin(nullRenderer);
+
+        manager.loadAd(mockParams, activity, mockMaxListener);
+
+        verify(mockMaxListener).onRewardedAdLoadFailed(any());
+    }
+
+
+    private void buildAndCacheBidResponse(String rendererName, String rendererVersion) {
+        BidResponse mockResponse = mock(BidResponse.class);
+        when(mockResponse.getId()).thenReturn(RESPONSE_ID);
+        when(mockResponse.getPreferredPluginRendererName()).thenReturn(rendererName);
+        when(mockResponse.getPreferredPluginRendererVersion()).thenReturn(rendererVersion);
+        HashMap<String, String> targeting = new HashMap<>();
+        targeting.put(KEYWORD_KEY, KEYWORD_VALUE);
+        when(mockResponse.getTargeting()).thenReturn(targeting);
+        AdUnitConfiguration config = new AdUnitConfiguration();
+        when(mockResponse.getAdUnitConfiguration()).thenReturn(config);
+        BidResponseCache.getInstance().putBidResponse(RESPONSE_ID, mockResponse);
+    }
+
+    private MaxAdapterResponseParameters buildParams(String responseId) {
+        MaxAdapterResponseParameters params = mock(MaxAdapterResponseParameters.class);
+        Map<String, Object> extras = new HashMap<>();
+        extras.put(PrebidMaxMediationAdapter.EXTRA_RESPONSE_ID, responseId);
+        when(params.getLocalExtraParameters()).thenReturn(extras);
+        Bundle customParams = new Bundle();
+        customParams.putString(KEYWORD_KEY, KEYWORD_VALUE);
+        when(params.getCustomParameters()).thenReturn(customParams);
+        return params;
+    }
+
+    private PrebidMobilePluginRenderer buildRenderer(
+            String name,
+            String version,
+            boolean supports,
+            PrebidMobileInterstitialControllerInterface controller
+    ) {
+        PrebidMobilePluginRenderer renderer = mock(PrebidMobilePluginRenderer.class);
+        when(renderer.getName()).thenReturn(name);
+        when(renderer.getVersion()).thenReturn(version);
+        when(renderer.isSupportRenderingFor(any())).thenReturn(supports);
+        when(renderer.createInterstitialController(any(), any(), any(), any()))
+                .thenReturn(controller);
+        return renderer;
+    }
+
+    private void registerPlugin(PrebidMobilePluginRenderer renderer) {
+        PrebidMobilePluginRegister.getInstance().registerPlugin(renderer);
+        registeredRenderers.add(renderer);
+    }
+}


### PR DESCRIPTION
[#1071](https://github.com/prebid/prebid-mobile-ios/issues/1071)

- Added `MediationRendererFactory` to centralize renderer selection and fallback for mediation banner/interstitial paths.
- Added `MediationBannerView` so banner adapters can use plugin renderers while preserving win notification and surfacing renderer creation failures.
- Updated AdMob and MAX banner/interstitial/rewarded adapters to use renderer factory paths instead of directly creating default SDK rendering classes.
- Ensured interstitial/rewarded configs are updated from bid metadata before renderer creation and passed through to custom renderers.
- Added unit coverage for custom/default renderers, null renderer fallback/error handling, win notification, test isolation cleanup, and adapter wiring for AdMob/MAX.
