### PR TITLE
Send ext.prebid.targeting flags as booleans, not strings

### DIFF
--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/bidding/data/bid/Prebid.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/bidding/data/bid/Prebid.java
@@ -137,15 +137,15 @@ public class Prebid {
         JSONObject targeting = new JSONObject();
 
         if (config.isOriginalAdUnit() && config.getAdFormats().size() > 1) {
-            Utils.addValue(targeting, "includeformat", "true");
+            Utils.addValue(targeting, "includeformat", true);
         }
 
         if(PrebidMobile.getIncludeWinnersFlag()){
-            Utils.addValue(targeting, "includewinners", "true");
+            Utils.addValue(targeting, "includewinners", true);
         }
 
         if(PrebidMobile.getIncludeBidderKeysFlag()){
-            Utils.addValue(targeting, "includebidderkeys", "true");
+            Utils.addValue(targeting, "includebidderkeys", true);
         }
 
         Utils.addValue(prebid, "targeting", targeting);

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/bidding/data/bid/PrebidTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/bidding/data/bid/PrebidTest.java
@@ -129,7 +129,7 @@ public class PrebidTest {
         config.addAdFormat(AdFormat.BANNER);
         config.addAdFormat(AdFormat.VAST);
         assertEquals(
-                "{\"storedrequest\":{\"id\":\"test\"},\"cache\":{\"bids\":{}},\"targeting\":{\"includeformat\":\"true\"}}",
+                "{\"storedrequest\":{\"id\":\"test\"},\"cache\":{\"bids\":{}},\"targeting\":{\"includeformat\":true}}",
                 Prebid.getJsonObjectForBidRequest("test", false, config).toString()
         );
     }
@@ -178,7 +178,7 @@ public class PrebidTest {
         expected.put("cache", expectedCache);
 
         JSONObject expectedTargeting = new JSONObject();
-        expectedTargeting.put("includebidderkeys", "true");
+        expectedTargeting.put("includebidderkeys", true);
         expected.put("targeting", expectedTargeting);
 
         AdUnitConfiguration config = new AdUnitConfiguration();
@@ -198,7 +198,7 @@ public class PrebidTest {
         expected.put("cache", expectedCache);
 
         JSONObject expectedTargeting = new JSONObject();
-        expectedTargeting.put("includewinners", "true");
+        expectedTargeting.put("includewinners", true);
 
         expected.put("targeting", expectedTargeting);
 


### PR DESCRIPTION
Prebid Server declares the targeting flags as booleans in openrtb_ext.ExtRequestTargeting:

    IncludeWinners    *bool `json:"includewinners,omitempty"`
    IncludeBidderKeys *bool `json:"includebidderkeys,omitempty"`
    IncludeFormat     bool  `json:"includeformat,omitempty"`

The SDK was sending the JSON string "true" for all three, so unmarshalling fails server-side and the auction is rejected with HTTP 400.

includeformat is the visible case because it is set automatically whenever an original-API ad unit declares more than one format, so every multiformat request fails. includewinners and includebidderkeys carry the identical bug but default to false, so they only break for publishers who opt in via setIncludeWinnersFlag / setIncludeBidderKeysFlag.

Fixes #961