### PR TITLE
Fix COPPA flag sent as regs.ext.coppa instead of regs.coppa

### DIFF
--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/networking/parameters/UserConsentParameterBuilder.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/networking/parameters/UserConsentParameterBuilder.java
@@ -26,7 +26,6 @@ public class UserConsentParameterBuilder extends ParameterBuilder {
     private static final String GDPR = "gdpr";
     private static final String US_PRIVACY = "us_privacy";
     private static final String CONSENT = "consent";
-    private static final String COPPA_SUBJECT = "coppa";
 
     private final UserConsentManager userConsentManager;
 
@@ -69,7 +68,7 @@ public class UserConsentParameterBuilder extends ParameterBuilder {
     private void appendCoppaParameter(BidRequest bidRequest) {
         Boolean subjectToCoppa = userConsentManager.getSubjectToCoppa();
         if (subjectToCoppa != null) {
-            bidRequest.getRegs().getExt().put(COPPA_SUBJECT, subjectToCoppa ? 1 : 0);
+            bidRequest.getRegs().coppa = subjectToCoppa ? 1 : 0;
         }
     }
 

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/networking/parameters/UserConsentParameterBuilderTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/networking/parameters/UserConsentParameterBuilderTest.java
@@ -149,6 +149,51 @@ public class UserConsentParameterBuilderTest {
     }
 
     @Test
+    public void subjectToCoppaTrue_CoppaEqualsOneOnTopLevelRegs() throws JSONException {
+        ManagersResolver.getInstance().getUserConsentManager().setSubjectToCoppa(true);
+        AdRequestInput adRequestInput = new AdRequestInput();
+
+        builder.appendBuilderParameters(adRequestInput);
+
+        String expectedJSON = "{\"regs\":{\"coppa\":1}}";
+        assertEquals(
+            "Generated JSON is wrong!",
+            expectedJSON,
+            adRequestInput.getBidRequest().getJsonObject().toString()
+        );
+    }
+
+    @Test
+    public void subjectToCoppaFalse_CoppaEqualsZeroOnTopLevelRegs() throws JSONException {
+        ManagersResolver.getInstance().getUserConsentManager().setSubjectToCoppa(false);
+        AdRequestInput adRequestInput = new AdRequestInput();
+
+        builder.appendBuilderParameters(adRequestInput);
+
+        String expectedJSON = "{\"regs\":{\"coppa\":0}}";
+        assertEquals(
+            "Generated JSON is wrong!",
+            expectedJSON,
+            adRequestInput.getBidRequest().getJsonObject().toString()
+        );
+    }
+
+    @Test
+    public void subjectToCoppaNull_CoppaNotAppended() throws JSONException {
+        ManagersResolver.getInstance().getUserConsentManager().setSubjectToCoppa(null);
+        AdRequestInput adRequestInput = new AdRequestInput();
+
+        builder.appendBuilderParameters(adRequestInput);
+
+        String expectedJSON = "{}";
+        assertEquals(
+            "Generated JSON is wrong!",
+            expectedJSON,
+            adRequestInput.getBidRequest().getJsonObject().toString()
+        );
+    }
+
+    @Test
     public void gppString_AppendToUserConsentValues() throws JSONException {
         sharedPreferences.edit().putString(UserConsentManager.GPP_STRING_KEY, "testString").commit();
 


### PR DESCRIPTION
## Summary
Fixes #995

`TargetingParams.setSubjectToCOPPA()` was writing the COPPA compliance flag into `regs.ext.coppa` instead of the OpenRTB 2.6 top-level `regs.coppa` field. Prebid Server only reads the top-level field, so the flag was silently ignored and COPPA enforcement never triggered.

## Change
- `UserConsentParameterBuilder.appendCoppaParameter()` now sets `bidRequest.getRegs().coppa` directly instead of putting the value into `regs.ext`. The `Regs` class already serializes this field at the top level of the request JSON.
- Removed the now-unused `COPPA_SUBJECT` ext key constant.

## Before / After
- Before: `"regs": { "ext": { "coppa": 1 } }`
- After: `"regs": { "coppa": 1 }`

## Testing
Added unit tests in `UserConsentParameterBuilderTest` covering `subjectToCoppa` true/false/null, asserting the generated request JSON is `{"regs":{"coppa":1}}`, `{"regs":{"coppa":0}}`, and `{}` respectively.