### PR TITLE
Gradle Cleanup Part 1 - Clean root build scripts and update

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,30 +10,3 @@ ext {
     omSdkVersion = "1.4.1"
     omSdkModuleName = "omsdk-android"
 }
-
-buildscript {
-    repositories {
-        google()
-        mavenCentral()
-    }
-
-    dependencies {
-        classpath libs.gradle
-        classpath libs.kotlin.gradle.plugin
-    }
-}
-
-allprojects {
-    repositories {
-        google()
-        maven {
-            name = "Central Portal Snapshots"
-            url = uri("https://central.sonatype.com/repository/maven-snapshots/")
-        }
-        mavenCentral()
-        mavenCentral()
-        maven { url 'https://maven.google.com' }
-        maven { url 'https://jitpack.io' }
-//        maven { url "https://oss.sonatype.org/content/repositories/orgprebid-1079" }
-    }
-}

--- a/gradle.properties
+++ b/gradle.properties
@@ -22,3 +22,9 @@ android.defaults.buildfeatures.buildconfig=true
 android.nonTransitiveRClass=false
 android.nonFinalResIds=false
 #android.useAndroidX and android.enableJetifier are specified in each module separately
+
+# Kotlin version for library and plugin
+kotlin.version=2.3.0
+
+# Android AGP version
+android.agp.version=8.13.2

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -23,7 +23,6 @@ glide = "4.14.2"
 google-play-services-ads = "+"
 google-play-services-ads-identifier = "18.0.1"
 google-play-services-base = "18.1.0"
-gradle = "8.13.2"
 gson = "2.8.6"
 hamcrest = "2.2"
 jackson-databind = "2.14.3"
@@ -31,7 +30,6 @@ json = "20180813"
 jsonassert = "1.5.0"
 junit = "4.13.2"
 androidx-junit = "1.1.3"
-kotlin-stdlib = "2.3.0"
 mockito-core = "5.15.2"
 okhttp3 = "4.9.3"
 robolectric = "4.12.2"
@@ -73,7 +71,6 @@ glide = { module = "com.github.bumptech.glide:glide", version.ref = "glide" }
 google-play-services-ads = { group = "com.google.android.gms", name = "play-services-ads", version.ref = "google-play-services-ads" }
 google-play-services-ads-identifier = { module = "com.google.android.gms:play-services-ads-identifier", version.ref = "google-play-services-ads-identifier" }
 google-play-services-base = { module = "com.google.android.gms:play-services-base", version.ref = "google-play-services-base" }
-gradle = { module = "com.android.tools.build:gradle", version.ref = "gradle" }
 gson = { module = "com.google.code.gson:gson", version.ref = "gson" }
 hamcrest-core = { module = "org.hamcrest:hamcrest-core", version.ref = "hamcrest" }
 hamcrest-library = { module = "org.hamcrest:hamcrest-library", version.ref = "hamcrest" }
@@ -81,7 +78,6 @@ jackson-databind = { module = "com.fasterxml.jackson.core:jackson-databind", ver
 json = { module = "org.json:json", version.ref = "json" }
 jsonassert = { module = "org.skyscreamer:jsonassert", version.ref = "jsonassert" }
 junit = { module = "junit:junit", version.ref = "junit" }
-kotlin-gradle-plugin = { module = "org.jetbrains.kotlin:kotlin-gradle-plugin", version.ref = "kotlin-stdlib" }
 kotlin-stdlib = { module = "org.jetbrains.kotlin:kotlin-stdlib", version.ref = "kotlin-stdlib" }
 mockito-core = { module = "org.mockito:mockito-core", version.ref = "mockito-core" }
 okhttp = { module = "com.squareup.okhttp3:okhttp", version.ref = "okhttp3" }

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,21 +1,68 @@
-include ':PrebidMobile',
-        ':PrebidMobile-core',
-        ':PrebidMobile-gamEventHandlers',
-        ':PrebidMobile-nextGenEventHandlers',
-        ':PrebidMobile-admobAdapters',
-        ':PrebidMobile-maxAdapters',
-        ':test-utils',
-        ':omsdk-android',
-        // Prebid Demo apps
-        ':PrebidDemoJava',
-        ':PrebidDemoKotlin',
-        ':PrebidInternalTestApp',
-        ':PrebidNextGenDemo'
-        // Other
-//        ':DrPrebid'
+import org.gradle.api.initialization.resolve.RepositoriesMode
 
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        google()
+        mavenCentral()
+    }
 
-project(':PrebidMobile').projectDir = new File('PrebidMobile')
+    plugins {
+        id("com.android.application") version providers.gradleProperty("android.agp.version")
+        id("com.android.library") version providers.gradleProperty("android.agp.version")
+        id("org.jetbrains.kotlin.android") version providers.gradleProperty("kotlin.version")
+        id("org.jetbrains.kotlin.jvm") version providers.gradleProperty("kotlin.version")
+    }
+}
+
+plugins {
+    id("com.android.application") apply false
+    id("com.android.library") apply false
+    id("org.jetbrains.kotlin.android") apply false
+    id("org.jetbrains.kotlin.jvm") apply false
+}
+
+dependencyResolutionManagement {
+    repositoriesMode.set(RepositoriesMode.FAIL_ON_PROJECT_REPOS)
+    repositories {
+        google()
+        mavenCentral()
+        maven {
+            name = "Central Portal Snapshots"
+            url = uri("https://central.sonatype.com/repository/maven-snapshots/")
+        }
+        maven { url 'https://jitpack.io' }
+//        maven { url "https://oss.sonatype.org/content/repositories/orgprebid-1079" }
+    }
+
+    versionCatalogs {
+        register("libs") {
+            version(
+                    "kotlin-stdlib",
+                    providers.gradleProperty("kotlin.version").get()
+            )
+        }
+    }
+}
+
+include ':PrebidMobile'
+include ':PrebidMobile-core'
+include ':PrebidMobile-gamEventHandlers'
+include ':PrebidMobile-nextGenEventHandlers'
+include ':PrebidMobile-admobAdapters'
+include ':PrebidMobile-maxAdapters'
+include ':test-utils'
+include ':omsdk-android'
+
+// Prebid Demo apps
+include ':PrebidDemoJava'
+include ':PrebidDemoKotlin'
+include ':PrebidInternalTestApp'
+include ':PrebidNextGenDemo'
+
+// Other
+//include ':DrPrebid'
+
 project(':PrebidMobile-core').projectDir = new File('PrebidMobile/PrebidMobile-core')
 project(':PrebidMobile-gamEventHandlers').projectDir = new File('PrebidMobile/PrebidMobile-gamEventHandlers')
 project(':PrebidMobile-nextGenEventHandlers').projectDir = new File('PrebidMobile/PrebidMobile-nextGenEventHandlers')


### PR DESCRIPTION
I'm working on a fork of this project that has some custom changes, but that is also tracking this project. The current build setup is causing issues on several fronts, and rather than maintain a totally different build architecture, I'd rather contribute back to this project. This is the start of what I hope will be accepted changes to the build logic. I have no intention on changing the SDK source code, though I may move some directories around to remove the need for `project(':foobar').projectDir`.

This PR does cleanup on the plugin resolution.