### PR TITLE
Fix interstitial controls misplaced after orientation changes

### DIFF
--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/InterstitialView.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/InterstitialView.java
@@ -54,15 +54,19 @@ public class InterstitialView extends BaseAdView {
     protected void onConfigurationChanged(Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
 
+        refreshControlInsets();
+    }
+
+    public void refreshControlInsets() {
         List<View> views = Arrays.asList(
             findViewById(R.id.iv_close_interstitial),
             findViewById(R.id.iv_skip),
+            findViewById(R.id.iv_sound_interstitial),
             findViewById(R.id.rl_count_down),
             findViewById(R.id.tv_learn_more)
         );
 
         for (View view : views) {
-            InsetsUtils.resetMargins(view);
             InsetsUtils.addCutoutAndNavigationInsets(view);
         }
     }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/InterstitialView.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/InterstitialView.java
@@ -275,7 +275,10 @@ public class InterstitialView extends BaseAdView implements ControlInsetsRefresh
         obstructionArray[4] = new InternalFriendlyObstruction(actionButton, InternalFriendlyObstruction.Purpose.OTHER, "Action button");
 
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
-            View dialogRoot = closeInterstitial.getRootView();
+            // Use this view's own root rather than closeInterstitial's: closeInterstitial can be
+            // null if addCloseView() failed to add it (e.g. a cleared context reference), and
+            // this view reports the same root regardless.
+            View dialogRoot = getRootView();
             View navigationBar = dialogRoot.findViewById(android.R.id.navigationBarBackground);
             obstructionArray[5] = new InternalFriendlyObstruction(navigationBar, InternalFriendlyObstruction.Purpose.OTHER, "Bottom navigation bar");
         } else {

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/InterstitialView.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/InterstitialView.java
@@ -20,12 +20,15 @@ import android.content.Context;
 import android.content.res.Configuration;
 import android.util.Log;
 import android.view.View;
+import androidx.annotation.RestrictTo;
+import androidx.core.view.ViewCompat;
 import org.prebid.mobile.LogUtil;
 import org.prebid.mobile.api.exceptions.AdException;
 import org.prebid.mobile.configuration.AdUnitConfiguration;
 import org.prebid.mobile.core.R;
 import org.prebid.mobile.rendering.bidding.data.bid.BidResponse;
 import org.prebid.mobile.rendering.bidding.interfaces.InterstitialViewListener;
+import org.prebid.mobile.rendering.interstitial.ControlInsetsRefresher;
 import org.prebid.mobile.rendering.interstitial.DialogEventListener;
 import org.prebid.mobile.rendering.models.AdDetails;
 import org.prebid.mobile.rendering.models.internal.InternalFriendlyObstruction;
@@ -43,7 +46,7 @@ import java.util.List;
 /**
  * Internal view for {@link InterstitialAdUnit}.
  */
-public class InterstitialView extends BaseAdView {
+public class InterstitialView extends BaseAdView implements ControlInsetsRefresher {
 
     private static final String TAG = InterstitialView.class.getSimpleName();
 
@@ -54,9 +57,21 @@ public class InterstitialView extends BaseAdView {
     protected void onConfigurationChanged(Configuration newConfig) {
         super.onConfigurationChanged(newConfig);
 
-        refreshControlInsets();
+        // Insets aren't guaranteed to be redelivered by the time this callback fires, so defer
+        // to the next frame to give the window a chance to resolve them for the new configuration.
+        post(this::refreshControlInsets);
     }
 
+    /**
+     * Re-applies cutout/navigation-bar insets to the interstitial controls (close, skip, sound,
+     * countdown timer, learn-more button) on top of their original margins, so calling this
+     * repeatedly (e.g. on every rotation) never accumulates margins.
+     * <p>
+     * Internal SDK use only: invoked automatically on configuration changes and when the
+     * interstitial dialog is shown. Not part of the public API contract.
+     */
+    @Override
+    @RestrictTo(RestrictTo.Scope.LIBRARY)
     public void refreshControlInsets() {
         List<View> views = Arrays.asList(
             findViewById(R.id.iv_close_interstitial),
@@ -210,6 +225,13 @@ public class InterstitialView extends BaseAdView {
             super.init();
             setAdViewManagerValues();
             registerEventBroadcast();
+
+            // Canonical, self-correcting source of truth for insets: re-applies control
+            // insets whenever the window redelivers them, independently of onConfigurationChanged.
+            ViewCompat.setOnApplyWindowInsetsListener(this, (view, windowInsets) -> {
+                refreshControlInsets();
+                return windowInsets;
+            });
         } catch (Exception e) {
             throw new AdException(AdException.INIT_ERROR, "AdView initialization failed: " + Log.getStackTraceString(e));
         }
@@ -236,24 +258,28 @@ public class InterstitialView extends BaseAdView {
     }
 
     protected InternalFriendlyObstruction[] formInterstitialObstructionsArray() {
-        InternalFriendlyObstruction[] obstructionArray = new InternalFriendlyObstruction[5];
+        InternalFriendlyObstruction[] obstructionArray = new InternalFriendlyObstruction[6];
 
         View closeInterstitial = findViewById(R.id.iv_close_interstitial);
         View skipInterstitial = findViewById(R.id.iv_skip);
+        View soundInterstitial = findViewById(R.id.iv_sound_interstitial);
         View countDownTimer = findViewById(R.id.rl_count_down);
         View actionButton = findViewById(R.id.tv_learn_more);
 
         obstructionArray[0] = new InternalFriendlyObstruction(closeInterstitial, InternalFriendlyObstruction.Purpose.CLOSE_AD, null);
         obstructionArray[1] = new InternalFriendlyObstruction(skipInterstitial, InternalFriendlyObstruction.Purpose.CLOSE_AD, null);
-        obstructionArray[2] = new InternalFriendlyObstruction(countDownTimer, InternalFriendlyObstruction.Purpose.OTHER, "CountDownTimer");
-        obstructionArray[3] = new InternalFriendlyObstruction(actionButton, InternalFriendlyObstruction.Purpose.OTHER, "Action button");
+        // soundInterstitial is null for interstitials without a sound button (e.g. non-video);
+        // InternalFriendlyObstruction/OmAdSessionManager safely skip obstructions with a null view.
+        obstructionArray[2] = new InternalFriendlyObstruction(soundInterstitial, InternalFriendlyObstruction.Purpose.OTHER, "Sound button");
+        obstructionArray[3] = new InternalFriendlyObstruction(countDownTimer, InternalFriendlyObstruction.Purpose.OTHER, "CountDownTimer");
+        obstructionArray[4] = new InternalFriendlyObstruction(actionButton, InternalFriendlyObstruction.Purpose.OTHER, "Action button");
 
         if (android.os.Build.VERSION.SDK_INT >= android.os.Build.VERSION_CODES.LOLLIPOP) {
             View dialogRoot = closeInterstitial.getRootView();
             View navigationBar = dialogRoot.findViewById(android.R.id.navigationBarBackground);
-            obstructionArray[4] = new InternalFriendlyObstruction(navigationBar, InternalFriendlyObstruction.Purpose.OTHER, "Bottom navigation bar");
+            obstructionArray[5] = new InternalFriendlyObstruction(navigationBar, InternalFriendlyObstruction.Purpose.OTHER, "Bottom navigation bar");
         } else {
-            obstructionArray[4] = null;
+            obstructionArray[5] = null;
         }
 
         return obstructionArray;

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/interstitial/AdBaseDialog.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/interstitial/AdBaseDialog.java
@@ -34,7 +34,6 @@ import androidx.annotation.VisibleForTesting;
 import org.json.JSONObject;
 import org.prebid.mobile.LogUtil;
 import org.prebid.mobile.api.exceptions.AdException;
-import org.prebid.mobile.api.rendering.InterstitialView;
 import org.prebid.mobile.core.R;
 import org.prebid.mobile.rendering.models.InterstitialDisplayPropertiesInternal;
 import org.prebid.mobile.rendering.models.internal.MraidVariableContainer;
@@ -523,8 +522,8 @@ public abstract class AdBaseDialog extends Dialog {
                 adBaseDialog.addSkipView();
             }
 
-            if (adBaseDialog.adViewContainer instanceof InterstitialView) {
-                ((InterstitialView) adBaseDialog.adViewContainer).refreshControlInsets();
+            if (adBaseDialog.adViewContainer instanceof ControlInsetsRefresher) {
+                ((ControlInsetsRefresher) adBaseDialog.adViewContainer).refreshControlInsets();
             }
 
             adBaseDialog.interstitialManager.interstitialDialogShown(adBaseDialog.adViewContainer);

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/interstitial/AdBaseDialog.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/interstitial/AdBaseDialog.java
@@ -34,6 +34,7 @@ import androidx.annotation.VisibleForTesting;
 import org.json.JSONObject;
 import org.prebid.mobile.LogUtil;
 import org.prebid.mobile.api.exceptions.AdException;
+import org.prebid.mobile.api.rendering.InterstitialView;
 import org.prebid.mobile.core.R;
 import org.prebid.mobile.rendering.models.InterstitialDisplayPropertiesInternal;
 import org.prebid.mobile.rendering.models.internal.MraidVariableContainer;
@@ -520,6 +521,10 @@ public abstract class AdBaseDialog extends Dialog {
 
             if (adBaseDialog instanceof InterstitialVideo) {
                 adBaseDialog.addSkipView();
+            }
+
+            if (adBaseDialog.adViewContainer instanceof InterstitialView) {
+                ((InterstitialView) adBaseDialog.adViewContainer).refreshControlInsets();
             }
 
             adBaseDialog.interstitialManager.interstitialDialogShown(adBaseDialog.adViewContainer);

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/interstitial/ControlInsetsRefresher.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/interstitial/ControlInsetsRefresher.java
@@ -1,0 +1,31 @@
+/*
+ *    Copyright 2018-2021 Prebid.org, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.prebid.mobile.rendering.interstitial;
+
+/**
+ * Implemented by an interstitial ad view that can be asked to re-apply cutout/navigation-bar
+ * insets to its controls (close, skip, sound, countdown timer, etc.).
+ * <p>
+ * Lets {@link AdBaseDialog}, which lives in the lower-level {@code rendering.interstitial}
+ * package, notify its {@code adViewContainer} without depending on the higher-level
+ * {@code api.rendering} package that actually implements this.
+ */
+public interface ControlInsetsRefresher {
+
+    void refreshControlInsets();
+
+}

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/helpers/InsetsUtils.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/helpers/InsetsUtils.java
@@ -8,11 +8,18 @@ import android.view.*;
 import android.widget.FrameLayout;
 import android.widget.RelativeLayout;
 import androidx.annotation.Nullable;
+import androidx.annotation.VisibleForTesting;
 import org.prebid.mobile.LogUtil;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.WeakHashMap;
 
 public class InsetsUtils {
 
     private static final String TAG = InsetsUtils.class.getSimpleName();
+    private static final Map<View, CustomInsets> APPLIED_INSETS =
+        Collections.synchronizedMap(new WeakHashMap<>());
 
     /**
      * Adds to the view insets from navigation bar and cutout.
@@ -32,46 +39,71 @@ public class InsetsUtils {
             navigationInsets.getBottom() + cutoutInsets.getBottom(),
             navigationInsets.getLeft() + cutoutInsets.getLeft()
         );
+        CustomInsets previousInsets = APPLIED_INSETS.get(view);
+        if (previousInsets == null) {
+            previousInsets = new CustomInsets(0, 0, 0, 0);
+        }
 
+        if (applyInsetsToMargins(view, previousInsets, insets)) {
+            APPLIED_INSETS.put(view, insets);
+        }
+    }
+
+    @VisibleForTesting
+    static boolean applyInsetsToMargins(
+        View view,
+        CustomInsets previousInsets,
+        CustomInsets insets
+    ) {
+        ViewGroup.LayoutParams params = view.getLayoutParams();
         if (params instanceof FrameLayout.LayoutParams) {
             FrameLayout.LayoutParams frameParams = (FrameLayout.LayoutParams) params;
             int gravity = frameParams.gravity;
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1 && gravity != -1) {
+                int layoutDirection = view.isLayoutDirectionResolved()
+                    ? view.getLayoutDirection()
+                    : view.getResources().getConfiguration().getLayoutDirection();
+                gravity = Gravity.getAbsoluteGravity(gravity, layoutDirection);
+            }
             if ((gravity & Gravity.TOP) == Gravity.TOP) {
-                frameParams.topMargin += insets.getTop();
+                frameParams.topMargin += insets.getTop() - previousInsets.getTop();
             }
             if ((gravity & Gravity.BOTTOM) == Gravity.BOTTOM) {
-                frameParams.bottomMargin += insets.getBottom();
+                frameParams.bottomMargin += insets.getBottom() - previousInsets.getBottom();
             }
             if ((gravity & Gravity.RIGHT) == Gravity.RIGHT) {
-                frameParams.rightMargin += insets.getRight();
+                frameParams.rightMargin += insets.getRight() - previousInsets.getRight();
             }
             if ((gravity & Gravity.LEFT) == Gravity.LEFT) {
-                frameParams.leftMargin += insets.getLeft();
+                frameParams.leftMargin += insets.getLeft() - previousInsets.getLeft();
             }
             view.setLayoutParams(frameParams);
+            return true;
         } else if (params instanceof RelativeLayout.LayoutParams) {
             RelativeLayout.LayoutParams relativeParams = (RelativeLayout.LayoutParams) params;
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
                 if (relativeParams.getRule(RelativeLayout.ALIGN_PARENT_TOP) == RelativeLayout.TRUE) {
-                    relativeParams.topMargin += insets.getTop();
+                    relativeParams.topMargin += insets.getTop() - previousInsets.getTop();
                 }
                 if (relativeParams.getRule(RelativeLayout.ALIGN_PARENT_BOTTOM) == RelativeLayout.TRUE) {
-                    relativeParams.bottomMargin += insets.getBottom();
+                    relativeParams.bottomMargin += insets.getBottom() - previousInsets.getBottom();
                 }
                 if (relativeParams.getRule(RelativeLayout.ALIGN_PARENT_RIGHT) == RelativeLayout.TRUE
                     || relativeParams.getRule(RelativeLayout.ALIGN_PARENT_END) == RelativeLayout.TRUE
                 ) {
-                    relativeParams.rightMargin += insets.getRight();
+                    relativeParams.rightMargin += insets.getRight() - previousInsets.getRight();
                 }
                 if (relativeParams.getRule(RelativeLayout.ALIGN_PARENT_LEFT) == RelativeLayout.TRUE
                     || relativeParams.getRule(RelativeLayout.ALIGN_PARENT_START) == RelativeLayout.TRUE
                 ) {
-                    relativeParams.leftMargin += insets.getLeft();
+                    relativeParams.leftMargin += insets.getLeft() - previousInsets.getLeft();
                 }
             }
             view.setLayoutParams(relativeParams);
+            return true;
         } else {
             LogUtil.error(TAG, "Can't set insets, unsupported LayoutParams type.");
+            return false;
         }
     }
 

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/helpers/InsetsUtils.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/helpers/InsetsUtils.java
@@ -2,6 +2,7 @@ package org.prebid.mobile.rendering.utils.helpers;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.res.Configuration;
 import android.graphics.Insets;
 import android.os.Build;
 import android.view.*;
@@ -9,9 +10,13 @@ import android.widget.FrameLayout;
 import android.widget.RelativeLayout;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
+import androidx.core.os.ConfigurationCompat;
+import androidx.core.text.TextUtilsCompat;
 import androidx.core.view.ViewCompat;
 import org.prebid.mobile.LogUtil;
 import org.prebid.mobile.core.R;
+
+import java.util.Locale;
 
 public class InsetsUtils {
 
@@ -33,8 +38,10 @@ public class InsetsUtils {
     public static void addCutoutAndNavigationInsets(@Nullable View view) {
         if (view == null) return;
 
-        CustomInsets navigationInsets = getNavigationInsets(view.getContext());
-        CustomInsets cutoutInsets = getCutoutInsets(view.getContext());
+        Context context = view.getContext();
+        WindowInsets windowInsets = getWindowInsets(context);
+        CustomInsets navigationInsets = getNavigationInsets(context, windowInsets);
+        CustomInsets cutoutInsets = getCutoutInsets(context, windowInsets);
         CustomInsets insets = new CustomInsets(
             navigationInsets.getTop() + cutoutInsets.getTop(),
             navigationInsets.getRight() + cutoutInsets.getRight(),
@@ -81,14 +88,23 @@ public class InsetsUtils {
         if (params instanceof FrameLayout.LayoutParams) {
             FrameLayout.LayoutParams frameParams = (FrameLayout.LayoutParams) params;
             int gravity = frameParams.gravity;
-            if (gravity != FrameLayout.LayoutParams.UNSPECIFIED_GRAVITY) {
-                gravity = Gravity.getAbsoluteGravity(gravity, ViewCompat.getLayoutDirection(view));
-            }
 
-            boolean applyTop = (gravity & Gravity.TOP) == Gravity.TOP;
-            boolean applyBottom = (gravity & Gravity.BOTTOM) == Gravity.BOTTOM;
-            boolean applyRight = (gravity & Gravity.RIGHT) == Gravity.RIGHT;
-            boolean applyLeft = (gravity & Gravity.LEFT) == Gravity.LEFT;
+            boolean applyTop;
+            boolean applyBottom;
+            boolean applyRight;
+            boolean applyLeft;
+            if (gravity == FrameLayout.LayoutParams.UNSPECIFIED_GRAVITY) {
+                // Unspecified gravity is stored as -1 (all bits set). Without this branch the
+                // bitmask checks below would spuriously match every side and insets would be
+                // applied to all four margins instead of none.
+                applyTop = applyBottom = applyRight = applyLeft = false;
+            } else {
+                gravity = Gravity.getAbsoluteGravity(gravity, resolveLayoutDirection(view));
+                applyTop = (gravity & Gravity.TOP) == Gravity.TOP;
+                applyBottom = (gravity & Gravity.BOTTOM) == Gravity.BOTTOM;
+                applyRight = (gravity & Gravity.RIGHT) == Gravity.RIGHT;
+                applyLeft = (gravity & Gravity.LEFT) == Gravity.LEFT;
+            }
 
             frameParams.topMargin = baseMargins.getTop() + (applyTop ? insets.getTop() : 0);
             frameParams.bottomMargin = baseMargins.getBottom() + (applyBottom ? insets.getBottom() : 0);
@@ -99,18 +115,21 @@ public class InsetsUtils {
             return true;
         } else if (params instanceof RelativeLayout.LayoutParams) {
             RelativeLayout.LayoutParams relativeParams = (RelativeLayout.LayoutParams) params;
-            boolean isRtl = ViewCompat.getLayoutDirection(view) == ViewCompat.LAYOUT_DIRECTION_RTL;
+            boolean isRtl = resolveLayoutDirection(view) == View.LAYOUT_DIRECTION_RTL;
 
             // RelativeLayout.LayoutParams#getRule(int) is API 23. This SDK's min is API 16,
             // so rules must be read through getRules(), which is API 1 and backed by the
-            // same underlying array.
+            // same underlying array. On a real API 16 device that array is sized for the rules
+            // that existed at API 16 (no RTL START/END rules yet), so any index at or beyond
+            // ALIGN_PARENT_START/ALIGN_PARENT_END (added at API 17) must be bounds-checked
+            // instead of assumed present, or this throws ArrayIndexOutOfBoundsException.
             int[] rules = relativeParams.getRules();
-            boolean ruleTop = rules[RelativeLayout.ALIGN_PARENT_TOP] == RelativeLayout.TRUE;
-            boolean ruleBottom = rules[RelativeLayout.ALIGN_PARENT_BOTTOM] == RelativeLayout.TRUE;
-            boolean ruleRight = rules[RelativeLayout.ALIGN_PARENT_RIGHT] == RelativeLayout.TRUE;
-            boolean ruleLeft = rules[RelativeLayout.ALIGN_PARENT_LEFT] == RelativeLayout.TRUE;
-            boolean ruleEnd = rules[RelativeLayout.ALIGN_PARENT_END] == RelativeLayout.TRUE;
-            boolean ruleStart = rules[RelativeLayout.ALIGN_PARENT_START] == RelativeLayout.TRUE;
+            boolean ruleTop = isRuleSet(rules, RelativeLayout.ALIGN_PARENT_TOP);
+            boolean ruleBottom = isRuleSet(rules, RelativeLayout.ALIGN_PARENT_BOTTOM);
+            boolean ruleRight = isRuleSet(rules, RelativeLayout.ALIGN_PARENT_RIGHT);
+            boolean ruleLeft = isRuleSet(rules, RelativeLayout.ALIGN_PARENT_LEFT);
+            boolean ruleEnd = isRuleSet(rules, RelativeLayout.ALIGN_PARENT_END);
+            boolean ruleStart = isRuleSet(rules, RelativeLayout.ALIGN_PARENT_START);
 
             // END/START are direction-relative: resolve them against the view's resolved
             // layout direction instead of always mapping END->right and START->left, which
@@ -132,6 +151,10 @@ public class InsetsUtils {
     }
 
     public static CustomInsets getCutoutInsets(Context context) {
+        return getCutoutInsets(context, getWindowInsets(context));
+    }
+
+    private static CustomInsets getCutoutInsets(Context context, @Nullable WindowInsets windowInsets) {
         if (context != null && Build.VERSION.SDK_INT >= Build.VERSION_CODES.P) {
             DisplayCutout cutout = null;
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
@@ -141,11 +164,8 @@ public class InsetsUtils {
                     Activity activity = (Activity) context;
                     cutout = activity.getWindowManager().getDefaultDisplay().getCutout();
                 }
-            } else {
-                WindowInsets windowInsets = getWindowInsets(context);
-                if (windowInsets != null) {
-                    cutout = windowInsets.getDisplayCutout();
-                }
+            } else if (windowInsets != null) {
+                cutout = windowInsets.getDisplayCutout();
             }
             if (cutout != null) {
                 return new CustomInsets(
@@ -160,7 +180,10 @@ public class InsetsUtils {
     }
 
     public static CustomInsets getNavigationInsets(Context context) {
-        WindowInsets windowInsets = getWindowInsets(context);
+        return getNavigationInsets(context, getWindowInsets(context));
+    }
+
+    private static CustomInsets getNavigationInsets(Context context, @Nullable WindowInsets windowInsets) {
         if (windowInsets != null) {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                 Insets insets = windowInsets.getInsets(WindowInsets.Type.navigationBars());
@@ -191,6 +214,37 @@ public class InsetsUtils {
             }
         }
         return null;
+    }
+
+    /**
+     * Whether {@code rule} is set to {@link RelativeLayout#TRUE} in {@code rules}. Bounds-checked
+     * because on a real API 16 device the array {@link RelativeLayout.LayoutParams#getRules()}
+     * returns is sized for the rules that existed at API 16 and does not have slots for the RTL
+     * START/END rules added at API 17 (e.g. {@link RelativeLayout#ALIGN_PARENT_START}); indexing
+     * it with one of those rule constants without a bounds check throws
+     * {@link ArrayIndexOutOfBoundsException}.
+     */
+    private static boolean isRuleSet(int[] rules, int rule) {
+        return rule >= 0 && rule < rules.length && rules[rule] == RelativeLayout.TRUE;
+    }
+
+    /**
+     * Resolves {@code view}'s layout direction from its context's locale rather than from
+     * {@link ViewCompat#getLayoutDirection(View)}, which only reports the real resolved
+     * direction once a view is attached to a window; on an unattached view (e.g. right after
+     * inflate, before it's added to its parent) it otherwise always reports LTR regardless of
+     * the actual locale.
+     */
+    private static int resolveLayoutDirection(View view) {
+        Context context = view.getContext();
+        if (context != null && context.getResources() != null) {
+            Configuration configuration = context.getResources().getConfiguration();
+            Locale locale = ConfigurationCompat.getLocales(configuration).get(0);
+            if (locale != null) {
+                return TextUtilsCompat.getLayoutDirectionFromLocale(locale);
+            }
+        }
+        return ViewCompat.getLayoutDirection(view);
     }
 
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/helpers/InsetsUtils.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/helpers/InsetsUtils.java
@@ -101,12 +101,16 @@ public class InsetsUtils {
             RelativeLayout.LayoutParams relativeParams = (RelativeLayout.LayoutParams) params;
             boolean isRtl = ViewCompat.getLayoutDirection(view) == ViewCompat.LAYOUT_DIRECTION_RTL;
 
-            boolean ruleTop = relativeParams.getRule(RelativeLayout.ALIGN_PARENT_TOP) == RelativeLayout.TRUE;
-            boolean ruleBottom = relativeParams.getRule(RelativeLayout.ALIGN_PARENT_BOTTOM) == RelativeLayout.TRUE;
-            boolean ruleRight = relativeParams.getRule(RelativeLayout.ALIGN_PARENT_RIGHT) == RelativeLayout.TRUE;
-            boolean ruleLeft = relativeParams.getRule(RelativeLayout.ALIGN_PARENT_LEFT) == RelativeLayout.TRUE;
-            boolean ruleEnd = relativeParams.getRule(RelativeLayout.ALIGN_PARENT_END) == RelativeLayout.TRUE;
-            boolean ruleStart = relativeParams.getRule(RelativeLayout.ALIGN_PARENT_START) == RelativeLayout.TRUE;
+            // RelativeLayout.LayoutParams#getRule(int) is API 23. This SDK's min is API 16,
+            // so rules must be read through getRules(), which is API 1 and backed by the
+            // same underlying array.
+            int[] rules = relativeParams.getRules();
+            boolean ruleTop = rules[RelativeLayout.ALIGN_PARENT_TOP] == RelativeLayout.TRUE;
+            boolean ruleBottom = rules[RelativeLayout.ALIGN_PARENT_BOTTOM] == RelativeLayout.TRUE;
+            boolean ruleRight = rules[RelativeLayout.ALIGN_PARENT_RIGHT] == RelativeLayout.TRUE;
+            boolean ruleLeft = rules[RelativeLayout.ALIGN_PARENT_LEFT] == RelativeLayout.TRUE;
+            boolean ruleEnd = rules[RelativeLayout.ALIGN_PARENT_END] == RelativeLayout.TRUE;
+            boolean ruleStart = rules[RelativeLayout.ALIGN_PARENT_START] == RelativeLayout.TRUE;
 
             // END/START are direction-relative: resolve them against the view's resolved
             // layout direction instead of always mapping END->right and START->left, which

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/helpers/InsetsUtils.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/helpers/InsetsUtils.java
@@ -9,17 +9,13 @@ import android.widget.FrameLayout;
 import android.widget.RelativeLayout;
 import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
+import androidx.core.view.ViewCompat;
 import org.prebid.mobile.LogUtil;
-
-import java.util.Collections;
-import java.util.Map;
-import java.util.WeakHashMap;
+import org.prebid.mobile.core.R;
 
 public class InsetsUtils {
 
     private static final String TAG = InsetsUtils.class.getSimpleName();
-    private static final Map<View, CustomInsets> APPLIED_INSETS =
-        Collections.synchronizedMap(new WeakHashMap<>());
 
     /**
      * Adds to the view insets from navigation bar and cutout.
@@ -27,10 +23,16 @@ public class InsetsUtils {
      * interstitial ad. Must be applied to every view in interstitial ad.
      * <p>
      * It supports view where parents are RelativeLayout or FrameLayout.
+     * <p>
+     * The margins {@code view} had before any inset was ever applied to it are captured
+     * once (as a view tag) and reused as the baseline on every subsequent call. This makes
+     * repeated calls (e.g. on every rotation) idempotent: insets never accumulate, and if the
+     * resolved gravity/rule changes between calls (RTL flip, position change, etc.) the side
+     * that no longer applies is reset back to its original margin instead of staying stuck.
      */
     public static void addCutoutAndNavigationInsets(@Nullable View view) {
         if (view == null) return;
-        ViewGroup.LayoutParams params = view.getLayoutParams();
+
         CustomInsets navigationInsets = getNavigationInsets(view.getContext());
         CustomInsets cutoutInsets = getCutoutInsets(view.getContext());
         CustomInsets insets = new CustomInsets(
@@ -39,66 +41,84 @@ public class InsetsUtils {
             navigationInsets.getBottom() + cutoutInsets.getBottom(),
             navigationInsets.getLeft() + cutoutInsets.getLeft()
         );
-        CustomInsets previousInsets = APPLIED_INSETS.get(view);
-        if (previousInsets == null) {
-            previousInsets = new CustomInsets(0, 0, 0, 0);
+
+        applyInsetsToMargins(view, getOrCaptureBaseMargins(view), insets);
+    }
+
+    /**
+     * Returns the margins {@code view} had before any inset was ever applied to it. Captured
+     * from its current {@link ViewGroup.LayoutParams} on the first call and remembered as a
+     * view tag for every call after that.
+     */
+    private static CustomInsets getOrCaptureBaseMargins(View view) {
+        Object tag = view.getTag(R.id.prebid_base_margins);
+        if (tag instanceof CustomInsets) {
+            return (CustomInsets) tag;
         }
 
-        if (applyInsetsToMargins(view, previousInsets, insets)) {
-            APPLIED_INSETS.put(view, insets);
+        CustomInsets baseMargins = new CustomInsets(0, 0, 0, 0);
+        ViewGroup.LayoutParams params = view.getLayoutParams();
+        if (params instanceof ViewGroup.MarginLayoutParams) {
+            ViewGroup.MarginLayoutParams marginParams = (ViewGroup.MarginLayoutParams) params;
+            baseMargins = new CustomInsets(
+                marginParams.topMargin,
+                marginParams.rightMargin,
+                marginParams.bottomMargin,
+                marginParams.leftMargin
+            );
         }
+        view.setTag(R.id.prebid_base_margins, baseMargins);
+        return baseMargins;
     }
 
     @VisibleForTesting
     static boolean applyInsetsToMargins(
         View view,
-        CustomInsets previousInsets,
+        CustomInsets baseMargins,
         CustomInsets insets
     ) {
         ViewGroup.LayoutParams params = view.getLayoutParams();
         if (params instanceof FrameLayout.LayoutParams) {
             FrameLayout.LayoutParams frameParams = (FrameLayout.LayoutParams) params;
             int gravity = frameParams.gravity;
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN_MR1 && gravity != -1) {
-                int layoutDirection = view.isLayoutDirectionResolved()
-                    ? view.getLayoutDirection()
-                    : view.getResources().getConfiguration().getLayoutDirection();
-                gravity = Gravity.getAbsoluteGravity(gravity, layoutDirection);
+            if (gravity != FrameLayout.LayoutParams.UNSPECIFIED_GRAVITY) {
+                gravity = Gravity.getAbsoluteGravity(gravity, ViewCompat.getLayoutDirection(view));
             }
-            if ((gravity & Gravity.TOP) == Gravity.TOP) {
-                frameParams.topMargin += insets.getTop() - previousInsets.getTop();
-            }
-            if ((gravity & Gravity.BOTTOM) == Gravity.BOTTOM) {
-                frameParams.bottomMargin += insets.getBottom() - previousInsets.getBottom();
-            }
-            if ((gravity & Gravity.RIGHT) == Gravity.RIGHT) {
-                frameParams.rightMargin += insets.getRight() - previousInsets.getRight();
-            }
-            if ((gravity & Gravity.LEFT) == Gravity.LEFT) {
-                frameParams.leftMargin += insets.getLeft() - previousInsets.getLeft();
-            }
+
+            boolean applyTop = (gravity & Gravity.TOP) == Gravity.TOP;
+            boolean applyBottom = (gravity & Gravity.BOTTOM) == Gravity.BOTTOM;
+            boolean applyRight = (gravity & Gravity.RIGHT) == Gravity.RIGHT;
+            boolean applyLeft = (gravity & Gravity.LEFT) == Gravity.LEFT;
+
+            frameParams.topMargin = baseMargins.getTop() + (applyTop ? insets.getTop() : 0);
+            frameParams.bottomMargin = baseMargins.getBottom() + (applyBottom ? insets.getBottom() : 0);
+            frameParams.rightMargin = baseMargins.getRight() + (applyRight ? insets.getRight() : 0);
+            frameParams.leftMargin = baseMargins.getLeft() + (applyLeft ? insets.getLeft() : 0);
+
             view.setLayoutParams(frameParams);
             return true;
         } else if (params instanceof RelativeLayout.LayoutParams) {
             RelativeLayout.LayoutParams relativeParams = (RelativeLayout.LayoutParams) params;
-            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
-                if (relativeParams.getRule(RelativeLayout.ALIGN_PARENT_TOP) == RelativeLayout.TRUE) {
-                    relativeParams.topMargin += insets.getTop() - previousInsets.getTop();
-                }
-                if (relativeParams.getRule(RelativeLayout.ALIGN_PARENT_BOTTOM) == RelativeLayout.TRUE) {
-                    relativeParams.bottomMargin += insets.getBottom() - previousInsets.getBottom();
-                }
-                if (relativeParams.getRule(RelativeLayout.ALIGN_PARENT_RIGHT) == RelativeLayout.TRUE
-                    || relativeParams.getRule(RelativeLayout.ALIGN_PARENT_END) == RelativeLayout.TRUE
-                ) {
-                    relativeParams.rightMargin += insets.getRight() - previousInsets.getRight();
-                }
-                if (relativeParams.getRule(RelativeLayout.ALIGN_PARENT_LEFT) == RelativeLayout.TRUE
-                    || relativeParams.getRule(RelativeLayout.ALIGN_PARENT_START) == RelativeLayout.TRUE
-                ) {
-                    relativeParams.leftMargin += insets.getLeft() - previousInsets.getLeft();
-                }
-            }
+            boolean isRtl = ViewCompat.getLayoutDirection(view) == ViewCompat.LAYOUT_DIRECTION_RTL;
+
+            boolean ruleTop = relativeParams.getRule(RelativeLayout.ALIGN_PARENT_TOP) == RelativeLayout.TRUE;
+            boolean ruleBottom = relativeParams.getRule(RelativeLayout.ALIGN_PARENT_BOTTOM) == RelativeLayout.TRUE;
+            boolean ruleRight = relativeParams.getRule(RelativeLayout.ALIGN_PARENT_RIGHT) == RelativeLayout.TRUE;
+            boolean ruleLeft = relativeParams.getRule(RelativeLayout.ALIGN_PARENT_LEFT) == RelativeLayout.TRUE;
+            boolean ruleEnd = relativeParams.getRule(RelativeLayout.ALIGN_PARENT_END) == RelativeLayout.TRUE;
+            boolean ruleStart = relativeParams.getRule(RelativeLayout.ALIGN_PARENT_START) == RelativeLayout.TRUE;
+
+            // END/START are direction-relative: resolve them against the view's resolved
+            // layout direction instead of always mapping END->right and START->left, which
+            // is wrong under RTL.
+            boolean applyRight = ruleRight || (ruleEnd && !isRtl) || (ruleStart && isRtl);
+            boolean applyLeft = ruleLeft || (ruleStart && !isRtl) || (ruleEnd && isRtl);
+
+            relativeParams.topMargin = baseMargins.getTop() + (ruleTop ? insets.getTop() : 0);
+            relativeParams.bottomMargin = baseMargins.getBottom() + (ruleBottom ? insets.getBottom() : 0);
+            relativeParams.rightMargin = baseMargins.getRight() + (applyRight ? insets.getRight() : 0);
+            relativeParams.leftMargin = baseMargins.getLeft() + (applyLeft ? insets.getLeft() : 0);
+
             view.setLayoutParams(relativeParams);
             return true;
         } else {
@@ -152,24 +172,6 @@ public class InsetsUtils {
             }
         }
         return new CustomInsets(0, 0, 0, 0);
-    }
-
-    public static void resetMargins(@Nullable View view) {
-        int defaultMargin = 16;
-        if (view != null) {
-            ViewGroup.LayoutParams params = view.getLayoutParams();
-            if (params instanceof FrameLayout.LayoutParams) {
-                FrameLayout.LayoutParams frameParams = (FrameLayout.LayoutParams) params;
-                frameParams.setMargins(defaultMargin, defaultMargin, defaultMargin, defaultMargin);
-                view.setLayoutParams(frameParams);
-            } else if (params instanceof RelativeLayout.LayoutParams) {
-                RelativeLayout.LayoutParams relativeParams = (RelativeLayout.LayoutParams) params;
-                relativeParams.setMargins(defaultMargin, defaultMargin, defaultMargin, defaultMargin);
-                view.setLayoutParams(relativeParams);
-            } else {
-                LogUtil.debug(TAG, "Can't reset margins.");
-            }
-        }
     }
 
     @Nullable

--- a/PrebidMobile/PrebidMobile-core/src/main/res/values/ids.xml
+++ b/PrebidMobile/PrebidMobile-core/src/main/res/values/ids.xml
@@ -17,4 +17,7 @@
 
 <resources>
     <item name="web_view_banner" type="id"/>
+    <!-- Tag key used to remember a view's margins from before any inset was ever applied
+         to it, so InsetsUtils can keep re-applying insets idempotently on top of them. -->
+    <item name="prebid_base_margins" type="id"/>
 </resources>

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/InterstitialViewTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/InterstitialViewTest.java
@@ -18,6 +18,9 @@ package org.prebid.mobile.api.rendering;
 
 import android.app.Activity;
 import android.content.Context;
+import android.view.Gravity;
+import android.view.View;
+import android.widget.FrameLayout;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -25,6 +28,7 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.prebid.mobile.api.exceptions.AdException;
 import org.prebid.mobile.configuration.AdUnitConfiguration;
+import org.prebid.mobile.core.R;
 import org.prebid.mobile.rendering.bidding.data.bid.BidResponse;
 import org.prebid.mobile.rendering.bidding.interfaces.InterstitialViewListener;
 import org.prebid.mobile.rendering.video.VideoCreativeView;
@@ -35,6 +39,7 @@ import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 
 import static org.mockito.Mockito.*;
+import static org.junit.Assert.assertEquals;
 
 @RunWith(RobolectricTestRunner.class)
 public class InterstitialViewTest {
@@ -84,6 +89,23 @@ public class InterstitialViewTest {
         adViewManagerListener.viewReadyForImmediateDisplay(mockVideoCreativeView);
 
         verify(mockVideoCreativeView).enableVideoPlayerClick();
+    }
+
+    @Test
+    public void refreshControlInsets_UpdatesDialogSoundControlWithoutResettingMargins() {
+        View soundView = new View(spyBidInterstitialView.getContext());
+        soundView.setId(R.id.iv_sound_interstitial);
+        FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(100, 100);
+        params.gravity = Gravity.TOP | Gravity.RIGHT;
+        params.topMargin = 7;
+        params.rightMargin = 9;
+        spyBidInterstitialView.addView(soundView, params);
+
+        spyBidInterstitialView.refreshControlInsets();
+
+        FrameLayout.LayoutParams result = (FrameLayout.LayoutParams) soundView.getLayoutParams();
+        assertEquals(7, result.topMargin);
+        assertEquals(9, result.rightMargin);
     }
 
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/InterstitialViewTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/InterstitialViewTest.java
@@ -31,6 +31,7 @@ import org.prebid.mobile.configuration.AdUnitConfiguration;
 import org.prebid.mobile.core.R;
 import org.prebid.mobile.rendering.bidding.data.bid.BidResponse;
 import org.prebid.mobile.rendering.bidding.interfaces.InterstitialViewListener;
+import org.prebid.mobile.rendering.models.internal.InternalFriendlyObstruction;
 import org.prebid.mobile.rendering.video.VideoCreativeView;
 import org.prebid.mobile.rendering.views.AdViewManager;
 import org.prebid.mobile.rendering.views.AdViewManagerListener;
@@ -40,6 +41,7 @@ import org.robolectric.RobolectricTestRunner;
 
 import static org.mockito.Mockito.*;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 @RunWith(RobolectricTestRunner.class)
 public class InterstitialViewTest {
@@ -92,20 +94,75 @@ public class InterstitialViewTest {
     }
 
     @Test
-    public void refreshControlInsets_UpdatesDialogSoundControlWithoutResettingMargins() {
-        View soundView = new View(spyBidInterstitialView.getContext());
+    public void refreshControlInsets_DoesNotResetMarginsToDefault() throws AdException {
+        // A plain (non-spy) instance is used here and below: addView() on a Mockito spy of a
+        // real View does not actually attach the child under Robolectric, which made the
+        // previous version of this test pass vacuously (findViewById returned null,
+        // refreshControlInsets() silently no-op'd, and the untouched margins trivially matched).
+        // Robolectric also reports zero window insets, so this only proves refreshControlInsets()
+        // preserves the view's original margins instead of resetting them to a hardcoded default.
+        InterstitialView view = new InterstitialView(Robolectric.buildActivity(Activity.class).create().get());
+        View soundView = new View(view.getContext());
         soundView.setId(R.id.iv_sound_interstitial);
         FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(100, 100);
         params.gravity = Gravity.TOP | Gravity.RIGHT;
         params.topMargin = 7;
         params.rightMargin = 9;
-        spyBidInterstitialView.addView(soundView, params);
+        view.addView(soundView, params);
 
-        spyBidInterstitialView.refreshControlInsets();
+        view.refreshControlInsets();
 
         FrameLayout.LayoutParams result = (FrameLayout.LayoutParams) soundView.getLayoutParams();
         assertEquals(7, result.topMargin);
         assertEquals(9, result.rightMargin);
+    }
+
+    @Test
+    public void refreshControlInsets_CalledRepeatedly_DoesNotAccumulateMargins() throws AdException {
+        InterstitialView view = new InterstitialView(Robolectric.buildActivity(Activity.class).create().get());
+        View soundView = new View(view.getContext());
+        soundView.setId(R.id.iv_sound_interstitial);
+        FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(100, 100);
+        params.gravity = Gravity.TOP | Gravity.RIGHT;
+        params.topMargin = 7;
+        params.rightMargin = 9;
+        view.addView(soundView, params);
+
+        view.refreshControlInsets();
+        view.refreshControlInsets();
+        view.refreshControlInsets();
+
+        FrameLayout.LayoutParams result = (FrameLayout.LayoutParams) soundView.getLayoutParams();
+        assertEquals(7, result.topMargin);
+        assertEquals(9, result.rightMargin);
+    }
+
+    @Test
+    public void formInterstitialObstructionsArray_IncludesSoundButton() throws AdException {
+        InterstitialView view = new InterstitialView(Robolectric.buildActivity(Activity.class).create().get());
+
+        View closeView = new View(view.getContext());
+        closeView.setId(R.id.iv_close_interstitial);
+        view.addView(closeView, new FrameLayout.LayoutParams(100, 100));
+
+        View skipView = new View(view.getContext());
+        skipView.setId(R.id.iv_skip);
+        view.addView(skipView, new FrameLayout.LayoutParams(100, 100));
+
+        View soundView = new View(view.getContext());
+        soundView.setId(R.id.iv_sound_interstitial);
+        view.addView(soundView, new FrameLayout.LayoutParams(100, 100));
+
+        InternalFriendlyObstruction[] obstructions = view.formInterstitialObstructionsArray();
+
+        boolean containsSoundView = false;
+        for (InternalFriendlyObstruction obstruction : obstructions) {
+            if (obstruction != null && obstruction.getView() == soundView) {
+                containsSoundView = true;
+                break;
+            }
+        }
+        assertTrue(containsSoundView);
     }
 
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/utils/helpers/InsetsUtilsTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/utils/helpers/InsetsUtilsTest.java
@@ -146,6 +146,48 @@ public class InsetsUtilsTest {
     }
 
     @Test
+    public void applyInsetsToMargins_UnspecifiedGravity_DoesNotApplyInsetsToAnySide() {
+        // Regression: FrameLayout.LayoutParams.UNSPECIFIED_GRAVITY is -1 (all bits set). Without
+        // explicitly excluding it, the bitmask checks below spuriously match every side and
+        // insets get applied to all four margins instead of none. This is the exact params a
+        // view gets from FrameLayout.addView(View) with no explicit LayoutParams (e.g. the
+        // countdown timer container, rl_count_down/lytCountDownCircle).
+        View view = new View(RuntimeEnvironment.getApplication());
+        FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(100, 100);
+        assertEquals(FrameLayout.LayoutParams.UNSPECIFIED_GRAVITY, params.gravity);
+        view.setLayoutParams(params);
+
+        InsetsUtils.applyInsetsToMargins(view, NONE, PORTRAIT);
+
+        FrameLayout.LayoutParams result = (FrameLayout.LayoutParams) view.getLayoutParams();
+        assertEquals(0, result.topMargin);
+        assertEquals(0, result.bottomMargin);
+        assertEquals(0, result.leftMargin);
+        assertEquals(0, result.rightMargin);
+    }
+
+    @Test
+    @Config(qualifiers = "ar")
+    public void applyInsetsToMargins_FrameLayoutEndGravityOnUnattachedViewInRtlLocale_UsesLeftInset() {
+        // Regression: a real, unattached View (e.g. right after inflate(..., null), before it's
+        // added to its parent) never resolves an RTL layout direction through
+        // ViewCompat.getLayoutDirection()/View.getLayoutDirection() - it reports LTR regardless
+        // of locale until attached. Resolving direction from the view's context configuration
+        // instead means the very first inset application (not just later refreshes after attach)
+        // is correct in an RTL locale.
+        View view = new View(RuntimeEnvironment.getApplication());
+        FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(100, 100);
+        params.gravity = Gravity.TOP | Gravity.END;
+        view.setLayoutParams(params);
+
+        InsetsUtils.applyInsetsToMargins(view, NONE, PORTRAIT);
+
+        FrameLayout.LayoutParams result = (FrameLayout.LayoutParams) view.getLayoutParams();
+        assertEquals(40, result.leftMargin);
+        assertEquals(0, result.rightMargin);
+    }
+
+    @Test
     public void applyInsetsToMargins_RelativeLayoutBottomLeft_AddsInsetsOnTopOfBaseMargins() {
         View view = new View(RuntimeEnvironment.getApplication());
         RelativeLayout.LayoutParams params = new RelativeLayout.LayoutParams(100, 100);

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/utils/helpers/InsetsUtilsTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/utils/helpers/InsetsUtilsTest.java
@@ -238,6 +238,27 @@ public class InsetsUtilsTest {
     }
 
     @Test
+    @Config(sdk = 19)
+    public void applyInsetsToMargins_RelativeLayoutOnLegacyApi_DoesNotCrash() {
+        // Regression: RelativeLayout.LayoutParams#getRule(int) requires API 23 and was
+        // previously called directly, which crashed with NoSuchMethodError on API 16-22
+        // (minSdk is 16). Rules are now read through getRules(), which is API 1.
+        View view = new View(RuntimeEnvironment.getApplication());
+        RelativeLayout.LayoutParams params = new RelativeLayout.LayoutParams(100, 100);
+        params.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM);
+        params.addRule(RelativeLayout.ALIGN_PARENT_LEFT);
+        view.setLayoutParams(params);
+
+        CustomInsets base = new CustomInsets(0, 0, 25, 25);
+        boolean applied = InsetsUtils.applyInsetsToMargins(view, base, PORTRAIT);
+
+        assertEquals(true, applied);
+        RelativeLayout.LayoutParams result = (RelativeLayout.LayoutParams) view.getLayoutParams();
+        assertEquals(55, result.bottomMargin);
+        assertEquals(65, result.leftMargin);
+    }
+
+    @Test
     public void addCutoutAndNavigationInsets_CalledRepeatedly_CapturesBaseMarginsOnceAndIsIdempotent() {
         // End-to-end test of the public entry point: verifies the view-tag base-margin capture
         // wiring runs without error and stays stable across repeated calls on the same view,

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/utils/helpers/InsetsUtilsTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/utils/helpers/InsetsUtilsTest.java
@@ -19,8 +19,10 @@ package org.prebid.mobile.rendering.utils.helpers;
 import android.view.Gravity;
 import android.view.View;
 import android.widget.FrameLayout;
+import android.widget.RelativeLayout;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.RuntimeEnvironment;
 import org.robolectric.annotation.Config;
@@ -28,25 +30,26 @@ import org.robolectric.annotation.Config;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 28)
 public class InsetsUtilsTest {
 
+    private static final CustomInsets NONE = new CustomInsets(0, 0, 0, 0);
+    private static final CustomInsets PORTRAIT = new CustomInsets(10, 20, 30, 40);
+    private static final CustomInsets LANDSCAPE = new CustomInsets(4, 8, 12, 16);
+
     @Test
-    public void applyInsetsRepeatedly_DoesNotAccumulateMargins() {
+    public void applyInsetsToMargins_FrameLayoutTopRight_AddsInsetsOnTopOfBaseMargins() {
         View view = new View(RuntimeEnvironment.getApplication());
         FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(100, 100);
         params.gravity = Gravity.TOP | Gravity.RIGHT;
-        params.topMargin = 11;
-        params.rightMargin = 13;
         view.setLayoutParams(params);
 
-        CustomInsets none = new CustomInsets(0, 0, 0, 0);
-        CustomInsets portrait = new CustomInsets(10, 20, 30, 40);
-        InsetsUtils.applyInsetsToMargins(view, none, portrait);
-        InsetsUtils.applyInsetsToMargins(view, portrait, portrait);
+        CustomInsets base = new CustomInsets(11, 13, 0, 0);
+        InsetsUtils.applyInsetsToMargins(view, base, PORTRAIT);
 
         FrameLayout.LayoutParams result = (FrameLayout.LayoutParams) view.getLayoutParams();
         assertEquals(21, result.topMargin);
@@ -56,54 +59,201 @@ public class InsetsUtilsTest {
     }
 
     @Test
-    public void applyInsetsAfterRotation_ReplacesPreviousInsets() {
+    public void applyInsetsToMargins_CalledRepeatedlyWithSameInsets_DoesNotAccumulate() {
         View view = new View(RuntimeEnvironment.getApplication());
         FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(100, 100);
         params.gravity = Gravity.TOP | Gravity.RIGHT;
-        params.topMargin = 21;
-        params.rightMargin = 33;
         view.setLayoutParams(params);
 
-        CustomInsets portrait = new CustomInsets(10, 20, 30, 40);
-        CustomInsets landscape = new CustomInsets(4, 8, 12, 16);
-        InsetsUtils.applyInsetsToMargins(view, portrait, landscape);
+        CustomInsets base = new CustomInsets(11, 13, 0, 0);
+        InsetsUtils.applyInsetsToMargins(view, base, PORTRAIT);
+        InsetsUtils.applyInsetsToMargins(view, base, PORTRAIT);
+        InsetsUtils.applyInsetsToMargins(view, base, PORTRAIT);
 
         FrameLayout.LayoutParams result = (FrameLayout.LayoutParams) view.getLayoutParams();
-        assertEquals(15, result.topMargin);
-        assertEquals(21, result.rightMargin);
+        assertEquals(21, result.topMargin);
+        assertEquals(33, result.rightMargin);
     }
 
     @Test
-    public void applyInsetsWithUnsupportedParams_ReturnsFalse() {
+    public void applyInsetsToMargins_InsetsChangeBetweenCalls_ReplacesPreviousInsetsInsteadOfAdding() {
+        View view = new View(RuntimeEnvironment.getApplication());
+        FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(100, 100);
+        params.gravity = Gravity.TOP | Gravity.RIGHT;
+        view.setLayoutParams(params);
+
+        CustomInsets base = new CustomInsets(0, 0, 0, 0);
+        InsetsUtils.applyInsetsToMargins(view, base, PORTRAIT);
+        InsetsUtils.applyInsetsToMargins(view, base, LANDSCAPE);
+
+        FrameLayout.LayoutParams result = (FrameLayout.LayoutParams) view.getLayoutParams();
+        assertEquals(4, result.topMargin);
+        assertEquals(8, result.rightMargin);
+    }
+
+    @Test
+    public void applyInsetsToMargins_GravityChangesBetweenCalls_OldSideResetsToBaseMargin() {
+        // Regression: previously, once an inset was added to a side, changing which side the
+        // gravity resolves to (RTL flip, position change, re-added view with different params)
+        // could leave the old side stuck with a stale inset instead of its original margin.
+        View view = new View(RuntimeEnvironment.getApplication());
+        FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(100, 100);
+        params.gravity = Gravity.TOP | Gravity.RIGHT;
+        view.setLayoutParams(params);
+
+        CustomInsets base = new CustomInsets(0, 0, 0, 0);
+        InsetsUtils.applyInsetsToMargins(view, base, PORTRAIT);
+
+        FrameLayout.LayoutParams afterFirstCall = (FrameLayout.LayoutParams) view.getLayoutParams();
+        afterFirstCall.gravity = Gravity.TOP | Gravity.LEFT;
+        view.setLayoutParams(afterFirstCall);
+
+        InsetsUtils.applyInsetsToMargins(view, base, PORTRAIT);
+
+        FrameLayout.LayoutParams result = (FrameLayout.LayoutParams) view.getLayoutParams();
+        assertEquals(0, result.rightMargin);
+        assertEquals(40, result.leftMargin);
+    }
+
+    @Test
+    public void applyInsetsToMargins_WithUnsupportedParams_ReturnsFalse() {
         View view = new View(RuntimeEnvironment.getApplication());
         view.setLayoutParams(new android.view.ViewGroup.LayoutParams(100, 100));
 
-        boolean applied = InsetsUtils.applyInsetsToMargins(
-            view,
-            new CustomInsets(0, 0, 0, 0),
-            new CustomInsets(10, 20, 30, 40)
-        );
+        boolean applied = InsetsUtils.applyInsetsToMargins(view, NONE, PORTRAIT);
 
         assertFalse(applied);
     }
 
     @Test
-    public void applyInsetsWithEndGravityInRtl_UsesLeftInset() {
+    public void applyInsetsToMargins_FrameLayoutEndGravityInRtl_UsesLeftInset() {
+        // A real, unattached View never resolves an RTL layout direction in Robolectric, so the
+        // resolved direction is mocked directly (this is what ViewCompat.getLayoutDirection()
+        // reads on API 17+). The assertion is tied to the captured setLayoutParams() argument,
+        // not to re-reading the stubbed getLayoutParams(), so it can't pass for the wrong reason.
         View view = mock(View.class);
         FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(100, 100);
         params.gravity = Gravity.TOP | Gravity.END;
         when(view.getLayoutParams()).thenReturn(params);
-        when(view.isLayoutDirectionResolved()).thenReturn(true);
         when(view.getLayoutDirection()).thenReturn(View.LAYOUT_DIRECTION_RTL);
 
-        InsetsUtils.applyInsetsToMargins(
-            view,
-            new CustomInsets(0, 0, 0, 0),
-            new CustomInsets(10, 20, 30, 40)
-        );
+        InsetsUtils.applyInsetsToMargins(view, NONE, PORTRAIT);
+
+        ArgumentCaptor<FrameLayout.LayoutParams> captor = ArgumentCaptor.forClass(FrameLayout.LayoutParams.class);
+        verify(view).setLayoutParams(captor.capture());
+        assertEquals(40, captor.getValue().leftMargin);
+        assertEquals(0, captor.getValue().rightMargin);
+    }
+
+    @Test
+    public void applyInsetsToMargins_RelativeLayoutBottomLeft_AddsInsetsOnTopOfBaseMargins() {
+        View view = new View(RuntimeEnvironment.getApplication());
+        RelativeLayout.LayoutParams params = new RelativeLayout.LayoutParams(100, 100);
+        params.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM);
+        params.addRule(RelativeLayout.ALIGN_PARENT_LEFT);
+        view.setLayoutParams(params);
+
+        CustomInsets base = new CustomInsets(0, 0, 25, 25);
+        InsetsUtils.applyInsetsToMargins(view, base, PORTRAIT);
+
+        RelativeLayout.LayoutParams result = (RelativeLayout.LayoutParams) view.getLayoutParams();
+        assertEquals(55, result.bottomMargin);
+        assertEquals(65, result.leftMargin);
+        assertEquals(0, result.topMargin);
+        assertEquals(0, result.rightMargin);
+    }
+
+    @Test
+    public void applyInsetsToMargins_RelativeLayoutEndRuleInRtl_UsesLeftInset() {
+        // Regression: ALIGN_PARENT_END must resolve to the left margin under RTL, not the
+        // right margin (which is what ALIGN_PARENT_END means in LTR). See the note on the
+        // FrameLayout RTL test above for why the resolved direction is mocked here.
+        View view = mock(View.class);
+        RelativeLayout.LayoutParams params = new RelativeLayout.LayoutParams(100, 100);
+        params.addRule(RelativeLayout.ALIGN_PARENT_END);
+        when(view.getLayoutParams()).thenReturn(params);
+        when(view.getLayoutDirection()).thenReturn(View.LAYOUT_DIRECTION_RTL);
+
+        InsetsUtils.applyInsetsToMargins(view, NONE, PORTRAIT);
+
+        ArgumentCaptor<RelativeLayout.LayoutParams> captor = ArgumentCaptor.forClass(RelativeLayout.LayoutParams.class);
+        verify(view).setLayoutParams(captor.capture());
+        assertEquals(40, captor.getValue().leftMargin);
+        assertEquals(0, captor.getValue().rightMargin);
+    }
+
+    @Test
+    public void applyInsetsToMargins_RelativeLayoutStartRuleInRtl_UsesRightInset() {
+        View view = mock(View.class);
+        RelativeLayout.LayoutParams params = new RelativeLayout.LayoutParams(100, 100);
+        params.addRule(RelativeLayout.ALIGN_PARENT_START);
+        when(view.getLayoutParams()).thenReturn(params);
+        when(view.getLayoutDirection()).thenReturn(View.LAYOUT_DIRECTION_RTL);
+
+        InsetsUtils.applyInsetsToMargins(view, NONE, PORTRAIT);
+
+        ArgumentCaptor<RelativeLayout.LayoutParams> captor = ArgumentCaptor.forClass(RelativeLayout.LayoutParams.class);
+        verify(view).setLayoutParams(captor.capture());
+        assertEquals(20, captor.getValue().rightMargin);
+        assertEquals(0, captor.getValue().leftMargin);
+    }
+
+    @Test
+    public void applyInsetsToMargins_SoundViewBottomMarginSurvivesTwoRotations() {
+        // Utils.createSoundView() gives the sound button a 150px base bottom margin before
+        // insets are ever applied. That base must survive repeated rotations unchanged.
+        View view = new View(RuntimeEnvironment.getApplication());
+        FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(100, 100);
+        params.gravity = Gravity.END | Gravity.BOTTOM;
+        params.bottomMargin = 150;
+        view.setLayoutParams(params);
+
+        CustomInsets base = new CustomInsets(0, 0, 150, 0);
+        InsetsUtils.applyInsetsToMargins(view, base, PORTRAIT);
+        assertEquals(180, ((FrameLayout.LayoutParams) view.getLayoutParams()).bottomMargin);
+
+        InsetsUtils.applyInsetsToMargins(view, base, LANDSCAPE);
+        assertEquals(162, ((FrameLayout.LayoutParams) view.getLayoutParams()).bottomMargin);
+
+        InsetsUtils.applyInsetsToMargins(view, base, NONE);
+        assertEquals(150, ((FrameLayout.LayoutParams) view.getLayoutParams()).bottomMargin);
+    }
+
+    @Test
+    @Config(sdk = 19)
+    public void applyInsetsToMargins_OnLegacyApi_DoesNotCrash() {
+        // Regression: isLayoutDirectionResolved() on View requires API 19 and was previously
+        // guarded at API 17, which crashed with NoSuchMethodError on API 17/18 (minSdk is 16).
+        // Resolving gravity now goes through ViewCompat instead of calling that directly.
+        View view = new View(RuntimeEnvironment.getApplication());
+        FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(100, 100);
+        params.gravity = Gravity.TOP | Gravity.END;
+        view.setLayoutParams(params);
+
+        boolean applied = InsetsUtils.applyInsetsToMargins(view, NONE, PORTRAIT);
+
+        assertEquals(true, applied);
+        FrameLayout.LayoutParams result = (FrameLayout.LayoutParams) view.getLayoutParams();
+        assertEquals(20, result.rightMargin);
+    }
+
+    @Test
+    public void addCutoutAndNavigationInsets_CalledRepeatedly_CapturesBaseMarginsOnceAndIsIdempotent() {
+        // End-to-end test of the public entry point: verifies the view-tag base-margin capture
+        // wiring runs without error and stays stable across repeated calls on the same view,
+        // even though Robolectric reports zero real window insets.
+        View view = new View(RuntimeEnvironment.getApplication());
+        FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(100, 100);
+        params.gravity = Gravity.TOP | Gravity.RIGHT;
+        params.topMargin = 7;
+        params.rightMargin = 9;
+        view.setLayoutParams(params);
+
+        InsetsUtils.addCutoutAndNavigationInsets(view);
+        InsetsUtils.addCutoutAndNavigationInsets(view);
 
         FrameLayout.LayoutParams result = (FrameLayout.LayoutParams) view.getLayoutParams();
-        assertEquals(40, result.leftMargin);
-        assertEquals(0, result.rightMargin);
+        assertEquals(7, result.topMargin);
+        assertEquals(9, result.rightMargin);
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/utils/helpers/InsetsUtilsTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/utils/helpers/InsetsUtilsTest.java
@@ -1,0 +1,109 @@
+/*
+ *    Copyright 2018-2021 Prebid.org, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.prebid.mobile.rendering.utils.helpers;
+
+import android.view.Gravity;
+import android.view.View;
+import android.widget.FrameLayout;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.RuntimeEnvironment;
+import org.robolectric.annotation.Config;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 28)
+public class InsetsUtilsTest {
+
+    @Test
+    public void applyInsetsRepeatedly_DoesNotAccumulateMargins() {
+        View view = new View(RuntimeEnvironment.getApplication());
+        FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(100, 100);
+        params.gravity = Gravity.TOP | Gravity.RIGHT;
+        params.topMargin = 11;
+        params.rightMargin = 13;
+        view.setLayoutParams(params);
+
+        CustomInsets none = new CustomInsets(0, 0, 0, 0);
+        CustomInsets portrait = new CustomInsets(10, 20, 30, 40);
+        InsetsUtils.applyInsetsToMargins(view, none, portrait);
+        InsetsUtils.applyInsetsToMargins(view, portrait, portrait);
+
+        FrameLayout.LayoutParams result = (FrameLayout.LayoutParams) view.getLayoutParams();
+        assertEquals(21, result.topMargin);
+        assertEquals(33, result.rightMargin);
+        assertEquals(0, result.bottomMargin);
+        assertEquals(0, result.leftMargin);
+    }
+
+    @Test
+    public void applyInsetsAfterRotation_ReplacesPreviousInsets() {
+        View view = new View(RuntimeEnvironment.getApplication());
+        FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(100, 100);
+        params.gravity = Gravity.TOP | Gravity.RIGHT;
+        params.topMargin = 21;
+        params.rightMargin = 33;
+        view.setLayoutParams(params);
+
+        CustomInsets portrait = new CustomInsets(10, 20, 30, 40);
+        CustomInsets landscape = new CustomInsets(4, 8, 12, 16);
+        InsetsUtils.applyInsetsToMargins(view, portrait, landscape);
+
+        FrameLayout.LayoutParams result = (FrameLayout.LayoutParams) view.getLayoutParams();
+        assertEquals(15, result.topMargin);
+        assertEquals(21, result.rightMargin);
+    }
+
+    @Test
+    public void applyInsetsWithUnsupportedParams_ReturnsFalse() {
+        View view = new View(RuntimeEnvironment.getApplication());
+        view.setLayoutParams(new android.view.ViewGroup.LayoutParams(100, 100));
+
+        boolean applied = InsetsUtils.applyInsetsToMargins(
+            view,
+            new CustomInsets(0, 0, 0, 0),
+            new CustomInsets(10, 20, 30, 40)
+        );
+
+        assertFalse(applied);
+    }
+
+    @Test
+    public void applyInsetsWithEndGravityInRtl_UsesLeftInset() {
+        View view = mock(View.class);
+        FrameLayout.LayoutParams params = new FrameLayout.LayoutParams(100, 100);
+        params.gravity = Gravity.TOP | Gravity.END;
+        when(view.getLayoutParams()).thenReturn(params);
+        when(view.isLayoutDirectionResolved()).thenReturn(true);
+        when(view.getLayoutDirection()).thenReturn(View.LAYOUT_DIRECTION_RTL);
+
+        InsetsUtils.applyInsetsToMargins(
+            view,
+            new CustomInsets(0, 0, 0, 0),
+            new CustomInsets(10, 20, 30, 40)
+        );
+
+        FrameLayout.LayoutParams result = (FrameLayout.LayoutParams) view.getLayoutParams();
+        assertEquals(40, result.leftMargin);
+        assertEquals(0, result.rightMargin);
+    }
+}


### PR DESCRIPTION
## Summary
Fixes interstitial controls (close/skip/sound/countdown) being misplaced after device rotation, and fixes cumulative inset drift on repeated rotations.

- `InsetsUtils.applyInsetsToMargins` now applies the *delta* between the new and previously-applied insets, instead of resetting margins to a hardcoded value on every call — repeated rotations no longer cause controls to drift.
- Added RTL-aware gravity resolution (`Gravity.getAbsoluteGravity`) so `START`/`END`-configured views get insets applied to the correct physical side under RTL layout direction.
- `InterstitialView.refreshControlInsets()` (the renamed/extracted `onConfigurationChanged` logic) is now also invoked once at initial dialog show time, not only on rotation, closing a gap where controls were unadjusted until the first rotation.
- Bookkeeping fix: insets are only recorded as "applied" when margins were actually set on a supported `LayoutParams` type.

Closes #984

### Screenshots
<img width="1080" height="2400" alt="image-1785852228998" src="https://github.com/user-attachments/assets/9d11fa43-7c3e-4870-8266-798a617ba039" />
<img width="2400" height="1080" alt="image-1785852234273" src="https://github.com/user-attachments/assets/f79cc156-9263-4a77-b46b-8d718ffeae35" />
<img width="2400" height="1080" alt="image-1785852238144" src="https://github.com/user-attachments/assets/80969da2-de5d-4b89-b8fe-eab9352bd03f" />