### PR TITLE
Fix close button missing on rewarded end card

### DIFF
--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/interstitial/AdInterstitialDialog.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/interstitial/AdInterstitialDialog.java
@@ -123,7 +123,9 @@ public class AdInterstitialDialog extends AdBaseDialog {
             }
 
             setBackgroundListener();
-            changeCloseViewVisibility(View.GONE);
+            if (!config.getHasEndCard()) {
+                changeCloseViewVisibility(View.GONE);
+            }
 
             RewardedExt rewardedExt = rewardManager.getRewardedExt();
             int defaultRewardTime = RewardedCompletionRules.DEFAULT_BANNER_TIME_MS;

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/interstitial/AdInterstitialDialogTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/interstitial/AdInterstitialDialogTest.java
@@ -162,6 +162,57 @@ public class AdInterstitialDialogTest {
     }
 
     @Test
+    public void setUpCloseButton_endCard_KeepsCloseButtonVisible() {
+        AdInterstitialDialog spySubject = adInterstitialDialog;
+        InterstitialDisplayPropertiesInternal mockProperties = mock(InterstitialDisplayPropertiesInternal.class);
+
+        AdUnitConfiguration mockConfig = mock(AdUnitConfiguration.class);
+        when(mockConfig.isRewarded()).thenReturn(true);
+        when(mockConfig.getHasEndCard()).thenReturn(true);
+        RewardedExt rewardedExt = RewardedExt.defaultExt();
+        mockProperties.config = mockConfig;
+
+        RewardManager mockRewardManager = mock(RewardManager.class);
+        when(mockRewardManager.getRewardedExt()).thenReturn(rewardedExt);
+        when(mockConfig.getRewardManager()).thenReturn(mockRewardManager);
+        when(mockInterstitialManager.getInterstitialDisplayProperties()).thenReturn(mockProperties);
+
+        spySubject.setUpCloseButtonTask();
+
+        verify(spySubject, never()).changeCloseViewVisibility(View.GONE);
+        verify(spySubject).scheduleRewardListener(RewardedCompletionRules.DEFAULT_BANNER_TIME_MS, 0, false);
+    }
+
+    @Test
+    public void setUpCloseButton_endCardWithAutoCloseEvent_KeepsCloseButtonVisible() {
+        AdInterstitialDialog spySubject = adInterstitialDialog;
+        InterstitialDisplayPropertiesInternal mockProperties = mock(InterstitialDisplayPropertiesInternal.class);
+
+        AdUnitConfiguration mockConfig = mock(AdUnitConfiguration.class);
+        when(mockConfig.isRewarded()).thenReturn(true);
+        when(mockConfig.getHasEndCard()).thenReturn(true);
+        RewardedCompletionRules completionRules = new RewardedCompletionRules(
+            null, null, null, null, null, "rwdd://yes"
+        );
+        RewardedClosingRules closingRules = new RewardedClosingRules(
+            2, RewardedClosingRules.Action.AUTO_CLOSE
+        );
+        RewardedExt rewardedExt = new RewardedExt(null, completionRules, closingRules);
+        mockProperties.config = mockConfig;
+
+        RewardManager mockRewardManager = mock(RewardManager.class);
+        when(mockRewardManager.getRewardedExt()).thenReturn(rewardedExt);
+        when(mockConfig.getRewardManager()).thenReturn(mockRewardManager);
+        when(mockInterstitialManager.getInterstitialDisplayProperties()).thenReturn(mockProperties);
+
+        spySubject.setUpCloseButtonTask();
+
+        verify(spySubject, never()).changeCloseViewVisibility(View.GONE);
+        verify(spySubject).scheduleRewardListener(RewardedCompletionRules.DEFAULT_BANNER_TIME_MS, 0, true);
+        verify(mockRewardManager).setAfterRewardListener(any());
+    }
+
+    @Test
     public void setUpCloseButton_rewardEventUrl() {
         AdInterstitialDialog spySubject = adInterstitialDialog;
         InterstitialDisplayPropertiesInternal mockProperties = mock(InterstitialDisplayPropertiesInternal.class);


### PR DESCRIPTION
## Summary
Fixes the close button never appearing on a rewarded ad's end card. `AdInterstitialDialog` unconditionally hid the close view for any rewarded dialog, including the one created for the end card — leaving users unable to dismiss the ad until the end-card/banner timer (up to 120s by default) elapsed, with no auto-close fallback. The fix only hides the close button when there is no end card (`!config.getHasEndCard()`), so the end-card dialog keeps its close button visible.

Related to #972 (auto-close-without-user-action). This change does not touch reward timing or the `AUTO_CLOSE` default-action logic — reward granting stays timer/event-driven and independent of the close action.

Closes #983

### Screenshots

<img width="1080" height="2400" alt="image-1785852376584" src="https://github.com/user-attachments/assets/e777f54b-c39a-4af4-9564-32bd0a3f61a3" />
<img width="1080" height="2400" alt="image-1785852380737" src="https://github.com/user-attachments/assets/97e70be5-1281-4dd1-802a-1514a84c25de" />


