### PR TITLE
Fix CTA button missing in rewarded ads

### DIFF
--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/VideoCreative.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/video/VideoCreative.java
@@ -389,11 +389,8 @@ public class VideoCreative extends VideoCreativeProtocol
     protected void showCallToAction() {
         if (!model.getAdConfiguration().isBuiltInVideo()
                 && Utils.isNotBlank(model.getVastClickthroughUrl())
-                && !model.getAdConfiguration().isRewarded()
         ) {
             videoCreativeView.showCallToAction(true);
-        } else if (model.getAdConfiguration().isRewarded()) {
-            videoCreativeView.showCallToAction(false);
         }
     }
 

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/video/VideoCreativeTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/video/VideoCreativeTest.java
@@ -242,6 +242,30 @@ public class VideoCreativeTest {
     }
 
     @Test
+    public void rewardedVideoWithClickThrough_ShowsCallToAction() {
+        AdUnitConfiguration configuration = new AdUnitConfiguration();
+        configuration.setRewarded(true);
+        when(mockModel.getAdConfiguration()).thenReturn(configuration);
+        when(mockModel.getVastClickthroughUrl()).thenReturn("https://example.com");
+
+        videoCreative.showCallToAction();
+
+        verify(mockVideoCreativeView).showCallToAction(true);
+    }
+
+    @Test
+    public void rewardedVideoWithBlankClickThrough_DoesNotShowCallToAction() {
+        AdUnitConfiguration configuration = new AdUnitConfiguration();
+        configuration.setRewarded(true);
+        when(mockModel.getAdConfiguration()).thenReturn(configuration);
+        when(mockModel.getVastClickthroughUrl()).thenReturn(" ");
+
+        videoCreative.showCallToAction();
+
+        verify(mockVideoCreativeView, never()).showCallToAction(anyBoolean());
+    }
+
+    @Test
     public void whenOnVideoInterstitialClosed_DestroyCreativeViewAndCallCreativeDidComplete() {
         CreativeViewListener mockListener = mock(CreativeViewListener.class);
 


### PR DESCRIPTION
## Summary
Fixes the call-to-action (CTA) button being missing on rewarded video ads. `VideoCreative.showCallToAction()` had a rewarded-specific branch that unconditionally suppressed the CTA overlay regardless of whether a valid VAST clickthrough URL existed. This PR removes that special case, so rewarded video now follows the same rule as interstitial video: show the CTA if the creative is not built-in video and has a non-blank clickthrough URL.

Closes #982

### Screenshots
<img width="1080" height="2400" alt="image-1785852446398" src="https://github.com/user-attachments/assets/299b1c7c-a8ce-4e2b-8829-5e1eaf8a3541" />
<img width="1080" height="2400" alt="image-1785852449992" src="https://github.com/user-attachments/assets/9c29c58b-4d1f-4cce-9aef-bc5bd30a8cb7" />


