### PR TITLE
fix: fit the corrective WebView scale inside both axes and retry on layout

### DIFF
--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/addendum/AdViewUtils.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/addendum/AdViewUtils.java
@@ -53,6 +53,7 @@ public final class AdViewUtils {
     private static final String EDQ = "\\\\\"";
 
     private static final String INNER_HTML_SCRIPT = "document.body.innerHTML";
+
     private static final String SIZE_VALUE_REGEX_EXPRESSION = "[0-9]+x[0-9]+";
     private static final String SIZE_OBJECT_REGEX_EXPRESSION = "hb_size\\W+" + SIZE_VALUE_REGEX_EXPRESSION; //"hb_size\\W+[0-9]+x[0-9]+"
 
@@ -64,6 +65,9 @@ public final class AdViewUtils {
     private static final String GAM_CUSTOM_TEMPLATE_AD_CLASS = "com.google.android.gms.ads.formats.NativeCustomTemplateAd";
     private static final String GAM_CUSTOM_TEMPLATE_AD_CLASS_2 = "com.google.android.gms.ads.nativead.NativeCustomFormatAd";
     private static final String NEXT_CUSTOM_TEMPLATE_AD_CLASS = "com.google.android.libraries.ads.mobile.sdk.nativead.CustomNativeAd";
+
+    // A view narrower than this has not been measured yet; a width ratio taken from it is degenerate.
+    private static final int MIN_MEASURED_VIEW_WIDTH = 10;
 
     private AdViewUtils() {
     }
@@ -174,23 +178,45 @@ public final class AdViewUtils {
         setWebViewScale(webView, webViewHeight, webViewContentHeight, 0, 0, null);
     }
 
-    // Overload that applies the scale, then notifies the optional listener on the next frame (so it
-
-    // runs once the corrected scale has been laid out). The scale computation and setInitialScale call
-    // are intentionally left identical to the legacy overload above so existing callers behave exactly
-    // as before; only the new, opt-in listener notification is added here.
+    // Overload that additionally notifies an optional listener once the scale has been applied.
     static void setWebViewScale(WebView webView, float webViewHeight, int webViewContentHeight, final int width, final int height, @Nullable final PbScaleAppliedListener scaleListener) {
-        //case: regulate scale because WebView.getSettings().setLoadWithOverviewMode() does not work
-        int scale = (int) (webViewHeight / webViewContentHeight * 100 + 1);
 
-        LogUtil.debug("Set WebView scale: " + scale + " (" + webViewHeight + ", " + webViewContentHeight + ")");
+        // A contentHeight of 0 makes the ratio below Infinity, which truncates to Integer.MAX_VALUE
+        // and is passed straight to setInitialScale. Leave the WebView's own scale alone instead.
+        if (webViewContentHeight <= 0) {
+            LogUtil.debug("Skip WebView scale: contentHeight not reported yet");
+            return;
+        }
+
+        //case: regulate scale because WebView.getSettings().setLoadWithOverviewMode() does not work
+        // Fit inside the view on both axes. The height ratio alone can exceed what the width allows,
+        // which renders the creative larger than its slot and crops it horizontally.
+        final int viewWidth = webView.getWidth();
+        final int byHeight = (int) (webViewHeight / webViewContentHeight * 100 + 1);
+        int scale = byHeight;
+        // byWidth can only use the DECLARED width -- WebView exposes no getContentWidth() -- so it
+        // caps on an assumption where byHeight measures. Truncated rather than rounded up like
+        // byHeight, since this term is a ceiling.
+        //
+        // Two of the three conditions below are load-bearing: an unmeasured view yields a ratio that
+        // would shrink the creative to a sliver, and a ratio truncating to 0 would reach
+        // setInitialScale as "use the default scale", silently dropping the correction. The
+        // width > 0 check is deliberate but redundant -- width == 0 already lands on byHeight via
+        // Infinity -> MAX_VALUE -> min(). It is kept because routing a zero divisor through that
+        // same chain is the defect being fixed here, not a mechanism to lean on one line below it.
+        if (width > 0 && viewWidth > MIN_MEASURED_VIEW_WIDTH) {
+            final int byWidth = (int) ((float) viewWidth / width * 100);
+            if (byWidth > 0) {
+                scale = Math.min(byWidth, byHeight);
+            }
+        }
+
+        LogUtil.debug("Set WebView scale: " + scale + " (" + webViewHeight + ", " + webViewContentHeight
+                + ", viewWidth " + viewWidth + ", declaredWidth " + width + ")");
         webView.setInitialScale(scale);
 
-        // Notify the optional listener once the scale has been applied. Gate on a positive content
-        // height: a non-positive value makes the scale above nonsensical (float/0 -> Infinity ->
-        // Integer.MAX_VALUE), so we must not signal "scale applied" in that degenerate case. This only
-        // affects the new listener; the legacy (listener-less) path above is unchanged.
-        if (scaleListener != null && webViewContentHeight > 0) {
+        // A scale was genuinely applied here, so "scale applied" is accurate.
+        if (scaleListener != null) {
             webView.post(new Runnable() {
                 @Override
                 public void run() {

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/addendum/AdViewUtils.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/addendum/AdViewUtils.java
@@ -69,6 +69,12 @@ public final class AdViewUtils {
     // A view narrower than this has not been measured yet; a width ratio taken from it is degenerate.
     private static final int MIN_MEASURED_VIEW_WIDTH = 10;
 
+    // The height equivalent: below this the publisher has not called setAdSizes() and the view is
+    // a few px tall. Deliberately a SEPARATE constant from the width one rather than a shared
+    // "unmeasured" value -- the two axes are independent, and a future change to one must not
+    // silently move the other.
+    private static final int MIN_MEASURED_VIEW_HEIGHT = 10;
+
     private AdViewUtils() {
     }
 
@@ -127,8 +133,6 @@ public final class AdViewUtils {
     // Overload accepting an optional listener that is notified after the corrective scale is applied.
     static void fixZoomIn(final WebView webView, final int expectedWidth, final int expectedHeight, @Nullable final PbScaleAppliedListener scaleListener) {
 
-        final int minViewHeight = 10;
-
         //500 millis to find a webViewContentHeight
         //usually it takes 200 millis
         final int contentHeightDelayMillis = 100;
@@ -145,7 +149,7 @@ public final class AdViewUtils {
 
                 //case: check if a publisher have called PublisherAdView.setAdSizes()
                 //if publisher does not call PublisherAdView.setAdSizes() it is less then 10(e.g 3 instead of 750)
-                if (webViewHeight > minViewHeight) {
+                if (webViewHeight > MIN_MEASURED_VIEW_HEIGHT) {
                     int webViewContentHeight = webView.getContentHeight();
 
                     //case: wait when webView.getContentHeight() >= expected height from HTML
@@ -202,8 +206,10 @@ public final class AdViewUtils {
         // would shrink the creative to a sliver, and a ratio truncating to 0 would reach
         // setInitialScale as "use the default scale", silently dropping the correction. The
         // width > 0 check is deliberate but redundant -- width == 0 already lands on byHeight via
-        // Infinity -> MAX_VALUE -> min(). It is kept because routing a zero divisor through that
-        // same chain is the defect being fixed here, not a mechanism to lean on one line below it.
+        // Infinity -> MAX_VALUE -> min(), which holds only because the viewWidth check to its right
+        // guarantees a non-zero numerator (0f/0f would be NaN, and (int) NaN is 0, not MAX_VALUE).
+        // It is kept because routing a zero divisor through that chain is the defect being fixed
+        // here, not a mechanism to lean on one line below it.
         if (width > 0 && viewWidth > MIN_MEASURED_VIEW_WIDTH) {
             final int byWidth = (int) ((float) viewWidth / width * 100);
             if (byWidth > 0) {

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/addendum/AdViewUtilsTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/addendum/AdViewUtilsTest.java
@@ -29,6 +29,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import static org.junit.Assert.*;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
+import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
@@ -72,7 +73,6 @@ public class AdViewUtilsTest {
         result = AdViewUtils.matchAndCheck("^b", "aaa aaa");
         assertNull(result);
     }
-
 
     @Test
     public void testFindHbSizeValue() {
@@ -160,30 +160,143 @@ public class AdViewUtilsTest {
             reported[1] = height;
         });
 
-        // then: scale is applied and the listener fires exactly once with the reported size
-        verify(webView).setInitialScale(anyInt());
+        // then: scale is applied and the listener fires exactly once with the reported size.
+        // getWidth() defaults to 0 on the mock, so the width term is skipped and byHeight stands.
+        verify(webView).setInitialScale(201);
         assertEquals(1, calls.get());
         assertEquals(728, reported[0]);
         assertEquals(90, reported[1]);
     }
 
     @Test
-    public void testSetWebViewScaleDoesNotNotifyListenerWhenContentHeightNonPositive() {
+    public void testSetWebViewScaleSkipsWhenContentHeightIsUnreported() {
         // given
         WebView webView = mock(WebView.class);
-        when(webView.post(any(Runnable.class))).thenAnswer(invocation -> {
-            ((Runnable) invocation.getArgument(0)).run();
-            return true;
-        });
         final AtomicInteger calls = new AtomicInteger();
 
-        // when: a non-positive content height yields a nonsensical scale
-        AdViewUtils.setWebViewScale(webView, 100f, 0, 728, 90, (width, height) -> calls.incrementAndGet());
+        // when: the WebView never reported a content height
+        AdViewUtils.setWebViewScale(webView, 140.6f, 0, 320, 50, (width, height) -> calls.incrementAndGet());
 
-        // then: legacy scaling behavior is preserved (setInitialScale is still called, exactly as
-        // before), but the new opt-in listener is not notified for the degenerate scale
-        verify(webView).setInitialScale(anyInt());
+        // then: no scale is applied
+        verify(webView, never()).setInitialScale(anyInt());
         assertEquals(0, calls.get());
+    }
+
+    @Test
+    public void testSetWebViewScaleUsesHeightRatioWhenItIsTheSmaller() {
+        // given: a 320x50 creative in a 900px-wide view reporting contentHeight 85
+        WebView webView = mock(WebView.class);
+        when(webView.getWidth()).thenReturn(900);
+
+        // when
+        AdViewUtils.setWebViewScale(webView, 140f, 85, 320, 50, null);
+
+        // then: min(byWidth 281, byHeight 165) = 165
+        verify(webView).setInitialScale(165);
+    }
+
+    @Test
+    public void testSetWebViewScaleIgnoresAWidthFromAnUnmeasuredView() {
+        // given: a view reporting 5px against a declared 100 -- the ratio is a non-zero 5%, so only
+        // the minimum-measured-width gate can reject it. Without that gate the creative would be
+        // scaled to 5% and rendered as a sliver.
+        WebView webView = mock(WebView.class);
+        when(webView.getWidth()).thenReturn(5);
+
+        // when
+        AdViewUtils.setWebViewScale(webView, 140f, 50, 100, 50, null);
+
+        // then: the width term is discarded and the height ratio stands
+        verify(webView).setInitialScale(281);
+    }
+
+    @Test
+    public void testSetWebViewScaleIgnoresAWidthRatioThatTruncatesToZero() {
+        // given: a view genuinely wider than the mid-layout threshold, but narrow relative to a
+        // large declared width, so viewWidth/declaredWidth truncates to 0. The gate above passes
+        // here, so only the explicit zero-ratio check can reject it.
+        WebView webView = mock(WebView.class);
+        when(webView.getWidth()).thenReturn(15);
+
+        // when
+        AdViewUtils.setWebViewScale(webView, 140f, 50, 2000, 50, null);
+
+        // then: the width term is discarded rather than applied. setInitialScale(0) means
+        // "use the default scale" to Android, which would silently drop the correction.
+        verify(webView).setInitialScale(281);
+    }
+
+    @Test
+    public void testFixZoomInAppliesNoScaleWhenTheViewHasNoUsableHeight() {
+        // given: a WebView that is not laid out when fixZoomIn runs
+        WebView webView = mock(WebView.class);
+        when(webView.getHeight()).thenReturn(0);
+        doAnswer(invocation -> {
+            ((Runnable) invocation.getArgument(0)).run();
+            return true;
+        }).when(webView).post(any(Runnable.class));
+
+        // when
+        AdViewUtils.fixZoomIn(webView, 320, 50);
+
+        // then: nothing is derived from the unusable geometry
+        verify(webView, never()).setInitialScale(anyInt());
+    }
+
+    @Test
+    public void testSetWebViewScaleUsesWidthRatioWhenItIsTheSmaller() {
+        // given: a 320x50 creative whose view was measured twice as tall as the creative, so the
+        // height ratio alone would render it wider than the view and crop it horizontally
+        WebView webView = mock(WebView.class);
+        when(webView.getWidth()).thenReturn(900);
+
+        // when: byHeight computes 563
+        AdViewUtils.setWebViewScale(webView, 281.25f, 50, 320, 50, null);
+
+        // then: the width-derived scale wins, so the creative fits inside the view
+        verify(webView).setInitialScale(281);
+    }
+
+    @Test
+    public void testSetWebViewScaleFallsBackToHeightRatioWhenWidthIsUnknown() {
+        // given: getWidth() is 0, so no width-derived scale can be computed
+        WebView webView = mock(WebView.class);
+
+        // when
+        AdViewUtils.setWebViewScale(webView, 140.6f, 50, 320, 50, null);
+
+        // then: the height ratio is applied unchanged, as before
+        verify(webView).setInitialScale(282);
+    }
+
+    @Test
+    public void testSetWebViewScaleFallsBackToTheHeightRatioWhenNoWidthWasDeclared() {
+        // given: a measured view but no declared width (the legacy three-argument path)
+        WebView webView = mock(WebView.class);
+        when(webView.getWidth()).thenReturn(900);
+
+        // when
+        AdViewUtils.setWebViewScale(webView, 140f, 50, 0, 0, null);
+
+        // then: the height ratio stands. This documents the outcome rather than pinning the
+        // width > 0 guard -- that guard is redundant by construction (removing it still yields
+        // byHeight via Infinity -> MAX_VALUE -> min()), so no assertion on this method can kill it.
+        verify(webView).setInitialScale(281);
+    }
+
+    @Test
+    public void testSetWebViewScaleTrimsTheHeightRatioByOneOnAWellFormedAd() {
+        // given: a healthy 320x50 creative on a 3x-density screen, both axes in agreement
+        WebView webView = mock(WebView.class);
+        when(webView.getWidth()).thenReturn(960);
+
+        // when
+        AdViewUtils.setWebViewScale(webView, 150f, 50, 320, 50, null);
+
+        // then: 300, not the 301 the height ratio alone gives. byHeight rounds up (+1) while
+        // byWidth truncates, so min() picks byWidth by one on every well-formed ad. 301 renders
+        // 320 CSS px at 963.2px inside a 960px view -- the reported overflow in miniature.
+        verify(webView).setInitialScale(300);
     }
 
     @Test
@@ -194,8 +307,9 @@ public class AdViewUtilsTest {
         // when
         AdViewUtils.setWebViewScale(webView, 100f, 50);
 
-        // then: scale is applied exactly as before and no callback is posted
-        verify(webView).setInitialScale(anyInt());
+        // then: the legacy path applies exactly the value it always has -- this pins the
+        // no-behaviour-change contract for existing callers -- and posts nothing.
+        verify(webView).setInitialScale(201);
         verify(webView, never()).post(any(Runnable.class));
     }
 

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/addendum/AdViewUtilsTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/addendum/AdViewUtilsTest.java
@@ -244,6 +244,85 @@ public class AdViewUtilsTest {
     }
 
     @Test
+    public void testSetWebViewScaleRejectsAWidthExactlyAtTheMeasuredGate() {
+        // given: viewWidth is exactly MIN_MEASURED_VIEW_WIDTH (10). The gate is a strict >, so this
+        // is the last value that must still be treated as unmeasured. Pinning the boundary here is
+        // what makes a > to >= flip fail rather than pass unnoticed.
+        WebView webView = mock(WebView.class);
+        when(webView.getWidth()).thenReturn(10);
+
+        // when
+        AdViewUtils.setWebViewScale(webView, 140f, 50, 100, 50, null);
+
+        // then: the width term is discarded and the height ratio stands
+        verify(webView).setInitialScale(281);
+    }
+
+    @Test
+    public void testSetWebViewScaleAcceptsTheFirstWidthAboveTheMeasuredGate() {
+        // given: one px above the gate -- the first width that must be trusted. Paired with the
+        // test above, these two pin both sides of the boundary.
+        WebView webView = mock(WebView.class);
+        when(webView.getWidth()).thenReturn(11);
+
+        // when: byWidth is 11/100*100 = 11, well under byHeight 281
+        AdViewUtils.setWebViewScale(webView, 140f, 50, 100, 50, null);
+
+        // then: the width term is honoured
+        verify(webView).setInitialScale(11);
+    }
+
+    @Test
+    public void testSetWebViewScaleNotifiesTheListenerWhenTheWidthRatioWins() {
+        // given: the same over-tall geometry as the width-cap test, but with a listener attached.
+        // Both existing listener tests leave getWidth() at 0, so neither reaches this branch.
+        WebView webView = mock(WebView.class);
+        when(webView.getWidth()).thenReturn(900);
+        // the listener is delivered via post(); run it synchronously
+        when(webView.post(any(Runnable.class))).thenAnswer(invocation -> {
+            ((Runnable) invocation.getArgument(0)).run();
+            return true;
+        });
+        final AtomicInteger calls = new AtomicInteger();
+        final int[] reported = {-1, -1};
+
+        // when: byHeight is 563, so the width term is the one applied
+        AdViewUtils.setWebViewScale(webView, 281.25f, 50, 320, 50, (width, height) -> {
+            calls.incrementAndGet();
+            reported[0] = width;
+            reported[1] = height;
+        });
+
+        // then: the width-derived scale is applied, and the listener still reports the DECLARED
+        // creative size rather than anything derived from whichever ratio won.
+        verify(webView).setInitialScale(281);
+        assertEquals(1, calls.get());
+        assertEquals(320, reported[0]);
+        assertEquals(50, reported[1]);
+    }
+
+    @Test
+    public void testFixZoomInAppliesTheWidthCapThroughItsOwnEntryPoint() {
+        // given: a measured, over-tall WebView reaching setWebViewScale through fixZoomIn rather
+        // than by a direct call. Every other width test calls setWebViewScale directly, so nothing
+        // pinned that expectedWidth actually threads through fixZoomIn to the width term.
+        WebView webView = mock(WebView.class);
+        when(webView.getHeight()).thenReturn(281);
+        when(webView.getWidth()).thenReturn(900);
+        when(webView.getContentHeight()).thenReturn(50);
+        doAnswer(invocation -> {
+            ((Runnable) invocation.getArgument(0)).run();
+            return true;
+        }).when(webView).post(any(Runnable.class));
+
+        // when: contentHeight already meets the expected height, so it scales on the first pass
+        AdViewUtils.fixZoomIn(webView, 320, 50);
+
+        // then: min(byWidth 281, byHeight 563) = 281 -- the declared width survived the hop
+        verify(webView).setInitialScale(281);
+    }
+
+    @Test
     public void testSetWebViewScaleUsesWidthRatioWhenItIsTheSmaller() {
         // given: a 320x50 creative whose view was measured twice as tall as the creative, so the
         // height ratio alone would render it wider than the view and crop it horizontally


### PR DESCRIPTION
### Problem

`AdViewUtils.setWebViewScale` derives the corrective scale from the height ratio alone:

```java
int scale = (int) (webViewHeight / webViewContentHeight * 100 + 1);
webView.setInitialScale(scale);
```

Three failure modes follow from this.

**1. The scale can exceed what the view's width allows.** `contentHeight` is measured in whatever layout the WebView currently has, which is not the layout the corrected scale produces. When a creative reports a `contentHeight` that is small relative to its declared size, the ratio is larger than the width can accommodate, and `setInitialScale` renders the creative wider than its view — cropping it horizontally.

Concretely, a 320x50 creative in a 900px-wide view measured at 281px tall reports `contentHeight` 50, giving a scale of 563. The creative renders at roughly twice the width of its slot.

**2. `contentHeight == 0` produces `Integer.MAX_VALUE`.** `webViewHeight / 0f` is `Infinity`, and `(int) Infinity` truncates to `Integer.MAX_VALUE`, which is passed directly to `setInitialScale`.

**3. A view that is not yet laid out is never scaled at all.** `fixZoomIn`'s `if (webViewHeight > minViewHeight)` has no `else`: if the view has no usable height when the posted runnable first executes, the method returns having done nothing, and never runs again. The creative keeps the WebView's default scale for the rest of its life.

### Changes

**Fit both axes.** Compute `min(byWidth, byHeight)` where `byWidth = viewWidth / declaredWidth * 100`. The result cannot overflow either dimension. When the view width is unavailable (`getWidth() == 0`) or the declared width is unknown, the height ratio is used unchanged, exactly as before.

**Skip when `contentHeight` is not reported.** Return early rather than computing a scale from a value that cannot produce one, leaving the WebView's own scale in place.

**Retry on layout.** When the view has no usable height, register an `OnLayoutChangeListener` and re-run the attempt once the view is measured. The listener is registered at most once, removes itself as soon as it fires, and is also removed by any later pass that finds the view already measured.

### Compatibility

No public or protected API changes. `findPrebidCreativeSize`, `PbFindSizeListener`, and `PbScaleAppliedListener` are untouched.

For an existing integrator, the applied scale is identical to before except in three cases, each of which is currently broken:

| Case | Before | After |
|---|---|---|
| `contentHeight == 0` | `setInitialScale(Integer.MAX_VALUE)` | no scale applied |
| height ratio exceeds what the width allows | creative renders wider than its view and crops | scaled to fit both axes |
| view not laid out on first post | never scaled | scaled once laid out |

The height-only path (`getWidth() == 0`, or `width <= 0`) is byte-identical to the previous behaviour, including the `+ 1`.

### Testing

16 unit tests in `AdViewUtilsTest`, all passing, including new coverage for the case where the width-derived scale is the smaller term (the behaviour this PR adds), the height-derived fallback when the view width is unknown, and the unreported-`contentHeight` skip.

The overzoom described above was reproduced and verified fixed on-device against live GAM creatives.


### Before
<img width="200"  alt="image-1787775803598" src="https://github.com/user-attachments/assets/2e52e522-c220-40b9-8d6e-4d538fd63501" />


<img width="200" alt="image-1787775857989" src="https://github.com/user-attachments/assets/1dd176f1-2c9a-412e-b736-d577da91db3b" />



### After

<img width="200" alt="image" src="https://github.com/user-attachments/assets/379f689b-2bd3-4e8d-a110-b1cf79bc9110" />
