### PR TITLE
Read screen size from WindowMetrics on API 30+

### DIFF
--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/helpers/Utils.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/helpers/Utils.java
@@ -391,37 +391,48 @@ public final class Utils {
     }
 
     public static int getScreenWidth(WindowManager windowManager) {
-        if (windowManager != null) {
-            if (Build.VERSION.SDK_INT >= 17) {
-                Point size = new Point();
-                windowManager.getDefaultDisplay().getRealSize(size);
-                return size.x;
-            }
-            else {
-                DisplayMetrics metrics = new DisplayMetrics();
-                windowManager.getDefaultDisplay().getMetrics(metrics);
-                return metrics.widthPixels;
-            }
+        if (windowManager == null) {
+            return 0;
         }
 
-        return 0;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            return windowManager.getCurrentWindowMetrics().getBounds().width();
+        }
+        return legacyDisplaySize(windowManager).x;
     }
 
     public static int getScreenHeight(WindowManager windowManager) {
-        if (windowManager != null) {
-            if (Build.VERSION.SDK_INT >= 17) {
-                Point size = new Point();
-                windowManager.getDefaultDisplay().getRealSize(size);
-                return size.y;
-            }
-            else {
-                DisplayMetrics metrics = new DisplayMetrics();
-                windowManager.getDefaultDisplay().getMetrics(metrics);
-                return metrics.heightPixels;
-            }
+        if (windowManager == null) {
+            return 0;
         }
 
-        return 0;
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            return windowManager.getCurrentWindowMetrics().getBounds().height();
+        }
+        return legacyDisplaySize(windowManager).y;
+    }
+
+    /**
+     * WindowManager.getDefaultDisplay() and Display.getRealSize() are both deprecated
+     * from API 30, where getCurrentWindowMetrics() replaces them. minSdk is still far
+     * below that, so this path stays for older devices. Both report the full display
+     * area including system decorations, so the reported size is unchanged.
+     */
+    @SuppressWarnings("deprecation")
+    private static Point legacyDisplaySize(@NonNull WindowManager windowManager) {
+        Point size = new Point();
+        Display display = windowManager.getDefaultDisplay();
+
+        if (Build.VERSION.SDK_INT >= 17) {
+            display.getRealSize(size);
+        }
+        else {
+            DisplayMetrics metrics = new DisplayMetrics();
+            display.getMetrics(metrics);
+            size.set(metrics.widthPixels, metrics.heightPixels);
+        }
+
+        return size;
     }
 
     public static Map<String, String> getQueryMap(String query) {

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/helpers/Utils.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/helpers/Utils.java
@@ -390,6 +390,11 @@ public final class Utils {
         }
     }
 
