### PR TITLE
Detect connection type through NetworkCapabilities on API 23+

### DIFF
--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/deviceData/managers/NetworkConnectionInfoManager.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/deviceData/managers/NetworkConnectionInfoManager.java
@@ -21,7 +21,12 @@ import android.annotation.SuppressLint;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.net.ConnectivityManager;
+import android.net.Network;
+import android.net.NetworkCapabilities;
 import android.net.NetworkInfo;
+import android.os.Build;
+
+import androidx.annotation.RequiresApi;
 
 import org.prebid.mobile.rendering.networking.parameters.UserParameters;
 import org.prebid.mobile.rendering.sdk.BaseManager;
@@ -38,26 +43,65 @@ public final class NetworkConnectionInfoManager extends BaseManager implements C
         }
     }
 
-    @SuppressLint("MissingPermission")
     @Override
     public UserParameters.ConnectionType getConnectionType() {
-        NetworkInfo info = null;
-        UserParameters.ConnectionType result = UserParameters.ConnectionType.OFFLINE;
-        if (getContext() != null) {
-            if (connectivityManager != null) {
-                if (getContext().checkCallingOrSelfPermission(Manifest.permission.ACCESS_NETWORK_STATE) == PackageManager.PERMISSION_GRANTED) {
-                    info = connectivityManager.getActiveNetworkInfo();
-                }
-            }
-            if (info != null) {
-                int netType = info.getType();
-                if (info.isConnected()) {
-                    boolean isMobile = netType == ConnectivityManager.TYPE_MOBILE || netType == ConnectivityManager.TYPE_MOBILE_DUN || netType == ConnectivityManager.TYPE_MOBILE_HIPRI || netType == ConnectivityManager.TYPE_MOBILE_MMS || netType == ConnectivityManager.TYPE_MOBILE_SUPL;
-                    result = isMobile ? UserParameters.ConnectionType.CELL
-                             : UserParameters.ConnectionType.WIFI;
-                }
-            }
+        if (getContext() == null || connectivityManager == null) {
+            return UserParameters.ConnectionType.OFFLINE;
         }
-        return result;
+        if (getContext().checkCallingOrSelfPermission(Manifest.permission.ACCESS_NETWORK_STATE)
+                != PackageManager.PERMISSION_GRANTED) {
+            return UserParameters.ConnectionType.OFFLINE;
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
+            return connectionTypeFromCapabilities();
+        }
+        return legacyConnectionType();
+    }
+
+    @RequiresApi(api = Build.VERSION_CODES.M)
+    @SuppressLint("MissingPermission")
+    private UserParameters.ConnectionType connectionTypeFromCapabilities() {
+        Network activeNetwork = connectivityManager.getActiveNetwork();
+        if (activeNetwork == null) {
+            return UserParameters.ConnectionType.OFFLINE;
+        }
+
+        NetworkCapabilities capabilities = connectivityManager.getNetworkCapabilities(activeNetwork);
+        if (capabilities == null
+                || !capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)) {
+            return UserParameters.ConnectionType.OFFLINE;
+        }
+
+        // Mirrors the legacy mapping: cellular transports report CELL, and any other
+        // active transport reports WIFI.
+        if (capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)) {
+            return UserParameters.ConnectionType.CELL;
+        }
+        return UserParameters.ConnectionType.WIFI;
+    }
+
+    /**
+     * NetworkInfo and the ConnectivityManager.TYPE_* constants are deprecated from
+     * API 28/29 onwards, but minSdk is still below the API 23 that
+     * {@link ConnectivityManager#getActiveNetwork()} needs, so this path remains for
+     * older devices.
+     */
+    @SuppressWarnings("deprecation")
+    @SuppressLint("MissingPermission")
+    private UserParameters.ConnectionType legacyConnectionType() {
+        NetworkInfo info = connectivityManager.getActiveNetworkInfo();
+        if (info == null || !info.isConnected()) {
+            return UserParameters.ConnectionType.OFFLINE;
+        }
+
+        int netType = info.getType();
+        boolean isMobile = netType == ConnectivityManager.TYPE_MOBILE
+                || netType == ConnectivityManager.TYPE_MOBILE_DUN
+                || netType == ConnectivityManager.TYPE_MOBILE_HIPRI
+                || netType == ConnectivityManager.TYPE_MOBILE_MMS
+                || netType == ConnectivityManager.TYPE_MOBILE_SUPL;
+
+        return isMobile ? UserParameters.ConnectionType.CELL : UserParameters.ConnectionType.WIFI;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/deviceData/managers/NetworkConnectionInfoManager.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/sdk/deviceData/managers/NetworkConnectionInfoManager.java
@@ -28,10 +28,13 @@ import android.os.Build;
 
 import androidx.annotation.RequiresApi;
 
+import org.prebid.mobile.LogUtil;
 import org.prebid.mobile.rendering.networking.parameters.UserParameters;
 import org.prebid.mobile.rendering.sdk.BaseManager;
 
 public final class NetworkConnectionInfoManager extends BaseManager implements ConnectionInfoManager {
+    private static final String TAG = NetworkConnectionInfoManager.class.getSimpleName();
+
     private ConnectivityManager connectivityManager;
 
     public NetworkConnectionInfoManager(Context context) {
@@ -68,8 +71,15 @@ public final class NetworkConnectionInfoManager extends BaseManager implements C
         }
 
         NetworkCapabilities capabilities = connectivityManager.getNetworkCapabilities(activeNetwork);
-        if (capabilities == null
-                || !capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)) {
+        if (capabilities == null) {
+            // There is an active network but its capabilities could not be read — it
+            // disappeared between the two calls, or the lookup was refused. OFFLINE
+            // here stops the bid request in Requester, so say so rather than failing
+            // silently.
+            LogUtil.warning(TAG, "Active network reports no NetworkCapabilities; treating connection as OFFLINE.");
+            return UserParameters.ConnectionType.OFFLINE;
+        }
+        if (!capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)) {
             return UserParameters.ConnectionType.OFFLINE;
         }
 

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/sdk/deviceData/managers/NetworkConnectionInfoManagerTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/sdk/deviceData/managers/NetworkConnectionInfoManagerTest.java
@@ -24,6 +24,8 @@ import android.Manifest;
 import android.content.Context;
 import android.content.pm.PackageManager;
 import android.net.ConnectivityManager;
+import android.net.Network;
+import android.net.NetworkCapabilities;
 import android.net.NetworkInfo;
 
 import org.junit.Before;
@@ -62,5 +64,56 @@ public class NetworkConnectionInfoManagerTest {
         when(connectivityManager.getActiveNetworkInfo()).thenReturn(mockInfo);
 
         assertEquals(UserParameters.ConnectionType.CELL, networkConnectionManager.getConnectionType());
+    }
+
+    @Test
+    @Config(sdk = 29)
+    public void whenCellularTransportIsActive_reportsCell() {
+        NetworkCapabilities capabilities = grantedNetworkWithCapabilities();
+        when(capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)).thenReturn(true);
+
+        assertEquals(UserParameters.ConnectionType.CELL, networkConnectionManager.getConnectionType());
+    }
+
+    @Test
+    @Config(sdk = 29)
+    public void whenNonCellularTransportIsActive_reportsWifi() {
+        NetworkCapabilities capabilities = grantedNetworkWithCapabilities();
+        when(capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)).thenReturn(true);
+
+        assertEquals(UserParameters.ConnectionType.WIFI, networkConnectionManager.getConnectionType());
+    }
+
+    @Test
+    @Config(sdk = 29)
+    public void whenThereIsNoActiveNetwork_reportsOffline() {
+        when(mockContext.checkCallingOrSelfPermission(Manifest.permission.ACCESS_NETWORK_STATE)).thenReturn(
+                PackageManager.PERMISSION_GRANTED);
+        when(connectivityManager.getActiveNetwork()).thenReturn(null);
+
+        assertEquals(UserParameters.ConnectionType.OFFLINE, networkConnectionManager.getConnectionType());
+    }
+
+    @Test
+    @Config(sdk = 29)
+    public void whenNetworkStatePermissionIsMissing_reportsOffline() {
+        when(mockContext.checkCallingOrSelfPermission(Manifest.permission.ACCESS_NETWORK_STATE)).thenReturn(
+                PackageManager.PERMISSION_DENIED);
+
+        assertEquals(UserParameters.ConnectionType.OFFLINE, networkConnectionManager.getConnectionType());
+    }
+
+    /** An active, internet-capable default network with the permission granted. */
+    private NetworkCapabilities grantedNetworkWithCapabilities() {
+        Network network = mock(Network.class);
+        NetworkCapabilities capabilities = mock(NetworkCapabilities.class);
+
+        when(mockContext.checkCallingOrSelfPermission(Manifest.permission.ACCESS_NETWORK_STATE)).thenReturn(
+                PackageManager.PERMISSION_GRANTED);
+        when(connectivityManager.getActiveNetwork()).thenReturn(network);
+        when(connectivityManager.getNetworkCapabilities(network)).thenReturn(capabilities);
+        when(capabilities.hasCapability(NetworkCapabilities.NET_CAPABILITY_INTERNET)).thenReturn(true);
+
+        return capabilities;
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/sdk/deviceData/managers/NetworkConnectionInfoManagerTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/sdk/deviceData/managers/NetworkConnectionInfoManagerTest.java
@@ -18,6 +18,8 @@ package org.prebid.mobile.rendering.sdk.deviceData.managers;
 
 import static org.junit.Assert.assertEquals;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import android.Manifest;
@@ -78,10 +80,34 @@ public class NetworkConnectionInfoManagerTest {
     @Test
     @Config(sdk = 29)
     public void whenNonCellularTransportIsActive_reportsWifi() {
-        NetworkCapabilities capabilities = grantedNetworkWithCapabilities();
-        when(capabilities.hasTransport(NetworkCapabilities.TRANSPORT_WIFI)).thenReturn(true);
+        // Only TRANSPORT_CELLULAR is consulted; every other active transport falls
+        // through to WIFI, so leaving it unstubbed is the scenario under test.
+        grantedNetworkWithCapabilities();
 
         assertEquals(UserParameters.ConnectionType.WIFI, networkConnectionManager.getConnectionType());
+    }
+
+    @Test
+    @Config(sdk = 29)
+    public void whenCapabilitiesAreUnavailable_reportsOffline() {
+        Network network = mock(Network.class);
+
+        when(mockContext.checkCallingOrSelfPermission(Manifest.permission.ACCESS_NETWORK_STATE)).thenReturn(
+                PackageManager.PERMISSION_GRANTED);
+        when(connectivityManager.getActiveNetwork()).thenReturn(network);
+        when(connectivityManager.getNetworkCapabilities(network)).thenReturn(null);
+
+        assertEquals(UserParameters.ConnectionType.OFFLINE, networkConnectionManager.getConnectionType());
+    }
+
+    @Test
+    @Config(sdk = 23)
+    public void whenSdkIsAtTheCapabilitiesBoundary_usesCapabilitiesNotNetworkInfo() {
+        NetworkCapabilities capabilities = grantedNetworkWithCapabilities();
+        when(capabilities.hasTransport(NetworkCapabilities.TRANSPORT_CELLULAR)).thenReturn(true);
+
+        assertEquals(UserParameters.ConnectionType.CELL, networkConnectionManager.getConnectionType());
+        verify(connectivityManager, never()).getActiveNetworkInfo();
     }
 
     @Test


### PR DESCRIPTION
Change Log with reasoning

- NetworkConnectionInfoManager determined CELL vs WIFI from ConnectivityManager.getActiveNetworkInfo() and the ConnectivityManager.TYPE_* constants. NetworkInfo was deprecated in API 29 and the TYPE_* constants in API 28; on modern Android getActiveNetworkInfo() is a compatibility shim over the capabilities API and reports nothing useful for transports that have no legacy TYPE_ equivalent.

- From API 23 the type is now read from getActiveNetwork() plus getNetworkCapabilities(), using TRANSPORT_CELLULAR to distinguish CELL and NET_CAPABILITY_INTERNET as the equivalent of the old isConnected() check. minSdk is still below 23, so the NetworkInfo path is kept for older devices behind a version check and marked @SuppressWarnings("deprecation") so it stops producing build warnings for the whole class.
 
- The mapping is deliberately unchanged: a cellular transport reports CELL and any other active transport reports WIFI, exactly as the TYPE_MOBILE* check did before. This is an API modernisation, not a change to what the SDK sends in the bid request.
 
- The permission and null checks are hoisted to the top of getConnectionType() so both paths share them, and a missing ACCESS_NETWORK_STATE now returns OFFLINE explicitly rather than falling through the nested conditionals.
 
- Extends NetworkConnectionInfoManagerTest with the capabilities path at sdk 29 -- cellular, non-cellular, no active network, and missing permission. The existing sdk 19 test is untouched and still exercises the legacy branch.
 
- Partially addresses #956 (network connection type). The location permission and display metrics items in that issue are handled separately.