### PR TITLE
Fix controls misplaced in rewarded ads

### DIFF
--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/helpers/Utils.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/helpers/Utils.java
@@ -477,9 +477,9 @@ public final class Utils {
 
         FrameLayout.LayoutParams params;
         params = calculateButtonSize(view, buttonArea);
-        params.gravity = Gravity.END | Gravity.TOP;
+        params.gravity = Gravity.RIGHT | Gravity.TOP;
         if (buttonPosition == Position.TOP_LEFT) {
-            params.gravity = Gravity.START | Gravity.TOP;
+            params.gravity = Gravity.LEFT | Gravity.TOP;
         }
 
         view.setLayoutParams(params);
@@ -524,8 +524,7 @@ public final class Utils {
             ViewGroup.LayoutParams.WRAP_CONTENT,
             ViewGroup.LayoutParams.WRAP_CONTENT
         );
-        params.gravity = Gravity.END | Gravity.BOTTOM;
-        params.bottomMargin += 150;
+        params.gravity = Gravity.RIGHT | Gravity.TOP;
         view.setLayoutParams(params);
         InsetsUtils.addCutoutAndNavigationInsets(view);
         return view;

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/views/interstitial/InterstitialVideo.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/views/interstitial/InterstitialVideo.java
@@ -462,14 +462,54 @@ public class InterstitialVideo extends AdBaseDialog {
 
         RelativeLayout countdown = lytCountDownCircle.findViewById(R.id.lytCountdown);
         RelativeLayout.LayoutParams params = (RelativeLayout.LayoutParams) countdown.getLayoutParams();
-        double buttonArea = useSkipButton ? properties.skipButtonArea : properties.closeButtonArea;
-        int buttonSize = Utils.convertDpToPx(70, countdown.getContext());
-        if (buttonArea >= 0.05 && buttonArea <= 1) {
-            DisplayMetrics metrics = countdown.getResources().getDisplayMetrics();
-            buttonSize = (int) (Math.min(metrics.widthPixels, metrics.heightPixels) * buttonArea);
-        }
+        int buttonSize = getCloseOrSkipButtonSizePx(properties, countdown.getContext());
         params.leftMargin = buttonSize + Utils.convertDpToPx(10, countdown.getContext());
         countdown.setLayoutParams(params);
+    }
+
+    /**
+     * The close/skip control is added on top of the sound control (or vice versa) and both
+     * default to the same TOP_RIGHT corner, so without this the sound icon either gets hidden
+     * behind the close/skip control or blocks taps meant for it. Nudge the sound control past
+     * whichever close/skip control is currently active, mirroring {@link #moveCountdownPastTopLeftControl()}.
+     */
+    private void moveSoundViewPastTopRightControl(@Nullable View soundView) {
+        if (soundView == null || interstitialManager == null) {
+            return;
+        }
+
+        InterstitialDisplayPropertiesInternal properties = interstitialManager.getInterstitialDisplayProperties();
+        Position buttonPosition = useSkipButton
+            ? properties.skipButtonPosition
+            : properties.closeButtonPosition;
+        if (buttonPosition == Position.TOP_LEFT) {
+            return;
+        }
+
+        FrameLayout.LayoutParams params = (FrameLayout.LayoutParams) soundView.getLayoutParams();
+        int buttonSize = getCloseOrSkipButtonSizePx(properties, soundView.getContext());
+        params.rightMargin = buttonSize + Utils.convertDpToPx(10, soundView.getContext());
+        soundView.setLayoutParams(params);
+    }
+
+    private int getCloseOrSkipButtonSizePx(
+            InterstitialDisplayPropertiesInternal properties,
+            Context context
+    ) {
+        double buttonArea = useSkipButton ? properties.skipButtonArea : properties.closeButtonArea;
+        int buttonSize = Utils.convertDpToPx(70, context);
+        if (buttonArea >= 0.05 && buttonArea <= 1) {
+            DisplayMetrics metrics = context.getResources().getDisplayMetrics();
+            buttonSize = (int) (Math.min(metrics.widthPixels, metrics.heightPixels) * buttonArea);
+        }
+        return buttonSize;
+    }
+
+    @Override
+    protected View createSoundView(Context context) {
+        View soundView = super.createSoundView(context);
+        moveSoundViewPastTopRightControl(soundView);
+        return soundView;
     }
 
     @VisibleForTesting

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/views/interstitial/InterstitialVideo.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/views/interstitial/InterstitialVideo.java
@@ -21,6 +21,7 @@ import android.content.Context;
 import android.os.CountDownTimer;
 import android.os.Handler;
 import android.os.Looper;
+import android.util.DisplayMetrics;
 import android.util.Log;
 import android.view.KeyEvent;
 import android.view.LayoutInflater;
@@ -34,13 +35,13 @@ import android.widget.TextView;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import org.prebid.mobile.LogUtil;
+import org.prebid.mobile.api.data.Position;
 import org.prebid.mobile.configuration.AdUnitConfiguration;
 import org.prebid.mobile.core.R;
 import org.prebid.mobile.rendering.interstitial.AdBaseDialog;
 import org.prebid.mobile.rendering.interstitial.rewarded.RewardedCompletionRules;
 import org.prebid.mobile.rendering.interstitial.rewarded.RewardedExt;
 import org.prebid.mobile.rendering.models.InterstitialDisplayPropertiesInternal;
-import org.prebid.mobile.rendering.sdk.PrebidContextHolder;
 import org.prebid.mobile.rendering.utils.helpers.InsetsUtils;
 import org.prebid.mobile.rendering.utils.helpers.Utils;
 import org.prebid.mobile.rendering.views.base.BaseAdView;
@@ -399,10 +400,8 @@ public class InterstitialVideo extends AdBaseDialog {
             return;
         }
 
-        int paddingTop = (int) (50 * PrebidContextHolder.getContext().getResources().getDisplayMetrics().density);
-        lytCountDownCircle.setPadding(0, 0, 0, paddingTop);
-
         final ProgressBar pbProgress = lytCountDownCircle.findViewById(R.id.Progress);
+        moveCountdownPastTopLeftControl();
         pbProgress.setMax((int) durationInMillis);
 
         // Turns progress bar ccw 90 degrees so progress starts from the top
@@ -450,6 +449,27 @@ public class InterstitialVideo extends AdBaseDialog {
         }
         adViewContainer.addView(lytCountDownCircle);
         InsetsUtils.addCutoutAndNavigationInsets(lytCountDownCircle);
+    }
+
+    private void moveCountdownPastTopLeftControl() {
+        InterstitialDisplayPropertiesInternal properties = interstitialManager.getInterstitialDisplayProperties();
+        Position buttonPosition = useSkipButton
+            ? properties.skipButtonPosition
+            : properties.closeButtonPosition;
+        if (buttonPosition != Position.TOP_LEFT) {
+            return;
+        }
+
+        RelativeLayout countdown = lytCountDownCircle.findViewById(R.id.lytCountdown);
+        RelativeLayout.LayoutParams params = (RelativeLayout.LayoutParams) countdown.getLayoutParams();
+        double buttonArea = useSkipButton ? properties.skipButtonArea : properties.closeButtonArea;
+        int buttonSize = Utils.convertDpToPx(70, countdown.getContext());
+        if (buttonArea >= 0.05 && buttonArea <= 1) {
+            DisplayMetrics metrics = countdown.getResources().getDisplayMetrics();
+            buttonSize = (int) (Math.min(metrics.widthPixels, metrics.heightPixels) * buttonArea);
+        }
+        params.leftMargin = buttonSize + Utils.convertDpToPx(10, countdown.getContext());
+        countdown.setLayoutParams(params);
     }
 
     @VisibleForTesting

