### PR TITLE
Multiformat banner ad unit in the rendering and mediation APIs

### DIFF
--- a/Example/PrebidDemoKotlin/src/main/AndroidManifest.xml
+++ b/Example/PrebidDemoKotlin/src/main/AndroidManifest.xml
@@ -127,6 +127,9 @@
             android:name=".activities.ads.inapp.InAppVideoBannerActivity"
             android:exported="true" />
         <activity
+            android:name=".activities.ads.inapp.InAppMultiformatBannerActivity"
+            android:exported="true" />
+        <activity
             android:name=".activities.ads.inapp.InAppDisplayInterstitialActivity"
             android:exported="true" />
         <activity

--- a/Example/PrebidDemoKotlin/src/main/java/org/prebid/mobile/prebidkotlindemo/activities/ads/inapp/InAppMultiformatBannerActivity.kt
+++ b/Example/PrebidDemoKotlin/src/main/java/org/prebid/mobile/prebidkotlindemo/activities/ads/inapp/InAppMultiformatBannerActivity.kt
@@ -1,0 +1,82 @@
+/*
+ *    Copyright 2018-2019 Prebid.org, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+package org.prebid.mobile.prebidkotlindemo.activities.ads.inapp
+
+import android.os.Bundle
+import android.util.Log
+import org.prebid.mobile.AdSize
+import org.prebid.mobile.api.data.AdUnitFormat
+import org.prebid.mobile.api.data.VideoPlacementType
+import org.prebid.mobile.api.exceptions.AdException
+import org.prebid.mobile.api.rendering.BannerView
+import org.prebid.mobile.api.rendering.listeners.BannerViewListener
+import org.prebid.mobile.prebidkotlindemo.activities.BaseAdActivity
+import java.util.EnumSet
+
+class InAppMultiformatBannerActivity : BaseAdActivity() {
+
+    companion object {
+        const val WIDTH = 300
+        const val HEIGHT = 250
+    }
+
+    private var bannerView: BannerView? = null
+
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+
+        createAd()
+    }
+
+    private fun createAd() {
+        // Random for test cases
+        val configId = mutableListOf(
+            "prebid-demo-banner-300-250",
+            "prebid-demo-video-outstream"
+        ).shuffled().first()
+
+        bannerView = BannerView(
+            this,
+            configId,
+            AdSize(WIDTH, HEIGHT)
+        )
+
+        // Let display and outstream video demand compete on the same impression
+        bannerView?.setAdUnitFormats(EnumSet.of(AdUnitFormat.BANNER, AdUnitFormat.VIDEO))
+        bannerView?.videoPlacementType = VideoPlacementType.IN_BANNER
+        bannerView?.setBannerListener(object : BannerViewListener {
+            override fun onAdFailed(bannerView: BannerView?, exception: AdException?) {
+                Log.e("InAppMultiformatBanner", "Ad failed: ${exception?.message}")
+            }
+
+            override fun onAdLoaded(bannerView: BannerView?) {}
+            override fun onAdClicked(bannerView: BannerView?) {}
+            override fun onAdDisplayed(bannerView: BannerView?) {}
+            override fun onAdClosed(bannerView: BannerView?) {}
+        })
+        bannerView?.loadAd()
+
+        adWrapperView.addView(bannerView)
+    }
+
+
+    override fun onDestroy() {
+        super.onDestroy()
+        bannerView?.destroy()
+    }
+
+}

--- a/Example/PrebidDemoKotlin/src/main/java/org/prebid/mobile/prebidkotlindemo/testcases/TestCaseRepository.kt
+++ b/Example/PrebidDemoKotlin/src/main/java/org/prebid/mobile/prebidkotlindemo/testcases/TestCaseRepository.kt
@@ -174,6 +174,12 @@ object TestCaseRepository {
             InAppVideoBannerActivity::class.java,
         ),
         TestCase(
+            R.string.in_app_multiformat_banner,
+            AdFormat.MULTIFORMAT,
+            IntegrationKind.NO_AD_SERVER,
+            InAppMultiformatBannerActivity::class.java,
+        ),
+        TestCase(
             R.string.in_app_display_interstitial,
             AdFormat.DISPLAY_INTERSTITIAL,
             IntegrationKind.NO_AD_SERVER,

--- a/Example/PrebidDemoKotlin/src/main/res/values/strings.xml
+++ b/Example/PrebidDemoKotlin/src/main/res/values/strings.xml
@@ -38,6 +38,7 @@
     <string name="in_app_display_banner_mraid_expand">In-App Display Banner 320x50 MRAID Expand 1-Part</string>
     <string name="in_app_display_banner_mraid_resize_errors">In-App Display Banner 320x50 MRAID Resize With Errors</string>
     <string name="in_app_video_banner">In-App Video Banner</string>
+    <string name="in_app_multiformat_banner">In-App Multiformat Banner</string>
     <string name="in_app_display_interstitial">In-App Display Interstitial</string>
     <string name="in_app_video_interstitial">In-App Video Interstitial</string>
     <string name="in_app_video_interstitial_end_card">In-App Video Interstitial With End Card</string>

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/ppm/PpmMultiformatBannerFragment.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/plugplay/bidding/ppm/PpmMultiformatBannerFragment.kt
@@ -1,0 +1,51 @@
+/*
+ *    Copyright 2018-2021 Prebid.org, Inc.
+ *
+ *    Licensed under the Apache License, Version 2.0 (the "License");
+ *    you may not use this file except in compliance with the License.
+ *    You may obtain a copy of the License at
+ *
+ *        http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *    Unless required by applicable law or agreed to in writing, software
+ *    distributed under the License is distributed on an "AS IS" BASIS,
+ *    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *    See the License for the specific language governing permissions and
+ *    limitations under the License.
+ */
+
+package org.prebid.mobile.renderingtestapp.plugplay.bidding.ppm
+
+import org.prebid.mobile.AdSize
+import org.prebid.mobile.api.data.AdUnitFormat
+import org.prebid.mobile.api.data.VideoPlacementType
+import org.prebid.mobile.api.rendering.BannerView
+import org.prebid.mobile.renderingtestapp.R
+import java.util.EnumSet
+
+/**
+ * Requests banner and outstream video demand on a single impression. The config id is picked at
+ * random between a display and a video stored request, so either creative can win.
+ */
+open class PpmMultiformatBannerFragment : PpmVideoFragment() {
+
+    override fun initAd(): Any? {
+        val context = requireContext()
+        bannerView = BannerView(
+            context,
+            listOf(
+                context.getString(R.string.imp_prebid_id_banner_300x250),
+                context.getString(R.string.imp_prebid_id_video_outstream)
+            ).shuffled().first(),
+            AdSize(width, height)
+        )
+        bannerView?.setAdUnitFormats(EnumSet.of(AdUnitFormat.BANNER, AdUnitFormat.VIDEO))
+        bannerView?.videoPlacementType = VideoPlacementType.IN_BANNER
+        bannerView?.setAutoRefreshDelay(refreshDelay)
+        bannerView?.setBannerListener(this)
+        bannerView?.setBannerVideoListener(this)
+        binding.viewContainer.addView(bannerView)
+        return bannerView
+    }
+
+}

