### PR TITLE
Bound click URL resolution and keep the click on network failure

### DIFF
--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/mraid/methods/network/UrlResolutionTask.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/mraid/methods/network/UrlResolutionTask.java
@@ -22,6 +22,7 @@ import androidx.annotation.Nullable;
 import androidx.annotation.VisibleForTesting;
 import org.prebid.mobile.LogUtil;
 import org.prebid.mobile.PrebidMobile;
+import org.prebid.mobile.rendering.networking.BaseNetworkTask;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -65,9 +66,17 @@ public class UrlResolutionTask extends AsyncTask<String, Void, String> {
             }
         }
         catch (IOException e) {
-            return null;
+            // A slow or unreachable host in the middle of the redirect chain must not
+            // swallow the click. previousUrl is a location we already decided to follow
+            // -- either the original click-through or a fully resolved hop -- so handing
+            // it back lets the browser finish the chain instead of the tap doing nothing.
+            LogUtil.debug(TAG, "Url resolution stopped at " + previousUrl + ": " + e.getMessage());
+            return previousUrl;
         }
         catch (URISyntaxException e) {
+            // Deliberately not falling back here: resolveRedirectLocation throws this
+            // when the chain is malformed, and it must stay cancelled rather than open
+            // an intermediary URL.
             return null;
         }
         catch (NullPointerException e) {
@@ -86,6 +95,13 @@ public class UrlResolutionTask extends AsyncTask<String, Void, String> {
         try {
             httpUrlConnection = (HttpURLConnection) url.openConnection();
             httpUrlConnection.setInstanceFollowRedirects(false);
+            // HttpURLConnection defaults to no timeout at all, so a hanging redirect
+            // host blocks this task indefinitely and the click never opens anything.
+            // Bound it with the same values BaseNetworkTask already uses.
+            httpUrlConnection.setConnectTimeout(PrebidMobile.getTimeoutMillis());
+            httpUrlConnection.setReadTimeout(PrebidMobile.getTimeoutModified()
+                    ? PrebidMobile.getTimeoutMillis()
+                    : BaseNetworkTask.SOCKET_TIMEOUT);
 
             return resolveRedirectLocation(urlString, httpUrlConnection);
         }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/mraid/methods/network/UrlResolutionTask.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/mraid/methods/network/UrlResolutionTask.java
@@ -26,12 +26,15 @@ import org.prebid.mobile.rendering.networking.BaseNetworkTask;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.net.ConnectException;
 import java.net.HttpURLConnection;
-import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.net.UnknownHostException;
 import java.util.concurrent.TimeUnit;
+
+import javax.net.ssl.SSLHandshakeException;
 
 @VisibleForTesting
 public class UrlResolutionTask extends AsyncTask<String, Void, String> {
@@ -77,17 +80,27 @@ public class UrlResolutionTask extends AsyncTask<String, Void, String> {
                 redirectCount++;
             }
         }
-        catch (SocketTimeoutException e) {
-            // The reported case: the host accepted the socket and then stalled. The URL
-            // we were about to resolve is still worth opening, and the browser can
-            // finish the chain itself.
-            LogUtil.debug(TAG, "Url resolution timed out at " + previousUrl);
+        catch (UnknownHostException | ConnectException | SSLHandshakeException e) {
+            // The destination is known to be unreachable: DNS did not resolve, the
+            // connection was refused, or TLS could not be established. Opening the
+            // browser there would fail too, and it would record a click that never
+            // landed, so this stays cancelled.
+            LogUtil.debug(TAG, "Url resolution failed for " + previousUrl + ": " + e.getMessage());
+            return null;
+        }
+        catch (IOException e) {
+            // Everything else, including a stalled host and an abrupt disconnect. The
+            // JDK does not classify these consistently -- whether a reset surfaces as
+            // SocketException or as SocketTimeoutException depends on OS-level timing
+            // of the RST against the read -- so reachability must not be inferred from
+            // the exception type here. The URL in hand is one we had already decided to
+            // follow, so hand it to the browser and let it finish the chain.
+            LogUtil.debug(TAG, "Url resolution stopped at " + previousUrl + ": " + e.getMessage());
             return previousUrl;
         }
-        catch (IOException | URISyntaxException | NullPointerException e) {
-            // Hard failures -- unknown host, TLS, connection reset -- and malformed
-            // redirects stay cancelled. The destination is known to be unreachable or
-            // unsafe to open, so onFailure remains the correct outcome.
+        catch (URISyntaxException | NullPointerException e) {
+            // A malformed redirect target stays cancelled rather than opening an
+            // intermediary URL, as resolveRedirectLocation intends.
             return null;
         }
 

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/mraid/methods/network/UrlResolutionTask.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/mraid/methods/network/UrlResolutionTask.java
@@ -27,9 +27,11 @@ import org.prebid.mobile.rendering.networking.BaseNetworkTask;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.HttpURLConnection;
+import java.net.SocketTimeoutException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
+import java.util.concurrent.TimeUnit;
 
 @VisibleForTesting
 public class UrlResolutionTask extends AsyncTask<String, Void, String> {
@@ -49,6 +51,10 @@ public class UrlResolutionTask extends AsyncTask<String, Void, String> {
         }
 
         String previousUrl = null;
+        // One budget for the whole chain rather than per hop, so a slow host cannot
+        // multiply the delay by MAX_REDIRECTS before the browser is handed anything.
+        final long deadlineNanos = System.nanoTime()
+                + TimeUnit.MILLISECONDS.toNanos(resolutionBudgetMillis());
         try {
             String locationUrl = urls[0];
 
@@ -60,48 +66,60 @@ public class UrlResolutionTask extends AsyncTask<String, Void, String> {
                     return locationUrl;
                 }
 
+                long remainingMillis = TimeUnit.NANOSECONDS.toMillis(deadlineNanos - System.nanoTime());
+                if (remainingMillis <= 0) {
+                    LogUtil.debug(TAG, "Url resolution budget spent; opening " + locationUrl);
+                    return locationUrl;
+                }
+
                 previousUrl = locationUrl;
-                locationUrl = getRedirectLocation(locationUrl);
+                locationUrl = getRedirectLocation(locationUrl, (int) remainingMillis);
                 redirectCount++;
             }
         }
-        catch (IOException e) {
-            // A slow or unreachable host in the middle of the redirect chain must not
-            // swallow the click. previousUrl is a location we already decided to follow
-            // -- either the original click-through or a fully resolved hop -- so handing
-            // it back lets the browser finish the chain instead of the tap doing nothing.
-            LogUtil.debug(TAG, "Url resolution stopped at " + previousUrl + ": " + e.getMessage());
+        catch (SocketTimeoutException e) {
+            // The reported case: the host accepted the socket and then stalled. The URL
+            // we were about to resolve is still worth opening, and the browser can
+            // finish the chain itself.
+            LogUtil.debug(TAG, "Url resolution timed out at " + previousUrl);
             return previousUrl;
         }
-        catch (URISyntaxException e) {
-            // Deliberately not falling back here: resolveRedirectLocation throws this
-            // when the chain is malformed, and it must stay cancelled rather than open
-            // an intermediary URL.
-            return null;
-        }
-        catch (NullPointerException e) {
+        catch (IOException | URISyntaxException | NullPointerException e) {
+            // Hard failures -- unknown host, TLS, connection reset -- and malformed
+            // redirects stay cancelled. The destination is known to be unreachable or
+            // unsafe to open, so onFailure remains the correct outcome.
             return null;
         }
 
         return previousUrl;
     }
 
+    /** Read timeout for a single hop, mirroring {@link BaseNetworkTask}. */
+    private static int readTimeoutMillis() {
+        return PrebidMobile.getTimeoutModified()
+                ? PrebidMobile.getTimeoutMillis()
+                : BaseNetworkTask.SOCKET_TIMEOUT;
+    }
+
+    /** Total time allowed to resolve the chain: one connect plus one read. */
+    private static int resolutionBudgetMillis() {
+        return PrebidMobile.getTimeoutMillis() + readTimeoutMillis();
+    }
+
     @Nullable
-    private String getRedirectLocation(@NonNull final String urlString) throws IOException,
-                                                                               URISyntaxException {
+    private String getRedirectLocation(@NonNull final String urlString, final int budgetMillis)
+    throws IOException, URISyntaxException {
         final URL url = new URL(urlString);
 
         HttpURLConnection httpUrlConnection = null;
         try {
             httpUrlConnection = (HttpURLConnection) url.openConnection();
             httpUrlConnection.setInstanceFollowRedirects(false);
-            // HttpURLConnection defaults to no timeout at all, so a hanging redirect
-            // host blocks this task indefinitely and the click never opens anything.
-            // Bound it with the same values BaseNetworkTask already uses.
-            httpUrlConnection.setConnectTimeout(PrebidMobile.getTimeoutMillis());
-            httpUrlConnection.setReadTimeout(PrebidMobile.getTimeoutModified()
-                    ? PrebidMobile.getTimeoutMillis()
-                    : BaseNetworkTask.SOCKET_TIMEOUT);
+            // HttpURLConnection defaults to no timeout at all. Capping each hop at
+            // what is left of the budget also bounds the stream close below, which
+            // would otherwise wait a further read timeout after a stalled hop.
+            httpUrlConnection.setConnectTimeout(Math.min(PrebidMobile.getTimeoutMillis(), budgetMillis));
+            httpUrlConnection.setReadTimeout(Math.min(readTimeoutMillis(), budgetMillis));
 
             return resolveRedirectLocation(urlString, httpUrlConnection);
         }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/mraid/methods/network/UrlResolutionTask.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/mraid/methods/network/UrlResolutionTask.java
@@ -25,16 +25,14 @@ import org.prebid.mobile.PrebidMobile;
 import org.prebid.mobile.rendering.networking.BaseNetworkTask;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.net.ConnectException;
 import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
 import java.net.URI;
 import java.net.URISyntaxException;
 import java.net.URL;
 import java.net.UnknownHostException;
 import java.util.concurrent.TimeUnit;
-
-import javax.net.ssl.SSLHandshakeException;
 
 @VisibleForTesting
 public class UrlResolutionTask extends AsyncTask<String, Void, String> {
@@ -53,11 +51,22 @@ public class UrlResolutionTask extends AsyncTask<String, Void, String> {
             return null;
         }
 
+        // Read the timeout configuration once. PrebidMobile's statics are settable from
+        // any thread and this runs on THREAD_POOL_EXECUTOR, so re-reading them per hop
+        // against a deadline frozen here would let the two disagree mid-chain. Clamping
+        // at zero also keeps a negative value away from setConnectTimeout, which would
+        // throw.
+        final int configuredConnectMillis = Math.max(0, PrebidMobile.getTimeoutMillis());
+        final int configuredReadMillis = Math.max(0, BaseNetworkTask.readTimeoutMillis());
+        // Summed as a long: both are ints, and their sum overflows for a very large
+        // configured timeout, which would put the deadline in the past and stop the
+        // chain being resolved at all.
+        final long budgetMillis = Math.max(1L, (long) configuredConnectMillis + configuredReadMillis);
+
         String previousUrl = null;
         // One budget for the whole chain rather than per hop, so a slow host cannot
         // multiply the delay by MAX_REDIRECTS before the browser is handed anything.
-        final long deadlineNanos = System.nanoTime()
-                + TimeUnit.MILLISECONDS.toNanos(resolutionBudgetMillis());
+        final long deadlineNanos = System.nanoTime() + TimeUnit.MILLISECONDS.toNanos(budgetMillis);
         try {
             String locationUrl = urls[0];
 
@@ -76,25 +85,43 @@ public class UrlResolutionTask extends AsyncTask<String, Void, String> {
                 }
 
                 previousUrl = locationUrl;
-                locationUrl = getRedirectLocation(locationUrl, (int) remainingMillis);
+                locationUrl = getRedirectLocation(
+                        locationUrl, remainingMillis, configuredConnectMillis, configuredReadMillis);
                 redirectCount++;
             }
         }
-        catch (UnknownHostException | ConnectException | SSLHandshakeException e) {
-            // The destination is known to be unreachable: DNS did not resolve, the
-            // connection was refused, or TLS could not be established. Opening the
-            // browser there would fail too, and it would record a click that never
-            // landed, so this stays cancelled.
-            LogUtil.debug(TAG, "Url resolution failed for " + previousUrl + ": " + e.getMessage());
+        catch (MalformedURLException e) {
+            // A target java.net.URI accepts but java.net.URL cannot parse -- a
+            // non-numeric port, say. URI treats that authority as registry-based and
+            // resolves it happily, so the failure only surfaces on the next hop, and
+            // as an IOException rather than a URISyntaxException. It is a malformed
+            // target either way and must not reach an Intent.
+            LogUtil.error(TAG, "Malformed redirect target: " + previousUrl);
+            return null;
+        }
+        catch (UnknownHostException | ConnectException e) {
+            // DNS did not resolve, or the connection was refused. Neither depends on
+            // which HTTP stack asks, so the browser would fail here too; cancelling
+            // avoids recording a click that cannot land. This applies at any point in
+            // the chain: a hop confirmed unreachable is not worth handing over, even
+            // when an earlier hop succeeded.
+            //
+            // Deliberately not SSLHandshakeException. This probes with
+            // HttpURLConnection, which does not chase Authority Information Access for
+            // a server missing an intermediate certificate, while Chrome and WebView
+            // do -- so a handshake failure here does not predict one in the browser,
+            // and cancelling on it would drop clicks to pages a device renders fine.
+            LogUtil.debug(TAG, "Destination unreachable at " + previousUrl + ": " + e.getMessage());
             return null;
         }
         catch (IOException e) {
-            // Everything else, including a stalled host and an abrupt disconnect. The
-            // JDK does not classify these consistently -- whether a reset surfaces as
-            // SocketException or as SocketTimeoutException depends on OS-level timing
-            // of the RST against the read -- so reachability must not be inferred from
-            // the exception type here. The URL in hand is one we had already decided to
-            // follow, so hand it to the browser and let it finish the chain.
+            // Everything else: a stalled host, an abrupt disconnect, a TLS failure this
+            // stack is stricter about than a browser. The JDK does not classify these
+            // consistently -- whether a reset surfaces as SocketException or as
+            // SocketTimeoutException depends on OS-level timing of the RST against the
+            // read -- so reachability must not be inferred from the exception type. The
+            // URL in hand is one we had already decided to follow, so hand it to the
+            // browser and let it finish the chain.
             LogUtil.debug(TAG, "Url resolution stopped at " + previousUrl + ": " + e.getMessage());
             return previousUrl;
         }
@@ -107,46 +134,47 @@ public class UrlResolutionTask extends AsyncTask<String, Void, String> {
         return previousUrl;
     }
 
-    /** Read timeout for a single hop, mirroring {@link BaseNetworkTask}. */
-    private static int readTimeoutMillis() {
-        return PrebidMobile.getTimeoutModified()
-                ? PrebidMobile.getTimeoutMillis()
-                : BaseNetworkTask.SOCKET_TIMEOUT;
-    }
-
-    /** Total time allowed to resolve the chain: one connect plus one read. */
-    private static int resolutionBudgetMillis() {
-        return PrebidMobile.getTimeoutMillis() + readTimeoutMillis();
+    /**
+     * A timeout bounded by what is left of the chain budget. A configured value of
+     * zero means "unset" here rather than URLConnection's "wait forever", which is the
+     * hang this class exists to prevent.
+     */
+    private static int boundedTimeout(final int configuredMillis, final long capMillis) {
+        final long cap = Math.min(Integer.MAX_VALUE, Math.max(1L, capMillis));
+        return (int) (configuredMillis > 0 ? Math.min(configuredMillis, cap) : cap);
     }
 
     @Nullable
-    private String getRedirectLocation(@NonNull final String urlString, final int budgetMillis)
-    throws IOException, URISyntaxException {
+    private String getRedirectLocation(
+            @NonNull final String urlString,
+            final long remainingMillis,
+            final int configuredConnectMillis,
+            final int configuredReadMillis
+    ) throws IOException, URISyntaxException {
         final URL url = new URL(urlString);
+
+        // Split what is left of the chain budget across this hop's two blocking phases.
+        // Capping each at the full remainder independently would let one hop run for
+        // roughly twice it, which is what the whole-chain bound is meant to stop.
+        final int connectMillis = boundedTimeout(configuredConnectMillis, remainingMillis / 2);
+        final int readMillis = boundedTimeout(configuredReadMillis, remainingMillis - connectMillis);
 
         HttpURLConnection httpUrlConnection = null;
         try {
             httpUrlConnection = (HttpURLConnection) url.openConnection();
             httpUrlConnection.setInstanceFollowRedirects(false);
-            // HttpURLConnection defaults to no timeout at all. Capping each hop at
-            // what is left of the budget also bounds the stream close below, which
-            // would otherwise wait a further read timeout after a stalled hop.
-            httpUrlConnection.setConnectTimeout(Math.min(PrebidMobile.getTimeoutMillis(), budgetMillis));
-            httpUrlConnection.setReadTimeout(Math.min(readTimeoutMillis(), budgetMillis));
+            // HttpURLConnection defaults to no timeout at all.
+            httpUrlConnection.setConnectTimeout(connectMillis);
+            httpUrlConnection.setReadTimeout(readMillis);
 
             return resolveRedirectLocation(urlString, httpUrlConnection);
         }
         finally {
             if (httpUrlConnection != null) {
-                try {
-                    final InputStream is = httpUrlConnection.getInputStream();
-                    if (is != null) {
-                        is.close();
-                    }
-                }
-                catch (IOException e) {
-                    LogUtil.error(TAG, "IOException when closing httpUrlConnection. Ignoring.");
-                }
+                // Only the status line and the Location header are read and the
+                // connection is discarded immediately, so there is no body worth
+                // draining for reuse -- and draining it would block for a further read
+                // timeout after a hop that has already stalled.
                 httpUrlConnection.disconnect();
             }
         }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/networking/BaseNetworkTask.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/networking/BaseNetworkTask.java
@@ -44,6 +44,16 @@ public class BaseNetworkTask
 
     public static final int MAX_REDIRECTS_COUNT = 5;
 
+    /**
+     * Read timeout for a single request: the publisher's configured value once one has
+     * been set, otherwise {@link #SOCKET_TIMEOUT}. Exposed so callers outside this
+     * class apply the same policy instead of repeating the condition, which would then
+     * be free to drift from it.
+     */
+    public static int readTimeoutMillis() {
+        return PrebidMobile.getTimeoutModified() ? PrebidMobile.getTimeoutMillis() : SOCKET_TIMEOUT;
+    }
+
     public static final String REDIRECT_TASK = "RedirectTask";
     public static final String DOWNLOAD_TASK = "DownloadTask";
     public static final String STATUS_TASK = "StatusTask";
@@ -270,8 +280,7 @@ public class BaseNetworkTask
 
         connection.setConnectTimeout(PrebidMobile.getTimeoutMillis());
         if (!(this instanceof FileDownloadTask)) {
-            int timeout = PrebidMobile.getTimeoutModified() ? PrebidMobile.getTimeoutMillis() : SOCKET_TIMEOUT;
-            connection.setReadTimeout(timeout);
+            connection.setReadTimeout(readTimeoutMillis());
         }
 
         if ("POST".equals(param.requestType)) {

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/mraid/methods/network/UrlResolutionTaskTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/mraid/methods/network/UrlResolutionTaskTest.java
@@ -1,0 +1,104 @@
+/*
+ *    Copyright 2018-2021 Prebid.org, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.prebid.mobile.rendering.mraid.methods.network;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.robolectric.annotation.LooperMode.Mode.LEGACY;
+
+import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.SocketPolicy;
+
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.prebid.mobile.PrebidMobile;
+import org.robolectric.RobolectricTestRunner;
+import org.robolectric.annotation.Config;
+import org.robolectric.annotation.LooperMode;
+
+@RunWith(RobolectricTestRunner.class)
+@Config(sdk = 25)
+@LooperMode(LEGACY)
+public class UrlResolutionTaskTest {
+
+    private MockWebServer server;
+    private UrlResolutionTask task;
+
+    private final UrlResolutionTask.UrlResolutionListener noOpListener =
+            new UrlResolutionTask.UrlResolutionListener() {
+                @Override
+                public void onSuccess(@NonNull String resolvedUrl) {
+                }
+
+                @Override
+                public void onFailure(@NonNull String message, @Nullable Throwable throwable) {
+                }
+            };
+
+    @Before
+    public void setUp() throws Exception {
+        server = new MockWebServer();
+        server.start();
+        task = new UrlResolutionTask(noOpListener);
+        // Keep the stalled-host case fast; this also exercises the configured
+        // timeout rather than the SOCKET_TIMEOUT default.
+        PrebidMobile.setTimeoutMillis(300);
+    }
+
+    @After
+    public void tearDown() throws Exception {
+        server.shutdown();
+    }
+
+    @Test
+    public void whenRedirectChainCompletes_resolvesToFinalUrl() {
+        String finalUrl = server.url("/final").toString();
+        server.enqueue(new MockResponse().setResponseCode(302).setHeader("location", finalUrl));
+        server.enqueue(new MockResponse().setResponseCode(200));
+
+        assertEquals(finalUrl, task.doInBackground(server.url("/click").toString()));
+    }
+
+    @Test
+    public void whenRedirectHostStalls_returnsLastKnownUrlInsteadOfDroppingClick() {
+        // A host that accepts the connection and then never answers is exactly the
+        // slow-landing-page case: without a read timeout this blocks forever, and
+        // without the fallback the tap resolves to null and nothing opens.
+        server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.NO_RESPONSE));
+        String clickUrl = server.url("/click").toString();
+
+        assertEquals(clickUrl, task.doInBackground(clickUrl));
+    }
+
+    @Test
+    public void whenUrlIsNotHttp_returnsDeepLinkUnchanged() {
+        String deepLink = "myapp://product/1";
+
+        assertEquals(deepLink, task.doInBackground(deepLink));
+    }
+
+    @Test
+    public void whenNoUrlSupplied_returnsNull() {
+        assertNull(task.doInBackground());
+    }
+}

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/mraid/methods/network/UrlResolutionTaskTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/mraid/methods/network/UrlResolutionTaskTest.java
@@ -32,6 +32,7 @@ import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.prebid.mobile.PrebidMobile;
+import org.prebid.mobile.test.utils.WhiteBox;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 import org.robolectric.annotation.LooperMode;
@@ -60,7 +61,7 @@ public class UrlResolutionTaskTest {
         server = new MockWebServer();
         server.start();
         task = new UrlResolutionTask(noOpListener);
-        // Keep the stalled-host case fast; this also exercises the configured
+        // Keep the stalled-host cases fast; this also exercises the configured
         // timeout rather than the SOCKET_TIMEOUT default.
         PrebidMobile.setTimeoutMillis(300);
     }
@@ -68,6 +69,11 @@ public class UrlResolutionTaskTest {
     @After
     public void tearDown() throws Exception {
         server.shutdown();
+        // setTimeoutMillis also flips isTimeoutModified, and Robolectric does not reset
+        // app statics between test classes sharing a sandbox. Left alone, every later
+        // BaseNetworkTask read timeout would become 300ms instead of SOCKET_TIMEOUT.
+        WhiteBox.setStaticVariableTo(PrebidMobile.class, "timeoutMillis", 2_000);
+        WhiteBox.setStaticVariableTo(PrebidMobile.class, "isTimeoutModified", false);
     }
 
     @Test
@@ -88,6 +94,27 @@ public class UrlResolutionTaskTest {
         String clickUrl = server.url("/click").toString();
 
         assertEquals(clickUrl, task.doInBackground(clickUrl));
+    }
+
+    @Test
+    public void whenLaterHopStalls_returnsTheHopAlreadyResolved() {
+        // The more interesting half of the fallback: one redirect succeeded before the
+        // stall, so the URL handed back is a resolved hop rather than the original.
+        String secondHop = server.url("/second").toString();
+        server.enqueue(new MockResponse().setResponseCode(302).setHeader("location", secondHop));
+        server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.NO_RESPONSE));
+
+        assertEquals(secondHop, task.doInBackground(server.url("/click").toString()));
+    }
+
+    @Test
+    public void whenHostFailsHard_staysCancelled() {
+        // Only timeouts fall back. A refused or dropped connection means the
+        // destination is unreachable, so the click stays cancelled and no
+        // click-tracking fires.
+        server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
+
+        assertNull(task.doInBackground(server.url("/click").toString()));
     }
 
     @Test

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/mraid/methods/network/UrlResolutionTaskTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/mraid/methods/network/UrlResolutionTaskTest.java
@@ -37,6 +37,9 @@ import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 import org.robolectric.annotation.LooperMode;
 
+import java.io.IOException;
+import java.net.ServerSocket;
+
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 25)
 @LooperMode(LEGACY)
@@ -108,13 +111,17 @@ public class UrlResolutionTaskTest {
     }
 
     @Test
-    public void whenHostFailsHard_staysCancelled() {
-        // Only timeouts fall back. A refused or dropped connection means the
-        // destination is unreachable, so the click stays cancelled and no
-        // click-tracking fires.
-        server.enqueue(new MockResponse().setSocketPolicy(SocketPolicy.DISCONNECT_AT_START));
+    public void whenDestinationIsUnreachable_staysCancelled() throws IOException {
+        // A closed port refuses the connection, which is a ConnectException on every
+        // platform. Deliberately not an abrupt disconnect from a live server: whether
+        // that surfaces as a reset or as a read timeout depends on OS timing, so it
+        // cannot assert which branch was taken.
+        int closedPort;
+        try (ServerSocket socket = new ServerSocket(0)) {
+            closedPort = socket.getLocalPort();
+        }
 
-        assertNull(task.doInBackground(server.url("/click").toString()));
+        assertNull(task.doInBackground("http://127.0.0.1:" + closedPort + "/click"));
     }
 
     @Test

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/mraid/methods/network/UrlResolutionTaskTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/mraid/methods/network/UrlResolutionTaskTest.java
@@ -116,12 +116,51 @@ public class UrlResolutionTaskTest {
         // platform. Deliberately not an abrupt disconnect from a live server: whether
         // that surfaces as a reset or as a read timeout depends on OS timing, so it
         // cannot assert which branch was taken.
-        int closedPort;
-        try (ServerSocket socket = new ServerSocket(0)) {
-            closedPort = socket.getLocalPort();
-        }
+        assertNull(task.doInBackground("http://127.0.0.1:" + closedPort() + "/click"));
+    }
 
-        assertNull(task.doInBackground("http://127.0.0.1:" + closedPort + "/click"));
+    @Test
+    public void whenALaterHopIsUnreachable_staysCancelled() throws IOException {
+        // Same branch, but after a hop has already resolved. Cancelling is deliberate:
+        // a hop confirmed unreachable is not worth handing to the browser even though
+        // an ambiguous failure at the same point would be.
+        server.enqueue(new MockResponse()
+                .setResponseCode(302)
+                .setHeader("location", "http://127.0.0.1:" + closedPort() + "/landing"));
+
+        assertNull(task.doInBackground(server.url("/click").toString()));
+    }
+
+    @Test
+    public void whenRedirectTargetIsMalformed_staysCancelled() {
+        // java.net.URI accepts a non-numeric port as a registry-based authority and
+        // resolves it, so this only fails on the next hop, in new URL(), as a
+        // MalformedURLException. It must not be handed on as a resolved URL.
+        server.enqueue(new MockResponse()
+                .setResponseCode(302)
+                .setHeader("location", "http://example.com:abc/landing"));
+
+        assertNull(task.doInBackground(server.url("/click").toString()));
+    }
+
+    @Test
+    public void whenConfiguredTimeoutIsVeryLarge_stillResolvesTheChain() {
+        // The budget is one connect plus one read. Summed as int, this value overflows
+        // to a negative budget, putting the deadline in the past so no hop is ever
+        // attempted and the unresolved URL comes straight back.
+        PrebidMobile.setTimeoutMillis(1_073_741_824);
+        String finalUrl = server.url("/final").toString();
+        server.enqueue(new MockResponse().setResponseCode(302).setHeader("location", finalUrl));
+        server.enqueue(new MockResponse().setResponseCode(200));
+
+        assertEquals(finalUrl, task.doInBackground(server.url("/click").toString()));
+    }
+
+    /** A port nothing is listening on, so connecting to it is refused immediately. */
+    private int closedPort() throws IOException {
+        try (ServerSocket socket = new ServerSocket(0)) {
+            return socket.getLocalPort();
+        }
     }
 
     @Test


### PR DESCRIPTION
Change Log with reasoning:

- UrlResolutionTask resolves a click-through by walking the redirect chain itself before handing a final URL to the browser. Two problems make a slow landing page swallow the click entirely.
 
- First, the connection is never bounded. HttpURLConnection defaults to no connect or read timeout at all, so a click-tracking host that accepts the socket and then stalls blocks doInBackground indefinitely. Nothing opens, and nothing reports a failure -- the tap simply does nothing.
 
- Second, an IOException anywhere in the chain discards the work already done: the catch returns null, onPostExecute treats null as a cancellation, and the click is dropped even though a perfectly usable URL was already in hand.
 
- This applies the timeouts BaseNetworkTask already uses for every other network call (PrebidMobile.getTimeoutMillis() for connect, the same value or SOCKET_TIMEOUT for read), and returns the last URL we had decided to follow when the chain fails mid-way. That URL is either the original click-through or a fully resolved hop, so handing it to the browser lets the browser finish the redirect chain instead of the user seeing nothing.
 
- The URISyntaxException path is deliberately left returning null. resolveRedirectLocation raises it when a redirect target is malformed, and the existing comment there is explicit that the request must stay cancelled rather than open an intermediary URL.

- Adds UrlResolutionTaskTest, which had no coverage: a normal redirect chain resolves to the final URL, a host that accepts and never answers now returns the click URL instead of null, deep links pass through untouched, and an empty argument list still returns null.
 
Fixes #952