+    /**
+     * Full physical screen width in pixels, independent of how much of it this app
+     * currently occupies. Backs OpenRTB device.w, which the spec defines as the
+     * physical screen size, and MRAID getScreenSize().
+     */
     public static int getScreenWidth(WindowManager windowManager) {
         if (windowManager == null) {
             return 0;
@@ -401,6 +406,9 @@ public final class Utils {
         return legacyDisplaySize(windowManager).x;
     }
 
+    /**
+     * Full physical screen height in pixels. See {@link #getScreenWidth(WindowManager)}.
+     */
     public static int getScreenHeight(WindowManager windowManager) {
         if (windowManager == null) {
             return 0;
@@ -412,6 +420,16 @@ public final class Utils {
         return legacyDisplaySize(windowManager).y;
     }
 
+    /**
+     * Width in pixels of the window this app is actually drawing into, which in
+     * split-screen or freeform multi-window is a fraction of the screen. Used for
+     * sizing ad containers, where the space available to the creative matters rather
+     * than the size of the device.
+     * <p>
+     * Below API 30 there is no window-metrics API, so this falls back to the display
+     * size — the same value these call sites received before the split, and therefore
+     * not a behaviour change on those versions.
+     */
     public static int getWindowWidth(WindowManager windowManager) {
         if (windowManager == null) {
             return 0;
@@ -423,6 +441,9 @@ public final class Utils {
         return legacyDisplaySize(windowManager).x;
     }
 
+    /**
+     * Height in pixels of the current app window. See {@link #getWindowWidth(WindowManager)}.
+     */
     public static int getWindowHeight(WindowManager windowManager) {
         if (windowManager == null) {
             return 0;
@@ -437,6 +458,8 @@ public final class Utils {
     /**
      * WindowManager.getDefaultDisplay() and Display.getRealSize() are both deprecated
      * from API 30. minSdk is still far below that, so this path stays for older devices.
+     * getRealSize() reports the whole physical display including system decorations,
+     * matching getMaximumWindowMetrics() rather than getCurrentWindowMetrics().
      */
     @SuppressWarnings("deprecation")
     private static Point legacyDisplaySize(@NonNull WindowManager windowManager) {

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/helpers/Utils.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/utils/helpers/Utils.java
@@ -396,12 +396,34 @@ public final class Utils {
         }
 
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
-            return windowManager.getCurrentWindowMetrics().getBounds().width();
+            return windowManager.getMaximumWindowMetrics().getBounds().width();
         }
         return legacyDisplaySize(windowManager).x;
     }
 
     public static int getScreenHeight(WindowManager windowManager) {
+        if (windowManager == null) {
+            return 0;
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            return windowManager.getMaximumWindowMetrics().getBounds().height();
+        }
+        return legacyDisplaySize(windowManager).y;
+    }
+
+    public static int getWindowWidth(WindowManager windowManager) {
+        if (windowManager == null) {
+            return 0;
+        }
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+            return windowManager.getCurrentWindowMetrics().getBounds().width();
+        }
+        return legacyDisplaySize(windowManager).x;
+    }
+
+    public static int getWindowHeight(WindowManager windowManager) {
         if (windowManager == null) {
             return 0;
         }
@@ -414,9 +436,7 @@ public final class Utils {
 
     /**
      * WindowManager.getDefaultDisplay() and Display.getRealSize() are both deprecated
-     * from API 30, where getCurrentWindowMetrics() replaces them. minSdk is still far
-     * below that, so this path stays for older devices. Both report the full display
-     * area including system decorations, so the reported size is unchanged.
+     * from API 30. minSdk is still far below that, so this path stays for older devices.
      */
     @SuppressWarnings("deprecation")
     private static Point legacyDisplaySize(@NonNull WindowManager windowManager) {

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/views/webview/AdWebView.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/views/webview/AdWebView.java
@@ -83,8 +83,8 @@ public class AdWebView extends WebView {
 
         if (getContext() != null) {
             WindowManager windowManager = (WindowManager) getContext().getSystemService(Context.WINDOW_SERVICE);
-            screenWidth = Utils.getScreenWidth(windowManager);
-            screenHeight = Utils.getScreenHeight(windowManager);
+            screenWidth = Utils.getWindowWidth(windowManager);
+            screenHeight = Utils.getWindowHeight(windowManager);
         }
 
         if (this instanceof WebViewInterstitial) {

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/views/webview/PrebidWebViewBase.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/views/webview/PrebidWebViewBase.java
@@ -250,8 +250,8 @@ public class PrebidWebViewBase extends FrameLayout implements PreloadManager.Pre
         int orientation = Configuration.ORIENTATION_UNDEFINED;
 
         WindowManager windowManager = (WindowManager) getContext().getSystemService(Context.WINDOW_SERVICE);
-        int screenWidth = Utils.getScreenWidth(windowManager);
-        int screenHeight = Utils.getScreenHeight(windowManager);
+        int screenWidth = Utils.getWindowWidth(windowManager);
+        int screenHeight = Utils.getWindowHeight(windowManager);
 
         int deviceWidth = Math.min(screenWidth, screenHeight);
         int deviceHeight = Math.max(screenWidth, screenHeight);

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/utils/helpers/UtilsTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/utils/helpers/UtilsTest.java
@@ -311,22 +311,33 @@ public class UtilsTest extends TestCase {
         assertThat(Utils.getScreenHeight(mockWindowManager), equalTo(2001));
     }
 
-    /**
-     * From API 30 the size must come from getCurrentWindowMetrics(); getDefaultDisplay()
-     * and getRealSize() are deprecated there. Runs under its own Robolectric SDK so
-     * android.view.WindowMetrics is present on the runtime classpath.
-     */
     @Test
     @Config(sdk = 30)
-    public void testGetScreenSizeUsesWindowMetricsFromSdkInt30() {
+    public void testGetScreenSizeUsesMaximumWindowMetricsFromSdkInt30() {
         WindowManager mockWindowManager = mock(WindowManager.class);
-        WindowMetrics mockWindowMetrics = mock(WindowMetrics.class);
+        WindowMetrics mockMaximumWindowMetrics = mock(WindowMetrics.class);
 
-        when(mockWindowMetrics.getBounds()).thenReturn(new Rect(0, 0, 1100, 2001));
-        when(mockWindowManager.getCurrentWindowMetrics()).thenReturn(mockWindowMetrics);
+        when(mockMaximumWindowMetrics.getBounds()).thenReturn(new Rect(0, 0, 2200, 2001));
+        when(mockWindowManager.getMaximumWindowMetrics()).thenReturn(mockMaximumWindowMetrics);
 
-        assertThat(Utils.getScreenWidth(mockWindowManager), equalTo(1100));
+        assertThat(Utils.getScreenWidth(mockWindowManager), equalTo(2200));
         assertThat(Utils.getScreenHeight(mockWindowManager), equalTo(2001));
+        verify(mockWindowManager, never()).getCurrentWindowMetrics();
+        verify(mockWindowManager, never()).getDefaultDisplay();
+    }
+
+    @Test
+    @Config(sdk = 30)
+    public void testGetWindowSizeUsesCurrentWindowMetricsFromSdkInt30() {
+        WindowManager mockWindowManager = mock(WindowManager.class);
+        WindowMetrics mockCurrentWindowMetrics = mock(WindowMetrics.class);
+
+        when(mockCurrentWindowMetrics.getBounds()).thenReturn(new Rect(0, 0, 1100, 1001));
+        when(mockWindowManager.getCurrentWindowMetrics()).thenReturn(mockCurrentWindowMetrics);
+
+        assertThat(Utils.getWindowWidth(mockWindowManager), equalTo(1100));
+        assertThat(Utils.getWindowHeight(mockWindowManager), equalTo(1001));
+        verify(mockWindowManager, never()).getMaximumWindowMetrics();
         verify(mockWindowManager, never()).getDefaultDisplay();
     }
 
@@ -335,6 +346,8 @@ public class UtilsTest extends TestCase {
     public void testGetScreenSizeReturnsZeroWithoutWindowManager() {
         assertThat(Utils.getScreenWidth(null), equalTo(0));
         assertThat(Utils.getScreenHeight(null), equalTo(0));
+        assertThat(Utils.getWindowWidth(null), equalTo(0));
+        assertThat(Utils.getWindowHeight(null), equalTo(0));
     }
 
     @Test

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/utils/helpers/UtilsTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/utils/helpers/UtilsTest.java
@@ -19,12 +19,14 @@ package org.prebid.mobile.rendering.utils.helpers;
 import android.app.Activity;
 import android.content.Context;
 import android.graphics.Point;
+import android.graphics.Rect;
 import android.os.Build;
 import android.util.DisplayMetrics;
 import android.view.Display;
 import android.view.Gravity;
 import android.view.View;
 import android.view.WindowManager;
+import android.view.WindowMetrics;
 import android.widget.FrameLayout;
 import androidx.test.filters.Suppress;
 import junit.framework.TestCase;
@@ -307,6 +309,32 @@ public class UtilsTest extends TestCase {
         setFinalStatic(Build.VERSION.class.getField("SDK_INT"), 17);
 
         assertThat(Utils.getScreenHeight(mockWindowManager), equalTo(2001));
+    }
+
+    /**
+     * From API 30 the size must come from getCurrentWindowMetrics(); getDefaultDisplay()
+     * and getRealSize() are deprecated there. Runs under its own Robolectric SDK so
+     * android.view.WindowMetrics is present on the runtime classpath.
+     */
+    @Test
+    @Config(sdk = 30)
+    public void testGetScreenSizeUsesWindowMetricsFromSdkInt30() {
+        WindowManager mockWindowManager = mock(WindowManager.class);
+        WindowMetrics mockWindowMetrics = mock(WindowMetrics.class);
+
+        when(mockWindowMetrics.getBounds()).thenReturn(new Rect(0, 0, 1100, 2001));
+        when(mockWindowManager.getCurrentWindowMetrics()).thenReturn(mockWindowMetrics);
+
+        assertThat(Utils.getScreenWidth(mockWindowManager), equalTo(1100));
+        assertThat(Utils.getScreenHeight(mockWindowManager), equalTo(2001));
+        verify(mockWindowManager, never()).getDefaultDisplay();
+    }
+
+    @Test
+    @Config(sdk = 30)
+    public void testGetScreenSizeReturnsZeroWithoutWindowManager() {
+        assertThat(Utils.getScreenWidth(null), equalTo(0));
+        assertThat(Utils.getScreenHeight(null), equalTo(0));
     }
 
     @Test


### PR DESCRIPTION
Change log and rationale:

- `WindowManager.getDefaultDisplay()` and `Display.getRealSize()` are deprecated from API 30. The old utility also served two consumers with different size semantics: OpenRTB device dimensions and WebView/interstitial layout.

- On API 30+, `Utils.getScreenWidth()/getScreenHeight()` now use `getMaximumWindowMetrics().getBounds()`. This preserves the full physical-screen dimensions required by OpenRTB `device.w`/`device.h`, including when the Activity is in split-screen or freeform mode.

- New `Utils.getWindowWidth()/getWindowHeight()` helpers use `getCurrentWindowMetrics().getBounds()`. `AdWebView` and `PrebidWebViewBase` use these current-window dimensions for resize and scale calculations, which reflects the space where the creative actually renders.

- The pre-30 implementation is preserved in a single `legacyDisplaySize()` helper. Deprecated calls and their suppression remain scoped to that compatibility path.

- Robolectric coverage for API 30 models split-screen by returning different current and maximum window bounds. Tests verify that OpenRTB-facing screen dimensions use maximum metrics, rendering uses current metrics, deprecated display APIs are not consulted, and a null `WindowManager` returns zero.

Partially addresses #956 (display metrics). The location permission and network connection items in that issue are handled separately.