### PR TITLE
Read location providers according to the permission actually granted

### DIFF
--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/deviceData/managers/LastKnownLocationInfoManager.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/deviceData/managers/LastKnownLocationInfoManager.java
@@ -44,33 +44,54 @@ public final class LastKnownLocationInfoManager extends BaseManager implements L
         }
     }
 
-    @SuppressLint("MissingPermission")
     @Override
     public void resetLocation() {
-        Location gpsLastKnownLocation = null;
-        Location ntwLastKnownLocation = null;
-        if (getContext() != null) {
-            try {
-                locManager = (android.location.LocationManager) getContext().getSystemService(Context.LOCATION_SERVICE);
-
-                if (isLocationPermissionGranted() && locManager != null) {
-                    gpsLastKnownLocation = locManager.getLastKnownLocation(android.location.LocationManager.GPS_PROVIDER);
-                    ntwLastKnownLocation = locManager.getLastKnownLocation(android.location.LocationManager.NETWORK_PROVIDER);
-                }
-
-                if (gpsLastKnownLocation != null) {
-                    location = gpsLastKnownLocation;
-
-                    if (ntwLastKnownLocation != null && isBetterLocation(ntwLastKnownLocation, location)) {
-                        location = ntwLastKnownLocation;
-                    }
-                } else if (ntwLastKnownLocation != null) {
-                    location = ntwLastKnownLocation;
-                }
-            } catch (SecurityException exception) {
-                LogUtil.warning(TAG, "Unable to access locationManager due to android firmware bug.");
-            }
+        if (getContext() == null) {
+            return;
         }
+
+        locManager = (android.location.LocationManager) getContext().getSystemService(Context.LOCATION_SERVICE);
+        if (locManager == null) {
+            return;
+        }
+
+        // GPS_PROVIDER requires ACCESS_FINE_LOCATION; NETWORK_PROVIDER is satisfied by
+        // ACCESS_COARSE_LOCATION. Since Android 12 the user can grant approximate
+        // location on its own, so each provider is asked for separately and only when
+        // the permission it actually needs is held.
+        Location gpsLastKnownLocation = isFineLocationPermissionGranted()
+                ? lastKnownLocation(android.location.LocationManager.GPS_PROVIDER)
+                : null;
+        Location ntwLastKnownLocation = isLocationPermissionGranted()
+                ? lastKnownLocation(android.location.LocationManager.NETWORK_PROVIDER)
+                : null;
+
+        if (gpsLastKnownLocation != null) {
+            location = gpsLastKnownLocation;
+
+            if (ntwLastKnownLocation != null && isBetterLocation(ntwLastKnownLocation, location)) {
+                location = ntwLastKnownLocation;
+            }
+        } else if (ntwLastKnownLocation != null) {
+            location = ntwLastKnownLocation;
+        }
+    }
+
+    /**
+     * Reads a single provider in isolation. A provider that the platform refuses or
+     * that does not exist on this device must not stop the other provider from being
+     * read.
+     */
+    @SuppressLint("MissingPermission")
+    private Location lastKnownLocation(String provider) {
+        try {
+            return locManager.getLastKnownLocation(provider);
+        } catch (SecurityException exception) {
+            LogUtil.warning(TAG, "No permission to read the last known location from " + provider + ".");
+        } catch (IllegalArgumentException exception) {
+            LogUtil.warning(TAG, "Location provider " + provider + " does not exist on this device.");
+        }
+        return null;
     }
 
     /**
@@ -170,9 +191,16 @@ public final class LastKnownLocationInfoManager extends BaseManager implements L
         return location != null;
     }
 
+    /** True when either approximate or precise location has been granted. */
     private boolean isLocationPermissionGranted() {
         return getContext() != null
                && (getContext().checkCallingOrSelfPermission(ACCESS_COARSE_LOCATION) == PERMISSION_GRANTED
-                   || getContext().checkCallingOrSelfPermission(ACCESS_FINE_LOCATION) == PERMISSION_GRANTED);
+                   || isFineLocationPermissionGranted());
+    }
+
+    /** True only for precise location, which is what GPS_PROVIDER requires. */
+    private boolean isFineLocationPermissionGranted() {
+        return getContext() != null
+               && getContext().checkCallingOrSelfPermission(ACCESS_FINE_LOCATION) == PERMISSION_GRANTED;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/deviceData/managers/LastKnownLocationInfoManager.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/deviceData/managers/LastKnownLocationInfoManager.java
@@ -30,7 +30,6 @@ import org.prebid.mobile.LogUtil;
 
 public final class LastKnownLocationInfoManager extends BaseManager implements LocationInfoManager {
 
-    private android.location.LocationManager locManager;
     private Location location;
     private static final String TAG = LastKnownLocationInfoManager.class.getSimpleName();
 
@@ -46,25 +45,33 @@ public final class LastKnownLocationInfoManager extends BaseManager implements L
 
     @Override
     public void resetLocation() {
-        if (getContext() == null) {
+        // Drop the previous fix first. Location permissions are runtime-revocable, and
+        // without this a revoked grant leaves stale coordinates going out in bid
+        // requests via GeoLocationParameterBuilder.
+        location = null;
+
+        Context context = getContext();
+        if (context == null) {
             return;
         }
 
-        locManager = (android.location.LocationManager) getContext().getSystemService(Context.LOCATION_SERVICE);
-        if (locManager == null) {
+        android.location.LocationManager locManager =
+                (android.location.LocationManager) context.getSystemService(Context.LOCATION_SERVICE);
+        if (locManager == null || !isLocationPermissionGranted(context)) {
             return;
         }
 
-        // GPS_PROVIDER requires ACCESS_FINE_LOCATION; NETWORK_PROVIDER is satisfied by
-        // ACCESS_COARSE_LOCATION. Since Android 12 the user can grant approximate
-        // location on its own, so each provider is asked for separately and only when
-        // the permission it actually needs is held.
-        Location gpsLastKnownLocation = isFineLocationPermissionGranted()
-                ? lastKnownLocation(android.location.LocationManager.GPS_PROVIDER)
-                : null;
-        Location ntwLastKnownLocation = isLocationPermissionGranted()
-                ? lastKnownLocation(android.location.LocationManager.NETWORK_PROVIDER)
-                : null;
+        // Both providers are asked for, and the per-provider catch below absorbs a
+        // refusal. Deliberately not gated on the fine permission: before API 31
+        // LocationManagerService rejected GPS_PROVIDER outright for a coarse-only
+        // client, but from API 31 that check was replaced by coarsening through
+        // LocationFudger, so an approximate-only client receives an obfuscated fix
+        // from every provider instead. Skipping GPS on the strength of the permission
+        // would therefore throw away a usable location on the newer platforms.
+        Location gpsLastKnownLocation =
+                lastKnownLocation(locManager, android.location.LocationManager.GPS_PROVIDER);
+        Location ntwLastKnownLocation =
+                lastKnownLocation(locManager, android.location.LocationManager.NETWORK_PROVIDER);
 
         if (gpsLastKnownLocation != null) {
             location = gpsLastKnownLocation;
@@ -78,15 +85,15 @@ public final class LastKnownLocationInfoManager extends BaseManager implements L
     }
 
     /**
-     * Reads a single provider in isolation. A provider that the platform refuses or
-     * that does not exist on this device must not stop the other provider from being
-     * read.
+     * Reads a single provider in isolation. A provider the platform refuses, or that
+     * does not exist on this device, must not stop the other one from being read.
      */
     @SuppressLint("MissingPermission")
-    private Location lastKnownLocation(String provider) {
+    private Location lastKnownLocation(android.location.LocationManager locManager, String provider) {
         try {
             return locManager.getLastKnownLocation(provider);
         } catch (SecurityException exception) {
+            // Where a coarse-only client meets GPS_PROVIDER before API 31.
             LogUtil.warning(TAG, "No permission to read the last known location from " + provider + ".");
         } catch (IllegalArgumentException exception) {
             LogUtil.warning(TAG, "Location provider " + provider + " does not exist on this device.");
@@ -192,15 +199,8 @@ public final class LastKnownLocationInfoManager extends BaseManager implements L
     }
 
     /** True when either approximate or precise location has been granted. */
-    private boolean isLocationPermissionGranted() {
-        return getContext() != null
-               && (getContext().checkCallingOrSelfPermission(ACCESS_COARSE_LOCATION) == PERMISSION_GRANTED
-                   || isFineLocationPermissionGranted());
-    }
-
-    /** True only for precise location, which is what GPS_PROVIDER requires. */
-    private boolean isFineLocationPermissionGranted() {
-        return getContext() != null
-               && getContext().checkCallingOrSelfPermission(ACCESS_FINE_LOCATION) == PERMISSION_GRANTED;
+    private boolean isLocationPermissionGranted(Context context) {
+        return context.checkCallingOrSelfPermission(ACCESS_COARSE_LOCATION) == PERMISSION_GRANTED
+               || context.checkCallingOrSelfPermission(ACCESS_FINE_LOCATION) == PERMISSION_GRANTED;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/sdk/deviceData/managers/LastKnownLocationInfoManagerTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/sdk/deviceData/managers/LastKnownLocationInfoManagerTest.java
@@ -16,13 +16,22 @@
 
 package org.prebid.mobile.rendering.sdk.deviceData.managers;
 
+import static android.Manifest.permission.ACCESS_COARSE_LOCATION;
+import static android.Manifest.permission.ACCESS_FINE_LOCATION;
+import static android.content.pm.PackageManager.PERMISSION_DENIED;
+import static android.content.pm.PackageManager.PERMISSION_GRANTED;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import android.content.Context;
 import android.location.Location;
+import android.location.LocationManager;
 
 import org.junit.Before;
 import org.junit.Test;
@@ -82,5 +91,58 @@ public class LastKnownLocationInfoManagerTest {
         when(location.getAccuracy()).thenReturn((float) 0);
         when(currentLocation.getAccuracy()).thenReturn((float) 0);
         assertTrue(locationImpl.isBetterLocation(location, currentLocation));
+    }
+
+    @Test
+    public void whenOnlyCoarseGranted_readsNetworkProviderAndNeverAsksGps() {
+        Context context = mock(Context.class);
+        LocationManager locationManager = mock(LocationManager.class);
+        Location networkLocation = mock(Location.class);
+
+        when(context.checkCallingOrSelfPermission(ACCESS_COARSE_LOCATION)).thenReturn(PERMISSION_GRANTED);
+        when(context.checkCallingOrSelfPermission(ACCESS_FINE_LOCATION)).thenReturn(PERMISSION_DENIED);
+        when(context.getSystemService(Context.LOCATION_SERVICE)).thenReturn(locationManager);
+        when(locationManager.getLastKnownLocation(LocationManager.NETWORK_PROVIDER)).thenReturn(networkLocation);
+
+        LastKnownLocationInfoManager manager = new LastKnownLocationInfoManager(context);
+
+        assertTrue(manager.isLocationAvailable());
+        // GPS_PROVIDER needs ACCESS_FINE_LOCATION; asking for it with approximate
+        // location only is what raises SecurityException on Android 12+.
+        verify(locationManager, never()).getLastKnownLocation(LocationManager.GPS_PROVIDER);
+    }
+
+    @Test
+    public void whenGpsProviderIsRefused_networkProviderIsStillRead() {
+        Context context = mock(Context.class);
+        LocationManager locationManager = mock(LocationManager.class);
+        Location networkLocation = mock(Location.class);
+
+        when(context.checkCallingOrSelfPermission(ACCESS_COARSE_LOCATION)).thenReturn(PERMISSION_GRANTED);
+        when(context.checkCallingOrSelfPermission(ACCESS_FINE_LOCATION)).thenReturn(PERMISSION_GRANTED);
+        when(context.getSystemService(Context.LOCATION_SERVICE)).thenReturn(locationManager);
+        when(locationManager.getLastKnownLocation(LocationManager.GPS_PROVIDER))
+                .thenThrow(new SecurityException("gps refused"));
+        when(locationManager.getLastKnownLocation(LocationManager.NETWORK_PROVIDER)).thenReturn(networkLocation);
+        when(networkLocation.getLatitude()).thenReturn(51.5);
+
+        LastKnownLocationInfoManager manager = new LastKnownLocationInfoManager(context);
+
+        assertTrue(manager.isLocationAvailable());
+        assertEquals(51.5, manager.getLatitude(), 0.0001);
+    }
+
+    @Test
+    public void whenNoLocationPermissionGranted_noProviderIsRead() {
+        Context context = mock(Context.class);
+        LocationManager locationManager = mock(LocationManager.class);
+
+        when(context.checkCallingOrSelfPermission(anyString())).thenReturn(PERMISSION_DENIED);
+        when(context.getSystemService(Context.LOCATION_SERVICE)).thenReturn(locationManager);
+
+        LastKnownLocationInfoManager manager = new LastKnownLocationInfoManager(context);
+
+        assertFalse(manager.isLocationAvailable());
+        verify(locationManager, never()).getLastKnownLocation(anyString());
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/sdk/deviceData/managers/LastKnownLocationInfoManagerTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/sdk/deviceData/managers/LastKnownLocationInfoManagerTest.java
@@ -45,6 +45,8 @@ public class LastKnownLocationInfoManagerTest {
 
     private LastKnownLocationInfoManager locationImpl;
     private Context context;
+    /** Held for the lifetime of a test; the manager only weakly references it. */
+    private Context permissionContext;
 
     private final int TWO_MINUTES = 1000 * 60 * 2;
 
@@ -94,55 +96,95 @@ public class LastKnownLocationInfoManagerTest {
     }
 
     @Test
-    public void whenOnlyCoarseGranted_readsNetworkProviderAndNeverAsksGps() {
-        Context context = mock(Context.class);
+    public void whenOnlyCoarseGranted_bothProvidersAreStillAsked() {
         LocationManager locationManager = mock(LocationManager.class);
         Location networkLocation = mock(Location.class);
-
-        when(context.checkCallingOrSelfPermission(ACCESS_COARSE_LOCATION)).thenReturn(PERMISSION_GRANTED);
-        when(context.checkCallingOrSelfPermission(ACCESS_FINE_LOCATION)).thenReturn(PERMISSION_DENIED);
-        when(context.getSystemService(Context.LOCATION_SERVICE)).thenReturn(locationManager);
         when(locationManager.getLastKnownLocation(LocationManager.NETWORK_PROVIDER)).thenReturn(networkLocation);
 
-        LastKnownLocationInfoManager manager = new LastKnownLocationInfoManager(context);
+        LastKnownLocationInfoManager manager =
+                managerWith(locationManager, PERMISSION_GRANTED, PERMISSION_DENIED);
 
         assertTrue(manager.isLocationAvailable());
-        // GPS_PROVIDER needs ACCESS_FINE_LOCATION; asking for it with approximate
-        // location only is what raises SecurityException on Android 12+.
-        verify(locationManager, never()).getLastKnownLocation(LocationManager.GPS_PROVIDER);
+        // From API 31 a coarse-only client still receives a fix from GPS_PROVIDER,
+        // coarsened by LocationFudger, so the provider must not be skipped on the
+        // strength of the permission alone.
+        verify(locationManager).getLastKnownLocation(LocationManager.GPS_PROVIDER);
+        verify(locationManager).getLastKnownLocation(LocationManager.NETWORK_PROVIDER);
     }
 
     @Test
-    public void whenGpsProviderIsRefused_networkProviderIsStillRead() {
-        Context context = mock(Context.class);
+    public void whenCoarseOnlyAndGpsIsRefused_networkProviderIsStillRead() {
+        // The pre-API-31 case, where LocationManagerService rejected GPS_PROVIDER for a
+        // coarse-only client. The refusal must not discard the network fix, which is
+        // the defect this class had.
         LocationManager locationManager = mock(LocationManager.class);
         Location networkLocation = mock(Location.class);
-
-        when(context.checkCallingOrSelfPermission(ACCESS_COARSE_LOCATION)).thenReturn(PERMISSION_GRANTED);
-        when(context.checkCallingOrSelfPermission(ACCESS_FINE_LOCATION)).thenReturn(PERMISSION_GRANTED);
-        when(context.getSystemService(Context.LOCATION_SERVICE)).thenReturn(locationManager);
         when(locationManager.getLastKnownLocation(LocationManager.GPS_PROVIDER))
-                .thenThrow(new SecurityException("gps refused"));
+                .thenThrow(new SecurityException("coarse permission is insufficient for GPS_PROVIDER"));
         when(locationManager.getLastKnownLocation(LocationManager.NETWORK_PROVIDER)).thenReturn(networkLocation);
         when(networkLocation.getLatitude()).thenReturn(51.5);
 
-        LastKnownLocationInfoManager manager = new LastKnownLocationInfoManager(context);
+        LastKnownLocationInfoManager manager =
+                managerWith(locationManager, PERMISSION_GRANTED, PERMISSION_DENIED);
 
         assertTrue(manager.isLocationAvailable());
         assertEquals(51.5, manager.getLatitude(), 0.0001);
     }
 
     @Test
+    public void whenAProviderIsAbsentFromTheDevice_theOtherIsStillRead() {
+        LocationManager locationManager = mock(LocationManager.class);
+        Location networkLocation = mock(Location.class);
+        when(locationManager.getLastKnownLocation(LocationManager.GPS_PROVIDER))
+                .thenThrow(new IllegalArgumentException("no GPS_PROVIDER on this device"));
+        when(locationManager.getLastKnownLocation(LocationManager.NETWORK_PROVIDER)).thenReturn(networkLocation);
+
+        LastKnownLocationInfoManager manager =
+                managerWith(locationManager, PERMISSION_GRANTED, PERMISSION_GRANTED);
+
+        assertTrue(manager.isLocationAvailable());
+    }
+
+    @Test
     public void whenNoLocationPermissionGranted_noProviderIsRead() {
-        Context context = mock(Context.class);
         LocationManager locationManager = mock(LocationManager.class);
 
-        when(context.checkCallingOrSelfPermission(anyString())).thenReturn(PERMISSION_DENIED);
-        when(context.getSystemService(Context.LOCATION_SERVICE)).thenReturn(locationManager);
-
-        LastKnownLocationInfoManager manager = new LastKnownLocationInfoManager(context);
+        LastKnownLocationInfoManager manager =
+                managerWith(locationManager, PERMISSION_DENIED, PERMISSION_DENIED);
 
         assertFalse(manager.isLocationAvailable());
         verify(locationManager, never()).getLastKnownLocation(anyString());
+    }
+
+    @Test
+    public void whenPermissionIsRevoked_theCachedFixIsCleared() {
+        LocationManager locationManager = mock(LocationManager.class);
+        Location networkLocation = mock(Location.class);
+        when(locationManager.getLastKnownLocation(LocationManager.NETWORK_PROVIDER)).thenReturn(networkLocation);
+
+        LastKnownLocationInfoManager manager =
+                managerWith(locationManager, PERMISSION_GRANTED, PERMISSION_DENIED);
+        assertTrue(manager.isLocationAvailable());
+
+        when(permissionContext.checkCallingOrSelfPermission(ACCESS_COARSE_LOCATION)).thenReturn(PERMISSION_DENIED);
+        manager.resetLocation();
+
+        assertFalse(manager.isLocationAvailable());
+    }
+
+    /**
+     * Builds a manager over a mocked context with the given grants. The context is held
+     * in a field because the manager keeps only a WeakReference to it.
+     */
+    private LastKnownLocationInfoManager managerWith(
+            LocationManager locationManager,
+            int coarseGrant,
+            int fineGrant
+    ) {
+        permissionContext = mock(Context.class);
+        when(permissionContext.getSystemService(Context.LOCATION_SERVICE)).thenReturn(locationManager);
+        when(permissionContext.checkCallingOrSelfPermission(ACCESS_COARSE_LOCATION)).thenReturn(coarseGrant);
+        when(permissionContext.checkCallingOrSelfPermission(ACCESS_FINE_LOCATION)).thenReturn(fineGrant);
+        return new LastKnownLocationInfoManager(permissionContext);
     }
 }


### PR DESCRIPTION
Change Log with reasoning:

- LastKnownLocationInfoManager gated both providers behind a single check that passed when either ACCESS_COARSE_LOCATION or ACCESS_FINE_LOCATION was granted, then read GPS_PROVIDER and NETWORK_PROVIDER inside one try block.

- GPS_PROVIDER requires precise location. Since Android 12 a user can grant approximate location on its own, and that is the common case -- the runtime dialog offers it as a first-class choice. In that state the GPS read throws SecurityException, which unwinds to the shared catch before NETWORK_PROVIDER is ever reached, so the SDK ends up with no location at all rather than the coarse fix the user did consent to. The only trace is a log line blaming an "android firmware bug", which sends anyone debugging it in the wrong direction.
 
- Each provider is now asked for separately and only when the permission it actually needs is held: GPS_PROVIDER for precise, NETWORK_PROVIDER for either grant. The read itself is isolated per provider, so a refusal or a provider missing on the device no longer prevents the other from being consulted -- IllegalArgumentException is handled for that second case, which the previous code did not cover at all. The selection logic that prefers GPS and falls back to the network fix via isBetterLocation is unchanged.
 
- Covers the new behaviour in LastKnownLocationInfoManagerTest: coarse-only never asks for GPS, a refused GPS read still yields the network location, and no grant reads no provider.
 
- Partially addresses #956 (location permissions). The deprecated display metrics and network connection APIs named in that issue are handled separately.