### PR TITLE
Protect global ORTB consent fields at the level where the SDK writes them

### DIFF
--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/OpenRtbMerger.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/OpenRtbMerger.java
@@ -100,14 +100,26 @@ public class OpenRtbMerger {
         }
     }
 
+    /**
+     * Removes the fields that the SDK computes itself, so that the publisher provided
+     * global ORTB config can't override them.
+     * <p>
+     * Each list is applied at the level where the SDK actually writes the field, i.e.
+     * {@code regs.ext.gdpr} is stripped from {@code regs.ext} and not from {@code regs}.
+     */
     private static void removeSensitiveData(@NonNull JSONObject openRtbJson) {
-        JSONObject userJson = openRtbJson.optJSONObject("user");
-        JSONObject extJson = userJson != null ? userJson.optJSONObject("ext") : null;
-        removeFields(extJson, FIELDS_USER_EXT);
+        removeFieldsWithExt(openRtbJson.optJSONObject("regs"), FIELDS_REGS, FIELDS_REGS_EXT);
+        removeFieldsWithExt(openRtbJson.optJSONObject("user"), FIELDS_USER, FIELDS_USER_EXT);
 
-        removeFields(openRtbJson.optJSONObject("regs"), FIELDS_REGS);
-        removeFields(openRtbJson.optJSONObject("geo"), FIELDS_GEO);
+        // "device" has no separate ext list, FIELDS_DEVICE drops the whole "device.ext" object.
         removeFields(openRtbJson.optJSONObject("device"), FIELDS_DEVICE);
+    }
+
+    private static void removeFieldsWithExt(@Nullable JSONObject json, String[] fields, String[] extFields) {
+        if (json == null) return;
+
+        removeFields(json, fields);
+        removeFields(json.optJSONObject("ext"), extFields);
     }
 
     private static void removeFields(@Nullable JSONObject json, String... fields) {
@@ -119,29 +131,27 @@ public class OpenRtbMerger {
     }
 
 
+    private static final String[] FIELDS_USER = {
+            "geo"
+    };
+
     private static final String[] FIELDS_USER_EXT = {
             "consent"
     };
 
     private static final String[] FIELDS_REGS = {
-            "gdpr",
-            "us_privacy",
-            "coppa"
+            "coppa",
+            "gpp",
+            "gpp_sid"
     };
 
-    private static final String[] FIELDS_GEO = {
-            "lat",
-            "lon",
-            "type",
-            "accuracy",
-            "lastfix",
-            "country",
-            "region",
-            "regionfips104",
-            "metro",
-            "city",
-            "zip",
-            "utcoffset"
+    /**
+     * Note: "tfua" is intentionally not protected. The global ORTB config is the only way
+     * for publishers to send it (see issue #997).
+     */
+    private static final String[] FIELDS_REGS_EXT = {
+            "gdpr",
+            "us_privacy"
     };
 
     private static final String[] FIELDS_DEVICE = {

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/openrtb/bidRequests/Regs.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/openrtb/bidRequests/Regs.java
@@ -35,7 +35,9 @@ public class Regs extends BaseBid {
     private JSONArray gppSid;
 
     /**
-     * When you add a new field to this list, don't forget to add it to the {@link org.prebid.mobile.OpenRtbMerger}.
+     * When you add a new field to this list, don't forget to protect it in the
+     * {@link org.prebid.mobile.OpenRtbMerger}: FIELDS_REGS for the fields written here,
+     * FIELDS_REGS_EXT for the ones written into {@link #getExt()}.
      */
     public JSONObject getJsonObject() throws JSONException {
         JSONObject jsonObject = new JSONObject();

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/openrtb/bidRequests/geo/Geo.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/rendering/models/openrtb/bidRequests/geo/Geo.java
@@ -41,7 +41,8 @@ public class Geo extends BaseBid {
     public Integer utcoffset = null;
 
     /**
-     * When you add a new field to this list, don't forget to add it to the {@link org.prebid.mobile.OpenRtbMerger}.
+     * No per-field list is needed in the {@link org.prebid.mobile.OpenRtbMerger}: the whole
+     * "geo" object is protected by its parent ("device" via FIELDS_DEVICE, "user" via FIELDS_USER).
      */
     public JSONObject getJsonObject() throws JSONException {
         JSONObject jsonObject = new JSONObject();

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/OpenRtbMergerTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/OpenRtbMergerTest.java
@@ -53,6 +53,56 @@ public class OpenRtbMergerTest {
     }
 
     @Test
+    public void mergeSensitiveData_regsExtConsentFields_areNotOverridden() throws JSONException {
+        String request = "{\"regs\":{\"ext\":{\"gdpr\":1,\"us_privacy\":\"1YNN\"}}}";
+        String openRtb = "{\"regs\":{\"ext\":{\"gdpr\":0,\"us_privacy\":\"1---\"}}}";
+
+        JSONObject mergedJson = merge(request, openRtb);
+
+        assertJsonEquals(request, mergedJson.toString());
+    }
+
+    @Test
+    public void mergeSensitiveData_regsExtConsentFields_areNotAddedToEmptyRequest() throws JSONException {
+        String request = "{}";
+        String openRtb = "{\"regs\":{\"ext\":{\"gdpr\":0,\"us_privacy\":\"1---\"}}}";
+
+        JSONObject mergedJson = merge(request, openRtb);
+
+        assertJsonEquals("{\"regs\":{\"ext\":{}}}", mergedJson.toString());
+    }
+
+    @Test
+    public void mergeSensitiveData_regsExtTfua_passesThrough() throws JSONException {
+        String request = "{\"regs\":{\"ext\":{\"gdpr\":1}}}";
+        String openRtb = "{\"regs\":{\"ext\":{\"tfua\":1,\"gdpr\":0}}}";
+
+        JSONObject mergedJson = merge(request, openRtb);
+
+        assertJsonEquals("{\"regs\":{\"ext\":{\"gdpr\":1,\"tfua\":1}}}", mergedJson.toString());
+    }
+
+    @Test
+    public void mergeSensitiveData_regsCoppaGppAndGppSid_areNotOverridden() throws JSONException {
+        String request = "{\"regs\":{\"coppa\":1,\"gpp\":\"real\",\"gpp_sid\":[7]}}";
+        String openRtb = "{\"regs\":{\"coppa\":0,\"gpp\":\"fake\",\"gpp_sid\":[1,2]}}";
+
+        JSONObject mergedJson = merge(request, openRtb);
+
+        assertJsonEquals(request, mergedJson.toString());
+    }
+
+    @Test
+    public void mergeSensitiveData_userGeo_isNotOverridden() throws JSONException {
+        String request = "{\"user\":{\"geo\":{\"lat\":1.5,\"lon\":2.5}}}";
+        String openRtb = "{\"user\":{\"geo\":{\"lat\":9.9,\"lon\":8.8},\"keywords\":\"new\"}}";
+
+        JSONObject mergedJson = merge(request, openRtb);
+
+        assertJsonEquals("{\"user\":{\"geo\":{\"lat\":1.5,\"lon\":2.5},\"keywords\":\"new\"}}", mergedJson.toString());
+    }
+
+    @Test
     public void merge_differentTypes() throws JSONException {
         String request = "{}";
         String openRtb = fromResources("merge_all_types.json");

--- a/PrebidMobile/PrebidMobile-core/src/test/resources/OpenRtbMerger/sensitive_data_empty.json
+++ b/PrebidMobile/PrebidMobile-core/src/test/resources/OpenRtbMerger/sensitive_data_empty.json
@@ -1,12 +1,9 @@
 {
   "user": {
-    "ext": {
-    }
+    "ext": {}
   },
   "regs": {
+    "ext": {}
   },
-  "geo": {
-  },
-  "device": {
-  }
+  "device": {}
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/resources/OpenRtbMerger/sensitive_data_fake.json
+++ b/PrebidMobile/PrebidMobile-core/src/test/resources/OpenRtbMerger/sensitive_data_fake.json
@@ -1,27 +1,21 @@
 {
   "user": {
+    "geo": {
+      "lat": "fake",
+      "lon": "fake"
+    },
     "ext": {
       "consent": "fake"
     }
   },
   "regs": {
-    "gdpr": "fake",
-    "us_privacy": "fake",
-    "coppa": "fake"
-  },
-  "geo": {
-    "lat": "fake",
-    "lon": "fake",
-    "type": "fake",
-    "accuracy": "fake",
-    "lastfix": "fake",
-    "country": "fake",
-    "region": "fake",
-    "regionfips104": "fake",
-    "metro": "fake",
-    "city": "fake",
-    "zip": "fake",
-    "utcoffset": "fake"
+    "coppa": 1,
+    "gpp": "fake",
+    "gpp_sid": "fake",
+    "ext": {
+      "gdpr": 0,
+      "us_privacy": "fake"
+    }
   },
   "device": {
     "ua": 123,
@@ -30,29 +24,29 @@
       "fake": "fake"
     },
     "ip": "fake",
-    "ipv6":  "fake",
+    "ipv6": "fake",
     "devicetype": "fake",
-    "make":  "fake",
+    "make": "fake",
     "model": "fake",
-    "os":  "fake",
+    "os": "fake",
     "osv": "fake",
-    "hwv":  "fake",
+    "hwv": "fake",
     "flashver": "fake",
-    "language":  "fake",
+    "language": "fake",
     "carrier": "fake",
-    "mccmnc":  "fake",
+    "mccmnc": "fake",
     "ifa": "fake",
-    "didsha1":  "fake",
+    "didsha1": "fake",
     "didmd5": "fake",
-    "dpidsha1":  "fake",
+    "dpidsha1": "fake",
     "dpidmd5": "fake",
-    "h":  "fake",
+    "h": "fake",
     "w": "fake",
-    "ppi":  "fake",
+    "ppi": "fake",
     "js": "fake",
-    "connectiontype":  "fake",
+    "connectiontype": "fake",
     "pxratio": "fake",
-    "geo":  "fake",
+    "geo": "fake",
     "ext": "fake"
   }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/resources/OpenRtbMerger/sensitive_data_real.json
+++ b/PrebidMobile/PrebidMobile-core/src/test/resources/OpenRtbMerger/sensitive_data_real.json
@@ -1,56 +1,50 @@
 {
   "user": {
+    "geo": {
+      "lat": "real",
+      "lon": "real"
+    },
     "ext": {
       "consent": "real"
     }
   },
   "regs": {
-    "gdpr": "real",
-    "us_privacy": "real",
-    "coppa": "real"
-  },
-  "geo": {
-    "lat": "real",
-    "lon": "real",
-    "type": "real",
-    "accuracy": "real",
-    "lastfix": "real",
-    "country": "real",
-    "region": "real",
-    "regionfips104": "real",
-    "metro": "real",
-    "city": "real",
-    "zip": "real",
-    "utcoffset": "real"
+    "coppa": "real",
+    "gpp": "real",
+    "gpp_sid": "real",
+    "ext": {
+      "gdpr": "real",
+      "us_privacy": "real"
+    }
   },
   "device": {
     "ua": "real",
     "dnt": "real",
-    "lmt":  "real",
+    "lmt": "real",
     "ip": "real",
-    "ipv6":  "real",
+    "ipv6": "real",
     "devicetype": "real",
-    "make":  "real",
+    "make": "real",
     "model": "real",
-    "os":  "real",
+    "os": "real",
     "osv": "real",
-    "hwv":  "real",
+    "hwv": "real",
     "flashver": "real",
-    "language":  "real",
+    "language": "real",
     "carrier": "real",
-    "mccmnc":  "real",
+    "mccmnc": "real",
     "ifa": "real",
-    "didsha1":  "real",
+    "didsha1": "real",
     "didmd5": "real",
-    "dpidsha1":  "real",
+    "dpidsha1": "real",
     "dpidmd5": "real",
-    "h":  "real",
+    "h": "real",
     "w": "real",
-    "ppi":  "real",
+    "ppi": "real",
     "js": "real",
-    "connectiontype":  "real",
+    "connectiontype": "real",
     "pxratio": "real",
-    "geo":  "real",
+    "geo": "real",
     "ext": "real"
   }
 }


### PR DESCRIPTION
## Summary

`OpenRtbMerger.removeSensitiveData` strips SDK-computed fields out of the publisher-supplied global ORTB config before merging, so that a publisher can enrich the bid request but cannot overwrite signals the SDK is responsible for. Three of its field lists were applied at the wrong nesting level, so they protected nothing.

The result is a **privacy-compliance bug**: a global ORTB config could silently override the GDPR and US Privacy values the SDK computed from the consent storage, and could restore location precision the SDK had deliberately coarsened.

This PR re-applies each list at the level where the SDK actually writes the field, matching `ArbitraryGlobalORTBHelper.ProtectedFields` in prebid-mobile-ios.

## Why this needs fixing

### 1. `regs.ext.gdpr` and `regs.ext.us_privacy` were never protected

`FIELDS_REGS = {"gdpr", "us_privacy", "coppa"}` was applied to `openRtbJson.optJSONObject("regs")` — the top level of `regs`. But `UserConsentParameterBuilder` writes two of those three into `regs.ext`:

```java
bidRequest.getRegs().getExt().put(GDPR, gdprValue);          // UserConsentParameterBuilder:51
bidRequest.getRegs().getExt().put(US_PRIVACY, usPrivacyString); // :64
bidRequest.getRegs().coppa = subjectToCoppa ? 1 : 0;         // :71 — the only top-level one
```

So only `coppa` was ever removed. A publisher config of:

```json
{ "regs": { "ext": { "gdpr": 0 } } }
```

passed straight through the merger and overwrote the SDK's computed `gdpr` flag on the outgoing bid request. The same applies to `us_privacy`.

This is the whole point of the sanitization step: these values come from the CMP via `UserConsentManager`, and the SDK must be the single source of truth for them. A publisher able to flip `gdpr` to `0` (whether by mistake in a hand-written config, or by copying an example blob) turns off downstream GDPR handling for every request in the app while the CMP says otherwise.

### 2. `FIELDS_GEO` was dead code, and `user.geo` was unprotected

`FIELDS_GEO` was applied to `openRtbJson.optJSONObject("geo")` — a **root-level** `geo` object. There is no root-level `geo` in OpenRTB; geo lives at `device.geo` and `user.geo`. The list never matched anything.

`device.geo` happened to be covered anyway, because `FIELDS_DEVICE` already contains `"geo"`. `user.geo` was not covered by anything — and the SDK writes it:

```java
final Pair<Float, Float> userLatLng = TargetingParams.getUserLatLng();
if (userLatLng != null) {
    final Geo userGeo = user.getGeo();
    Integer precision = TargetingParams.getLocationDecimalPrecision();
    userGeo.lat = Util.applyLocationPrecision(userLatLng.first, precision);
    userGeo.lon = Util.applyLocationPrecision(userLatLng.second, precision);
}
```
<sub>`BasicParameterBuilder.appendUserTargetingParameters`</sub>

That `applyLocationPrecision` call is a deliberate privacy control — the publisher asked for coordinates to be truncated. Leaving `user.geo` open meant a global ORTB config could put full-precision coordinates back into the request, defeating the setting the app itself configured.

### 3. `regs.gpp` and `regs.gpp_sid` were missing

Both are serialized by `Regs.getJsonObject` and both are SDK-computed — `UserConsentParameterBuilder.appendGppParameter` feeds them from `UserConsentManager.getRealGppString()` / `getRealGppSid()`. They belong in the protected set for exactly the same reason as `gdpr` / `us_privacy`, and iOS already protects them.

## What changed

`removeSensitiveData` now pairs each object with its own `ext` list, mirroring the iOS `props` / `extProps` split:

| List | Applied at | Contents |
|---|---|---|
| `FIELDS_REGS` | `regs` | `coppa`, `gpp`, `gpp_sid` |
| `FIELDS_REGS_EXT` | `regs.ext` | `gdpr`, `us_privacy` |
| `FIELDS_USER` | `user` | `geo` |
| `FIELDS_USER_EXT` | `user.ext` | `consent` |
| `FIELDS_DEVICE` | `device` | unchanged |

`FIELDS_GEO` is deleted. Geo is now protected wholesale by its parents (`device.geo` via `FIELDS_DEVICE`, `user.geo` via `FIELDS_USER`), which is what iOS does — no per-field geo list is needed.

## Alignment with iOS

`ArbitraryGlobalORTBHelper.ProtectedFields` in prebid-mobile-ios gets the nesting right today, and its `removeProtectedFields(from:props:extProps:)` takes both an object-level and an `ext`-level list per object. After this PR the two SDKs agree on:

- `regsProps` → `FIELDS_REGS` (`gpp_sid`, `gpp`, `coppa`)
- `regsExtProps` → `FIELDS_REGS_EXT` (`gdpr`, `us_privacy`)
- `userProps` → `FIELDS_USER` (`geo`)
- `userExtProps` → `FIELDS_USER_EXT` (`consent`)

Beyond correctness, parity matters here because publishers ship the *same* ORTB config JSON to both platforms. Today, a config containing `regs.ext.gdpr` is stripped on iOS and honoured on Android — the same app sends different consent signals depending on the platform, which is the worst possible failure mode for a compliance signal, since it is invisible unless you diff the two bid requests.

### Deliberate divergences (both intentional, both noted in code)

- **`regs.ext.tfua` stays unprotected.** iOS doesn't protect it either, and per #997 the global ORTB config is currently the only way for publishers to send `tfua` for non-US child-protection regimes. There is now a comment on `FIELDS_REGS_EXT` so this isn't "tidied up" by a future change. A regression test covers it.
- **`device.ext` is still dropped wholesale on Android.** `FIELDS_DEVICE` contains `"ext"`, so the entire `device.ext` object is removed; iOS only strips `atts` and `ifv` from it. Android's behaviour is the stricter of the two, and narrowing it would *loosen* protection, so it is left alone here. Worth a follow-up decision, but out of scope for a fix.

## Tests

Five new tests in `OpenRtbMergerTest`:

- `mergeSensitiveData_regsExtConsentFields_areNotOverridden` — publisher `regs.ext.gdpr` / `us_privacy` cannot overwrite SDK values
- `mergeSensitiveData_regsExtConsentFields_areNotAddedToEmptyRequest` — nor can they be injected when the SDK set nothing
- `mergeSensitiveData_regsExtTfua_passesThrough` — `tfua` survives while a sibling `gdpr` in the same object is stripped
- `mergeSensitiveData_regsCoppaGppAndGppSid_areNotOverridden`
- `mergeSensitiveData_userGeo_isNotOverridden` — `user.geo` stripped while a sibling `user.keywords` still merges normally

The three `sensitive_data_*.json` fixtures were regenerated. They previously encoded the *wrong* request shape (`regs.gdpr` at the top level, a root-level `geo` object), which is why the existing tests passed against the bug — they asserted the merger removed fields from a structure the SDK never produces.

```
./gradlew :PrebidMobile-core:testDebugUnitTest --tests "org.prebid.mobile.OpenRtbMergerTest"
```

14/14 pass. The `rendering.networking.parameters` package was also run as a regression check; the two failures in `BasicParameterBuilderTest.whenSetPluginRendererList*` are pre-existing on `master` and unrelated to this change.

## Doc comments

`Regs.getJsonObject` carried "When you add a new field to this list, don't forget to add it to the OpenRtbMerger". Since `regs` fields now split across two lists, it names both (`FIELDS_REGS` for top-level, `FIELDS_REGS_EXT` for `ext`). The identical comment on `geo/Geo.java` had become misleading — a new `Geo` field needs no merger change at all now — so it explains that the object is protected by its parent instead. `Device.java`'s comment is still accurate and untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