--- a/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/utils/DemoItemProvider.kt
+++ b/Example/PrebidInternalTestApp/src/main/java/org/prebid/mobile/renderingtestapp/utils/DemoItemProvider.kt
@@ -55,6 +55,8 @@ class DemoItemProvider private constructor() {
         private const val ppmInterstitialPluginEventListenerAction = R.id.action_header_bidding_to_in_app_interstitial_plugin_event_listener
         private const val ppmInterstitialPluginRendererAction = R.id.action_header_bidding_to_in_app_interstitial_plugin_renderer
         private const val ppmRewardedAction = R.id.action_header_bidding_to_in_app_video_rewarded
+        private const val ppmMultiformatBannerAction =
+            R.id.action_header_bidding_to_in_app_multiformat_banner
 
         private const val gamBannerAction = R.id.action_header_bidding_to_gam_banner
         private const val gamBannerOriginalAction =
@@ -1123,6 +1125,19 @@ class DemoItemProvider private constructor() {
                     ppmVideoTagList,
                     createBannerBundle(
                         R.string.imp_prebid_id_video_outstream,
+                        null,
+                        300,
+                        250
+                    )
+                )
+            )
+            demoList.add(
+                DemoItem(
+                    getString(R.string.demo_bidding_in_app_multiformat_banner),
+                    ppmMultiformatBannerAction,
+                    ppmVideoTagList,
+                    createBannerBundle(
+                        R.string.imp_prebid_dynamic,
                         null,
                         300,
                         250

--- a/Example/PrebidInternalTestApp/src/main/res/navigation/bidding_navigation.xml
+++ b/Example/PrebidInternalTestApp/src/main/res/navigation/bidding_navigation.xml
@@ -217,6 +217,15 @@
             app:popUpTo="@+id/headerBiddingFragment" />
 
         <action
+            android:id="@+id/action_header_bidding_to_in_app_multiformat_banner"
+            app:destination="@id/navigation_in_app_multiformat_banner"
+            app:enterAnim="@anim/nav_default_enter_anim"
+            app:exitAnim="@anim/nav_default_exit_anim"
+            app:popEnterAnim="@anim/nav_default_pop_enter_anim"
+            app:popExitAnim="@anim/nav_default_pop_exit_anim"
+            app:popUpTo="@+id/headerBiddingFragment" />
+
+        <action
             android:id="@+id/action_header_bidding_to_in_app_banner_video_feed"
             app:destination="@id/navigation_in_app_banner_video_feed"
             app:enterAnim="@anim/nav_default_enter_anim"
@@ -696,6 +705,11 @@
         android:id="@+id/navigation_in_app_banner_video"
         android:name="org.prebid.mobile.renderingtestapp.plugplay.bidding.ppm.PpmVideoFragment"
         android:label="Video Outstream (In-App)" />
+
+    <fragment
+        android:id="@+id/navigation_in_app_multiformat_banner"
+        android:name="org.prebid.mobile.renderingtestapp.plugplay.bidding.ppm.PpmMultiformatBannerFragment"
+        android:label="Multiformat Banner (In-App)" />
 
     <fragment
         android:id="@+id/navigation_in_app_banner_video_feed"

--- a/Example/PrebidInternalTestApp/src/main/res/values/strings.xml
+++ b/Example/PrebidInternalTestApp/src/main/res/values/strings.xml
@@ -105,6 +105,7 @@
     <string name="demo_bidding_in_app_interstitial_320_480_no_bids">Display Interstitial 320x480 [noBids] (In-App)</string>
     <string name="demo_bidding_in_app_interstitial_320_480_multiformat">Multiformat Interstitial 320x480 (In-App)</string>
     <string name="demo_bidding_in_app_banner_video_outstream">Video Outstream (In-App)</string>
+    <string name="demo_bidding_in_app_multiformat_banner">Multiformat Banner 300x250 (In-App)</string>
     <string name="demo_bidding_in_app_banner_video_outstream_no_bids">Video Outstream [noBids] (In-App)</string>
     <string name="demo_bidding_in_app_banner_video_outstream_feed">Video Outstream Feed (In-App)</string>
     <string name="demo_bidding_in_app_banner_video_outstream_end_card">Video Outstream with End Card (In-App)</string>

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/data/AdFormat.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/data/AdFormat.java
@@ -1,5 +1,7 @@
 package org.prebid.mobile.api.data;
 
+import androidx.annotation.Nullable;
+
 import java.util.EnumSet;
 
 /**
@@ -29,6 +31,27 @@ public enum AdFormat {
             }
             if (format == AdUnitFormat.VIDEO) {
                 result.add(AdFormat.VAST);
+            }
+        }
+        return result;
+    }
+
+    /**
+     * Maps internal ad formats back to the public {@link AdUnitFormat} values.
+     * {@link #BANNER} and {@link #INTERSTITIAL} both map to {@link AdUnitFormat#BANNER},
+     * {@link #VAST} maps to {@link AdUnitFormat#VIDEO}. {@link #NATIVE} has no public
+     * counterpart and is skipped.
+     */
+    public static EnumSet<AdUnitFormat> toSet(@Nullable EnumSet<AdFormat> adFormats) {
+        EnumSet<AdUnitFormat> result = EnumSet.noneOf(AdUnitFormat.class);
+        if (adFormats == null) return result;
+
+        for (AdFormat format : adFormats) {
+            if (format == AdFormat.BANNER || format == AdFormat.INTERSTITIAL) {
+                result.add(AdUnitFormat.BANNER);
+            }
+            if (format == AdFormat.VAST) {
+                result.add(AdUnitFormat.VIDEO);
             }
         }
         return result;

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/mediation/MediationBannerAdUnit.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/mediation/MediationBannerAdUnit.java
@@ -18,13 +18,17 @@ package org.prebid.mobile.api.mediation;
 
 import android.content.Context;
 import androidx.annotation.NonNull;
+import androidx.annotation.Nullable;
 import org.prebid.mobile.AdSize;
 import org.prebid.mobile.LogUtil;
 import org.prebid.mobile.api.data.AdFormat;
+import org.prebid.mobile.api.data.AdUnitFormat;
 import org.prebid.mobile.api.mediation.listeners.OnFetchCompleteListener;
 import org.prebid.mobile.rendering.bidding.display.PrebidMediationDelegate;
 import org.prebid.mobile.rendering.models.AdPosition;
 import org.prebid.mobile.rendering.utils.broadcast.ScreenStateReceiver;
+
+import java.util.EnumSet;
 
 /**
  * Mediation banner ad unit for Rendering API with AdMob or AppLovin MAX.
@@ -106,6 +110,33 @@ public class MediationBannerAdUnit extends MediationBaseAdUnit {
 
     public final void addAdditionalSizes(AdSize... sizes) {
         adUnitConfig.addSizes(sizes);
+    }
+
+    /**
+     * Sets the ad unit formats requested on a single impression.
+     * <p>
+     * Defaults to {@link AdUnitFormat#BANNER}. Pass {@link AdUnitFormat#VIDEO} for an outstream
+     * video banner, or both values to let display and video demand compete on the same impression.
+     * <p>
+     * A null or empty set is ignored and the current value is kept.
+     * <p>
+     * Unlike {@code BannerView}, a mediation ad unit is not told whether the Prebid bid actually
+     * won in the primary ad server, so auto refresh keeps running when video is requested. Call
+     * {@link #stopRefresh()} and {@link #resumeRefresh()} around video playback if the refresh
+     * interval is shorter than the creatives being served.
+     */
+    public void setAdUnitFormats(@Nullable EnumSet<AdUnitFormat> adUnitFormats) {
+        if (adUnitFormats == null || adUnitFormats.isEmpty()) {
+            LogUtil.warning(TAG, "Ad unit formats must contain at least one item. The current value is kept.");
+            return;
+        }
+
+        adUnitConfig.setAdUnitFormats(adUnitFormats, false);
+    }
+
+    @NonNull
+    public EnumSet<AdUnitFormat> getAdUnitFormats() {
+        return adUnitConfig.getAdUnitFormats();
     }
 
     public final void setRefreshInterval(int seconds) {

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/BannerView.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/BannerView.java
@@ -29,6 +29,7 @@ import org.prebid.mobile.AdSize;
 import org.prebid.mobile.LogUtil;
 import org.prebid.mobile.PrebidMobile;
 import org.prebid.mobile.api.data.AdFormat;
+import org.prebid.mobile.api.data.AdUnitFormat;
 import org.prebid.mobile.api.data.VideoPlacementType;
 import org.prebid.mobile.api.exceptions.AdException;
 import org.prebid.mobile.api.rendering.listeners.BannerVideoListener;
@@ -55,6 +56,7 @@ import org.prebid.mobile.rendering.utils.helpers.RenderingExceptionParser;
 import org.prebid.mobile.rendering.utils.helpers.VisibilityChecker;
 import org.prebid.mobile.rendering.views.webview.mraid.Views;
 
+import java.util.EnumSet;
 import java.util.Set;
 
 import static android.view.ViewGroup.LayoutParams.MATCH_PARENT;
@@ -89,6 +91,13 @@ public class BannerView extends FrameLayout {
     private boolean adFailed;
 
     private String nativeStylesCreative = null;
+
+    /**
+     * True once the publisher configured the formats through {@link #setAdUnitFormats(EnumSet)}.
+     * Such an explicit choice takes precedence over the format implied by
+     * {@link #setVideoPlacementType(VideoPlacementType)}.
+     */
+    private boolean adUnitFormatsConfigured;
 
     //region ==================== Listener implementation
     private final DisplayViewListener displayViewListener = new DisplayViewListener() {
@@ -378,8 +387,14 @@ public class BannerView extends FrameLayout {
         PrebidMobilePluginRegister.getInstance().registerEventListener(pluginEventListener, adUnitConfig.getFingerprint());
     }
 
+    /**
+     * Sets the video placement type and, unless the formats were explicitly configured through
+     * {@link #setAdUnitFormats(EnumSet)}, switches the ad unit to a video only request.
+     */
     public void setVideoPlacementType(VideoPlacementType videoPlacement) {
-        adUnitConfig.setAdFormat(AdFormat.VAST);
+        if (!adUnitFormatsConfigured) {
+            adUnitConfig.setAdFormat(AdFormat.VAST);
+        }
 
         final PlacementType placementType = VideoPlacementType.mapToPlacementType(videoPlacement);
         adUnitConfig.setPlacementType(placementType);
@@ -388,6 +403,32 @@ public class BannerView extends FrameLayout {
     @Nullable
     public VideoPlacementType getVideoPlacementType() {
         return VideoPlacementType.mapToVideoPlacementType(adUnitConfig.getPlacementTypeValue());
+    }
+
+    /**
+     * Sets the ad unit formats requested on a single impression.
+     * <p>
+     * Defaults to {@link AdUnitFormat#BANNER}. Pass {@link AdUnitFormat#VIDEO} for an outstream
+     * video banner, or both values to let display and video demand compete on the same impression.
+     * <p>
+     * A null or empty set is ignored and the current value is kept.
+     * <p>
+     * When a video bid wins a multiformat auction, auto refresh is cancelled so that the creative
+     * is not torn down mid playback.
+     */
+    public void setAdUnitFormats(@Nullable EnumSet<AdUnitFormat> adUnitFormats) {
+        if (adUnitFormats == null || adUnitFormats.isEmpty()) {
+            LogUtil.warning(TAG, "Ad unit formats must contain at least one item. The current value is kept.");
+            return;
+        }
+
+        adUnitConfig.setAdUnitFormats(adUnitFormats, false);
+        adUnitFormatsConfigured = true;
+    }
+
+    @NonNull
+    public EnumSet<AdUnitFormat> getAdUnitFormats() {
+        return adUnitConfig.getAdUnitFormats();
     }
 
     /**
@@ -478,6 +519,13 @@ public class BannerView extends FrameLayout {
     }
 
     private void displayPrebidView() {
+        // The refresh timer is armed as soon as the bid response arrives, before the primary ad
+        // server answers, so the winning format can only be honoured here. A video creative must
+        // not be torn down mid playback.
+        if (bidResponse != null && bidResponse.isVideo()) {
+            stopRefresh();
+        }
+
         if (indexOfChild(displayView) != -1) {
             displayView.destroy();
             displayView = null;

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/BannerView.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/BannerView.java
@@ -413,8 +413,8 @@ public class BannerView extends FrameLayout {
      * <p>
      * A null or empty set is ignored and the current value is kept.
      * <p>
-     * When a video bid wins a multiformat auction, auto refresh is cancelled so that the creative
-     * is not torn down mid playback.
+     * Auto refresh is deferred while a video creative is playing and resumes once playback
+     * finishes, so a video is never torn down mid playback.
      */
     public void setAdUnitFormats(@Nullable EnumSet<AdUnitFormat> adUnitFormats) {
         if (adUnitFormats == null || adUnitFormats.isEmpty()) {
@@ -505,6 +505,12 @@ public class BannerView extends FrameLayout {
                 return true;
             }
 
+            // A video creative must not be torn down mid playback. The tick is skipped and the
+            // timer rescheduled, so refreshing resumes once playback finishes.
+            if (isVideoPlaying()) {
+                return false;
+            }
+
             final boolean isWindowVisibleToUser = screenStateReceiver.isScreenOn();
             return visibilityChecker.isVisibleForRefresh(this) && isWindowVisibleToUser;
         });
@@ -519,13 +525,6 @@ public class BannerView extends FrameLayout {
     }
 
     private void displayPrebidView() {
-        // The refresh timer is armed as soon as the bid response arrives, before the primary ad
-        // server answers, so the winning format can only be honoured here. A video creative must
-        // not be torn down mid playback.
-        if (bidResponse != null && bidResponse.isVideo()) {
-            stopRefresh();
-        }
-
         if (indexOfChild(displayView) != -1) {
             displayView.destroy();
             displayView = null;
@@ -559,6 +558,14 @@ public class BannerView extends FrameLayout {
         if (bannerViewListener != null) {
             bannerViewListener.onAdDisplayed(BannerView.this);
         }
+    }
+
+    /**
+     * True while a Prebid video creative deployed by this view is playing.
+     */
+    @VisibleForTesting
+    boolean isVideoPlaying() {
+        return displayView != null && displayView.isVideoPlaying();
     }
 
     private void markPrimaryAdRequestFinished() {

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/DisplayView.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/DisplayView.java
@@ -32,6 +32,10 @@ import org.prebid.mobile.rendering.networking.WinNotifier;
 
 /**
  * Internal view for {@link BannerView}.
+ * <p>
+ * Renders against its own copy of the ad unit's configuration. The creative pipeline rewrites the
+ * configuration it is given, so sharing the ad unit's instance would narrow a multiformat ad unit
+ * to the winning creative's format and break the following auctions.
  */
 public class DisplayView extends FrameLayout {
     private View adView;
@@ -47,7 +51,7 @@ public class DisplayView extends FrameLayout {
     ) {
         super(context);
 
-        this.adUnitConfiguration = adUnitConfiguration;
+        this.adUnitConfiguration = new AdUnitConfiguration(adUnitConfiguration);
         this.displayViewListener = displayViewListener;
 
         createBannerAdView(context, bidResponse);
@@ -62,7 +66,7 @@ public class DisplayView extends FrameLayout {
     ) {
         super(context);
 
-        this.adUnitConfiguration = adUnitConfiguration;
+        this.adUnitConfiguration = new AdUnitConfiguration(adUnitConfiguration);
         this.displayViewListener = displayViewListener;
         this.displayVideoListener = displayVideoListener;
 

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/DisplayView.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/DisplayView.java
@@ -84,6 +84,14 @@ public class DisplayView extends FrameLayout {
         });
     }
 
+    /**
+     * True while the rendered creative is a video that is currently playing. A creative that does
+     * not report playback, such as an HTML creative or a third party plugin renderer, reports false.
+     */
+    public boolean isVideoPlaying() {
+        return adView instanceof PrebidDisplayView && ((PrebidDisplayView) adView).isVideoPlaying();
+    }
+
     public void destroy() {
         LogUtil.debug("Destroying view");
         adUnitConfiguration = null;

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/PrebidDisplayView.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/PrebidDisplayView.java
@@ -223,6 +223,13 @@ public class PrebidDisplayView extends FrameLayout implements PrebidDestroyable 
         }
     }
 
+    /**
+     * True while a rendered video creative is playing. An HTML creative always reports false.
+     */
+    public boolean isVideoPlaying() {
+        return videoView != null && videoView.isVideoPlaybackInProgress();
+    }
+
     private void displayHtmlAd(BidResponse response) throws AdException {
         adViewManager = new AdViewManager(getContext(), adViewManagerListener, this, interstitialManager);
         adViewManager.loadBidTransaction(adUnitConfiguration, response);

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/PrebidDisplayView.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/PrebidDisplayView.java
@@ -180,6 +180,9 @@ public class PrebidDisplayView extends FrameLayout implements PrebidDestroyable 
         this.displayVideoListener = displayVideoListener;
         try {
             adUnitConfiguration.modifyUsingBidResponse(response);
+            // The configuration is shared across refreshes of a multiformat banner, so this must
+            // track the format of the current winning bid instead of latching to true.
+            adUnitConfiguration.setBuiltInVideo(response.isVideo());
             if (response.isVideo()) {
                 displayVideoAd(response);
             } else {

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/VideoView.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/api/rendering/VideoView.java
@@ -381,6 +381,18 @@ public class VideoView extends BaseAdView {
         videoViewState = undefined;
     }
 
+    /**
+     * True once playback has started and until it finishes, including while the video is paused.
+     * Callers use it to avoid tearing the creative down mid playback. Replaying through
+     * "watch again" moves the view back to {@link State#PLAYBACK_NOT_STARTED} and then to
+     * {@link State#PLAYING}, so a replay is covered as well.
+     */
+    public boolean isVideoPlaybackInProgress() {
+        return isInState(State.PLAYING)
+                || isInState(State.PAUSED_AUTO)
+                || isInState(State.PAUSED_BY_USER);
+    }
+
     private boolean canPlay() {
         return isInState(State.PLAYBACK_NOT_STARTED);
     }

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/configuration/AdUnitConfiguration.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/configuration/AdUnitConfiguration.java
@@ -41,7 +41,7 @@ public class AdUnitConfiguration {
     private int videoSkipOffset = SKIP_OFFSET_NOT_ASSIGNED;
     private int autoRefreshDelayInMillis = 0;
     private int skipDelay = 10;
-    private final int broadcastId = Utils.generateRandomInt();
+    private final int broadcastId;
     private float videoInitialVolume = ExoPlayerView.DEFAULT_INITIAL_VIDEO_VOLUME;
     private double closeButtonArea = 0;
     private double skipButtonArea = 0;
@@ -80,6 +80,66 @@ public class AdUnitConfiguration {
 
     private final EnumSet<AdFormat> adFormats = EnumSet.noneOf(AdFormat.class);
     private final HashSet<AdSize> adSizes = new HashSet<>();
+
+    public AdUnitConfiguration() {
+        broadcastId = Utils.generateRandomInt();
+    }
+
+    /**
+     * Creates a rendering copy of an ad unit's configuration.
+     * <p>
+     * Rendering rewrites the configuration it is handed: the creative pipeline narrows
+     * {@link #getAdFormats()} to the format of the winning creative, and the video player turns
+     * off auto refresh and records the built in video state. A copy keeps those writes away from
+     * the ad unit itself, so a multiformat ad unit still requests every configured format on the
+     * next auction.
+     * <p>
+     * {@code fingerprint} is carried over because plugin event listeners are registered under it.
+     * The mutable sub configurations are shared on purpose: the reward, banner, video and native
+     * settings are read back through the ad unit after rendering.
+     */
+    public AdUnitConfiguration(@NonNull AdUnitConfiguration source) {
+        broadcastId = source.broadcastId;
+        fingerprint = source.fingerprint;
+
+        isRewarded = source.isRewarded;
+        isBuiltInVideo = source.isBuiltInVideo;
+        isMuted = source.isMuted;
+        isSoundButtonVisible = source.isSoundButtonVisible;
+        isOriginalAdUnit = source.isOriginalAdUnit;
+        hasEndCard = source.hasEndCard;
+
+        videoSkipOffset = source.videoSkipOffset;
+        autoRefreshDelayInMillis = source.autoRefreshDelayInMillis;
+        skipDelay = source.skipDelay;
+        videoInitialVolume = source.videoInitialVolume;
+        closeButtonArea = source.closeButtonArea;
+        skipButtonArea = source.skipButtonArea;
+        maxVideoDuration = source.maxVideoDuration;
+
+        configId = source.configId;
+        pbAdSlot = source.pbAdSlot;
+        interstitialSize = source.interstitialSize;
+        impressionUrl = source.impressionUrl;
+        gpid = source.gpid;
+        impOrtbConfig = source.impOrtbConfig;
+        globalOrtbConfig = source.globalOrtbConfig;
+
+        closeButtonPosition = source.closeButtonPosition;
+        skipButtonPosition = source.skipButtonPosition;
+        minSizePercentage = source.minSizePercentage;
+        placementType = source.placementType;
+        adPosition = source.adPosition;
+
+        appContent = source.appContent;
+        bannerParameters = source.bannerParameters;
+        videoParameters = source.videoParameters;
+        nativeConfiguration = source.nativeConfiguration;
+        rewardManager = source.rewardManager;
+
+        adFormats.addAll(source.adFormats);
+        adSizes.addAll(source.adSizes);
+    }
 
     public void modifyUsingBidResponse(@Nullable BidResponse bidResponse) {
         if (bidResponse != null) {

--- a/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/configuration/AdUnitConfiguration.java
+++ b/PrebidMobile/PrebidMobile-core/src/main/java/org/prebid/mobile/configuration/AdUnitConfiguration.java
@@ -243,12 +243,38 @@ public class AdUnitConfiguration {
 
     /**
      * Clears previous ad formats and adds AdFormats corresponding to AdUnitFormat types.
+     * The formats are mapped as interstitial ones.
      */
     public void setAdUnitFormats(@Nullable EnumSet<AdUnitFormat> adUnitFormats) {
-        if (adUnitFormats == null) return;
+        setAdUnitFormats(adUnitFormats, true);
+    }
+
+    /**
+     * Clears previous ad formats and adds AdFormats corresponding to AdUnitFormat types.
+     * <p>
+     * A null or empty set is ignored and the current value is kept, so an ad unit never ends up
+     * without a format to request.
+     *
+     * @param adUnitFormats  formats requested by the publisher.
+     * @param isInterstitial whether {@link AdUnitFormat#BANNER} maps to {@link AdFormat#INTERSTITIAL}
+     *                       (full screen ad units) or to {@link AdFormat#BANNER}.
+     */
+    public void setAdUnitFormats(@Nullable EnumSet<AdUnitFormat> adUnitFormats, boolean isInterstitial) {
+        if (adUnitFormats == null || adUnitFormats.isEmpty()) {
+            LogUtil.warning(TAG, "Ad unit formats must contain at least one item. The current value is kept.");
+            return;
+        }
 
         adFormats.clear();
-        adFormats.addAll(AdFormat.fromSet(adUnitFormats, true));
+        adFormats.addAll(AdFormat.fromSet(adUnitFormats, isInterstitial));
+    }
+
+    /**
+     * Returns the currently requested formats mapped back to the public {@link AdUnitFormat} values.
+     */
+    @NonNull
+    public EnumSet<AdUnitFormat> getAdUnitFormats() {
+        return AdFormat.toSet(adFormats);
     }
 
     /**

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/data/AdFormatTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/data/AdFormatTest.java
@@ -48,4 +48,37 @@ public class AdFormatTest {
         assertEquals(expected, AdFormat.fromSet(input, false));
     }
 
+    @Test
+    public void adFormatsToSet_banner() {
+        assertEquals(EnumSet.of(AdUnitFormat.BANNER), AdFormat.toSet(EnumSet.of(AdFormat.BANNER)));
+    }
+
+    @Test
+    public void adFormatsToSet_interstitial() {
+        assertEquals(EnumSet.of(AdUnitFormat.BANNER), AdFormat.toSet(EnumSet.of(AdFormat.INTERSTITIAL)));
+    }
+
+    @Test
+    public void adFormatsToSet_vast() {
+        assertEquals(EnumSet.of(AdUnitFormat.VIDEO), AdFormat.toSet(EnumSet.of(AdFormat.VAST)));
+    }
+
+    @Test
+    public void adFormatsToSet_multiformat() {
+        EnumSet<AdFormat> input = EnumSet.of(AdFormat.BANNER, AdFormat.VAST);
+        EnumSet<AdUnitFormat> expected = EnumSet.of(AdUnitFormat.BANNER, AdUnitFormat.VIDEO);
+
+        assertEquals(expected, AdFormat.toSet(input));
+    }
+
+    @Test
+    public void adFormatsToSet_nativeHasNoPublicCounterpart() {
+        assertEquals(EnumSet.noneOf(AdUnitFormat.class), AdFormat.toSet(EnumSet.of(AdFormat.NATIVE)));
+    }
+
+    @Test
+    public void adFormatsToSet_null() {
+        assertEquals(EnumSet.noneOf(AdUnitFormat.class), AdFormat.toSet(null));
+    }
+
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/mediation/MediationBannerAdUnitTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/mediation/MediationBannerAdUnitTest.java
@@ -27,6 +27,7 @@ import org.mockito.MockitoAnnotations;
 import org.prebid.mobile.AdSize;
 import org.prebid.mobile.PrebidMobile;
 import org.prebid.mobile.api.data.AdFormat;
+import org.prebid.mobile.api.data.AdUnitFormat;
 import org.prebid.mobile.configuration.AdUnitConfiguration;
 import org.prebid.mobile.rendering.bidding.config.MockMediationUtils;
 import org.prebid.mobile.rendering.bidding.loader.BidLoader;
@@ -108,6 +109,39 @@ public class MediationBannerAdUnitTest {
         mediationBannerAdUnit.resumeRefresh();
 
         verify(mockBidLoader, times(1)).setupRefreshTimer();
+    }
+
+    @Test
+    public void adUnitFormatsDefaultToBanner() {
+        assertEquals(EnumSet.of(AdUnitFormat.BANNER), mediationBannerAdUnit.getAdUnitFormats());
+        assertEquals(EnumSet.of(AdFormat.BANNER), mediationBannerAdUnit.adUnitConfig.getAdFormats());
+    }
+
+    @Test
+    public void setAdUnitFormats_video_requestsVideoOnly() {
+        mediationBannerAdUnit.setAdUnitFormats(EnumSet.of(AdUnitFormat.VIDEO));
+
+        assertEquals(EnumSet.of(AdUnitFormat.VIDEO), mediationBannerAdUnit.getAdUnitFormats());
+        assertEquals(EnumSet.of(AdFormat.VAST), mediationBannerAdUnit.adUnitConfig.getAdFormats());
+    }
+
+    @Test
+    public void setAdUnitFormats_multiformat_requestsBannerAndVideo() {
+        mediationBannerAdUnit.setAdUnitFormats(EnumSet.of(AdUnitFormat.BANNER, AdUnitFormat.VIDEO));
+
+        assertEquals(EnumSet.of(AdUnitFormat.BANNER, AdUnitFormat.VIDEO), mediationBannerAdUnit.getAdUnitFormats());
+        assertEquals(EnumSet.of(AdFormat.BANNER, AdFormat.VAST), mediationBannerAdUnit.adUnitConfig.getAdFormats());
+    }
+
+    @Test
+    public void setAdUnitFormats_nullOrEmpty_keepsCurrentValue() {
+        mediationBannerAdUnit.setAdUnitFormats(EnumSet.of(AdUnitFormat.BANNER, AdUnitFormat.VIDEO));
+
+        mediationBannerAdUnit.setAdUnitFormats(null);
+        assertEquals(EnumSet.of(AdFormat.BANNER, AdFormat.VAST), mediationBannerAdUnit.adUnitConfig.getAdFormats());
+
+        mediationBannerAdUnit.setAdUnitFormats(EnumSet.noneOf(AdUnitFormat.class));
+        assertEquals(EnumSet.of(AdFormat.BANNER, AdFormat.VAST), mediationBannerAdUnit.adUnitConfig.getAdFormats());
     }
 
     @Test

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/BannerViewTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/BannerViewTest.java
@@ -28,10 +28,12 @@ import org.mockito.Mock;
 import org.mockito.MockitoAnnotations;
 import org.prebid.mobile.AdSize;
 import org.prebid.mobile.api.data.AdFormat;
+import org.prebid.mobile.api.data.AdUnitFormat;
 import org.prebid.mobile.api.data.VideoPlacementType;
 import org.prebid.mobile.api.exceptions.AdException;
 import org.prebid.mobile.api.rendering.listeners.BannerVideoListener;
 import org.prebid.mobile.api.rendering.listeners.BannerViewListener;
+import org.prebid.mobile.api.rendering.pluginrenderer.PrebidMobilePluginRegister;
 import org.prebid.mobile.configuration.AdUnitConfiguration;
 import org.prebid.mobile.rendering.bidding.data.bid.Bid;
 import org.prebid.mobile.rendering.bidding.data.bid.BidResponse;
@@ -49,6 +51,7 @@ import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
+import java.util.EnumSet;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -195,6 +198,105 @@ public class BannerViewTest {
         verify(mockAdConfiguration, times(1)).setPlacementType(eq(VideoPlacementType.mapToPlacementType(videoPlacement)));
         verify(mockAdConfiguration, times(1)).setAdFormat(eq(AdFormat.VAST));
     }
+
+    @Test
+    public void setVideoPlacementType_afterExplicitAdUnitFormats_keepsConfiguredFormats() {
+        bannerView.setAdUnitFormats(EnumSet.of(AdUnitFormat.BANNER, AdUnitFormat.VIDEO));
+
+        bannerView.setVideoPlacementType(VideoPlacementType.IN_BANNER);
+
+        assertEquals(EnumSet.of(AdUnitFormat.BANNER, AdUnitFormat.VIDEO), bannerView.getAdUnitFormats());
+        assertEquals(VideoPlacementType.IN_BANNER, bannerView.getVideoPlacementType());
+    }
+
+    @Test
+    public void setAdUnitFormats_afterVideoPlacementType_keepsConfiguredFormats() {
+        bannerView.setVideoPlacementType(VideoPlacementType.IN_BANNER);
+
+        bannerView.setAdUnitFormats(EnumSet.of(AdUnitFormat.BANNER, AdUnitFormat.VIDEO));
+
+        assertEquals(EnumSet.of(AdUnitFormat.BANNER, AdUnitFormat.VIDEO), bannerView.getAdUnitFormats());
+        assertEquals(VideoPlacementType.IN_BANNER, bannerView.getVideoPlacementType());
+    }
+
+    @Test
+    public void adUnitFormatsDefaultToBanner() {
+        assertEquals(EnumSet.of(AdUnitFormat.BANNER), bannerView.getAdUnitFormats());
+    }
+
+    @Test
+    public void setAdUnitFormats_video_requestsVideoOnly() throws IllegalAccessException {
+        bannerView.setAdUnitFormats(EnumSet.of(AdUnitFormat.VIDEO));
+
+        assertEquals(EnumSet.of(AdUnitFormat.VIDEO), bannerView.getAdUnitFormats());
+        assertEquals(EnumSet.of(AdFormat.VAST), getAdUnitConfig().getAdFormats());
+    }
+
+    @Test
+    public void setAdUnitFormats_multiformat_requestsBannerAndVideo() throws IllegalAccessException {
+        bannerView.setAdUnitFormats(EnumSet.of(AdUnitFormat.BANNER, AdUnitFormat.VIDEO));
+
+        assertEquals(EnumSet.of(AdUnitFormat.BANNER, AdUnitFormat.VIDEO), bannerView.getAdUnitFormats());
+        assertEquals(EnumSet.of(AdFormat.BANNER, AdFormat.VAST), getAdUnitConfig().getAdFormats());
+    }
+
+    @Test
+    public void setAdUnitFormats_nullOrEmpty_keepsCurrentValue() throws IllegalAccessException {
+        bannerView.setAdUnitFormats(EnumSet.of(AdUnitFormat.BANNER, AdUnitFormat.VIDEO));
+
+        bannerView.setAdUnitFormats(null);
+        assertEquals(EnumSet.of(AdFormat.BANNER, AdFormat.VAST), getAdUnitConfig().getAdFormats());
+
+        bannerView.setAdUnitFormats(EnumSet.noneOf(AdUnitFormat.class));
+        assertEquals(EnumSet.of(AdFormat.BANNER, AdFormat.VAST), getAdUnitConfig().getAdFormats());
+    }
+
+    @Test
+    public void setAdUnitFormats_multiformat_autoRefreshStaysAvailable() {
+        bannerView.setAdUnitFormats(EnumSet.of(AdUnitFormat.BANNER, AdUnitFormat.VIDEO));
+
+        bannerView.setAutoRefreshDelay(30);
+
+        assertEquals(30_000, bannerView.getAutoRefreshDelayInMs());
+    }
+
+    //region ================= Auto refresh vs. video creatives
+    @Test
+    public void onPrebidSdkWinWithVideoBid_CancelAutoRefresh() {
+        bannerView.setAdUnitFormats(EnumSet.of(AdUnitFormat.BANNER, AdUnitFormat.VIDEO));
+        bannerView.setBidResponse(mockBidResponse(true));
+
+        getBannerEventListener().onPrebidSdkWin();
+
+        verify(mockBidLoader, times(1)).cancelRefresh();
+    }
+
+    @Test
+    public void onPrebidSdkWinWithBannerBid_KeepAutoRefresh() {
+        bannerView.setAdUnitFormats(EnumSet.of(AdUnitFormat.BANNER, AdUnitFormat.VIDEO));
+        bannerView.setBidResponse(mockBidResponse(false));
+
+        getBannerEventListener().onPrebidSdkWin();
+
+        verify(mockBidLoader, never()).cancelRefresh();
+    }
+
+    private BidResponse mockBidResponse(boolean isVideo) {
+        final BidResponse response = mock(BidResponse.class);
+        final Bid bid = mock(Bid.class);
+
+        when(response.getWinningBid()).thenReturn(bid);
+        when(response.isVideo()).thenReturn(isVideo);
+        when(response.getPreferredPluginRendererName()).thenReturn(PrebidMobilePluginRegister.PREBID_MOBILE_RENDERER_NAME);
+        when(response.getWinningBidWidthHeightPairDips(any())).thenReturn(new Pair<>(320, 50));
+        when(bid.getPrice()).thenReturn(0.1);
+        return response;
+    }
+
+    private AdUnitConfiguration getAdUnitConfig() throws IllegalAccessException {
+        return (AdUnitConfiguration) WhiteBox.field(BannerView.class, "adUnitConfig").get(bannerView);
+    }
+    //endregion ================= Auto refresh vs. video creatives
 
     @Test
     public void setAdVideoPlacement_EqualsGetVideoPlacement() {

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/BannerViewTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/BannerViewTest.java
@@ -262,35 +262,46 @@ public class BannerViewTest {
 
     //region ================= Auto refresh vs. video creatives
     @Test
-    public void onPrebidSdkWinWithVideoBid_CancelAutoRefresh() {
-        bannerView.setAdUnitFormats(EnumSet.of(AdUnitFormat.BANNER, AdUnitFormat.VIDEO));
-        bannerView.setBidResponse(mockBidResponse(true));
+    public void canPerformRefreshWhileVideoIsPlaying_SkipTheTick() throws Exception {
+        when(mockDisplayView.isVideoPlaying()).thenReturn(true);
 
-        getBannerEventListener().onPrebidSdkWin();
-
-        verify(mockBidLoader, times(1)).cancelRefresh();
+        assertFalse(getBidRefreshListener().canPerformRefresh());
     }
 
     @Test
-    public void onPrebidSdkWinWithBannerBid_KeepAutoRefresh() {
-        bannerView.setAdUnitFormats(EnumSet.of(AdUnitFormat.BANNER, AdUnitFormat.VIDEO));
-        bannerView.setBidResponse(mockBidResponse(false));
+    public void canPerformRefreshAfterVideoFinished_AllowTheTick() throws Exception {
+        when(mockDisplayView.isVideoPlaying()).thenReturn(false);
+        when(mockScreenStateReceiver.isScreenOn()).thenReturn(true);
 
-        getBannerEventListener().onPrebidSdkWin();
+        // The visibility checker is the only remaining gate, so the video no longer blocks refresh.
+        getBidRefreshListener().canPerformRefresh();
 
-        verify(mockBidLoader, never()).cancelRefresh();
+        verify(mockDisplayView, times(1)).isVideoPlaying();
     }
 
-    private BidResponse mockBidResponse(boolean isVideo) {
-        final BidResponse response = mock(BidResponse.class);
-        final Bid bid = mock(Bid.class);
+    @Test
+    public void canPerformRefreshAfterAdFailed_AllowTheTickEvenIfVideoReportsPlaying() throws Exception {
+        when(mockDisplayView.isVideoPlaying()).thenReturn(true);
+        WhiteBox.field(BannerView.class, "adFailed").set(bannerView, true);
 
-        when(response.getWinningBid()).thenReturn(bid);
-        when(response.isVideo()).thenReturn(isVideo);
-        when(response.getPreferredPluginRendererName()).thenReturn(PrebidMobilePluginRegister.PREBID_MOBILE_RENDERER_NAME);
-        when(response.getWinningBidWidthHeightPairDips(any())).thenReturn(new Pair<>(320, 50));
-        when(bid.getPrice()).thenReturn(0.1);
-        return response;
+        assertTrue(getBidRefreshListener().canPerformRefresh());
+    }
+
+    @Test
+    public void isVideoPlayingWithoutDisplayView_False() throws IllegalAccessException {
+        WhiteBox.field(BannerView.class, "displayView").set(bannerView, null);
+
+        assertFalse(bannerView.isVideoPlaying());
+    }
+
+    private BidLoader.BidRefreshListener getBidRefreshListener() throws Exception {
+        // initBidLoader() builds a BidLoader and registers the refresh gate on it.
+        WhiteBox.method(BannerView.class, "initBidLoader").invoke(bannerView);
+
+        final BidLoader bidLoader = (BidLoader) WhiteBox.field(BannerView.class, "bidLoader").get(bannerView);
+        return (BidLoader.BidRefreshListener) WhiteBox
+                .field(BidLoader.class, "bidRefreshListener")
+                .get(bidLoader);
     }
 
     private AdUnitConfiguration getAdUnitConfig() throws IllegalAccessException {

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/DisplayViewTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/DisplayViewTest.java
@@ -1,6 +1,9 @@
 package org.prebid.mobile.api.rendering;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotSame;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -13,12 +16,14 @@ import android.view.View;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
 import org.mockito.Spy;
 import org.prebid.mobile.PrebidMobile;
 import org.prebid.mobile.api.data.AdFormat;
+import org.prebid.mobile.api.data.AdUnitFormat;
 import org.prebid.mobile.api.rendering.pluginrenderer.PrebidMobilePluginRenderer;
 import org.prebid.mobile.configuration.AdUnitConfiguration;
 import org.prebid.mobile.rendering.bidding.data.bid.Bid;
@@ -29,6 +34,8 @@ import org.prebid.mobile.testutils.FakePrebidMobilePluginRenderer;
 import org.robolectric.Robolectric;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
+
+import java.util.EnumSet;
 
 @RunWith(RobolectricTestRunner.class)
 @Config(sdk = 19)
@@ -70,9 +77,8 @@ public class DisplayViewTest {
     public void onDisplayViewWinNotification_returnBannerAdView() {
         displayView = new DisplayView(context, mockDisplayViewListener, adUnitConfiguration, mockResponse);
 
-
-        verify(adUnitConfiguration).modifyUsingBidResponse(mockResponse);
-        verify(fakePrebidMobilePluginRenderer).createBannerAdView(context, mockDisplayViewListener, null, adUnitConfiguration, mockResponse);
+        AdUnitConfiguration rendered = captureRenderedConfiguration(null);
+        assertEquals(adUnitConfiguration.getFingerprint(), rendered.getFingerprint());
         // bannerAdView added to view hierarchy
         assertEquals(1, displayView.getChildCount());
     }
@@ -81,9 +87,36 @@ public class DisplayViewTest {
     public void onDisplayViewWithVideoListenerWinNotification_returnBannerAdView() {
         displayView = new DisplayView(context, mockDisplayViewListener, mockDisplayVideoListener, adUnitConfiguration, mockResponse);
 
-        verify(adUnitConfiguration).modifyUsingBidResponse(mockResponse);
-        verify(fakePrebidMobilePluginRenderer).createBannerAdView(context, mockDisplayViewListener, mockDisplayVideoListener, adUnitConfiguration, mockResponse);
+        AdUnitConfiguration rendered = captureRenderedConfiguration(mockDisplayVideoListener);
+        assertEquals(adUnitConfiguration.getFingerprint(), rendered.getFingerprint());
         // bannerAdView added to view hierarchy
         assertEquals(1, displayView.getChildCount());
+    }
+
+    @Test
+    public void renderersGetACopy_soTheAdUnitConfigurationSurvivesRendering() {
+        adUnitConfiguration.setAdUnitFormats(EnumSet.of(AdUnitFormat.BANNER, AdUnitFormat.VIDEO), false);
+
+        displayView = new DisplayView(context, mockDisplayViewListener, adUnitConfiguration, mockResponse);
+
+        AdUnitConfiguration rendered = captureRenderedConfiguration(null);
+        assertNotSame("A renderer must never be handed the ad unit's own configuration", adUnitConfiguration, rendered);
+
+        // The creative pipeline narrows the configuration it is given down to the winning format.
+        rendered.setAdFormat(AdFormat.VAST);
+
+        assertEquals(EnumSet.of(AdFormat.BANNER, AdFormat.VAST), adUnitConfiguration.getAdFormats());
+    }
+
+    private AdUnitConfiguration captureRenderedConfiguration(DisplayVideoListener videoListener) {
+        ArgumentCaptor<AdUnitConfiguration> captor = ArgumentCaptor.forClass(AdUnitConfiguration.class);
+        verify(fakePrebidMobilePluginRenderer).createBannerAdView(
+                eq(context),
+                eq(mockDisplayViewListener),
+                videoListener == null ? any() : eq(videoListener),
+                captor.capture(),
+                eq(mockResponse)
+        );
+        return captor.getValue();
     }
 }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/PrebidDisplayViewTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/api/rendering/PrebidDisplayViewTest.java
@@ -77,6 +77,23 @@ public class PrebidDisplayViewTest {
     }
 
     @Test
+    public void whenHtmlBidWinsAfterVideo_BuiltInVideoIsCleared() {
+        // A multiformat banner shares one configuration across refreshes, so a video creative must
+        // not leave isBuiltInVideo latched for the next HTML creative.
+        adUnitConfiguration.setBuiltInVideo(true);
+
+        BidResponse htmlResponse = mock(BidResponse.class);
+        Bid htmlBid = mock(Bid.class);
+        when(htmlBid.getAdm()).thenReturn("adm");
+        when(htmlResponse.getWinningBid()).thenReturn(htmlBid);
+        when(htmlResponse.isVideo()).thenReturn(false);
+
+        new PrebidDisplayView(context, mockDisplayViewListener, mockDisplayVideoListener, adUnitConfiguration, htmlResponse);
+
+        Assert.assertFalse(adUnitConfiguration.isBuiltInVideo());
+    }
+
+    @Test
     public void whenDisplayAd_LoadBidTransaction() {
         Assert.assertNotNull(WhiteBox.getInternalState(prebidDisplayView, "adViewManager"));
     }

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/configuration/AdUnitConfigurationTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/configuration/AdUnitConfigurationTest.java
@@ -1,18 +1,26 @@
 package org.prebid.mobile.configuration;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertSame;
 
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
+import org.prebid.mobile.AdSize;
 import org.prebid.mobile.api.data.AdFormat;
 import org.prebid.mobile.api.data.AdUnitFormat;
 import org.robolectric.RobolectricTestRunner;
 import org.robolectric.annotation.Config;
 
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import java.util.Arrays;
 import java.util.EnumSet;
+import java.util.HashSet;
+import java.util.Set;
 import java.util.UUID;
 
 @RunWith(RobolectricTestRunner.class)
@@ -164,6 +172,84 @@ public class AdUnitConfigurationTest {
         subject.setAdUnitFormats(EnumSet.of(AdUnitFormat.BANNER, AdUnitFormat.VIDEO), true);
         assertEquals(EnumSet.of(AdUnitFormat.BANNER, AdUnitFormat.VIDEO), subject.getAdUnitFormats());
     }
+
+    //region ================= Rendering copy
+    @Test
+    public void copyConstructor_carriesEveryValueOver() {
+        subject.setAdUnitFormats(EnumSet.of(AdUnitFormat.BANNER, AdUnitFormat.VIDEO), false);
+        subject.setConfigId("config-id");
+        subject.setPbAdSlot("ad-slot");
+        subject.setAutoRefreshDelay(30);
+        subject.setRewarded(true);
+        subject.setBuiltInVideo(true);
+        subject.setImpOrtbConfig("{\"a\":1}");
+        subject.addSize(new AdSize(300, 250));
+
+        AdUnitConfiguration copy = new AdUnitConfiguration(subject);
+
+        assertEquals(subject.getAdFormats(), copy.getAdFormats());
+        assertEquals(subject.getConfigId(), copy.getConfigId());
+        assertEquals(subject.getPbAdSlot(), copy.getPbAdSlot());
+        assertEquals(subject.getAutoRefreshDelay(), copy.getAutoRefreshDelay());
+        assertEquals(subject.isRewarded(), copy.isRewarded());
+        assertEquals(subject.isBuiltInVideo(), copy.isBuiltInVideo());
+        assertEquals(subject.getImpOrtbConfig(), copy.getImpOrtbConfig());
+        assertEquals(subject.getSizes(), copy.getSizes());
+    }
+
+    @Test
+    public void copyConstructor_keepsFingerprintAndBroadcastId() {
+        AdUnitConfiguration copy = new AdUnitConfiguration(subject);
+
+        // Plugin event listeners are registered under the fingerprint, and creatives address the
+        // event receiver by broadcast id, so both must survive the copy.
+        assertEquals(subject.getFingerprint(), copy.getFingerprint());
+        assertEquals(subject.getBroadcastId(), copy.getBroadcastId());
+    }
+
+    @Test
+    public void copyConstructor_sharesTheRewardManager() {
+        // The reward is read back through the ad unit after rendering.
+        assertSame(subject.getRewardManager(), new AdUnitConfiguration(subject).getRewardManager());
+    }
+
+    @Test
+    public void copyConstructor_isolatesFormatAndSizeChanges() {
+        subject.setAdUnitFormats(EnumSet.of(AdUnitFormat.BANNER, AdUnitFormat.VIDEO), false);
+        AdUnitConfiguration copy = new AdUnitConfiguration(subject);
+
+        copy.setAdFormat(AdFormat.VAST);
+        copy.addSize(new AdSize(1, 1));
+
+        assertEquals(EnumSet.of(AdFormat.BANNER, AdFormat.VAST), subject.getAdFormats());
+        assertFalse(subject.getSizes().contains(new AdSize(1, 1)));
+    }
+
+    @Test
+    public void copyConstructor_coversEveryDeclaredField() {
+        // Tripwire: a field added to AdUnitConfiguration must also be added to the copy
+        // constructor, otherwise rendering silently loses it. Update both together.
+        Set<String> expected = new HashSet<>(Arrays.asList(
+                "isRewarded", "isBuiltInVideo", "isMuted", "isSoundButtonVisible", "isOriginalAdUnit",
+                "hasEndCard", "videoSkipOffset", "autoRefreshDelayInMillis", "skipDelay", "broadcastId",
+                "videoInitialVolume", "closeButtonArea", "skipButtonArea", "maxVideoDuration",
+                "configId", "pbAdSlot", "interstitialSize", "impressionUrl", "fingerprint", "gpid",
+                "impOrtbConfig", "globalOrtbConfig", "closeButtonPosition", "skipButtonPosition",
+                "minSizePercentage", "placementType", "adPosition", "appContent", "bannerParameters",
+                "videoParameters", "nativeConfiguration", "rewardManager", "adFormats", "adSizes"
+        ));
+
+        Set<String> actual = new HashSet<>();
+        for (Field field : AdUnitConfiguration.class.getDeclaredFields()) {
+            if (!Modifier.isStatic(field.getModifiers()) && !field.isSynthetic()) {
+                actual.add(field.getName());
+            }
+        }
+
+        assertEquals("AdUnitConfiguration fields changed: update the copy constructor and this list",
+                expected, actual);
+    }
+    //endregion ================= Rendering copy
 
     @Test
     public void fingerprintIsAValidRandomBasedUUID() {

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/configuration/AdUnitConfigurationTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/configuration/AdUnitConfigurationTest.java
@@ -137,6 +137,35 @@ public class AdUnitConfigurationTest {
     }
 
     @Test
+    public void setAdUnitFormats_notInterstitial_mapsBannerToBanner() {
+        subject.setAdUnitFormats(EnumSet.of(AdUnitFormat.BANNER), false);
+
+        assertEquals(EnumSet.of(AdFormat.BANNER), subject.getAdFormats());
+
+        subject.setAdUnitFormats(EnumSet.of(AdUnitFormat.BANNER, AdUnitFormat.VIDEO), false);
+
+        assertEquals(EnumSet.of(AdFormat.BANNER, AdFormat.VAST), subject.getAdFormats());
+    }
+
+    @Test
+    public void setAdUnitFormats_emptySet_keepsCurrentValue() {
+        subject.setAdUnitFormats(EnumSet.of(AdUnitFormat.BANNER, AdUnitFormat.VIDEO), false);
+
+        subject.setAdUnitFormats(EnumSet.noneOf(AdUnitFormat.class), false);
+
+        assertEquals(EnumSet.of(AdFormat.BANNER, AdFormat.VAST), subject.getAdFormats());
+    }
+
+    @Test
+    public void getAdUnitFormats_mapsBackToPublicFormats() {
+        subject.setAdUnitFormats(EnumSet.of(AdUnitFormat.BANNER, AdUnitFormat.VIDEO), false);
+        assertEquals(EnumSet.of(AdUnitFormat.BANNER, AdUnitFormat.VIDEO), subject.getAdUnitFormats());
+
+        subject.setAdUnitFormats(EnumSet.of(AdUnitFormat.BANNER, AdUnitFormat.VIDEO), true);
+        assertEquals(EnumSet.of(AdUnitFormat.BANNER, AdUnitFormat.VIDEO), subject.getAdUnitFormats());
+    }
+
+    @Test
     public void fingerprintIsAValidRandomBasedUUID() {
         // Assert
         String uuidString = subject.getFingerprint();

--- a/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/networking/parameters/BasicParameterBuilderTest.java
+++ b/PrebidMobile/PrebidMobile-core/src/test/java/org/prebid/mobile/rendering/networking/parameters/BasicParameterBuilderTest.java
@@ -788,6 +788,30 @@ public class BasicParameterBuilderTest {
     }
 
     @Test
+    public void testMultiFormatBannerAdUnit_bannerAndVideoObjectsAreNotNullAndImpIsNotInterstitial() {
+        AdUnitConfiguration configuration = new AdUnitConfiguration();
+        configuration.addSize(new AdSize(300, 250));
+        configuration.setAdUnitFormats(EnumSet.of(AdUnitFormat.BANNER, AdUnitFormat.VIDEO), false);
+
+        assertEquals(EnumSet.of(AdFormat.BANNER, AdFormat.VAST), configuration.getAdFormats());
+
+        BasicParameterBuilder builder = new BasicParameterBuilder(configuration, null, false);
+
+        AdRequestInput adRequestInput = new AdRequestInput();
+        builder.appendBuilderParameters(adRequestInput);
+
+        BidRequest bidRequest = adRequestInput.getBidRequest();
+        Imp firstImp = bidRequest.getImp().iterator().next();
+
+        assertNotNull(firstImp);
+
+        assertNull(firstImp.nativeObj);
+        assertNotNull(firstImp.banner);
+        assertNotNull(firstImp.video);
+        assertEquals(Integer.valueOf(0), firstImp.instl);
+    }
+
+    @Test
     public void testNativeAdUnit_nativeObjectIsNotNull() {
         AdUnitConfiguration configuration = new AdUnitConfiguration();
         configuration.addAdFormat(AdFormat.NATIVE);


### PR DESCRIPTION
Closes #1008
Related to #999
Android counterpart of prebid/prebid-mobile-ios#1341.

## Problem

`BannerView` and `MediationBannerAdUnit` could only ever request a single format. Their constructors set `AdFormat.BANNER`, and `setVideoPlacementType(...)` replaced it with `VAST`, so display and outstream video demand could never compete on one impression — unlike `InterstitialAdUnit` and the original API.

## What changed

### Public API

`setAdUnitFormats(EnumSet<AdUnitFormat>)` / `getAdUnitFormats()` on `BannerView` and `MediationBannerAdUnit`. Default stays banner only; a null or empty set is ignored with a warning and the current value is kept.

```java
BannerView bannerView = new BannerView(context, configId, new AdSize(300, 250));
bannerView.setAdUnitFormats(EnumSet.of(AdUnitFormat.BANNER, AdUnitFormat.VIDEO));
bannerView.setVideoPlacementType(VideoPlacementType.IN_BANNER);
```

`setVideoPlacementType(...)` no longer overrides formats that were configured explicitly, so the two can be called in either order. Its existing behaviour is unchanged when `setAdUnitFormats(...)` is not used.

### Request and rendering

No renderer changes were needed. `BasicParameterBuilder` already emits `imp.banner` and `imp.video` independently, and `PrebidDisplayView` already picks the renderer from `BidResponse.isVideo()`. `AdUnitConfiguration.setAdUnitFormats(...)` gained an `isInterstitial` flag so a banner ad unit maps `AdUnitFormat.BANNER` to `AdFormat.BANNER` rather than `AdFormat.INTERSTITIAL`.

### Auto refresh

Follows the reworked handling in the iOS PR: rather than cancelling auto refresh when a video bid wins, the refresh tick is skipped while the creative is playing and the timer is rescheduled, so refreshing continues once playback finishes. `VideoView.isVideoPlaybackInProgress()` reports this from the existing state machine — it stays true across pauses and across a "watch again" replay, matching the iOS window between `videoAdDidStart` and `videoAdDidFinish`. The gate sits after the existing "ad failed" escape hatch so a failed load can still retry.

### Rendering no longer mutates the ad unit's configuration

This is the least obvious part of the change, and the multiformat feature does not work without it.

The creative pipeline rewrites the configuration it is handed. `CreativeModelMakerBids.makeVideoModels()` narrows `adFormats` down to `VAST` so `CreativeFactory` can route the creative, and `VideoView` records the built in video state and clears the refresh delay. `DisplayView` passed `BannerView`'s own `AdUnitConfiguration` straight through, so rendering one video creative turned a multiformat ad unit into a video only one permanently.

That is what made auto refresh unrecoverable: once `adFormats` no longer holds `BANNER`, `BidLoader.setupRefreshTimer()` returns early and the timer can never be rescheduled, so deferring a refresh during playback would have stopped it for good rather than resuming it. The next auction would also have silently dropped the banner format.

`DisplayView` now renders against its own copy of the configuration. The copy carries `fingerprint` over, because plugin event listeners are registered under it, and `broadcastId`, because creatives address the event receiver by it. The mutable sub configurations (`RewardManager`, banner, video and native parameters) are shared by reference on purpose, since they are read back through the ad unit after rendering. A tripwire test fails if a field is added to `AdUnitConfiguration` without being added to the copy.

The alternative considered was routing `CreativeFactory` on `creativeModel instanceof VideoCreativeModel` and leaving `adFormats` alone. That would additionally have made `AdViewManager.handleCreativeDisplay()` deduplicate repeat displays of a banner video and silently break "watch again", because `lastCreativeShown` is never reset.

## Notes for reviewers

- `MediationBannerAdUnit` deliberately does not stop refreshing when a video bid is returned. Unlike `BannerView`, it never learns whether the Prebid bid actually won inside the mediation SDK, so cancelling would be wrong when the mediation SDK serves its own ad. This matches iOS. `stopRefresh()` / `resumeRefresh()` are documented on the new setter.
- Interstitials narrow their configuration the same way, but they do not auto refresh, so the impact is limited to a repeated `loadAd()`. Left out of this PR.
- `BasicParameterBuilder.setVideoImpValues()` defaults `video.placement` to `5` (interstitial) for any rendering API video imp with no placement type, including a banner one. Three existing tests assert this, so it looks intentional and is left alone. Publishers should keep calling `setVideoPlacementType(...)`, as the examples here do.

## Examples

- `PrebidDemoKotlin`: `InAppMultiformatBannerActivity`, registered as an `AdFormat.MULTIFORMAT` test case.
- `PrebidInternalTestApp`: "Multiformat Banner 300x250 (In-App)", picking a display or video config id at random so either creative can win, mirroring the iOS test case.

## Testing

1327 unit tests pass. `MraidInternalBrowserActionTest > handleInternalBrowserActionFollowUrlSuccessAndIsMraid_StartActionViewActivity` fails, and also fails on a clean `master`, so it is unrelated.

New coverage: format mapping both ways, multiformat request emitting `imp.banner` + `imp.video` with `instl=0`, call order independence between placement and formats, the refresh gate during and after playback, `isBuiltInVideo` no longer latching, and the configuration copy including the field tripwire.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