--- a/PrebidMobile/PrebidMobile-core/src/main/res/layout/lyt_countdown_circle_overlay.xml
+++ b/PrebidMobile/PrebidMobile-core/src/main/res/layout/lyt_countdown_circle_overlay.xml
@@ -21,14 +21,14 @@
     android:orientation="vertical"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
-    android:gravity="bottom|start"
+    android:gravity="top|left"
     >
 
     <RelativeLayout
         android:id="@+id/lytCountdown"
         android:layout_width="36dp"
         android:layout_height="36dp"
-        android:layout_marginBottom="25dp"
+        android:layout_marginTop="25dp"
         android:layout_marginLeft="25dp"
         >
 

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/utils/helpers/UtilsTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/utils/helpers/UtilsTest.java
@@ -411,7 +411,7 @@ public class UtilsTest extends TestCase {
         View closeView = Utils.createCloseView(activity);
         FrameLayout.LayoutParams params = (FrameLayout.LayoutParams) (closeView.getLayoutParams());
 
-        assertEquals(Gravity.END | Gravity.TOP, params.gravity);
+        assertEquals(Gravity.RIGHT | Gravity.TOP, params.gravity);
         assertEquals(FrameLayout.LayoutParams.WRAP_CONTENT, params.width);
         assertEquals(FrameLayout.LayoutParams.WRAP_CONTENT, params.height);
     }
