### PR TITLE
feat(rendering): expose winning creative size on BannerView

### DIFF
--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/BannerView.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/BannerView.java
@@ -535,6 +535,30 @@ public class BannerView extends FrameLayout {
         return bidResponse;
     }
 
+    /**
+     * Winning creative width in dp for the pure-rendering (Prebid SDK win) path,
+     * or 0 when there is no winning bid. Lets a multi-size placement learn which
+     * size actually rendered (e.g. 300x250 vs 320x50) from inside
+     * {@link org.prebid.mobile.api.rendering.listeners.BannerViewListener#onAdLoaded(BannerView)}
+     * so the host can size the slot to the creative. {@code onAdLoaded} fires
+     * after the bid response is set, so this is populated at callback time. On
+     * the ad-server (GAM) win path the served view owns its size, so this
+     * reflects the Prebid winning bid only.
+     */
+    public int getCreativeWidth() {
+        Bid bid = bidResponse != null ? bidResponse.getWinningBid() : null;
+        return bid != null ? bid.getWidth() : 0;
+    }
+
+    /**
+     * Winning creative height in dp for the pure-rendering (Prebid SDK win)
+     * path, or 0 when there is no winning bid. See {@link #getCreativeWidth()}.
+     */
+    public int getCreativeHeight() {
+        Bid bid = bidResponse != null ? bidResponse.getWinningBid() : null;
+        return bid != null ? bid.getHeight() : 0;
+    }
+
     @Nullable
     public String getImpOrtbConfig() {
         return adUnitConfig.getImpOrtbConfig();


### PR DESCRIPTION
Fixes #1006.

### Problem

The rendering `BannerView` gives consumers no way to learn **which requested size actually won**. `BannerViewListener.onAdLoaded(BannerView)` carries no size and there's no getter for the rendered creative's dimensions. For a multi-size rendering placement (multiple sizes on one `BannerView` via `addAdditionalSizes(...)`, e.g. 300x250 + 320x50) the host must reserve the bounding box of all requested sizes and, when a smaller creative wins, has no signal to shrink the slot — leaving whitespace. iOS already exposes this via `bannerView(_:didReceiveAdWithAdSize:)`.

### Change

Two non-breaking public getters on `BannerView`:

- `getCreativeWidth()` → winning bid width in dp (0 on no-fill)
- `getCreativeHeight()` → winning bid height in dp (0 on no-fill)

They delegate to the already-populated `bidResponse.getWinningBid()` (the same value `displayPrebidView()` uses to size the child via `getWinningBidWidthHeightPairDips`). `onAdLoaded` fires after `bidResponse` is set, so the value is available at callback time. Getters rather than a new listener method, so no existing implementer breaks.

On the ad-server (GAM) win path the served view owns its size, so these reflect the Prebid winning bid — which is exactly the pure-rendering case this targets.

### Notes

- No behavior change for existing consumers; purely additive read API.
- iOS parity with `didReceiveAdWithAdSize`.

_Developed with AI assistance._
