### PR TITLE
Exclude device.geo.country from the request.

### DIFF
--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/networking/parameters/GeoLocationParameterBuilder.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/networking/parameters/GeoLocationParameterBuilder.java
@@ -16,23 +16,13 @@
 
 package org.prebid.mobile.rendering.networking.parameters;
 
-import android.content.Context;
-import android.location.Address;
-import android.location.Geocoder;
-import android.telephony.TelephonyManager;
-
-import org.prebid.mobile.LogUtil;
 import org.prebid.mobile.PrebidMobile;
 import org.prebid.mobile.TargetingParams;
 import org.prebid.mobile.Util;
 import org.prebid.mobile.rendering.models.openrtb.bidRequests.geo.Geo;
 import org.prebid.mobile.rendering.sdk.ManagersResolver;
-import org.prebid.mobile.rendering.sdk.PrebidContextHolder;
 import org.prebid.mobile.rendering.sdk.deviceData.managers.DeviceInfoManager;
 import org.prebid.mobile.rendering.sdk.deviceData.managers.LocationInfoManager;
-
-import java.util.List;
-import java.util.Locale;
 
 public class GeoLocationParameterBuilder extends ParameterBuilder {
 
@@ -69,40 +59,6 @@ public class GeoLocationParameterBuilder extends ParameterBuilder {
             geo.lat = Util.applyLocationPrecision(latitude.floatValue(), precision);
             geo.lon = Util.applyLocationPrecision(longitude.floatValue(), precision);
             geo.type = LOCATION_SOURCE_GPS;
-            try {
-
-                geo.country = getTelephonyCountry(PrebidContextHolder.getContext());
-
-                if(geo.country.equals("")){
-                    Locale locale = PrebidContextHolder.getContext().getResources().getConfiguration().locale;
-                    geo.country = locale.getISO3Country();
-                }
-
-                if(geo.country.equals("")){
-                    Geocoder geoCoder = new Geocoder(PrebidContextHolder.getContext());
-                    List<Address> list = geoCoder.getFromLocation(locationInfoManager.getLatitude(), locationInfoManager.getLongitude(), 1);
-                    geo.country = list.get(0).getCountryCode();
-                }
-
-            }catch(Throwable thr){
-                LogUtil.debug("Error getting country code");
-            }
         }
-    }
-
-    private String getTelephonyCountry(Context ctx){
-        TelephonyManager tm = (TelephonyManager) ctx.getSystemService(Context.TELEPHONY_SERVICE);
-
-        if(tm != null) {
-            String simCountry = tm.getSimCountryIso().toUpperCase();
-            String networkCountry = tm.getNetworkCountryIso().toUpperCase();
-
-            if (!simCountry.equals("")) {
-                return simCountry;
-            } else if (!networkCountry.equals("")) {
-                return networkCountry;
-            }
-        }
-        return "";
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/networking/parameters/GeoLocationParameterBuilderTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/networking/parameters/GeoLocationParameterBuilderTest.java
@@ -17,12 +17,14 @@
 package org.prebid.mobile.rendering.networking.parameters;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 import static org.robolectric.Shadows.shadowOf;
 
 import android.app.Activity;
 import android.content.Context;
 import android.location.Location;
 import android.location.LocationManager;
+import android.telephony.TelephonyManager;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -37,17 +39,19 @@ import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.shadows.ShadowActivity;
 import org.robolectric.shadows.ShadowLocationManager;
+import org.robolectric.shadows.ShadowTelephonyManager;
 
 @RunWith(RobolectricTestRunner.class)
 public class GeoLocationParameterBuilderTest {
 
     private final Double LATITUDE = 1.0;
     private final Double LONGITUDE = -1.0;
+    private Activity robolectricActivity;
 
     @Before
     public void setUp() throws Exception {
         PrebidMobile.setShareGeoLocation(true);
-        Activity robolectricActivity = Robolectric.buildActivity(Activity.class).create().get();
+        robolectricActivity = Robolectric.buildActivity(Activity.class).create().get();
         ShadowActivity shadowActivity = shadowOf(robolectricActivity);
         shadowActivity.grantPermissions("android.permission.ACCESS_FINE_LOCATION");
 
@@ -76,6 +80,24 @@ public class GeoLocationParameterBuilderTest {
 
         assertEquals(expectedBidRequest.getJsonObject().toString(),
                      adRequestInput.getBidRequest().getJsonObject().toString());
+    }
+
+    @Test
+    public void testCountryIsNotPopulatedFromCarrierData() throws Exception {
+        ShadowTelephonyManager shadowTelephonyManager = shadowOf(
+                (TelephonyManager) robolectricActivity.getSystemService(Context.TELEPHONY_SERVICE)
+        );
+        shadowTelephonyManager.setSimCountryIso("us");
+        shadowTelephonyManager.setNetworkCountryIso("ca");
+
+        GeoLocationParameterBuilder builder = new GeoLocationParameterBuilder();
+        AdRequestInput adRequestInput = new AdRequestInput();
+        builder.appendBuilderParameters(adRequestInput);
+
+        Geo geo = adRequestInput.getBidRequest().getDevice().getGeo();
+        assertEquals(LATITUDE.floatValue(), geo.lat, 0.0f);
+        assertEquals(LONGITUDE.floatValue(), geo.lon, 0.0f);
+        assertNull(geo.country);
     }
 
     /**


### PR DESCRIPTION
#872 

## Summary

Fixes Android `device.geo.country` population to align with iOS behavior and OpenRTB expectations.

Previously, the SDK populated `device.geo.country` from carrier/locale data, which could produce ISO-3166-1 alpha-2 values such as `US` or `CA`. OpenRTB expects this field to use ISO-3166-1 alpha-3 when populated, and the value should generally come from location-based reverse geocoding rather than SIM/network carrier data.

## Changes

- Removed SDK-side population of `device.geo.country` from carrier, locale, and geocoder fallbacks.
- Added test coverage to verify `geo.country` is not populated from SIM/network carrier country values.
- Aligns Android behavior with iOS, where this field is not populated by the SDK.