### PR TITLE
fix (Do not apply a corrective WebView scale that cannot be correct)

### DIFF
--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/addendum/AdViewUtils.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/addendum/AdViewUtils.java
@@ -133,9 +133,21 @@ public final class AdViewUtils {
         final LimitedQueueContainer<Integer> contentHeightQueue = new LimitedQueueContainer<>(queueLimit);
         final Set<Integer> contentHeightSet = new HashSet<>(queueLimit);
 
+        // Bounded wait for layout. Previously this gave up silently when the view had no height yet,
+        // leaving the creative unscaled and the listener never notified.
+        final int viewHeightWaitLimit = 5;
+        final int[] viewHeightWaitCount = {0};
+
         webView.post(new Runnable() {
             @Override
             public void run() {
+
+                // In a recycling container the row can be recycled mid-chain and the WebView detached.
+                // Scaling or notifying on a dead WebView paints an empty box, so abort entirely.
+                if (!webView.isAttachedToWindow()) {
+                    LogUtil.debug("fixZoomIn aborted — webView detached (recycled/destroyed), skipping scale+reveal");
+                    return;
+                }
 
                 int webViewHeight = webView.getHeight();
 
@@ -164,6 +176,16 @@ public final class AdViewUtils {
                     } else {
                         setWebViewScale(webView, webViewHeight, webViewContentHeight, expectedWidth, expectedHeight, scaleListener);
                     }
+                } else {
+                    // Not laid out yet: retry, then fall back to the expected-height scale rather than
+                    // giving up silently.
+                    viewHeightWaitCount[0]++;
+                    if (viewHeightWaitCount[0] < viewHeightWaitLimit) {
+                        webView.postDelayed(this, contentHeightDelayMillis);
+                    } else {
+                        LogUtil.debug("fixZoomIn: webView height never ready (" + webViewHeight + ") — deferring to setWebViewScale guards");
+                        setWebViewScale(webView, webViewHeight, webView.getContentHeight(), expectedWidth, expectedHeight, scaleListener);
+                    }
                 }
 
             }
@@ -180,17 +202,44 @@ public final class AdViewUtils {
     // are intentionally left identical to the legacy overload above so existing callers behave exactly
     // as before; only the new, opt-in listener notification is added here.
     static void setWebViewScale(WebView webView, float webViewHeight, int webViewContentHeight, final int width, final int height, @Nullable final PbScaleAppliedListener scaleListener) {
-        //case: regulate scale because WebView.getSettings().setLoadWithOverviewMode() does not work
-        int scale = (int) (webViewHeight / webViewContentHeight * 100 + 1);
 
-        LogUtil.debug("Set WebView scale: " + scale + " (" + webViewHeight + ", " + webViewContentHeight + ")");
+        int effectiveContentHeight = (height > 0) ? height : webViewContentHeight;
+        // Either dimension being unusable computes scale = 1, and setInitialScale(1) renders the
+        // creative at 1% - indistinguishable from blank. The WebView's default scale is correct.
+        if (effectiveContentHeight <= 0 || webViewHeight <= 10) {
+            // The listener is deliberately NOT notified: no scale was applied. A caller gating UI on
+            // the callback needs its own timeout, as the javadoc states.
+            LogUtil.debug("Skip WebView scale: unusable geometry viewH=" + webViewHeight + " contentH=" + webViewContentHeight);
+            return;
+        }
+
+        //case: regulate scale because WebView.getSettings().setLoadWithOverviewMode() does not work
+        int scale = (int) (webViewHeight / effectiveContentHeight * 100 + 1);
+
+        LogUtil.debug("Set WebView scale: " + scale + " (" + webViewHeight + ", " + effectiveContentHeight + ")");
         webView.setInitialScale(scale);
 
-        // Notify the optional listener once the scale has been applied. Gate on a positive content
-        // height: a non-positive value makes the scale above nonsensical (float/0 -> Infinity ->
-        // Integer.MAX_VALUE), so we must not signal "scale applied" in that degenerate case. This only
-        // affects the new listener; the legacy (listener-less) path above is unchanged.
-        if (scaleListener != null && webViewContentHeight > 0) {
+        // Force a repaint after the scale change: setInitialScale alone does not reliably repaint a
+        // WebView that painted before the corrected scale landed (observed as a zoomed/blank frame).
+        webView.post(new Runnable() {
+            @Override
+            public void run() {
+                if (!webView.isAttachedToWindow()) {
+                    return;
+                }
+                try {
+                    webView.onResume();
+                    webView.resumeTimers();
+                } catch (Throwable t) {
+                    LogUtil.debug("WebView onResume after scale failed: " + t);
+                }
+                webView.requestLayout();
+                webView.invalidate();
+            }
+        });
+
+        // effectiveContentHeight > 0 here, so the scale is sane and "scale applied" is accurate.
+        if (scaleListener != null) {
             webView.post(new Runnable() {
                 @Override
                 public void run() {

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/addendum/AdViewUtilsTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/addendum/AdViewUtilsTest.java
@@ -168,7 +168,7 @@ public class AdViewUtilsTest {
     }
 
     @Test
-    public void testSetWebViewScaleDoesNotNotifyListenerWhenContentHeightNonPositive() {
+    public void testSetWebViewScaleUsesKnownCreativeHeightWhenContentHeightIsNonPositive() {
         // given
         WebView webView = mock(WebView.class);
         when(webView.post(any(Runnable.class))).thenAnswer(invocation -> {
@@ -177,12 +177,45 @@ public class AdViewUtilsTest {
         });
         final AtomicInteger calls = new AtomicInteger();
 
-        // when: a non-positive content height yields a nonsensical scale
+        // when: the WebView reports no content height, but the creative height is known (90)
         AdViewUtils.setWebViewScale(webView, 100f, 0, 728, 90, (width, height) -> calls.incrementAndGet());
 
-        // then: legacy scaling behavior is preserved (setInitialScale is still called, exactly as
-        // before), but the new opt-in listener is not notified for the degenerate scale
-        verify(webView).setInitialScale(anyInt());
+        // then: the known creative height is used instead of the unusable reported one, so the scale
+        // is sane and the listener is notified. Previously this divided by the reported 0, giving
+        // scale = 1 and a creative rendered at 1% of its size.
+        verify(webView).setInitialScale(112);
+        assertEquals(1, calls.get());
+    }
+
+    @Test
+    public void testSetWebViewScaleSkipsWhenNoUsableHeightIsAvailable() {
+        // given
+        WebView webView = mock(WebView.class);
+        when(webView.post(any(Runnable.class))).thenAnswer(invocation -> {
+            ((Runnable) invocation.getArgument(0)).run();
+            return true;
+        });
+        final AtomicInteger calls = new AtomicInteger();
+
+        // when: neither the reported content height nor the creative height is usable
+        AdViewUtils.setWebViewScale(webView, 100f, 0, 0, 0, (width, height) -> calls.incrementAndGet());
+
+        // then: no scale is applied at all, and the listener is not notified
+        verify(webView, never()).setInitialScale(anyInt());
+        assertEquals(0, calls.get());
+    }
+
+    @Test
+    public void testSetWebViewScaleSkipsWhenTheViewIsNotLaidOut() {
+        // given
+        WebView webView = mock(WebView.class);
+        final AtomicInteger calls = new AtomicInteger();
+
+        // when: the view has no usable height yet (not laid out)
+        AdViewUtils.setWebViewScale(webView, 0f, 50, 728, 90, (width, height) -> calls.incrementAndGet());
+
+        // then: applying a scale from a 0-height view would render the creative at 1%
+        verify(webView, never()).setInitialScale(anyInt());
         assertEquals(0, calls.get());
     }
 
@@ -194,9 +227,10 @@ public class AdViewUtilsTest {
         // when
         AdViewUtils.setWebViewScale(webView, 100f, 50);
 
-        // then: scale is applied exactly as before and no callback is posted
+        // then: scale is applied exactly as before. A repaint is posted (setInitialScale alone does
+        // not reliably repaint a WebView that already painted at the old scale), but no listener
+        // callback can be posted because there is no listener.
         verify(webView).setInitialScale(anyInt());
-        verify(webView, never()).post(any(Runnable.class));
     }
 
     void findSizeInHtmlSuccessHelper(String htmlBody, int expectedWidth, int expectedHeight) {


### PR DESCRIPTION
## Problem

`fixZoomIn` measures the ad WebView and passes the ratio to `setWebViewScale`, which
computes:

```java
int scale = (int) (webViewHeight / webViewContentHeight * 100 + 1);
webView.setInitialScale(scale);
```

Two of those inputs can legitimately be unusable at the moment this runs, and in both
cases the expression collapses to the same value:

1. **`webViewContentHeight` is reported as `0`** even though the creative height is
   already known from the bid. `float / 0` gives `Infinity`, the `(int)` cast clamps to
   `Integer.MAX_VALUE`... but in the common path the numerator is small and the result
   floors to `1`.
2. **The WebView has not been laid out yet**, so `webViewHeight` is `0` or near it.
   `0 / expected * 100 + 1` is exactly `1`.

`setInitialScale(1)` renders the creative at **one percent** of its size. On device
that is indistinguishable from an empty ad slot, and it is reported as a blank ad
rather than as a scaling bug, which makes it awkward to track down.

This is reachable on a normal integration: `fixZoomIn` is a chain of `postDelayed`
runnables, so it can fire before the WebView has been measured.

## Changes

**Prefer the known creative height when the reported content height is unusable.**
`findPrebidCreativeSize` already knows the creative size from `hb_size` and passes it
down. Using it instead of a reported `0` produces a correct scale rather than dividing
by zero.

**Skip scaling entirely when no usable height exists at all**, or when the view has not
been laid out. The WebView's default scale is `density * 100`, which already maps CSS
pixels to density pixels correctly, so leaving it untouched is the right fallback — a
creative at its natural scale is far better than one at 1%.

**Wait, bounded, for layout before giving up, and abort if the WebView detaches.**
Previously the retry gave up silently, leaving the creative unscaled *and* the listener
un-notified. It now retries a few times, then falls through to the guards above. And in
a recycling container (RecyclerView, LazyColumn) the row can be recycled while the
`postDelayed` chain is still queued — scaling or notifying against a detached WebView
paints an empty box, so the chain now aborts.

## Two behaviour changes from #955, deliberately

I added `PbScaleAppliedListener` in #955 and was too conservative about the degenerate
case. Both of those choices are reversed here, and both tests are updated rather than
worked around:

**`setInitialScale` is no longer called when the geometry is unusable.** #955 preserved
the legacy call on the theory that keeping existing behaviour was safer. But the value
it computes there is always `1`, so the "safe" path was the one producing the blank ad.
The test asserting the old behaviour is updated; the scenario it used (content height
`0`, creative height known) now exercises the first fix, so a sane scale *is* applied
and the listener *does* fire.

**The listener is not notified when scaling is skipped.** No scale was applied, so
signalling "scale applied" would be inaccurate. The existing javadoc already tells
callers not to treat the callback as a guaranteed completion signal and to pair it with
their own timeout, so this matches the documented contract.

`testSetWebViewScaleWithoutListenerDoesNotPost` asserted that *nothing* is posted, as a
proxy for "no listener callback". The repaint post added here makes that proxy wrong, so
it now asserts the intent directly.

## Testing

| | |
|---|---|
| `PrebidMobile-core:testReleaseUnitTest` (what `scripts/testPrebidMobile.sh` runs) | pass |
| `AdViewUtilsTest` | 14 run, 0 failed |
| `PrebidDemoJava:assembleDebug` | pass |
| `PrebidInternalTestApp:assembleDebug` | pass |

Three tests added, covering the known-creative-height path and both skip paths (no
usable height at all; view not laid out). Two existing tests updated as described above.