### PR TITLE
Fix banner load callbacks firing before creative attachment

### DIFF
--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/PrebidDisplayView.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/PrebidDisplayView.java
@@ -63,6 +63,8 @@ public class PrebidDisplayView extends FrameLayout implements PrebidDestroyable 
     @Nullable
     private VideoView videoView;
 
+    private boolean isAdLoadedNotificationPending;
+
     @Nullable
     private EventForwardingLocalBroadcastReceiver eventForwardingReceiver;
     private final EventForwardingLocalBroadcastReceiver.EventForwardingBroadcastListener broadcastListener = this::handleBroadcastAction;
@@ -71,7 +73,7 @@ public class PrebidDisplayView extends FrameLayout implements PrebidDestroyable 
         @Override
         public void adLoaded(AdDetails adDetails) {
             // for banner adViewManager.show() will be called automatically
-            notifyListenerLoaded();
+            isAdLoadedNotificationPending = true;
         }
 
         @Override
@@ -79,6 +81,7 @@ public class PrebidDisplayView extends FrameLayout implements PrebidDestroyable 
             removeAllViews();
             creative.setContentDescription(CONTENT_DESCRIPTION_AD_VIEW);
             addView(creative);
+            notifyListenerLoadedIfNeeded();
             notifyListenerDisplayed();
         }
 
@@ -203,6 +206,7 @@ public class PrebidDisplayView extends FrameLayout implements PrebidDestroyable 
         adUnitConfiguration = null;
         displayViewListener = null;
         interstitialManager = null;
+        isAdLoadedNotificationPending = false;
         if (videoView != null) {
             videoView.destroy();
         }
@@ -267,6 +271,15 @@ public class PrebidDisplayView extends FrameLayout implements PrebidDestroyable 
         if (displayViewListener != null) {
             displayViewListener.onAdLoaded();
         }
+    }
+
+    private void notifyListenerLoadedIfNeeded() {
+        if (!isAdLoadedNotificationPending) {
+            return;
+        }
+
+        isAdLoadedNotificationPending = false;
+        notifyListenerLoaded();
     }
 
     private void notifyVideoPaused() {

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/PrebidDisplayViewTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/PrebidDisplayViewTest.java
@@ -23,6 +23,7 @@ import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.prebid.mobile.PrebidMobile;
@@ -81,11 +82,11 @@ public class PrebidDisplayViewTest {
     }
 
     @Test
-    public void whenAdViewManagerListenerAdLoaded_NotifyListenerOnAdLoaded()
+    public void whenAdViewManagerListenerAdLoaded_DoesNotNotifyListenerBeforeViewReady()
         throws IllegalAccessException {
         AdViewManagerListener adViewManagerListener = getAdViewManagerListener();
         adViewManagerListener.adLoaded(mock(AdDetails.class));
-        verify(mockDisplayViewListener).onAdLoaded();
+        verify(mockDisplayViewListener, never()).onAdLoaded();
     }
 
     @Test
@@ -94,6 +95,26 @@ public class PrebidDisplayViewTest {
         AdViewManagerListener adViewManagerListener = getAdViewManagerListener();
         adViewManagerListener.viewReadyForImmediateDisplay(mock(View.class));
         verify(mockDisplayViewListener).onAdDisplayed();
+    }
+
+    @Test
+    public void whenAdLoadedAndViewReadyForImmediateDisplay_NotifyLoadedAfterCreativeAddedBeforeDisplayed()
+        throws IllegalAccessException {
+        AdViewManagerListener adViewManagerListener = getAdViewManagerListener();
+        View creative = new View(context);
+
+        doAnswer(invocation -> {
+            Assert.assertEquals(1, prebidDisplayView.getChildCount());
+            Assert.assertSame(creative, prebidDisplayView.getChildAt(0));
+            return null;
+        }).when(mockDisplayViewListener).onAdLoaded();
+
+        adViewManagerListener.adLoaded(mock(AdDetails.class));
+        adViewManagerListener.viewReadyForImmediateDisplay(creative);
+
+        InOrder inOrder = inOrder(mockDisplayViewListener);
+        inOrder.verify(mockDisplayViewListener).onAdLoaded();
+        inOrder.verify(mockDisplayViewListener).onAdDisplayed();
     }
 
     @Test


### PR DESCRIPTION
[#1220](https://github.com/prebid/prebid-mobile-ios/issues/1220)

## Summary

Fixed the banner/custom renderer load callback ordering on both iOS and Android so the load callback is not fired before the creative view is attached.
### Android

Updated `PrebidDisplayView.java` so `adLoaded` marks the load notification as pending instead of notifying immediately.

When `viewReadyForImmediateDisplay` is called, the creative is attached first, then pending `onAdLoaded` is fired, followed by `onAdDisplayed`.

Added regression coverage in `PrebidDisplayViewTest.java` to verify that:

- `onAdLoaded` is not fired before the creative is ready
- the creative is already attached when `onAdLoaded` fires
- `onAdLoaded` still fires before `onAdDisplayed`