### PR TITLE
Bid selector for winner override

### DIFF
--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/AdUnit.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/AdUnit.java
@@ -277,6 +277,13 @@ public abstract class AdUnit {
             public void onFetchCompleted(BidResponse response) {
                 bidResponse = response;
 
+                if (response.hasBidSelectorRejectedAllBids()) {
+                    LogUtil.debug(TAG, "Bid selector rejected all bids.");
+                    Util.apply(null, adObject);
+                    originalListener.onComplete(ResultCode.NO_BIDS);
+                    return;
+                }
+
                 HashMap<String, String> keywords = response.getTargeting();
                 LogUtil.debug(TAG, "Bid response received successfully: " + keywords);
 

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/NativeAdUnit.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/NativeAdUnit.java
@@ -45,6 +45,12 @@ public class NativeAdUnit extends AdUnit {
             public void onFetchCompleted(BidResponse response) {
                 bidResponse = response;
 
+                if (response.hasBidSelectorRejectedAllBids()) {
+                    Util.apply(null, adObject);
+                    originalListener.onComplete(ResultCode.NO_BIDS);
+                    return;
+                }
+
                 HashMap<String, String> keywords = response.getTargeting();
                 Util.apply(keywords, adObject);
 

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/mediation/MediationBaseAdUnit.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/mediation/MediationBaseAdUnit.java
@@ -31,6 +31,7 @@ import org.prebid.mobile.api.exceptions.AdException;
 import org.prebid.mobile.api.mediation.listeners.OnFetchCompleteListener;
 import org.prebid.mobile.configuration.AdUnitConfiguration;
 import org.prebid.mobile.rendering.bidding.data.bid.BidResponse;
+import org.prebid.mobile.rendering.bidding.data.bid.PrebidBidSelecting;
 import org.prebid.mobile.rendering.bidding.display.BidResponseCache;
 import org.prebid.mobile.rendering.bidding.display.PrebidMediationDelegate;
 import org.prebid.mobile.rendering.bidding.listeners.BidRequesterListener;
@@ -133,6 +134,11 @@ public abstract class MediationBaseAdUnit {
             cancelRefresh();
             return;
         }
+        if (response.hasBidSelectorRejectedAllBids()) {
+            LogUtil.debug(TAG, "Bid selector rejected all bids.");
+            onFetchCompleteListener.onComplete(FetchDemandResult.NO_BIDS);
+            return;
+        }
         BidResponseCache.getInstance().putBidResponse(response);
         mediationDelegate.handleKeywordsUpdate(response.getTargeting());
         mediationDelegate.setResponseToLocalExtras(response);
@@ -186,6 +192,18 @@ public abstract class MediationBaseAdUnit {
      */
     public void setGlobalOrtbConfig(@Nullable String ortbConfig) {
         adUnitConfig.setGlobalOrtbConfig(ortbConfig);
+    }
+
+    @Nullable
+    public PrebidBidSelecting getBidSelector() {
+        return adUnitConfig.getBidSelector();
+    }
+
+    /**
+     * Sets a publisher-supplied strategy for choosing the winning bid. See {@link PrebidBidSelecting}.
+     */
+    public void setBidSelector(@Nullable PrebidBidSelecting bidSelector) {
+        adUnitConfig.setBidSelector(bidSelector);
     }
 
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/mediation/MediationNativeAdUnit.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/mediation/MediationNativeAdUnit.java
@@ -1,6 +1,7 @@
 package org.prebid.mobile.api.mediation;
 
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 
 import org.prebid.mobile.LogUtil;
 import org.prebid.mobile.NativeAdUnit;
@@ -9,6 +10,7 @@ import org.prebid.mobile.NativeEventTracker;
 import org.prebid.mobile.ResultCode;
 import org.prebid.mobile.api.data.FetchDemandResult;
 import org.prebid.mobile.api.mediation.listeners.OnFetchCompleteListener;
+import org.prebid.mobile.rendering.bidding.data.bid.PrebidBidSelecting;
 
 import java.util.Set;
 
@@ -96,6 +98,18 @@ public class MediationNativeAdUnit {
 
     public void setDUrlSupport(boolean support) {
         nativeAdUnit.setDUrlSupport(support);
+    }
+
+    @Nullable
+    public PrebidBidSelecting getBidSelector() {
+        return nativeAdUnit.getConfiguration().getBidSelector();
+    }
+
+    /**
+     * Sets a publisher-supplied strategy for choosing the winning bid. See {@link PrebidBidSelecting}.
+     */
+    public void setBidSelector(@Nullable PrebidBidSelecting bidSelector) {
+        nativeAdUnit.getConfiguration().setBidSelector(bidSelector);
     }
 
     private FetchDemandResult convertResultCode(ResultCode originalResult) {

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/original/MultiformatAdUnitFacade.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/original/MultiformatAdUnitFacade.java
@@ -54,6 +54,12 @@ class MultiformatAdUnitFacade extends AdUnit {
             public void onFetchCompleted(BidResponse response) {
                 bidResponse = response;
 
+                if (response.hasBidSelectorRejectedAllBids()) {
+                    Util.apply(null, adObject);
+                    originalListener.onComplete(ResultCode.NO_BIDS);
+                    return;
+                }
+
                 HashMap<String, String> keywords = response.getTargeting();
                 Util.apply(keywords, adObject);
 
@@ -118,6 +124,8 @@ class MultiformatAdUnitFacade extends AdUnit {
 
         String gpid = request.getGpid();
         configuration.setGpid(gpid);
+
+        configuration.setBidSelector(request.getBidSelector());
 
         if (request.isInterstitial()) {
             configuration.setAdPosition(AdPosition.FULLSCREEN);

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/original/PrebidRequest.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/original/PrebidRequest.java
@@ -4,6 +4,7 @@ import org.jetbrains.annotations.Nullable;
 import org.prebid.mobile.BannerParameters;
 import org.prebid.mobile.NativeParameters;
 import org.prebid.mobile.VideoParameters;
+import org.prebid.mobile.rendering.bidding.data.bid.PrebidBidSelecting;
 import org.prebid.mobile.rendering.models.AdPosition;
 
 /**
@@ -26,6 +27,9 @@ public class PrebidRequest {
 
     @Nullable
     private AdPosition adPosition;
+
+    @Nullable
+    private PrebidBidSelecting bidSelector;
 
     public PrebidRequest() {
     }
@@ -91,5 +95,14 @@ public class PrebidRequest {
 
     public void setAdPosition(@Nullable AdPosition position) {
         this.adPosition = position;
+    }
+
+    @Nullable
+    PrebidBidSelecting getBidSelector() {
+        return bidSelector;
+    }
+
+    public void setBidSelector(@Nullable PrebidBidSelecting bidSelector) {
+        this.bidSelector = bidSelector;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/BannerView.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/BannerView.java
@@ -39,6 +39,7 @@ import org.prebid.mobile.configuration.AdUnitConfiguration;
 import org.prebid.mobile.core.R;
 import org.prebid.mobile.rendering.bidding.data.bid.Bid;
 import org.prebid.mobile.rendering.bidding.data.bid.BidResponse;
+import org.prebid.mobile.rendering.bidding.data.bid.PrebidBidSelecting;
 import org.prebid.mobile.rendering.bidding.interfaces.BannerEventHandler;
 import org.prebid.mobile.rendering.bidding.interfaces.StandaloneBannerEventHandler;
 import org.prebid.mobile.rendering.bidding.listeners.BannerEventListener;
@@ -561,6 +562,18 @@ public class BannerView extends FrameLayout {
      */
     public void setGlobalOrtbConfig(@Nullable String ortbConfig) {
         adUnitConfig.setGlobalOrtbConfig(ortbConfig);
+    }
+
+    @Nullable
+    public PrebidBidSelecting getBidSelector() {
+        return adUnitConfig.getBidSelector();
+    }
+
+    /**
+     * Sets a publisher-supplied strategy for choosing the winning bid. See {@link PrebidBidSelecting}.
+     */
+    public void setBidSelector(@Nullable PrebidBidSelecting bidSelector) {
+        adUnitConfig.setBidSelector(bidSelector);
     }
 
     //region ==================== HelperMethods for Unit Tests. Should be used only in tests

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/BaseInterstitialAdUnit.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/BaseInterstitialAdUnit.java
@@ -29,6 +29,7 @@ import org.prebid.mobile.api.rendering.pluginrenderer.PrebidMobilePluginRenderer
 import org.prebid.mobile.configuration.AdUnitConfiguration;
 import org.prebid.mobile.rendering.bidding.data.bid.Bid;
 import org.prebid.mobile.rendering.bidding.data.bid.BidResponse;
+import org.prebid.mobile.rendering.bidding.data.bid.PrebidBidSelecting;
 import org.prebid.mobile.rendering.bidding.interfaces.InterstitialControllerListener;
 import org.prebid.mobile.rendering.bidding.listeners.BidRequesterListener;
 import org.prebid.mobile.rendering.bidding.loader.BidLoader;
@@ -149,6 +150,18 @@ public abstract class BaseInterstitialAdUnit {
      */
     public void setGlobalOrtbConfig(@Nullable String ortbConfig) {
         config.setGlobalOrtbConfig(ortbConfig);
+    }
+
+    @Nullable
+    public PrebidBidSelecting getBidSelector() {
+        return config.getBidSelector();
+    }
+
+    /**
+     * Sets a publisher-supplied strategy for choosing the winning bid. See {@link PrebidBidSelecting}.
+     */
+    public void setBidSelector(@Nullable PrebidBidSelecting bidSelector) {
+        config.setBidSelector(bidSelector);
     }
 
     @Nullable

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/configuration/AdUnitConfiguration.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/configuration/AdUnitConfiguration.java
@@ -13,6 +13,7 @@ import org.prebid.mobile.api.data.AdFormat;
 import org.prebid.mobile.api.data.AdUnitFormat;
 import org.prebid.mobile.api.data.Position;
 import org.prebid.mobile.rendering.bidding.data.bid.BidResponse;
+import org.prebid.mobile.rendering.bidding.data.bid.PrebidBidSelecting;
 import org.prebid.mobile.rendering.interstitial.InterstitialSizes;
 import org.prebid.mobile.rendering.interstitial.rewarded.RewardManager;
 import org.prebid.mobile.rendering.models.AdPosition;
@@ -59,6 +60,8 @@ public class AdUnitConfiguration {
     private String impOrtbConfig;
     @Nullable
     private String globalOrtbConfig;
+    @Nullable
+    private PrebidBidSelecting bidSelector;
 
     private Position closeButtonPosition = Position.TOP_RIGHT;
     private Position skipButtonPosition = Position.TOP_RIGHT;
@@ -455,6 +458,15 @@ public class AdUnitConfiguration {
 
     public void setGlobalOrtbConfig(@Nullable String globalOrtbConfig) {
         this.globalOrtbConfig = globalOrtbConfig;
+    }
+
+    @Nullable
+    public PrebidBidSelecting getBidSelector() {
+        return bidSelector;
+    }
+
+    public void setBidSelector(@Nullable PrebidBidSelecting bidSelector) {
+        this.bidSelector = bidSelector;
     }
 
     public boolean getHasEndCard() {

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/bidding/data/bid/BidResponse.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/bidding/data/bid/BidResponse.java
@@ -32,8 +32,11 @@ import org.prebid.mobile.rendering.utils.helpers.Dips;
 import org.prebid.mobile.rendering.utils.helpers.Utils;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public class BidResponse {
 
@@ -43,6 +46,12 @@ public class BidResponse {
     public static final String KEY_RENDERER_NAME = "rendererName";
     public static final String KEY_RENDERER_VERSION = "rendererVersion";
     public static final String TYPE_VIDEO = "video";
+
+    // Standard winner-marker keys (see hasWinningKeywords). These specifically identify "the"
+    // winner, so they must never be attributed to a bid that isn't the (possibly
+    // selector-chosen) winner -- otherwise getTargeting() could still point at a different bid
+    // than getWinningBid() does.
+    private static final Set<String> WINNING_BID_MARKER_KEYS = new HashSet<>(Arrays.asList("hb_pb", "hb_bidder", "hb_cache_id"));
 
     // ID of the bid request to which this is a response
     private String id;
@@ -75,6 +84,21 @@ public class BidResponse {
 
     private MobileSdkPassThrough mobileSdkPassThrough;
 
+    // Snapshotted from adUnitConfiguration at construction time -- adUnitConfiguration is a
+    // mutable reference owned by the ad unit and can outlive this response (e.g. via
+    // BidResponseCache or a slow-rendering flow), so reading it live on every call would let a
+    // later selector change silently change the winner of an already-returned BidResponse.
+    @Nullable
+    private final PrebidBidSelecting bidSelector;
+
+    // Resolved exactly once, right after seatbids are parsed (see resolveWinningBid()). A
+    // publisher-supplied selector may be non-deterministic or stateful, so it must be evaluated
+    // a single time per response -- otherwise getWinningBid(), hasBidSelectorRejectedAllBids(),
+    // getTargeting(), and getWinningBidJson() could each observe a different "winner" for what
+    // is supposed to be one frozen auction result.
+    @Nullable
+    private Bid resolvedWinningBid;
+
     public BidResponse(
         String json,
         AdUnitConfiguration adUnitConfiguration
@@ -82,6 +106,7 @@ public class BidResponse {
         seatbids = new ArrayList<>();
         usesCache = adUnitConfiguration.isOriginalAdUnit() || PrebidMobile.isUseCacheForReportingWithRenderingApi();
         this.adUnitConfiguration = adUnitConfiguration;
+        this.bidSelector = adUnitConfiguration.getBidSelector();
 
         parseJson(json);
     }
@@ -164,8 +189,10 @@ public class BidResponse {
                 }
             }
 
+            resolveWinningBid();
+
             MobileSdkPassThrough bidMobilePassThrough = null;
-            Bid winningBid = getWinningBid();
+            Bid winningBid = resolvedWinningBid;
             if (winningBid != null) {
                 bidMobilePassThrough = winningBid.getMobileSdkPassThrough();
             }
@@ -186,25 +213,93 @@ public class BidResponse {
 
     @Nullable
     public Bid getWinningBid() {
-        if (seatbids == null) {
-            return null;
+        return resolvedWinningBid;
+    }
+
+    /**
+     * True if a bid selector is active for this response and it decided that no bid should win.
+     * Callers must treat this as final: no targeting keywords should be attached and the fetch
+     * should be reported as having no bids, not as a success.
+     */
+    public boolean hasBidSelectorRejectedAllBids() {
+        return bidSelector != null && resolvedWinningBid == null;
+    }
+
+    /**
+     * Resolves and caches the winning bid exactly once, right after seatbids are parsed. See
+     * the {@link #resolvedWinningBid} field doc for why this must not be re-evaluated per call.
+     */
+    private void resolveWinningBid() {
+        if (bidSelector != null) {
+            List<Bid> allBids = getAllBids();
+            Bid selectedBid = bidSelector.selectBid(allBids);
+            if (selectedBid != null && !allBids.contains(selectedBid)) {
+                LogUtil.warning(TAG, "PrebidBidSelecting.selectBid() returned a bid that is not part of the provided bids. Ignoring it.");
+                selectedBid = null;
+            }
+            resolvedWinningBid = selectedBid;
+            if (resolvedWinningBid != null) {
+                winningBidJson = resolvedWinningBid.getJsonString();
+            }
+            return;
         }
 
         for (Seatbid seatbid : seatbids) {
             for (Bid bid : seatbid.getBids()) {
                 if (hasWinningKeywords(bid.getPrebid())) {
                     winningBidJson = bid.getJsonString();
-                    return bid;
+                    resolvedWinningBid = bid;
+                    return;
                 }
             }
         }
 
-        return null;
+        resolvedWinningBid = null;
+    }
+
+    @NonNull
+    private List<Bid> getAllBids() {
+        List<Bid> allBids = new ArrayList<>();
+        if (seatbids == null) {
+            return allBids;
+        }
+        for (Seatbid seatbid : seatbids) {
+            allBids.addAll(seatbid.getBids());
+        }
+        return allBids;
     }
 
     @NonNull
     public HashMap<String, String> getTargeting() {
         HashMap<String, String> keywords = new HashMap<>();
+
+        if (bidSelector != null) {
+            Bid winningBid = getWinningBid();
+            if (winningBid == null) {
+                // The selector explicitly chose no winner -- no bid's targeting should be
+                // attached at all, not even non-marker keys from the other bids.
+                return keywords;
+            }
+
+            for (Seatbid seatbid : seatbids) {
+                for (Bid bid : seatbid.getBids()) {
+                    if (bid.getPrebid() == null || bid == winningBid) {
+                        continue;
+                    }
+                    // Strip the standard winner markers from every bid that isn't the
+                    // selector-chosen winner, or the ad server could still be targeted with a
+                    // different bid than the one getWinningBid() reports.
+                    HashMap<String, String> filtered = new HashMap<>(bid.getPrebid().getTargeting());
+                    filtered.keySet().removeAll(WINNING_BID_MARKER_KEYS);
+                    keywords.putAll(filtered);
+                }
+            }
+
+            // The winner's own targeting always takes precedence over other bids' contributions.
+            keywords.putAll(winningBid.getPrebid().getTargeting());
+            return keywords;
+        }
+
         for (Seatbid seatbid : seatbids) {
             for (Bid bid : seatbid.getBids()) {
                 if (bid.getPrebid() != null) {

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/bidding/data/bid/PrebidBidSelecting.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/bidding/data/bid/PrebidBidSelecting.java
@@ -1,0 +1,42 @@
+/*
+ *    Copyright 2018-2026 Prebid.org, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.prebid.mobile.rendering.bidding.data.bid;
+
+import androidx.annotation.Nullable;
+
+import java.util.List;
+
+/**
+ * A publisher-supplied strategy for choosing the winning bid out of the bids returned by Prebid Server.
+ * <p>
+ * When set, {@link #selectBid(List)} takes precedence over the SDK's default winner selection
+ * (based on the {@code hb_pb}/{@code hb_bidder} targeting markers).
+ */
+public interface PrebidBidSelecting {
+
+    /**
+     * Selects the winning bid from the given bids, or {@code null} if none should win.
+     * <p>
+     * Returning {@code null} is final: no bid's targeting keywords are attached and no ad is
+     * rendered. The returned bid must be one of the bids passed in; any other value is treated
+     * as {@code null}.
+     *
+     * @param bids all bids returned for the request.
+     */
+    @Nullable
+    Bid selectBid(List<Bid> bids);
+}

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/NativeAdUnitTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/NativeAdUnitTest.java
@@ -14,12 +14,17 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.prebid.mobile.api.data.AdFormat;
 import org.prebid.mobile.configuration.AdUnitConfiguration;
+import org.prebid.mobile.rendering.bidding.data.bid.Bid;
+import org.prebid.mobile.rendering.bidding.data.bid.BidResponse;
+import org.prebid.mobile.rendering.bidding.data.bid.PrebidBidSelecting;
+import org.prebid.mobile.rendering.bidding.listeners.BidRequesterListener;
 import org.prebid.mobile.testutils.BaseSetup;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import java.util.ArrayList;
 import java.util.EnumSet;
+import java.util.List;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = BaseSetup.testSDK, manifest = Config.NONE)
@@ -40,6 +45,29 @@ public class NativeAdUnitTest {
         assertEquals(PBS_CONFIG_ID_NATIVE_APPNEXUS, configuration.getConfigId());
         assertEquals(EnumSet.of(AdFormat.NATIVE), configuration.getAdFormats());
         assertNotNull(configuration.getNativeConfiguration());
+    }
+
+    @Test
+    public void whenBidSelectorRejectsAllBids_reportsNoBids() {
+        NativeAdUnit nativeUnit = new NativeAdUnit(PBS_CONFIG_ID_NATIVE_APPNEXUS);
+        nativeUnit.getConfiguration().setBidSelector(new PrebidBidSelecting() {
+            @Override
+            public Bid selectBid(List<Bid> bids) {
+                return null;
+            }
+        });
+
+        String responseJson = "{\"id\":\"response-id\",\"seatbid\":[{\"bid\":[" +
+                "{\"id\":\"bid-1\",\"impid\":\"imp-1\",\"price\":0.75,\"adm\":\"<html></html>\",\"w\":300,\"h\":250," +
+                "\"ext\":{\"prebid\":{\"targeting\":{\"hb_bidder\":\"openx\",\"hb_pb\":\"0.75\"},\"type\":\"banner\"}}}" +
+                "],\"seat\":\"openx\"}],\"cur\":\"USD\"}";
+        BidResponse bidResponse = new BidResponse(responseJson, nativeUnit.getConfiguration());
+
+        ResultCode[] reportedResultCode = new ResultCode[1];
+        BidRequesterListener listener = nativeUnit.createBidListener(code -> reportedResultCode[0] = code);
+        listener.onFetchCompleted(bidResponse);
+
+        assertEquals(ResultCode.NO_BIDS, reportedResultCode[0]);
     }
 
     @Test

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/mediation/MediationBannerAdUnitTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/mediation/MediationBannerAdUnitTest.java
@@ -29,6 +29,8 @@ import org.prebid.mobile.PrebidMobile;
 import org.prebid.mobile.api.data.AdFormat;
 import org.prebid.mobile.configuration.AdUnitConfiguration;
 import org.prebid.mobile.rendering.bidding.config.MockMediationUtils;
+import org.prebid.mobile.rendering.bidding.data.bid.Bid;
+import org.prebid.mobile.rendering.bidding.data.bid.PrebidBidSelecting;
 import org.prebid.mobile.rendering.bidding.loader.BidLoader;
 import org.prebid.mobile.rendering.models.AdPosition;
 import org.prebid.mobile.rendering.utils.broadcast.ScreenStateReceiver;
@@ -38,6 +40,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import java.util.EnumSet;
+import java.util.List;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
@@ -126,6 +129,20 @@ public class MediationBannerAdUnitTest {
 
         mediationBannerAdUnit.setAdPosition(AdPosition.UNKNOWN);
         assertEquals(AdPosition.UNKNOWN, mediationBannerAdUnit.getAdPosition());
+    }
+
+    @Test
+    public void setBidSelector_forwardsToAdUnitConfig() {
+        PrebidBidSelecting selector = new PrebidBidSelecting() {
+            @Override
+            public Bid selectBid(List<Bid> bids) {
+                return bids.isEmpty() ? null : bids.get(0);
+            }
+        };
+
+        mediationBannerAdUnit.setBidSelector(selector);
+
+        assertEquals(selector, mediationBannerAdUnit.getBidSelector());
     }
 
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/mediation/MediationBaseAdUnitTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/mediation/MediationBaseAdUnitTest.java
@@ -38,6 +38,9 @@ import org.prebid.mobile.api.exceptions.AdException;
 import org.prebid.mobile.api.mediation.listeners.OnFetchCompleteListener;
 import org.prebid.mobile.reflection.sdk.PrebidMobileReflection;
 import org.prebid.mobile.rendering.bidding.config.MockMediationUtils;
+import org.prebid.mobile.rendering.bidding.data.bid.Bid;
+import org.prebid.mobile.rendering.bidding.data.bid.BidResponse;
+import org.prebid.mobile.rendering.bidding.data.bid.PrebidBidSelecting;
 import org.prebid.mobile.rendering.bidding.loader.BidLoader;
 import org.prebid.mobile.rendering.models.AdPosition;
 import org.prebid.mobile.test.utils.WhiteBox;
@@ -47,6 +50,7 @@ import org.robolectric.annotation.Config;
 
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 
@@ -143,6 +147,29 @@ public class MediationBaseAdUnitTest {
         baseAdUnit.fetchDemand(mockListener);
         baseAdUnit.onErrorReceived(adException);
         verify(mockListener).onComplete(FetchDemandResult.SERVER_ERROR);
+    }
+
+    @Test
+    public void whenBidSelectorRejectsAllBids_ReportsNoBids() {
+        PrebidMobile.setPrebidServerAccountId("id");
+        baseAdUnit.adUnitConfig.setBidSelector(new PrebidBidSelecting() {
+            @Override
+            public Bid selectBid(List<Bid> bids) {
+                return null;
+            }
+        });
+
+        String responseJson = "{\"id\":\"response-id\",\"seatbid\":[{\"bid\":[" +
+                "{\"id\":\"bid-1\",\"impid\":\"imp-1\",\"price\":0.75,\"adm\":\"<html></html>\",\"w\":300,\"h\":250," +
+                "\"ext\":{\"prebid\":{\"targeting\":{\"hb_bidder\":\"openx\",\"hb_pb\":\"0.75\"},\"type\":\"banner\"}}}" +
+                "],\"seat\":\"openx\"}],\"cur\":\"USD\"}";
+        BidResponse bidResponse = new BidResponse(responseJson, baseAdUnit.adUnitConfig);
+
+        OnFetchCompleteListener mockListener = mock(OnFetchCompleteListener.class);
+        baseAdUnit.fetchDemand(mockListener);
+        baseAdUnit.onResponseReceived(bidResponse);
+
+        verify(mockListener).onComplete(FetchDemandResult.NO_BIDS);
     }
 
     @Test

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/mediation/MediationNativeAdUnitTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/mediation/MediationNativeAdUnitTest.java
@@ -1,0 +1,50 @@
+/*
+ *    Copyright 2018-2026 Prebid.org, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.prebid.mobile.api.mediation;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.prebid.mobile.rendering.bidding.data.bid.Bid;
+import org.prebid.mobile.rendering.bidding.data.bid.PrebidBidSelecting;
+import org.prebid.mobile.testutils.BaseSetup;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+
+import java.util.List;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = BaseSetup.testSDK, manifest = Config.NONE)
+public class MediationNativeAdUnitTest {
+
+    @Test
+    public void setBidSelector_forwardsToAdUnitConfig() {
+        MediationNativeAdUnit adUnit = new MediationNativeAdUnit("config-id", new Object());
+        PrebidBidSelecting selector = new PrebidBidSelecting() {
+            @Override
+            public Bid selectBid(List<Bid> bids) {
+                return bids.isEmpty() ? null : bids.get(0);
+            }
+        };
+
+        adUnit.setBidSelector(selector);
+
+        assertEquals(selector, adUnit.getBidSelector());
+    }
+
+}

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/original/MultiformatAdUnitFacadeTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/original/MultiformatAdUnitFacadeTest.java
@@ -13,9 +13,15 @@ import org.prebid.mobile.BannerParameters;
 import org.prebid.mobile.NativeAsset;
 import org.prebid.mobile.NativeParameters;
 import org.prebid.mobile.NativeTitleAsset;
+import org.prebid.mobile.OnCompleteListener;
+import org.prebid.mobile.ResultCode;
 import org.prebid.mobile.VideoParameters;
 import org.prebid.mobile.api.data.AdFormat;
 import org.prebid.mobile.configuration.AdUnitConfiguration;
+import org.prebid.mobile.rendering.bidding.data.bid.Bid;
+import org.prebid.mobile.rendering.bidding.data.bid.BidResponse;
+import org.prebid.mobile.rendering.bidding.data.bid.PrebidBidSelecting;
+import org.prebid.mobile.rendering.bidding.listeners.BidRequesterListener;
 import org.prebid.mobile.rendering.models.AdPosition;
 import org.prebid.mobile.rendering.models.PlacementType;
 
@@ -23,6 +29,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.EnumSet;
 import java.util.HashSet;
+import java.util.List;
 
 public class MultiformatAdUnitFacadeTest {
 
@@ -254,6 +261,50 @@ public class MultiformatAdUnitFacadeTest {
                 new HashSet<>(Arrays.asList(new AdSize(320, 50), new AdSize(320, 480))),
                 Matchers.equalTo(configurationSizes)
         );
+    }
+
+    @Test
+    public void configuration_bidSelector() {
+        PrebidRequest request = new PrebidRequest();
+        PrebidBidSelecting selector = new PrebidBidSelecting() {
+            @Override
+            public Bid selectBid(List<Bid> bids) {
+                return bids.isEmpty() ? null : bids.get(0);
+            }
+        };
+        request.setBidSelector(selector);
+
+        subject = new MultiformatAdUnitFacade(configId, request);
+        AdUnitConfiguration configuration = subject.getConfiguration();
+
+        assertEquals(selector, configuration.getBidSelector());
+    }
+
+    @Test
+    public void bidSelectorRejectsAllBids_reportsNoBids() {
+        PrebidRequest request = new PrebidRequest();
+        request.setBidSelector(new PrebidBidSelecting() {
+            @Override
+            public Bid selectBid(List<Bid> bids) {
+                return null;
+            }
+        });
+
+        subject = new MultiformatAdUnitFacade(configId, request);
+
+        String responseJson = "{\"id\":\"response-id\",\"seatbid\":[{\"bid\":[" +
+                "{\"id\":\"bid-1\",\"impid\":\"imp-1\",\"price\":0.75,\"adm\":\"<html></html>\",\"w\":300,\"h\":250," +
+                "\"ext\":{\"prebid\":{\"targeting\":{\"hb_bidder\":\"openx\",\"hb_pb\":\"0.75\"},\"type\":\"banner\"}}}" +
+                "],\"seat\":\"openx\"}],\"cur\":\"USD\"}";
+        BidResponse bidResponse = new BidResponse(responseJson, subject.getConfiguration());
+
+        ResultCode[] reportedResultCode = new ResultCode[1];
+        OnCompleteListener listener = resultCode -> reportedResultCode[0] = resultCode;
+        BidRequesterListener bidListener = subject.createBidListener(listener);
+
+        bidListener.onFetchCompleted(bidResponse);
+
+        assertEquals(ResultCode.NO_BIDS, reportedResultCode[0]);
     }
 
     @Test

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/BannerViewTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/BannerViewTest.java
@@ -35,6 +35,7 @@ import org.prebid.mobile.api.rendering.listeners.BannerViewListener;
 import org.prebid.mobile.configuration.AdUnitConfiguration;
 import org.prebid.mobile.rendering.bidding.data.bid.Bid;
 import org.prebid.mobile.rendering.bidding.data.bid.BidResponse;
+import org.prebid.mobile.rendering.bidding.data.bid.PrebidBidSelecting;
 import org.prebid.mobile.rendering.bidding.interfaces.BannerEventHandler;
 import org.prebid.mobile.rendering.bidding.interfaces.StandaloneBannerEventHandler;
 import org.prebid.mobile.rendering.bidding.listeners.BannerEventListener;
@@ -50,6 +51,7 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 
 import static org.junit.Assert.*;
@@ -490,6 +492,20 @@ public class BannerViewTest {
             e.printStackTrace();
         }
         return null;
+    }
+
+    @Test
+    public void setBidSelector_forwardsToAdUnitConfig() {
+        PrebidBidSelecting selector = new PrebidBidSelecting() {
+            @Override
+            public Bid selectBid(List<Bid> bids) {
+                return bids.isEmpty() ? null : bids.get(0);
+            }
+        };
+
+        bannerView.setBidSelector(selector);
+
+        assertEquals(selector, bannerView.getBidSelector());
     }
 
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/InterstitialAdUnitTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/InterstitialAdUnitTest.java
@@ -33,6 +33,7 @@ import org.prebid.mobile.api.rendering.pluginrenderer.PrebidMobilePluginRenderer
 import org.prebid.mobile.configuration.AdUnitConfiguration;
 import org.prebid.mobile.rendering.bidding.data.bid.Bid;
 import org.prebid.mobile.rendering.bidding.data.bid.BidResponse;
+import org.prebid.mobile.rendering.bidding.data.bid.PrebidBidSelecting;
 import org.prebid.mobile.rendering.bidding.display.InterstitialController;
 import org.prebid.mobile.rendering.bidding.interfaces.InterstitialEventHandler;
 import org.prebid.mobile.rendering.bidding.interfaces.StandaloneInterstitialEventHandler;
@@ -46,6 +47,7 @@ import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 
 import java.util.EnumSet;
+import java.util.List;
 
 import static org.junit.Assert.*;
 import static org.mockito.Mockito.*;
@@ -323,6 +325,20 @@ public class InterstitialAdUnitTest {
 
     private void changeInterstitialState(BaseInterstitialAdUnit.InterstitialAdUnitState adUnitState) {
         WhiteBox.setInternalState(interstitialAdUnit, "interstitialAdUnitState", adUnitState);
+    }
+
+    @Test
+    public void setBidSelector_forwardsToConfig() {
+        PrebidBidSelecting selector = new PrebidBidSelecting() {
+            @Override
+            public Bid selectBid(List<Bid> bids) {
+                return bids.isEmpty() ? null : bids.get(0);
+            }
+        };
+
+        interstitialAdUnit.setBidSelector(selector);
+
+        assertEquals(selector, interstitialAdUnit.getBidSelector());
     }
 
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/configuration/AdUnitConfigurationTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/configuration/AdUnitConfigurationTest.java
@@ -9,8 +9,12 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.prebid.mobile.api.data.AdFormat;
 import org.prebid.mobile.api.data.AdUnitFormat;
+import org.prebid.mobile.rendering.bidding.data.bid.Bid;
+import org.prebid.mobile.rendering.bidding.data.bid.PrebidBidSelecting;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
+
+import java.util.List;
 
 import java.util.EnumSet;
 import java.util.UUID;
@@ -143,6 +147,25 @@ public class AdUnitConfigurationTest {
         assertNotNull(uuidString);
         assertNotNull(UUID.fromString(uuidString)); // valid UUID
         assertEquals(4, UUID.fromString(uuidString).version()); // version 4 (random-based)
+    }
+
+    @Test
+    public void bidSelector_defaultsToNull() {
+        assertNull(subject.getBidSelector());
+    }
+
+    @Test
+    public void bidSelector_settableAndGettable() {
+        PrebidBidSelecting selector = new PrebidBidSelecting() {
+            @Override
+            public Bid selectBid(List<Bid> bids) {
+                return bids.isEmpty() ? null : bids.get(0);
+            }
+        };
+
+        subject.setBidSelector(selector);
+
+        assertEquals(selector, subject.getBidSelector());
     }
 
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/bidding/data/bid/BidResponseTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/bidding/data/bid/BidResponseTest.java
@@ -32,8 +32,238 @@ import org.prebid.mobile.rendering.models.openrtb.bidRequests.MobileSdkPassThrou
 import org.prebid.mobile.test.utils.ResourceUtils;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
 
 public class BidResponseTest {
+
+    // MARK: - bidSelector
+
+    private static class StubBidSelector implements PrebidBidSelecting {
+        interface Selection {
+            Bid select(List<Bid> bids);
+        }
+
+        private final Selection selection;
+
+        StubBidSelector(Selection selection) {
+            this.selection = selection;
+        }
+
+        @Override
+        public Bid selectBid(List<Bid> bids) {
+            return selection.select(bids);
+        }
+    }
+
+    @Test
+    public void noSelectorByDefault_defaultMarkerLogicPicksWinner() throws IOException {
+        String responseString = twoBidsResponseJson(
+            bidJson("marked", 0.75, "openx", null),
+            null
+        );
+        AdUnitConfiguration adUnitConfiguration = new AdUnitConfiguration();
+        BidResponse bidResponse = new BidResponse(responseString, adUnitConfiguration);
+
+        assertNull(adUnitConfiguration.getBidSelector());
+        assertNotNull(bidResponse.getWinningBid());
+        assertEquals("openx", bidResponse.getWinningBid().getPrebid().getTargeting().get("hb_bidder"));
+    }
+
+    @Test
+    public void selectorIsInvokedExactlyOncePerResponse() throws IOException {
+        // A stateful/non-deterministic selector must still be evaluated exactly once per
+        // response -- otherwise getWinningBid(), hasBidSelectorRejectedAllBids(), and
+        // getTargeting() could each observe a different "winner" for what is supposed to be one
+        // frozen auction result. This selector flips its answer on every invocation, so calling
+        // it more than once would make these methods disagree.
+        String responseString = twoBidsResponseJson(
+            bidJson("marked", 0.75, "openx", null),
+            bidJson("unmarked", 2.00, null, null)
+        );
+        AdUnitConfiguration adUnitConfiguration = new AdUnitConfiguration();
+        int[] callCount = {0};
+        adUnitConfiguration.setBidSelector(new StubBidSelector(bids -> {
+            callCount[0]++;
+            // Odd calls pick bid 0, even calls pick bid 1 (or null on a third call) -- any
+            // re-invocation changes the answer.
+            if (callCount[0] == 1) return bids.get(0);
+            if (callCount[0] == 2) return bids.get(1);
+            return null;
+        }));
+
+        BidResponse bidResponse = new BidResponse(responseString, adUnitConfiguration);
+
+        Bid winningBid = bidResponse.getWinningBid();
+        boolean rejected = bidResponse.hasBidSelectorRejectedAllBids();
+        HashMap<String, String> targeting = bidResponse.getTargeting();
+        String winningBidJson = bidResponse.getWinningBidJson();
+
+        assertEquals(1, callCount[0]);
+        assertNotNull(winningBid);
+        assertFalse(rejected);
+        // All accessors must agree with the single resolved winner.
+        assertEquals(winningBid.getJsonString(), winningBidJson);
+        assertEquals(winningBid.getPrice(), bidResponse.getWinningBid().getPrice(), 0.001);
+    }
+
+    private static StubBidSelector highestPriceSelector() {
+        return new StubBidSelector(bids -> {
+            Bid best = null;
+            for (Bid bid : bids) {
+                if (best == null || bid.getPrice() > best.getPrice()) {
+                    best = bid;
+                }
+            }
+            return best;
+        });
+    }
+
+    @Test
+    public void selectorOverridesDefaultWinner() throws IOException {
+        String responseString = twoBidsResponseJson(
+            bidJson("marked", 0.75, "openx", null),
+            bidJson("unmarked", 2.00, null, null)
+        );
+        AdUnitConfiguration adUnitConfiguration = new AdUnitConfiguration();
+
+        // Without a selector, the marker-driven bid wins.
+        BidResponse defaultResponse = new BidResponse(responseString, adUnitConfiguration);
+        assertEquals("openx", defaultResponse.getWinningBid().getPrebid().getTargeting().get("hb_bidder"));
+
+        // The selector must be set on the config *before* the response is constructed --
+        // BidResponse snapshots it at construction time (see selectorIsSnapshotAtConstruction_notReadLive).
+        adUnitConfiguration.setBidSelector(highestPriceSelector());
+        BidResponse bidResponse = new BidResponse(responseString, adUnitConfiguration);
+
+        assertEquals(2.00, bidResponse.getWinningBid().getPrice(), 0.001);
+    }
+
+    @Test
+    public void selectorReturningNull_resultsInNoWinningBid() throws IOException {
+        String responseString = twoBidsResponseJson(bidJson("marked", 0.75, "openx", null), null);
+        AdUnitConfiguration adUnitConfiguration = new AdUnitConfiguration();
+        adUnitConfiguration.setBidSelector(new StubBidSelector(bids -> null));
+
+        BidResponse bidResponse = new BidResponse(responseString, adUnitConfiguration);
+
+        assertNull(bidResponse.getWinningBid());
+        assertTrue(bidResponse.hasBidSelectorRejectedAllBids());
+    }
+
+    @Test
+    public void selectorReturningForeignBid_isRejected() throws IOException {
+        // A bid from an entirely separate response must never become the winner.
+        BidResponse staleResponse = new BidResponse(
+            twoBidsResponseJson(bidJson("stale", 5.00, "stale_bidder", null), null),
+            new AdUnitConfiguration()
+        );
+        Bid staleBid = staleResponse.getSeatbids().get(0).getBids().get(0);
+
+        AdUnitConfiguration adUnitConfiguration = new AdUnitConfiguration();
+        adUnitConfiguration.setBidSelector(new StubBidSelector(bids -> staleBid));
+        BidResponse bidResponse = new BidResponse(
+            twoBidsResponseJson(bidJson("marked", 0.75, "openx", null), null),
+            adUnitConfiguration
+        );
+
+        assertNull(bidResponse.getWinningBid());
+    }
+
+    @Test
+    public void selectorPickingUnmarkedBid_doesNotLeakOldWinnerMarkers() throws IOException {
+        String responseString = twoBidsResponseJson(
+            bidJson("marked", 0.75, "openx", null),
+            bidJson("unmarked", 2.00, null, null)
+        );
+        AdUnitConfiguration adUnitConfiguration = new AdUnitConfiguration();
+        adUnitConfiguration.setBidSelector(highestPriceSelector());
+        BidResponse bidResponse = new BidResponse(responseString, adUnitConfiguration);
+
+        assertEquals(2.00, bidResponse.getWinningBid().getPrice(), 0.001);
+        // The "marked" bid is no longer the winner -- its hb_bidder/hb_pb markers must not
+        // survive into the merged targeting, or the ad server would be targeted with a
+        // different bid than the one getWinningBid() actually reports.
+        assertNull(bidResponse.getTargeting().get("hb_bidder"));
+        assertNull(bidResponse.getTargeting().get("hb_pb"));
+    }
+
+    @Test
+    public void selectorReturningNull_targetingIsEmpty() throws IOException {
+        // Even non-marker/custom keys from other bids must not leak through once the selector
+        // has decided that no bid should win -- "null is final" means the whole targeting map
+        // is empty, not just stripped of hb_pb/hb_bidder/hb_cache_id.
+        String responseString = twoBidsResponseJson(
+            bidJson("marked", 0.75, "openx", null),
+            bidJson("unmarked", 2.00, null, null)
+        );
+        AdUnitConfiguration adUnitConfiguration = new AdUnitConfiguration();
+        adUnitConfiguration.setBidSelector(new StubBidSelector(bids -> null));
+        BidResponse bidResponse = new BidResponse(responseString, adUnitConfiguration);
+
+        assertTrue(bidResponse.getTargeting().isEmpty());
+    }
+
+    @Test
+    public void selectorIsSnapshotAtConstruction_notReadLive() throws IOException {
+        String responseString = twoBidsResponseJson(
+            bidJson("marked", 0.75, "openx", null),
+            bidJson("unmarked", 2.00, null, null)
+        );
+        AdUnitConfiguration adUnitConfiguration = new AdUnitConfiguration();
+        adUnitConfiguration.setBidSelector(highestPriceSelector());
+
+        BidResponse bidResponse = new BidResponse(responseString, adUnitConfiguration);
+        assertEquals(2.00, bidResponse.getWinningBid().getPrice(), 0.001);
+
+        // Mutating the (mutable, shared) AdUnitConfiguration *after* the response was
+        // constructed must not change this already-returned response's winner -- a BidResponse
+        // represents a frozen snapshot of one auction's outcome, e.g. for BidResponseCache or a
+        // slow-rendering flow that queries it again later.
+        adUnitConfiguration.setBidSelector(null);
+        assertEquals(2.00, bidResponse.getWinningBid().getPrice(), 0.001);
+
+        adUnitConfiguration.setBidSelector(new StubBidSelector(bids -> null));
+        assertEquals(2.00, bidResponse.getWinningBid().getPrice(), 0.001);
+    }
+
+    @Test
+    public void defaultLogic_stillReportsWinnerMarkers() throws IOException {
+        // Characterization: when no selector is active, the actual winner's own markers must
+        // still flow through untouched -- the leak fix only strips markers from bids that
+        // are *not* the winner.
+        String responseString = twoBidsResponseJson(bidJson("marked", 0.75, "openx", null), null);
+        BidResponse bidResponse = new BidResponse(responseString, new AdUnitConfiguration());
+
+        assertEquals("openx", bidResponse.getTargeting().get("hb_bidder"));
+        assertEquals("0.75", bidResponse.getTargeting().get("hb_pb"));
+    }
+
+    private static String bidJson(String id, double price, String bidder, String dealId) {
+        StringBuilder prebid = new StringBuilder("{\"type\":\"banner\"");
+        if (bidder != null) {
+            prebid.append(",\"targeting\":{\"hb_bidder\":\"").append(bidder).append("\",\"hb_pb\":\"").append(price).append("\"}");
+        }
+        prebid.append("}");
+
+        StringBuilder bid = new StringBuilder("{");
+        bid.append("\"id\":\"test-bid-id-").append(id).append("\",");
+        bid.append("\"impid\":\"test-imp-id-").append(id).append("\",");
+        bid.append("\"price\":").append(price).append(",");
+        bid.append("\"adm\":\"<html></html>\",");
+        bid.append("\"w\":300,\"h\":250,");
+        if (dealId != null) {
+            bid.append("\"dealid\":\"").append(dealId).append("\",");
+        }
+        bid.append("\"ext\":{\"prebid\":").append(prebid).append("}");
+        bid.append("}");
+        return bid.toString();
+    }
+
+    private static String twoBidsResponseJson(String bid1Json, String bid2Json) {
+        String bids = bid2Json == null ? bid1Json : (bid1Json + "," + bid2Json);
+        return "{\"id\":\"response-id\",\"seatbid\":[{\"bid\":[" + bids + "],\"seat\":\"openx\"}],\"cur\":\"USD\"}";
+    }
 
     @After
     public void tearDown() {


### PR DESCRIPTION
## Summary

- Adds `PrebidBidSelecting`, a functional interface letting publishers override the SDK's default marker-driven winning-bid selection, mirroring the equivalent iOS feature and resolving part 2 of [#950](https://github.com/prebid/prebid-mobile-ios/issues/950).
- The selector is evaluated **exactly once** per response, immediately after `seatbids` are parsed, and the resolved winner is cached on `BidResponse`:
 - The selector reference is snapshotted from `AdUnitConfiguration` at construction time, so mutating or clearing it afterward cannot change the winner of an already-returned response (e.g. one held by `BidResponseCache` or a slow-rendering flow).
 - `selectBid()` is invoked a single time — a stateful or non-deterministic selector could otherwise make `getWinningBid()`, `hasBidSelectorRejectedAllBids()`, `getTargeting()`, and `getWinningBidJson()` each observe a different "winner" for what should be one frozen auction result.
- Selector results are validated to be a member of the provided bids list.
- When a selector is active, non-winning bids' standard `hb_pb`/`hb_bidder`/`hb_cache_id` markers are stripped from the merged targeting; if the selector rejects all bids, targeting is empty and `AdUnit`, `NativeAdUnit`, `MultiformatAdUnitFacade`, and `MediationBaseAdUnit` all report `NO_BIDS` instead of `SUCCESS`.