### PR TITLE
Fix rewarded end card close button staying hidden when reward already granted

### DIFF
--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/interstitial/AdInterstitialDialog.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/interstitial/AdInterstitialDialog.java
@@ -118,18 +118,23 @@ public class AdInterstitialDialog extends AdBaseDialog {
         AdUnitConfiguration config = interstitialManager.getInterstitialDisplayProperties().config;
         RewardManager rewardManager = config.getRewardManager();
         if (config != null && config.isRewarded()) {
+            RewardedExt rewardedExt = rewardManager.getRewardedExt();
+            int postRewardTime = rewardedExt.getClosingRules().getPostRewardTime() * 1000;
+            boolean autoClose = rewardedExt.getClosingRules().getAction() == RewardedClosingRules.Action.AUTO_CLOSE;
+
             if (rewardManager.getUserRewardedAlready()) {
+                // The reward was already granted before this dialog (e.g. the end card) was created,
+                // so there is no reward event to wait for anymore. Still schedule the close button so
+                // it doesn't stay hidden forever, respecting close.action/postrewardtime rules.
+                changeCloseViewVisibility(View.GONE);
+                scheduleCloseButtonDisplaying(postRewardTime, autoClose);
                 return;
             }
 
             setBackgroundListener();
             changeCloseViewVisibility(View.GONE);
 
-            RewardedExt rewardedExt = rewardManager.getRewardedExt();
             int defaultRewardTime = RewardedCompletionRules.DEFAULT_BANNER_TIME_MS;
-            int postRewardTime = rewardedExt.getClosingRules().getPostRewardTime() * 1000;
-
-            boolean autoClose = rewardedExt.getClosingRules().getAction() == RewardedClosingRules.Action.AUTO_CLOSE;
             boolean isEndCard = config.getHasEndCard();
             boolean hasRewardEventUrl = getBannerEvent(rewardedExt, isEndCard) != null;
 

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/interstitial/AdInterstitialDialogTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/interstitial/AdInterstitialDialogTest.java
@@ -122,8 +122,13 @@ public class AdInterstitialDialogTest {
         InterstitialDisplayPropertiesInternal mockProperties = mock(InterstitialDisplayPropertiesInternal.class);
         when(mockInterstitialManager.getInterstitialDisplayProperties()).thenReturn(mockProperties);
 
+        RewardedCompletionRules completionRules = new RewardedCompletionRules();
+        RewardedClosingRules closingRules = new RewardedClosingRules(5, RewardedClosingRules.Action.AUTO_CLOSE);
+        RewardedExt rewardedExt = new RewardedExt(null, completionRules, closingRules);
+
         RewardManager mockRewardManager = mock(RewardManager.class);
         when(mockRewardManager.getUserRewardedAlready()).thenReturn(true);
+        when(mockRewardManager.getRewardedExt()).thenReturn(rewardedExt);
 
         AdUnitConfiguration mockConfig = mock(AdUnitConfiguration.class);
         when(mockConfig.isRewarded()).thenReturn(true);
@@ -132,8 +137,10 @@ public class AdInterstitialDialogTest {
 
         spySubject.setUpCloseButtonTask();
 
-        verify(spySubject, never()).changeCloseViewVisibility(View.GONE);
-        verify(spySubject, never()).scheduleCloseButtonDisplaying(anyInt(), anyBoolean());
+        // Even though the reward was already granted before this dialog was created (e.g. the
+        // end card), the close button must still be scheduled so it doesn't stay hidden forever.
+        verify(spySubject).changeCloseViewVisibility(View.GONE);
+        verify(spySubject).scheduleCloseButtonDisplaying(5_000, true);
         verify(spySubject, never()).scheduleRewardListener(anyInt(), anyInt(), anyBoolean());
     }
 


### PR DESCRIPTION
## Summary
Fixes #1004.

`AdInterstitialDialog.setUpCloseButtonTask()` returned early when `RewardManager.getUserRewardedAlready()` was already `true`, without ever scheduling the close button to appear (it defaults to `View.GONE`).

For a VAST rewarded ad with an end card:
1. The reward is granted during the video phase.
2. The end card is then displayed via `AdInterstitialDialog`.
3. `setUpCloseButtonTask()` hit the early return, so the close button was never scheduled — it stayed `GONE` for the lifetime of the end card, with no way to close the ad other than backgrounding/killing the app.

## Fix
When the user is already rewarded on entry, the close button is now explicitly scheduled via `scheduleCloseButtonDisplaying()`, honoring the `close.action`/`close.postrewardtime` rules, instead of returning without any UI update.

## Testing
- Updated `setUpCloseButton_userAlreadyRewarded` in `AdInterstitialDialogTest` to assert the close button is scheduled (respecting `postRewardTime`/`autoClose`) instead of asserting nothing happens.
- Ran `./gradlew :PrebidMobile-core:testDebugUnitTest --tests "org.prebid.mobile.rendering.interstitial.*"` — all suites pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)