### PR TITLE
`usepxratio` flag in bid request for interstitial DIP conversion

### DIFF
--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/bidding/data/bid/Prebid.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/bidding/data/bid/Prebid.java
@@ -157,6 +157,7 @@ public class Prebid {
         }
 
         setPluginRendererList(prebid, config);
+        setUsePxRatio(prebid);
 
         return prebid;
     }
@@ -188,6 +189,16 @@ public class Prebid {
                 LogUtil.error("setPluginRendererList", e.getMessage());
             }
         }
+    }
+
+    private static void setUsePxRatio(JSONObject prebid) {
+        JSONObject sdk = prebid.optJSONObject("sdk");
+        if (sdk == null) {
+            sdk = new JSONObject();
+            Utils.addValue(prebid, "sdk", sdk);
+        }
+
+        Utils.addValue(sdk, "usepxratio", true);
     }
 
     private static void parseEvents(

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/bidding/data/bid/PrebidTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/bidding/data/bid/PrebidTest.java
@@ -27,8 +27,10 @@ import org.junit.After;
 import org.junit.Test;
 import org.prebid.mobile.PrebidMobile;
 import org.prebid.mobile.api.data.AdFormat;
+import org.prebid.mobile.api.rendering.pluginrenderer.PrebidMobilePluginRenderer;
 import org.prebid.mobile.configuration.AdUnitConfiguration;
 import org.prebid.mobile.test.utils.ResourceUtils;
+import org.prebid.mobile.testutils.FakePrebidMobilePluginRenderer;
 
 import java.io.IOException;
 
@@ -39,6 +41,7 @@ public class PrebidTest {
         PrebidMobile.setIncludeBidderKeysFlag(false);
         PrebidMobile.setIncludeWinnersFlag(false);
         PrebidMobile.clearStoredBidResponses();
+        PrebidMobile.unregisterPluginRenderer(testPluginRenderer());
     }
     @Test
     public void whenFromJSONObjectAndJSONObjectPassed_ReturnParsedPrebid()
@@ -87,6 +90,7 @@ public class PrebidTest {
         expected.put("storedrequest", storedRequest.toJSONObject());
         expected.put("cache", cache);
         expected.put("targeting", new JSONObject());
+        expected.put("sdk", getExpectedSdkObject());
 
         AdUnitConfiguration config = new AdUnitConfiguration();
         config.setIsOriginalAdUnit(true);
@@ -129,7 +133,7 @@ public class PrebidTest {
         config.addAdFormat(AdFormat.BANNER);
         config.addAdFormat(AdFormat.VAST);
         assertEquals(
-                "{\"storedrequest\":{\"id\":\"test\"},\"cache\":{\"bids\":{}},\"targeting\":{\"includeformat\":\"true\"}}",
+                "{\"storedrequest\":{\"id\":\"test\"},\"cache\":{\"bids\":{}},\"targeting\":{\"includeformat\":\"true\"},\"sdk\":{\"usepxratio\":true}}",
                 Prebid.getJsonObjectForBidRequest("test", false, config).toString()
         );
     }
@@ -140,9 +144,31 @@ public class PrebidTest {
         config.setIsOriginalAdUnit(true);
         config.addAdFormat(AdFormat.BANNER);
         assertEquals(
-                "{\"storedrequest\":{\"id\":\"test\"},\"cache\":{\"bids\":{}},\"targeting\":{}}",
+                "{\"storedrequest\":{\"id\":\"test\"},\"cache\":{\"bids\":{}},\"targeting\":{},\"sdk\":{\"usepxratio\":true}}",
                 Prebid.getJsonObjectForBidRequest("test", false, config).toString()
         );
+    }
+
+    @Test
+    public void whenGetJsonObjectForBidRequestAndPluginRendererPresent_SdkContainsRendererAndUsePxRatio()
+    throws JSONException {
+        // given
+        AdUnitConfiguration config = new AdUnitConfiguration();
+        config.setIsOriginalAdUnit(false);
+        PrebidMobile.registerPluginRenderer(testPluginRenderer());
+
+        // when
+        JSONObject prebid = Prebid.getJsonObjectForBidRequest("test", false, config);
+
+        // then
+        JSONObject sdk = prebid.getJSONObject("sdk");
+        JSONArray renderers = sdk.getJSONArray("renderers");
+        JSONObject renderer = renderers.getJSONObject(0);
+
+        assertEquals(true, sdk.getBoolean("usepxratio"));
+        assertEquals(1, renderers.length());
+        assertEquals("TestPluginRenderer", renderer.getString("name"));
+        assertEquals("1.0", renderer.getString("version"));
     }
 
     @Test
@@ -160,6 +186,7 @@ public class PrebidTest {
 
         JSONObject expectedTargeting = new JSONObject();
         expected.put("targeting", expectedTargeting);
+        expected.put("sdk", getExpectedSdkObject());
 
         AdUnitConfiguration config = new AdUnitConfiguration();
         config.setIsOriginalAdUnit(true);
@@ -180,6 +207,7 @@ public class PrebidTest {
         JSONObject expectedTargeting = new JSONObject();
         expectedTargeting.put("includebidderkeys", "true");
         expected.put("targeting", expectedTargeting);
+        expected.put("sdk", getExpectedSdkObject());
 
         AdUnitConfiguration config = new AdUnitConfiguration();
         config.setIsOriginalAdUnit(true);
@@ -201,9 +229,20 @@ public class PrebidTest {
         expectedTargeting.put("includewinners", "true");
 
         expected.put("targeting", expectedTargeting);
+        expected.put("sdk", getExpectedSdkObject());
 
         AdUnitConfiguration config = new AdUnitConfiguration();
         config.setIsOriginalAdUnit(true);
         assertEquals(expected.toString(), Prebid.getJsonObjectForBidRequest("test", false, config).toString());
+    }
+
+    private static JSONObject getExpectedSdkObject() throws JSONException {
+        JSONObject expectedSdk = new JSONObject();
+        expectedSdk.put("usepxratio", true);
+        return expectedSdk;
+    }
+
+    private static PrebidMobilePluginRenderer testPluginRenderer() {
+        return FakePrebidMobilePluginRenderer.getFakePrebidRenderer(null, null, true, "TestPluginRenderer", "1.0");
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/bidding/data/bid/PrebidTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/bidding/data/bid/PrebidTest.java
@@ -27,8 +27,10 @@ import org.junit.After;
 import org.junit.Test;
 import org.prebid.mobile.PrebidMobile;
 import org.prebid.mobile.api.data.AdFormat;
+import org.prebid.mobile.api.rendering.pluginrenderer.PrebidMobilePluginRenderer;
 import org.prebid.mobile.configuration.AdUnitConfiguration;
 import org.prebid.mobile.test.utils.ResourceUtils;
+import org.prebid.mobile.testutils.FakePrebidMobilePluginRenderer;
 
 import java.io.IOException;
 
@@ -39,6 +41,7 @@ public class PrebidTest {
         PrebidMobile.setIncludeBidderKeysFlag(false);
         PrebidMobile.setIncludeWinnersFlag(false);
         PrebidMobile.clearStoredBidResponses();
+        PrebidMobile.unregisterPluginRenderer(testPluginRenderer());
     }
     @Test
     public void whenFromJSONObjectAndJSONObjectPassed_ReturnParsedPrebid()
@@ -87,6 +90,7 @@ public class PrebidTest {
         expected.put("storedrequest", storedRequest.toJSONObject());
         expected.put("cache", cache);
         expected.put("targeting", new JSONObject());
+        expected.put("sdk", getExpectedSdkObject());
 
         AdUnitConfiguration config = new AdUnitConfiguration();
         config.setIsOriginalAdUnit(true);
@@ -129,7 +133,7 @@ public class PrebidTest {
         config.addAdFormat(AdFormat.BANNER);
         config.addAdFormat(AdFormat.VAST);
         assertEquals(
-                "{\"storedrequest\":{\"id\":\"test\"},\"cache\":{\"bids\":{}},\"targeting\":{\"includeformat\":true}}",
+                "{\"storedrequest\":{\"id\":\"test\"},\"cache\":{\"bids\":{}},\"targeting\":{\"includeformat\":true},\"sdk\":{\"usepxratio\":true}}",
                 Prebid.getJsonObjectForBidRequest("test", false, config).toString()
         );
     }
@@ -140,9 +144,31 @@ public class PrebidTest {
         config.setIsOriginalAdUnit(true);
         config.addAdFormat(AdFormat.BANNER);
         assertEquals(
-                "{\"storedrequest\":{\"id\":\"test\"},\"cache\":{\"bids\":{}},\"targeting\":{}}",
+                "{\"storedrequest\":{\"id\":\"test\"},\"cache\":{\"bids\":{}},\"targeting\":{},\"sdk\":{\"usepxratio\":true}}",
                 Prebid.getJsonObjectForBidRequest("test", false, config).toString()
         );
+    }
+
+    @Test
+    public void whenGetJsonObjectForBidRequestAndPluginRendererPresent_SdkContainsRendererAndUsePxRatio()
+    throws JSONException {
+        // given
+        AdUnitConfiguration config = new AdUnitConfiguration();
+        config.setIsOriginalAdUnit(false);
+        PrebidMobile.registerPluginRenderer(testPluginRenderer());
+
+        // when
+        JSONObject prebid = Prebid.getJsonObjectForBidRequest("test", false, config);
+
+        // then
+        JSONObject sdk = prebid.getJSONObject("sdk");
+        JSONArray renderers = sdk.getJSONArray("renderers");
+        JSONObject renderer = renderers.getJSONObject(0);
+
+        assertEquals(true, sdk.getBoolean("usepxratio"));
+        assertEquals(1, renderers.length());
+        assertEquals("TestPluginRenderer", renderer.getString("name"));
+        assertEquals("1.0", renderer.getString("version"));
     }
 
     @Test
@@ -160,6 +186,7 @@ public class PrebidTest {
 
         JSONObject expectedTargeting = new JSONObject();
         expected.put("targeting", expectedTargeting);
+        expected.put("sdk", getExpectedSdkObject());
 
         AdUnitConfiguration config = new AdUnitConfiguration();
         config.setIsOriginalAdUnit(true);
@@ -180,6 +207,7 @@ public class PrebidTest {
         JSONObject expectedTargeting = new JSONObject();
         expectedTargeting.put("includebidderkeys", true);
         expected.put("targeting", expectedTargeting);
+        expected.put("sdk", getExpectedSdkObject());
 
         AdUnitConfiguration config = new AdUnitConfiguration();
         config.setIsOriginalAdUnit(true);
@@ -201,9 +229,20 @@ public class PrebidTest {
         expectedTargeting.put("includewinners", true);
 
         expected.put("targeting", expectedTargeting);
+        expected.put("sdk", getExpectedSdkObject());
 
         AdUnitConfiguration config = new AdUnitConfiguration();
         config.setIsOriginalAdUnit(true);
         assertEquals(expected.toString(), Prebid.getJsonObjectForBidRequest("test", false, config).toString());
+    }
+
+    private static JSONObject getExpectedSdkObject() throws JSONException {
+        JSONObject expectedSdk = new JSONObject();
+        expectedSdk.put("usepxratio", true);
+        return expectedSdk;
+    }
+
+    private static PrebidMobilePluginRenderer testPluginRenderer() {
+        return FakePrebidMobilePluginRenderer.getFakePrebidRenderer(null, null, true, "TestPluginRenderer", "1.0");
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/networking/parameters/BasicParameterBuilderTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/networking/parameters/BasicParameterBuilderTest.java
@@ -1044,7 +1044,6 @@ public class BasicParameterBuilderTest {
         AdUnitConfiguration configuration = new AdUnitConfiguration();
         configuration.setIsOriginalAdUnit(true);
         configuration.setAdFormat(AdFormat.BANNER);
-        String unwantedObjectNodeKey = "sdk";
 
         BasicParameterBuilder builder = new BasicParameterBuilder(configuration, context.getResources(), false);
         AdRequestInput adRequestInput = new AdRequestInput();
@@ -1057,7 +1056,8 @@ public class BasicParameterBuilderTest {
 
         // Then
         JSONObject prebidObj = (JSONObject) adRequestInput.getBidRequest().getExt().getMap().get("prebid");
-        assertFalse(prebidObj.has(unwantedObjectNodeKey));
+        JSONObject sdkObj = prebidObj.getJSONObject("sdk");
+        assertTrue(sdkObj.getBoolean("usepxratio"));
         assertEquals(actualBidRequest, bidRequest.getJsonObject().toString());
     }
 
@@ -1067,7 +1067,6 @@ public class BasicParameterBuilderTest {
         AdUnitConfiguration configuration = new AdUnitConfiguration();
         configuration.setIsOriginalAdUnit(false);
         configuration.setAdFormat(AdFormat.BANNER);
-        String unwantedObjectNodeKey = "sdk";
 
         BasicParameterBuilder builder = new BasicParameterBuilder(configuration, context.getResources(), false);
         AdRequestInput adRequestInput = new AdRequestInput();
@@ -1080,7 +1079,8 @@ public class BasicParameterBuilderTest {
 
         // Then
         JSONObject prebidObj = (JSONObject) adRequestInput.getBidRequest().getExt().getMap().get("prebid");
-        assertFalse(prebidObj.has(unwantedObjectNodeKey));
+        JSONObject sdkObj = prebidObj.getJSONObject("sdk");
+        assertTrue(sdkObj.getBoolean("usepxratio"));
         assertEquals(actualBidRequest, bidRequest.getJsonObject().toString());
     }
 


### PR DESCRIPTION
Part of [prebid/prebid-server#4501](https://github.com/prebid/prebid-server/issues/4501)

Opts in to server-side pxratio conversion by always including `ext.prebid.sdk.usepxratio: true` in bid requests. This allows Prebid Server to correctly convert physical pixels to DIPs when generating interstitial ad sizes for high-density screens. `device.w`/`device.h` already carried physical pixels via `DisplayMetrics.widthPixels`/`heightPixels`; `device.pxratio` was already set to `DisplayMetrics.density`.

## Changes

- `Prebid`: added `setUsePxRatio()` which appends `usepxratio: true` to `ext.prebid.sdk`; reuses the existing `sdk` object if one was already created by `setPluginRendererList`, otherwise creates a new one

## Testing

- `whenGetJsonObjectForBidRequestAndPluginRendererPresent_SdkContainsRendererAndUsePxRatio` — verifies `usepxratio: true` and `renderers` coexist correctly in `sdk` when a plugin renderer is registered
- All existing `getJsonObjectForBidRequest` test expectations updated to include `"sdk":{"usepxratio":true}`