@@ -423,7 +423,7 @@ public class UtilsTest extends TestCase {
         View closeView = Utils.createCloseView(activity, null);
         FrameLayout.LayoutParams params = (FrameLayout.LayoutParams) (closeView.getLayoutParams());
 
-        assertEquals(Gravity.END | Gravity.TOP, params.gravity);
+        assertEquals(Gravity.RIGHT | Gravity.TOP, params.gravity);
         assertEquals(FrameLayout.LayoutParams.WRAP_CONTENT, params.width);
         assertEquals(FrameLayout.LayoutParams.WRAP_CONTENT, params.height);
     }
@@ -437,7 +437,7 @@ public class UtilsTest extends TestCase {
         View closeView = Utils.createCloseView(activity, properties);
         FrameLayout.LayoutParams params = (FrameLayout.LayoutParams) (closeView.getLayoutParams());
 
-        assertEquals(Gravity.END | Gravity.TOP, params.gravity);
+        assertEquals(Gravity.RIGHT | Gravity.TOP, params.gravity);
         assertEquals(FrameLayout.LayoutParams.WRAP_CONTENT, params.width);
         assertEquals(FrameLayout.LayoutParams.WRAP_CONTENT, params.height);
     }
@@ -451,7 +451,7 @@ public class UtilsTest extends TestCase {
         View closeView = Utils.createCloseView(activity, properties);
         FrameLayout.LayoutParams params = (FrameLayout.LayoutParams) (closeView.getLayoutParams());
 
-        assertEquals(Gravity.END | Gravity.TOP, params.gravity);
+        assertEquals(Gravity.RIGHT | Gravity.TOP, params.gravity);
         assertEquals(216, params.width);
         assertEquals(216, params.height);
         assertEquals(43, closeView.getPaddingTop());
@@ -466,7 +466,7 @@ public class UtilsTest extends TestCase {
         View closeView = Utils.createCloseView(activity, properties);
         FrameLayout.LayoutParams params = (FrameLayout.LayoutParams) (closeView.getLayoutParams());
 
-        assertEquals(Gravity.START | Gravity.TOP, params.gravity);
+        assertEquals(Gravity.LEFT | Gravity.TOP, params.gravity);
     }
 
     @Test
@@ -478,7 +478,7 @@ public class UtilsTest extends TestCase {
         View closeView = Utils.createCloseView(activity, properties);
         FrameLayout.LayoutParams params = (FrameLayout.LayoutParams) (closeView.getLayoutParams());
 
-        assertEquals(Gravity.END | Gravity.TOP, params.gravity);
+        assertEquals(Gravity.RIGHT | Gravity.TOP, params.gravity);
     }
 
     @Test
@@ -488,7 +488,17 @@ public class UtilsTest extends TestCase {
         View closeView = Utils.createCloseView(activity, null);
         FrameLayout.LayoutParams params = (FrameLayout.LayoutParams) (closeView.getLayoutParams());
 
-        assertEquals(Gravity.END | Gravity.TOP, params.gravity);
+        assertEquals(Gravity.RIGHT | Gravity.TOP, params.gravity);
+    }
+
+    @Test
+    public void createSoundView_PositionsControlAtTopRight() {
+        Activity activity = Robolectric.buildActivity(Activity.class).get();
+
+        View soundView = Utils.createSoundView(activity);
+        FrameLayout.LayoutParams params = (FrameLayout.LayoutParams) soundView.getLayoutParams();
+
+        assertEquals(Gravity.RIGHT | Gravity.TOP, params.gravity);
     }
 
     @Test

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/views/interstitial/InterstitialVideoSoundViewTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/views/interstitial/InterstitialVideoSoundViewTest.java
@@ -1,0 +1,103 @@
+/*
+ *    Copyright 2018-2021 Prebid.org, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.prebid.mobile.rendering.views.interstitial;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import android.app.Activity;
+import android.content.Context;
+import android.view.View;
+import android.widget.FrameLayout;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.prebid.mobile.api.data.Position;
+import org.prebid.mobile.api.rendering.InterstitialView;
+import org.prebid.mobile.configuration.AdUnitConfiguration;
+import org.prebid.mobile.rendering.models.InterstitialDisplayPropertiesInternal;
+import org.prebid.mobile.test.utils.WhiteBox;
+import org.robolectric.Robolectric;
+import org.robolectric.RobolectricTestRunner;
+
+/**
+ * Covers the sound-vs-close/skip control overlap: {@code lyt_sound} and {@code lyt_close}/
+ * {@code lyt_skip} both default to the TOP_RIGHT corner of the ad container, so the sound
+ * control must be nudged out of the way whenever it would otherwise land on top of (or
+ * underneath) the close/skip control.
+ */
+@RunWith(RobolectricTestRunner.class)
+public class InterstitialVideoSoundViewTest {
+
+    private InterstitialVideo createInterstitialVideo(InterstitialDisplayPropertiesInternal properties) {
+        Context context = Robolectric.buildActivity(Activity.class).get();
+        InterstitialView mockAdView = mock(InterstitialView.class);
+        InterstitialManager mockInterstitialManager = mock(InterstitialManager.class);
+        AdUnitConfiguration mockAdConfiguration = mock(AdUnitConfiguration.class);
+        when(mockInterstitialManager.getInterstitialDisplayProperties()).thenReturn(properties);
+
+        return new InterstitialVideo(context, mockAdView, mockInterstitialManager, mockAdConfiguration);
+    }
+
+    @Test
+    public void createSoundView_CloseButtonAtDefaultTopRight_OffsetsSoundAwayFromCloseButton() {
+        InterstitialDisplayPropertiesInternal properties = new InterstitialDisplayPropertiesInternal();
+        InterstitialVideo interstitialVideo = createInterstitialVideo(properties);
+
+        View soundView = interstitialVideo.createSoundView(Robolectric.buildActivity(Activity.class).get());
+
+        FrameLayout.LayoutParams params = (FrameLayout.LayoutParams) soundView.getLayoutParams();
+        assertTrue(
+            "Sound button shares the default TOP_RIGHT corner with the close button, "
+                + "so it must be pushed clear of it",
+            params.rightMargin > 0
+        );
+    }
+
+    @Test
+    public void createSoundView_CloseButtonAtTopLeft_DoesNotOffsetSoundButton() {
+        InterstitialDisplayPropertiesInternal properties = new InterstitialDisplayPropertiesInternal();
+        properties.closeButtonPosition = Position.TOP_LEFT;
+        InterstitialVideo interstitialVideo = createInterstitialVideo(properties);
+
+        View soundView = interstitialVideo.createSoundView(Robolectric.buildActivity(Activity.class).get());
+
+        FrameLayout.LayoutParams params = (FrameLayout.LayoutParams) soundView.getLayoutParams();
+        assertEquals(
+            "Close button sits in the opposite (TOP_LEFT) corner, so no offset is needed",
+            0,
+            params.rightMargin
+        );
+    }
+
+    @Test
+    public void createSoundView_EndCardWithSkipButtonAtDefaultTopRight_OffsetsSoundAwayFromSkipButton() {
+        InterstitialDisplayPropertiesInternal properties = new InterstitialDisplayPropertiesInternal();
+        InterstitialVideo interstitialVideo = createInterstitialVideo(properties);
+        WhiteBox.setInternalState(interstitialVideo, "useSkipButton", true);
+
+        View soundView = interstitialVideo.createSoundView(Robolectric.buildActivity(Activity.class).get());
+
+        FrameLayout.LayoutParams params = (FrameLayout.LayoutParams) soundView.getLayoutParams();
+        assertTrue(
+            "Sound button shares the default TOP_RIGHT corner with the skip button, "
+                + "so it must be pushed clear of it",
+            params.rightMargin > 0
+        );
+    }
+}


### PR DESCRIPTION
## Summary
Fixes controls being misplaced in rewarded video ads: the countdown/progress circle and the mute button both rendered near the bottom edge instead of their intended top corners, and could overlap when a skip/close button was configured to `TOP_LEFT`.

- Progress/countdown circle moved from bottom to top, matching the mute button.
- Mute and skip/close buttons switched from RTL-relative (`START`/`END`) to fixed (`LEFT`/`RIGHT`) gravity to stay consistent with the countdown circle's own fixed-corner layout, removing the corner mismatch that caused overlap.
- Added `moveCountdownPastTopLeftControl()` so the countdown circle shifts right when a `TOP_LEFT` skip/close button is configured, avoiding a new overlap in that combination.

Closes #981

### Screenshots
<img width="1080" height="2400" alt="image-1785852518230" src="https://github.com/user-attachments/assets/7133200a-0e20-42f0-a96b-b17b0d9b64d0" />

<img width="1080" height="2400" alt="image-1785852521784" src="https://github.com/user-attachments/assets/bfd069e2-c1f1-48ed-96bc-912b4e84ec7e" />


